### PR TITLE
Refactor auth context caching and single-connection batching in events/matching

### DIFF
--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -24,9 +24,10 @@ use diesel_async::RunQueryDsl;
 use super::{
     error_response,
     state::{
-        extract_bearer_token, hash_session_token, is_valid_email, normalize_email, otp_in_cooldown,
-        require_auth_db, upsert_otp, user_model_to_view, DataResponse, ResendOtpBody,
-        SessionListItem, SignInBody, SignUpBody, SuccessResponse, VerifyOtpBody,
+        extract_bearer_token, hash_session_token, invalidate_auth_cache_for_token, is_valid_email,
+        normalize_email, otp_in_cooldown, require_auth_db, upsert_otp, user_model_to_view,
+        DataResponse, ResendOtpBody, SessionListItem, SignInBody, SignUpBody, SuccessResponse,
+        VerifyOtpBody,
     },
     ErrorSpec,
 };
@@ -157,6 +158,7 @@ pub(super) async fn sign_out(
                 .execute(&mut conn)
                 .await;
         }
+        invalidate_auth_cache_for_token(&token).await;
     }
     Ok(Json(SuccessResponse { success: true }).into_response())
 }

--- a/backend/src/api/events/mod.rs
+++ b/backend/src/api/events/mod.rs
@@ -32,7 +32,7 @@ use super::state::{DataResponse, EventsQuery};
 use events_service::{not_found_event, require_auth_profile};
 use events_view::attendee_info;
 
-pub(super) use events_view::{build_event_response, build_event_responses};
+pub(super) use events_view::{build_event_response, build_event_responses_with_conn};
 pub(super) use events_write_handler::{
     event_attend, event_create, event_delete, event_leave, event_update,
 };

