### PR TITLE
feat: show recommendations row only when >5 profiles

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -218,13 +218,16 @@ fun ExploreScreen(
                                 contentPadding = PaddingValues(bottom = LocalNavBarPadding.current),
                                 verticalArrangement = Arrangement.spacedBy(PoziomkiTheme.spacing.sm),
                             ) {
-                                item(key = "recommended-row") {
-                                    RecommendedPeopleRow(
-                                        profiles = state.recommendedProfiles,
-                                        onProfileClick = onNavigateToProfile,
-                                    )
+                                if (state.profiles.size > 5) {
+                                    item(key = "recommended-row") {
+                                        RecommendedPeopleRow(
+                                            profiles = state.recommendedProfiles,
+                                            onProfileClick = onNavigateToProfile,
+                                        )
+                                    }
                                 }
-                                items(state.remainingProfiles, key = { it.id }) { profile ->
+                                val cardProfiles = if (state.profiles.size > 5) state.remainingProfiles else state.profiles
+                                items(cardProfiles, key = { it.id }) { profile ->
                                     ProfileCard(
                                         name = profile.name,
                                         program = profile.program,


### PR DESCRIPTION
**Before:** "polecane osoby" row always shown, remaining profiles listed below (empty list when <=5 people).

**After:** row only appears when >5 profiles exist. When <=5, all profiles display as regular cards in recommendation order.