### PR TITLE
Disallow email-style names in migration API profile validation

### DIFF
--- a/backend/src/controllers/migration_api/state_profile.rs
+++ b/backend/src/controllers/migration_api/state_profile.rs
@@ -89,7 +89,11 @@ pub(in crate::controllers::migration_api) fn validate_profile_name(
         Err("Name is required")
     } else if name.chars().count() > 100 {
         Err("Name must be at most 100 characters")
-    } else if name.contains("http://") || name.contains("https://") || name.contains("www.") {
+    } else if name.contains("http://")
+        || name.contains("https://")
+        || name.contains("www.")
+        || name.contains('@')
+    {
         Err("Imie nie moze zawierac linkow ani adresow email")
     } else {
         Ok(())


### PR DESCRIPTION
### Motivation
- Prevent profile names from containing email-style addresses so migration API rejects names with `@` and reduces accidental PII/links in names.

### Description
- Add an `@` character check to `validate_profile_name` in `backend/src/controllers/migration_api/state_profile.rs` and reformat the conditional to include the new rule.

### Testing
- Ran `cargo fmt --all -- --check` in `backend/` (passed) and `cargo clippy --workspace --all-targets --all-features -- -D warnings` in `backend/` (passed), while `backend/scripts/rust-code-analysis.sh` failed due to `rust-code-analysis-cli` not being installed and `./gradlew ktlintCheck detekt` in `mobile/` failed due to an invalid `org.gradle.java.home` setting; running `cargo fmt` at repo root failed because there is no `Cargo.toml` at the top level.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a6f5e3a08328b1f0ef1e7a600579)