### PR TITLE
feat: move profile to top-right avatar, add grupy tab

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -88,6 +88,7 @@ import com.adamglin.phosphoricons.fill.MapPin
 fun EventsScreen(
     onNavigateToEventDetail: (String) -> Unit,
     onNavigateToEventCreate: () -> Unit,
+    profileAvatarAction: @Composable () -> Unit = {},
     viewModel: EventsViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -110,14 +111,7 @@ fun EventsScreen(
                 .background(Background),
     ) {
         ScreenHeader(title = "wydarzenia") {
-            IconButton(onClick = onNavigateToEventCreate) {
-                Icon(
-                    PhosphorIcons.Bold.PencilSimple,
-                    contentDescription = "Utwórz wydarzenie",
-                    modifier = Modifier.size(22.dp),
-                    tint = TextSecondary,
-                )
-            }
+            profileAvatarAction()
         }
 
         PoziomkiSearchBar(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -50,6 +50,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun ExploreScreen(
     onNavigateToProfile: (String) -> Unit,
     onNavigateToEventDetail: (String) -> Unit = {},
+    profileAvatarAction: @Composable () -> Unit = {},
     viewModel: ExploreViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -61,7 +62,9 @@ fun ExploreScreen(
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background),
     ) {
-        ScreenHeader(title = "poznaj")
+        ScreenHeader(title = "poznaj") {
+            profileAvatarAction()
+        }
 
         PoziomkiSearchBar(
             query = state.query,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/GroupsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/GroupsScreen.kt
@@ -1,0 +1,26 @@
+package com.poziomki.app.ui.feature.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.poziomki.app.ui.designsystem.components.EmptyView
+import com.poziomki.app.ui.designsystem.components.ScreenHeader
+
+@Composable
+fun GroupsScreen(
+    profileAvatarAction: @Composable () -> Unit = {},
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        ScreenHeader(title = "grupy") {
+            profileAvatarAction()
+        }
+        EmptyView("wkr\u00f3tce")
+    }
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -58,6 +58,7 @@ fun MessagesScreen(
     onNavigateToChat: (String) -> Unit,
     onNavigateToNewChat: () -> Unit,
     onNavigateToProfile: (String) -> Unit = {},
+    profileAvatarAction: @Composable () -> Unit = {},
     viewModel: MessagesViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -99,14 +100,7 @@ fun MessagesScreen(
                     }
                     Spacer(modifier = Modifier.width(4.dp))
                 }
-                IconButton(onClick = onNavigateToNewChat) {
-                    Icon(
-                        imageVector = PhosphorIcons.Bold.PencilSimple,
-                        contentDescription = "Nowa wiadomość",
-                        tint = TextSecondary,
-                        modifier = Modifier.size(22.dp),
-                    )
-                }
+                profileAvatarAction()
             }
             PoziomkiSearchBar(
                 query = state.searchQuery,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -52,7 +52,12 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.poziomki.app.chat.matrix.api.MatrixClient
 import com.poziomki.app.data.repository.ChatRoomRepository
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.collectAsState
+import coil3.compose.AsyncImage
 import com.poziomki.app.ui.designsystem.components.OfflineBanner
+import com.poziomki.app.ui.designsystem.components.UserAvatar
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.TextMuted
@@ -65,8 +70,10 @@ import com.poziomki.app.ui.feature.event.EventChatScreen
 import com.poziomki.app.ui.feature.event.EventCreateScreen
 import com.poziomki.app.ui.feature.home.EventsScreen
 import com.poziomki.app.ui.feature.home.ExploreScreen
+import com.poziomki.app.ui.feature.home.GroupsScreen
 import com.poziomki.app.ui.feature.home.MessagesScreen
 import com.poziomki.app.ui.feature.home.ProfileScreen
+import com.poziomki.app.ui.feature.home.ProfileViewModel
 import com.poziomki.app.ui.feature.onboarding.BasicInfoScreen
 import com.poziomki.app.ui.feature.onboarding.InterestsScreen
 import com.poziomki.app.ui.feature.onboarding.ProfileSetupScreen
@@ -80,14 +87,17 @@ import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.Fill
 import com.adamglin.phosphoricons.Regular
-import com.adamglin.phosphoricons.bold.User
+import com.adamglin.phosphoricons.bold.GearSix
 import com.adamglin.phosphoricons.fill.CalendarDots
 import com.adamglin.phosphoricons.fill.ChatCircle
+import com.adamglin.phosphoricons.fill.UsersFour
 import com.adamglin.phosphoricons.fill.UsersThree
 import com.adamglin.phosphoricons.regular.CalendarDots
 import com.adamglin.phosphoricons.regular.ChatCircle
-import com.adamglin.phosphoricons.regular.User
+import com.adamglin.phosphoricons.regular.UsersFour
 import com.adamglin.phosphoricons.regular.UsersThree
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 
 data class BottomNavItem(
     val label: String,
@@ -108,7 +118,7 @@ val bottomNavItems =
             PhosphorIcons.Fill.ChatCircle,
             Route.Messages,
         ),
-        BottomNavItem("Profil", PhosphorIcons.Regular.User, PhosphorIcons.Bold.User, Route.ProfileTab),
+        BottomNavItem("Grupy", PhosphorIcons.Regular.UsersFour, PhosphorIcons.Fill.UsersFour, Route.Groups),
     )
 
 @Composable
@@ -383,6 +393,27 @@ fun MainScreen(
     val topInsets = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     val safeTop = maxOf(topInsets, 16.dp)
 
+    val profileViewModel: ProfileViewModel = koinViewModel()
+    val profileState by profileViewModel.state.collectAsState()
+    val profilePicture = profileState.profile?.profilePicture
+
+    val navigateToProfileTab: () -> Unit = {
+        tabNavController.navigate(Route.ProfileTab) {
+            popUpTo(tabNavController.graph.findStartDestination().id) {
+                saveState = true
+            }
+            launchSingleTop = true
+            restoreState = true
+        }
+    }
+
+    val profileAvatarAction: @Composable () -> Unit = {
+        ProfileAvatarButton(
+            profilePicture = profilePicture,
+            onClick = navigateToProfileTab,
+        )
+    }
+
     Scaffold(
         containerColor = Background,
         bottomBar = {},
@@ -405,12 +436,14 @@ fun MainScreen(
                         ExploreScreen(
                             onNavigateToProfile = onNavigateToProfileView,
                             onNavigateToEventDetail = onNavigateToEventDetail,
+                            profileAvatarAction = profileAvatarAction,
                         )
                     }
                     composable<Route.Events> {
                         EventsScreen(
                             onNavigateToEventDetail = onNavigateToEventDetail,
                             onNavigateToEventCreate = onNavigateToEventCreate,
+                            profileAvatarAction = profileAvatarAction,
                         )
                     }
                     composable<Route.Messages> {
@@ -418,6 +451,7 @@ fun MainScreen(
                             onNavigateToChat = onNavigateToChat,
                             onNavigateToNewChat = onNavigateToNewChat,
                             onNavigateToProfile = onNavigateToProfileView,
+                            profileAvatarAction = profileAvatarAction,
                         )
                     }
                     composable<Route.ProfileTab> {
@@ -426,6 +460,11 @@ fun MainScreen(
                             onNavigateToPrivacy = onNavigateToPrivacy,
                             onNavigateToProfileView = onNavigateToProfileView,
                             onSignOut = onSignOut,
+                        )
+                    }
+                    composable<Route.Groups> {
+                        GroupsScreen(
+                            profileAvatarAction = profileAvatarAction,
                         )
                     }
                 }
@@ -494,6 +533,30 @@ fun MainScreen(
                 }
             }
         }
+        }
+    }
+}
+
+@Composable
+private fun ProfileAvatarButton(
+    profilePicture: String?,
+    onClick: () -> Unit,
+) {
+    val avatarSize = 28.dp
+    IconButton(onClick = onClick) {
+        if (profilePicture != null) {
+            UserAvatar(
+                picture = profilePicture,
+                displayName = null,
+                size = avatarSize,
+            )
+        } else {
+            Icon(
+                PhosphorIcons.Bold.GearSix,
+                contentDescription = "Profil",
+                modifier = Modifier.size(22.dp),
+                tint = TextMuted,
+            )
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/Route.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/Route.kt
@@ -36,6 +36,8 @@ sealed interface Route {
 
     @Serializable data object ProfileTab : Route
 
+    @Serializable data object Groups : Route
+
     // Detail screens
     @Serializable data class EventDetail(
         val id: String,


### PR DESCRIPTION
**Before:** profile was a bottom nav tab.

**After:** bottom nav "Profil" replaced with "Grupy" placeholder. Profile accessible from top-right avatar button (gear icon fallback) on all tab screens.