--- a/backend/src/api/events/view.rs
+++ b/backend/src/api/events/view.rs
@@ -94,7 +94,16 @@ pub(in crate::api) async fn build_event_responses(
     event_models: &[Event],
     profile_id: &Uuid,
 ) -> std::result::Result<Vec<EventResponse>, crate::error::AppError> {
-    let batch_ctx = load_event_batch_context(event_models).await?;
+    let mut conn = crate::db::conn().await?;
+    build_event_responses_with_conn(event_models, profile_id, &mut conn).await
+}
+
+pub(in crate::api) async fn build_event_responses_with_conn(
+    event_models: &[Event],
+    profile_id: &Uuid,
+    conn: &mut crate::db::DbConn,
+) -> std::result::Result<Vec<EventResponse>, crate::error::AppError> {
+    let batch_ctx = load_event_batch_context(event_models, conn).await?;
     let mut responses: Vec<EventResponse> = event_models
         .iter()
         .map(|event| build_from_context(event, profile_id, &batch_ctx))

--- a/backend/src/api/events/view_attendees.rs
+++ b/backend/src/api/events/view_attendees.rs
@@ -12,15 +12,15 @@ use crate::db::schema::users;
 
 async fn load_users_for_profiles(
     rows: &[AttendeeRow],
+    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<Vec<User>, crate::error::AppError> {
     let user_ids: Vec<i32> = rows.iter().map(|r| r.profile.user_id).collect();
     if user_ids.is_empty() {
         return Ok(vec![]);
     }
-    let mut conn = crate::db::conn().await?;
     Ok(users::table
         .filter(users::id.eq_any(&user_ids))
-        .load::<User>(&mut conn)
+        .load::<User>(conn)
         .await?)
 }
 
@@ -51,8 +51,9 @@ fn build_attendee_info(
 pub(in crate::api) async fn attendee_info(
     event_id: Uuid,
 ) -> std::result::Result<Vec<AttendeeFullInfo>, crate::error::AppError> {
-    let rows = load_attendee_rows(event_id).await?;
-    let user_models = load_users_for_profiles(&rows).await?;
+    let mut conn = crate::db::conn().await?;
+    let rows = load_attendee_rows(event_id, &mut conn).await?;
+    let user_models = load_users_for_profiles(&rows, &mut conn).await?;
 
     let filenames = rows
         .iter()

--- a/backend/src/api/events/view_repo.rs
+++ b/backend/src/api/events/view_repo.rs
@@ -35,27 +35,26 @@ fn scope_from_str(s: &str) -> TagScope {
 
 async fn load_profiles_by_ids(
     ids: &[Uuid],
+    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<HashMap<Uuid, Profile>, crate::error::AppError> {
     if ids.is_empty() {
         return Ok(HashMap::new());
     }
 
-    let mut conn = crate::db::conn().await?;
     let models = profiles::table
         .filter(profiles::id.eq_any(ids))
-        .load::<Profile>(&mut conn)
+        .load::<Profile>(conn)
         .await?;
     Ok(models.into_iter().map(|model| (model.id, model)).collect())
 }
 
 pub(super) async fn load_attendee_rows(
     event_id: Uuid,
+    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<Vec<AttendeeRow>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let links = event_attendees::table
         .filter(event_attendees::event_id.eq(event_id))
-        .load::<EventAttendee>(&mut conn)
+        .load::<EventAttendee>(conn)
         .await?;
 
     let profile_ids: HashSet<Uuid> = links.iter().map(|attendee| attendee.profile_id).collect();
@@ -63,7 +62,8 @@ pub(super) async fn load_attendee_rows(
         return Ok(vec![]);
     }
 
-    let profiles_map = load_profiles_by_ids(&profile_ids.into_iter().collect::<Vec<_>>()).await?;
+    let profiles_map =
+        load_profiles_by_ids(&profile_ids.into_iter().collect::<Vec<_>>(), conn).await?;
 
     let mut rows: Vec<AttendeeRow> = links
         .iter()
@@ -84,9 +84,11 @@ pub(super) async fn load_attendee_rows(
 
 async fn load_creator_previews(
     events_list: &[Event],
+    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<HashMap<Uuid, ProfilePreview>, crate::error::AppError> {
     let creator_ids: HashSet<Uuid> = events_list.iter().map(|event| event.creator_id).collect();
-    let creator_models = load_profiles_by_ids(&creator_ids.into_iter().collect::<Vec<_>>()).await?;
+    let creator_models =
+        load_profiles_by_ids(&creator_ids.into_iter().collect::<Vec<_>>(), conn).await?;
 
     Ok(creator_models
         .into_values()
@@ -105,12 +107,11 @@ async fn load_creator_previews(
 
 async fn load_event_attendee_map(
     event_ids: &[Uuid],
+    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<HashMap<Uuid, Vec<AttendeeRow>>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let attendee_links = event_attendees::table
         .filter(event_attendees::event_id.eq_any(event_ids))
-        .load::<EventAttendee>(&mut conn)
+        .load::<EventAttendee>(conn)
         .await?;
 
     let attendee_profile_ids: HashSet<Uuid> = attendee_links
@@ -118,7 +119,7 @@ async fn load_event_attendee_map(
         .map(|attendee| attendee.profile_id)
         .collect();
     let attendee_profiles =
-        load_profiles_by_ids(&attendee_profile_ids.into_iter().collect::<Vec<_>>()).await?;
+        load_profiles_by_ids(&attendee_profile_ids.into_iter().collect::<Vec<_>>(), conn).await?;
 
     let mut attendees: HashMap<Uuid, Vec<AttendeeRow>> = HashMap::new();
     for link in &attendee_links {
@@ -142,12 +143,11 @@ async fn load_event_attendee_map(
 
 async fn load_event_tag_map(
     event_ids: &[Uuid],
+    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<HashMap<Uuid, Vec<EventTagResponse>>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let tag_links = event_tags::table
         .filter(event_tags::event_id.eq_any(event_ids))
-        .load::<EventTag>(&mut conn)
+        .load::<EventTag>(conn)
         .await?;
 
     let tag_ids: HashSet<Uuid> = tag_links.iter().map(|link| link.tag_id).collect();
@@ -156,7 +156,7 @@ async fn load_event_tag_map(
     } else {
         tags::table
             .filter(tags::id.eq_any(&tag_ids.into_iter().collect::<Vec<_>>()))
-            .load::<Tag>(&mut conn)
+            .load::<Tag>(conn)
             .await?
             .into_iter()
             .map(|tag| (tag.id, tag))
@@ -182,6 +182,7 @@ async fn load_event_tag_map(
 
 pub(super) async fn load_event_batch_context(
     event_models: &[Event],
+    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<EventBatchContext, crate::error::AppError> {
     if event_models.is_empty() {
         return Ok(EventBatchContext {
@@ -192,9 +193,9 @@ pub(super) async fn load_event_batch_context(
     }
 
     let event_ids: Vec<Uuid> = event_models.iter().map(|event| event.id).collect();
-    let creators = load_creator_previews(event_models).await?;
-    let attendees = load_event_attendee_map(&event_ids).await?;
-    let tags = load_event_tag_map(&event_ids).await?;
+    let creators = load_creator_previews(event_models, conn).await?;
+    let attendees = load_event_attendee_map(&event_ids, conn).await?;
+    let tags = load_event_tag_map(&event_ids, conn).await?;
 
     Ok(EventBatchContext {
         creators,

--- a/backend/src/api/matching/assembler.rs
+++ b/backend/src/api/matching/assembler.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use super::matching_repo::MatchingRepository;
-use crate::api::{resolve_image_urls, resolve_thumbhashes};
 use crate::api::state::{MatchingTagResponse, ProfileRecommendation};
+use crate::api::{resolve_image_urls, resolve_thumbhashes};
 use crate::db::models::profiles::Profile;
 use crate::db::models::users::User;
 
@@ -56,12 +56,13 @@ fn build_profile_recommendation(
 pub(super) async fn build_recommendations_response(
     top: &[(f64, &Profile)],
     repo: &MatchingRepository,
+    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<Vec<ProfileRecommendation>, crate::error::AppError> {
     let user_ids: Vec<i32> = top.iter().map(|(_, p)| p.user_id).collect();
-    let user_models = repo.load_users_by_ids(&user_ids).await?;
+    let user_models = repo.load_users_by_ids(&user_ids, conn).await?;
 
     let top_ids: Vec<Uuid> = top.iter().map(|(_, p)| p.id).collect();
-    let top_tags = repo.batch_load_profile_tags(&top_ids).await?;
+    let top_tags = repo.batch_load_profile_tags(&top_ids, conn).await?;
 
     let pic_filenames: Vec<String> = top
         .iter()
@@ -72,8 +73,7 @@ pub(super) async fn build_recommendations_response(
         resolve_image_urls(&pic_filenames),
         resolve_thumbhashes(&pic_filenames),
     );
-    let pic_map: HashMap<String, String> =
-        pic_filenames.into_iter().zip(resolved_pics).collect();
+    let pic_map: HashMap<String, String> = pic_filenames.into_iter().zip(resolved_pics).collect();
 
     let ctx = RecommendationContext {
         user_models: &user_models,

--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -52,7 +52,9 @@ pub(super) async fn profiles_recommendations(
 
     // Batch-load all candidate tag IDs in one query
     let candidate_ids: Vec<Uuid> = candidates.iter().map(|c| c.id).collect();
-    let all_candidate_tags = repo.batch_load_profile_tag_ids(&candidate_ids).await?;
+    let all_candidate_tags = repo
+        .batch_load_profile_tag_ids(&candidate_ids, &mut conn)
+        .await?;
 
     let my_program = my_profile.as_ref().and_then(|p| p.program.clone());
 
@@ -76,7 +78,7 @@ pub(super) async fn profiles_recommendations(
 
     let top = rank_and_take(&mut scored, limit);
 
-    let data = build_recommendations_response(&top, &repo).await?;
+    let data = build_recommendations_response(&top, &repo, &mut conn).await?;
 
     let mut response = Json(DataResponse { data }).into_response();
     response
@@ -109,7 +111,7 @@ pub(super) async fn events_recommendations(
 
     // Batch-load all event tag IDs in one query
     let event_ids: Vec<Uuid> = future_events.iter().map(|e| e.id).collect();
-    let all_event_tags = repo.batch_load_event_tag_ids(&event_ids).await?;
+    let all_event_tags = repo.batch_load_event_tag_ids(&event_ids, &mut conn).await?;
 
     // Resolve user geo query: lat, lng, max radius in km (default 20 km)
     let user_geo = query.lat.zip(query.lng).map(|(lat, lng)| {
@@ -134,7 +136,9 @@ pub(super) async fn events_recommendations(
     let top = rank_events_and_take(&mut scored, limit);
 
     let top_models: Vec<Event> = top.iter().map(|(_, event)| (*event).clone()).collect();
-    let base = super::events::build_event_responses(&top_models, &my_profile_id).await?;
+    let base =
+        super::events::build_event_responses_with_conn(&top_models, &my_profile_id, &mut conn)
+            .await?;
     let score_by_event: HashMap<String, f64> = top
         .iter()
         .map(|(score, event)| (event.id.to_string(), *score))

--- a/backend/src/api/matching/repo.rs
+++ b/backend/src/api/matching/repo.rs
@@ -20,11 +20,11 @@ impl MatchingRepository {
     async fn load_profile_tag_ids(
         &self,
         profile_id: Uuid,
+        conn: &mut crate::db::DbConn,
     ) -> std::result::Result<HashSet<Uuid>, crate::error::AppError> {
-        let mut conn = crate::db::conn().await?;
         let tag_links = profile_tags::table
             .filter(profile_tags::profile_id.eq(profile_id))
-            .load::<ProfileTag>(&mut conn)
+            .load::<ProfileTag>(conn)
             .await?;
         Ok(tag_links.iter().map(|link| link.tag_id).collect())
     }
@@ -40,7 +40,7 @@ impl MatchingRepository {
             .await
             .optional()?;
         let my_tag_ids = match &my_profile {
-            Some(profile) => self.load_profile_tag_ids(profile.id).await?,
+            Some(profile) => self.load_profile_tag_ids(profile.id, conn).await?,
             None => HashSet::new(),
         };
         Ok((my_profile, my_tag_ids))
@@ -79,16 +79,15 @@ impl MatchingRepository {
     pub(super) async fn batch_load_profile_tags(
         &self,
         profile_ids: &[Uuid],
+        conn: &mut crate::db::DbConn,
     ) -> std::result::Result<HashMap<Uuid, Vec<MatchingTagResponse>>, crate::error::AppError> {
         if profile_ids.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let mut conn = crate::db::conn().await?;
-
         let all_links = profile_tags::table
             .filter(profile_tags::profile_id.eq_any(profile_ids))
-            .load::<ProfileTag>(&mut conn)
+            .load::<ProfileTag>(conn)
             .await?;
 
         let all_tag_ids: HashSet<Uuid> = all_links.iter().map(|link| link.tag_id).collect();
@@ -97,7 +96,7 @@ impl MatchingRepository {
         } else {
             tags::table
                 .filter(tags::id.eq_any(&all_tag_ids.into_iter().collect::<Vec<_>>()))
-                .load::<Tag>(&mut conn)
+                .load::<Tag>(conn)
                 .await?
         };
 
@@ -122,16 +121,15 @@ impl MatchingRepository {
     pub(super) async fn batch_load_profile_tag_ids(
         &self,
         profile_ids: &[Uuid],
+        conn: &mut crate::db::DbConn,
     ) -> std::result::Result<HashMap<Uuid, HashSet<Uuid>>, crate::error::AppError> {
         if profile_ids.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let mut conn = crate::db::conn().await?;
-
         let all_links = profile_tags::table
             .filter(profile_tags::profile_id.eq_any(profile_ids))
-            .load::<ProfileTag>(&mut conn)
+            .load::<ProfileTag>(conn)
             .await?;
 
         let mut result: HashMap<Uuid, HashSet<Uuid>> = HashMap::new();
@@ -147,16 +145,15 @@ impl MatchingRepository {
     pub(super) async fn batch_load_event_tag_ids(
         &self,
         event_ids: &[Uuid],
+        conn: &mut crate::db::DbConn,
     ) -> std::result::Result<HashMap<Uuid, HashSet<Uuid>>, crate::error::AppError> {
         if event_ids.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let mut conn = crate::db::conn().await?;
-
         let all_links = event_tags::table
             .filter(event_tags::event_id.eq_any(event_ids))
-            .load::<EventTag>(&mut conn)
+            .load::<EventTag>(conn)
             .await?;
 
         let mut result: HashMap<Uuid, HashSet<Uuid>> = HashMap::new();
@@ -169,15 +166,15 @@ impl MatchingRepository {
     pub(super) async fn load_users_by_ids(
         &self,
         user_ids: &[i32],
+        conn: &mut crate::db::DbConn,
     ) -> std::result::Result<Vec<User>, crate::error::AppError> {
         if user_ids.is_empty() {
             return Ok(vec![]);
         }
 
-        let mut conn = crate::db::conn().await?;
         users::table
             .filter(users::id.eq_any(user_ids))
-            .load::<User>(&mut conn)
+            .load::<User>(conn)
             .await
             .map_err(Into::into)
     }

--- a/backend/src/api/state/auth.rs
+++ b/backend/src/api/state/auth.rs
@@ -1,9 +1,13 @@
 use axum::http::HeaderMap;
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::env;
 use std::fmt::Write as _;
+use std::sync::OnceLock;
+use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use super::super::{error_response, ErrorSpec};
@@ -14,6 +18,7 @@ use crate::db::schema::{sessions, users};
 
 const SESSION_DURATION_SECS: i64 = 60 * 60 * 24 * 7;
 const SESSION_UPDATE_AGE_SECS: i64 = 60 * 60 * 24;
+const AUTH_CACHE_TTL_DEFAULT_SECS: i64 = 15;
 const SESSION_TOKEN_HASH_PREFIX: &str = "st2:";
 
 pub(in crate::api) fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
@@ -26,6 +31,19 @@ pub(in crate::api) fn extract_bearer_token(headers: &HeaderMap) -> Option<String
 pub(in crate::api) struct CreatedSession {
     pub(in crate::api) model: Session,
     pub(in crate::api) token: String,
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::api) struct AuthContext {
+    pub(in crate::api) session: Session,
+    pub(in crate::api) user: User,
+}
+
+#[derive(Clone)]
+struct CachedAuthEntry {
+    session: Session,
+    user: User,
+    cached_until: DateTime<Utc>,
 }
 
 fn session_token_hash(token: &str) -> String {
@@ -43,6 +61,64 @@ pub(in crate::api) fn hash_session_token(token: &str) -> String {
     session_token_hash(token)
 }
 
+fn auth_cache() -> &'static RwLock<HashMap<String, CachedAuthEntry>> {
+    static AUTH_CACHE: OnceLock<RwLock<HashMap<String, CachedAuthEntry>>> = OnceLock::new();
+    AUTH_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn auth_cache_ttl() -> Duration {
+    static AUTH_CACHE_TTL: OnceLock<Duration> = OnceLock::new();
+    *AUTH_CACHE_TTL.get_or_init(|| {
+        let ttl_secs = env::var("AUTH_CACHE_TTL_SECS")
+            .ok()
+            .and_then(|raw| raw.parse::<i64>().ok())
+            .filter(|value| *value >= 0)
+            .unwrap_or(AUTH_CACHE_TTL_DEFAULT_SECS);
+        Duration::seconds(ttl_secs)
+    })
+}
+
+async fn cache_auth_get(hashed_token: &str) -> Option<(Session, User)> {
+    let now = Utc::now();
+    let cached = {
+        let guard = auth_cache().read().await;
+        guard.get(hashed_token).cloned()
+    };
+    let Some(entry) = cached else {
+        return None;
+    };
+    if entry.cached_until <= now || entry.session.expires_at <= now {
+        auth_cache().write().await.remove(hashed_token);
+        return None;
+    }
+    Some((entry.session, entry.user))
+}
+
+async fn cache_auth_put(hashed_token: String, session: &Session, user: &User) {
+    let now = Utc::now();
+    let ttl_until = now + auth_cache_ttl();
+    let cached_until = if session.expires_at < ttl_until {
+        session.expires_at
+    } else {
+        ttl_until
+    };
+    auth_cache().write().await.insert(
+        hashed_token,
+        CachedAuthEntry {
+            session: session.clone(),
+            user: user.clone(),
+            cached_until,
+        },
+    );
+}
+
+pub(in crate::api) async fn invalidate_auth_cache_for_token(token: &str) {
+    auth_cache()
+        .write()
+        .await
+        .remove(&session_token_hash(token));
+}
+
 pub(in crate::api) async fn resolve_session_by_token(
     token: &str,
 ) -> std::result::Result<Option<Session>, crate::error::AppError> {
@@ -58,45 +134,46 @@ pub(in crate::api) async fn resolve_session_by_token(
 pub(in crate::api) async fn require_auth_db(
     headers: &HeaderMap,
 ) -> std::result::Result<(Session, User), Box<axum::response::Response>> {
+    let context = require_auth_context(headers).await?;
+    Ok((context.session, context.user))
+}
+
+pub(in crate::api) async fn require_auth_context(
+    headers: &HeaderMap,
+) -> std::result::Result<AuthContext, Box<axum::response::Response>> {
     let token =
         extract_bearer_token(headers).ok_or_else(|| Box::new(unauthorized_response(headers)))?;
+    let hashed = session_token_hash(&token);
 
-    let session = resolve_session_by_token(&token)
-        .await
-        .map_err(|_| Box::new(unauthorized_response(headers)))?
-        .ok_or_else(|| Box::new(unauthorized_response(headers)))?;
-
-    delete_if_expired(&session, headers).await?;
-    maybe_renew_session(&session).await;
+    if let Some((session, user)) = cache_auth_get(&hashed).await {
+        maybe_renew_session(&session).await;
+        return Ok(AuthContext { session, user });
+    }
 
     let mut conn = crate::db::conn()
         .await
         .map_err(|_| Box::new(unauthorized_response(headers)))?;
-    let user = users::table
-        .find(session.user_id)
-        .first::<User>(&mut conn)
+    let (session, user) = sessions::table
+        .inner_join(users::table.on(users::id.eq(sessions::user_id)))
+        .filter(sessions::token.eq(&hashed))
+        .select((Session::as_select(), User::as_select()))
+        .first::<(Session, User)>(&mut conn)
         .await
         .optional()
         .map_err(|_| Box::new(unauthorized_response(headers)))?
         .ok_or_else(|| Box::new(unauthorized_response(headers)))?;
 
-    Ok((session, user))
-}
-
-async fn delete_if_expired(
-    session: &Session,
-    headers: &HeaderMap,
-) -> std::result::Result<(), Box<axum::response::Response>> {
     let now = Utc::now();
     if session.expires_at <= now {
-        if let Ok(mut conn) = crate::db::conn().await {
-            let _ = diesel::delete(sessions::table.find(session.id))
-                .execute(&mut conn)
-                .await;
-        }
+        let _ = diesel::delete(sessions::table.find(session.id))
+            .execute(&mut conn)
+            .await;
         return Err(Box::new(unauthorized_response(headers)));
     }
-    Ok(())
+
+    let session = maybe_renew_session_on_conn(session, &mut conn).await;
+    cache_auth_put(hashed, &session, &user).await;
+    Ok(AuthContext { session, user })
 }
 
 async fn maybe_renew_session(session: &Session) {
@@ -113,6 +190,28 @@ async fn maybe_renew_session(session: &Session) {
                 .execute(&mut conn)
                 .await;
         }
+    }
+}
+
+async fn maybe_renew_session_on_conn(session: Session, conn: &mut crate::db::DbConn) -> Session {
+    let now = Utc::now();
+    if now - session.updated_at < Duration::seconds(SESSION_UPDATE_AGE_SECS) {
+        return session;
+    }
+
+    let new_expires = now + Duration::seconds(SESSION_DURATION_SECS);
+    let _ = diesel::update(sessions::table.find(session.id))
+        .set(&SessionUpdate {
+            updated_at: Some(now),
+            expires_at: Some(new_expires),
+        })
+        .execute(conn)
+        .await;
+
+    Session {
+        updated_at: now,
+        expires_at: new_expires,
+        ..session
     }
 }
 


### PR DESCRIPTION
**Summary**
- add `AuthContext` flow with short TTL auth cache (`AUTH_CACHE_TTL_SECS`, default 15s)
- collapse auth lookup into a single session+user query in `require_auth_context`
- invalidate auth cache on sign-out
- refactor events/matching read assembly to pass one `&mut DbConn` across batched loaders instead of opening multiple pooled connections

**Why**
- reduce connection churn and query hop overhead on hot authenticated endpoints
- lower pool/proxy contention (relevant even with PgDog)
- keep route behavior unchanged while improving scalability headroom

**Validation**
- `cargo check` passes in `backend/`
