### PR TITLE
refactor: deduplicate normalize_prefix

### DIFF
--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -50,6 +50,23 @@ pub fn error_response(
         .into_response()
 }
 
+/// Normalize an S3 object prefix: strip leading `/`, ensure trailing `/`,
+/// reject path-traversal patterns.
+pub fn normalize_object_prefix(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("object prefix must be non-empty".to_string());
+    }
+    if trimmed.contains("..") || trimmed.contains('\\') || trimmed.contains('\0') {
+        return Err("object prefix contains invalid characters".to_string());
+    }
+    let mut prefix = trimmed.trim_start_matches('/').to_string();
+    if !prefix.ends_with('/') {
+        prefix.push('/');
+    }
+    Ok(prefix)
+}
+
 /// Strip a presigned URL down to just the filename (last path segment).
 /// If the value is already a plain filename, return it unchanged.
 pub fn extract_filename(value: &str) -> String {

--- a/backend/src/api/imgproxy_signing.rs
+++ b/backend/src/api/imgproxy_signing.rs
@@ -49,18 +49,7 @@ fn config() -> Option<&'static ImgproxyConfig> {
 }
 
 fn normalize_prefix(raw: &str) -> Option<String> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    if trimmed.contains("..") || trimmed.contains('\\') || trimmed.contains('\0') {
-        return None;
-    }
-    let mut prefix = trimmed.trim_start_matches('/').to_string();
-    if !prefix.ends_with('/') {
-        prefix.push('/');
-    }
-    Some(prefix)
+    super::common::normalize_object_prefix(raw).ok()
 }
 
 pub fn is_configured() -> bool {

--- a/backend/src/api/uploads/storage.rs
+++ b/backend/src/api/uploads/storage.rs
@@ -63,18 +63,7 @@ fn presign_expiry_secs_u32(seconds: u64) -> u32 {
 }
 
 fn normalize_prefix(raw: &str) -> Result<String, String> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Err("IMGPROXY_ALLOWED_PREFIX must be non-empty".to_string());
-    }
-    if trimmed.contains("..") || trimmed.contains('\\') || trimmed.contains('\0') {
-        return Err("IMGPROXY_ALLOWED_PREFIX contains invalid characters".to_string());
-    }
-    let mut prefix = trimmed.trim_start_matches('/').to_string();
-    if !prefix.ends_with('/') {
-        prefix.push('/');
-    }
-    Ok(prefix)
+    crate::api::common::normalize_object_prefix(raw)
 }
 
 fn object_path(object_prefix: &str, filename: &str) -> String {


### PR DESCRIPTION
## Summary
- Extract duplicated `normalize_prefix` logic from `imgproxy_signing.rs` and `uploads/storage.rs` into a shared `common::normalize_object_prefix` function
- Both call sites now delegate to the single implementation

## Test plan
- [x] `cargo check` passes