### PR TITLE
chore: fix clippy errors 

### DIFF
--- a/backend/src/api/auth/account.rs
+++ b/backend/src/api/auth/account.rs
@@ -5,9 +5,10 @@ use axum::response::Response;
 use axum::{extract::State, http::HeaderMap, response::IntoResponse, Json};
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 
-use super::super::state::{require_auth_db, DataResponse, DeleteAccountBody, SuccessResponse};
+use crate::api::auth_or_respond;
+use super::super::state::{DataResponse, DeleteAccountBody, SuccessResponse};
 use super::auth_service::unauthorized_error;
 type Result<T> = crate::error::AppResult<T>;
 
@@ -18,15 +19,21 @@ use crate::db::schema::{profiles, sessions, users};
 async fn delete_user_data(user_id: i32) -> std::result::Result<(), crate::error::AppError> {
     let mut conn = crate::db::conn().await?;
 
-    let _ = diesel::delete(profiles::table.filter(profiles::user_id.eq(user_id)))
-        .execute(&mut conn)
-        .await;
-    let _ = diesel::delete(sessions::table.filter(sessions::user_id.eq(user_id)))
-        .execute(&mut conn)
-        .await;
-    let _ = diesel::delete(users::table.find(user_id))
-        .execute(&mut conn)
-        .await;
+    conn.transaction(|conn| {
+        Box::pin(async move {
+            diesel::delete(profiles::table.filter(profiles::user_id.eq(user_id)))
+                .execute(conn)
+                .await?;
+            diesel::delete(sessions::table.filter(sessions::user_id.eq(user_id)))
+                .execute(conn)
+                .await?;
+            diesel::delete(users::table.find(user_id))
+                .execute(conn)
+                .await?;
+            Ok::<(), diesel::result::Error>(())
+        })
+    })
+    .await?;
     Ok(())
 }
 
@@ -35,10 +42,7 @@ pub(in crate::api) async fn delete_account(
     headers: HeaderMap,
     Json(payload): Json<DeleteAccountBody>,
 ) -> Result<Response> {
-    let (_session, user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, user) = auth_or_respond!(headers);
 
     if payload.password.is_empty()
         || !crate::security::verify_password(&payload.password, &user.password)
@@ -55,10 +59,7 @@ pub(in crate::api) async fn export_data(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    let (_session, user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, user) = auth_or_respond!(headers);
 
     let mut conn = crate::db::conn().await?;
 

--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -21,11 +21,12 @@ use chrono::Utc;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
+use crate::api::auth_or_respond;
 use super::{
     error_response,
     state::{
         extract_bearer_token, hash_session_token, invalidate_auth_cache_for_token, is_valid_email,
-        normalize_email, otp_in_cooldown, require_auth_db, upsert_otp, user_model_to_view,
+        normalize_email, otp_in_cooldown, upsert_otp, user_model_to_view,
         DataResponse, ResendOtpBody, SessionListItem, SignInBody, SignUpBody, SuccessResponse,
         VerifyOtpBody,
     },
@@ -167,10 +168,7 @@ pub(super) async fn sessions(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    let (_session, user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, user) = auth_or_respond!(headers);
 
     let now = Utc::now();
     let mut conn = crate::db::conn().await?;

--- a/backend/src/api/catalog.rs
+++ b/backend/src/api/catalog.rs
@@ -13,10 +13,11 @@ use diesel::sql_types::{BigInt, Text};
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
+use crate::api::auth_or_respond;
 use super::{
     error_response,
     state::{
-        require_auth_db, CreateTagBody, DataResponse, DegreeResponse, DegreesQuery, TagResponse,
+        CreateTagBody, DataResponse, DegreeResponse, DegreesQuery, TagResponse,
         TagScope, TagsQuery,
     },
     ErrorSpec,
@@ -67,12 +68,20 @@ pub(super) async fn tags_search(
 
     let mut conn = crate::db::conn().await?;
 
-    let data = if !search.is_empty() {
+    let data = if search.is_empty() {
+        // No search term: use Diesel query builder
+        let mut query_builder = tags::table.into_boxed();
+        if let Some(scope) = query.scope {
+            query_builder = query_builder.filter(tags::scope.eq(scope_to_str(scope)));
+        }
+        let all_tags = query_builder.limit(limit).load::<Tag>(&mut conn).await?;
+        all_tags.iter().map(tag_model_to_response).collect::<Vec<_>>()
+    } else {
         // Use tsvector + ILIKE fallback for ranked search
+        use diesel::sql_types::Nullable;
         let pattern = format!("%{search}%");
         let scope_filter = query.scope.map(scope_to_str);
 
-        use diesel::sql_types::Nullable;
         let rows = diesel::sql_query(
             r"
             SELECT t.id, t.name, t.scope, t.category, t.emoji
@@ -106,14 +115,6 @@ pub(super) async fn tags_search(
                 onboarding_order: None,
             })
             .collect::<Vec<_>>()
-    } else {
-        // No search term: use Diesel query builder
-        let mut query_builder = tags::table.into_boxed();
-        if let Some(scope) = query.scope {
-            query_builder = query_builder.filter(tags::scope.eq(scope_to_str(scope)));
-        }
-        let all_tags = query_builder.limit(limit).load::<Tag>(&mut conn).await?;
-        all_tags.iter().map(tag_model_to_response).collect::<Vec<_>>()
     };
 
     let mut response = Json(DataResponse { data }).into_response();
@@ -222,10 +223,7 @@ pub(super) async fn tags_create(
     headers: HeaderMap,
     Json(payload): Json<CreateTagBody>,
 ) -> Result<Response> {
-    let (_session, _user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, _user) = auth_or_respond!(headers);
 
     match validate_and_insert_tag(&headers, payload).await {
         Ok(inserted) => {

--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -6,6 +6,18 @@ use axum::{
 use serde::Serialize;
 use uuid::Uuid;
 
+/// Authenticate via `require_auth_db` and early-return on failure.
+macro_rules! auth_or_respond {
+    ($headers:expr) => {
+        match $crate::api::state::require_auth_db(&$headers).await {
+            Ok(auth) => auth,
+            Err(response) => return Ok(*response),
+        }
+    };
+}
+
+pub(crate) use auth_or_respond;
+
 #[derive(Clone, Debug, Serialize)]
 struct ErrorResponse {
     error: String,
@@ -48,6 +60,29 @@ pub fn error_response(
         }),
     )
         .into_response()
+}
+
+pub fn parse_uuid(id: &str, label: &str) -> std::result::Result<Uuid, crate::error::AppError> {
+    Uuid::parse_str(id)
+        .map_err(|_| crate::error::AppError::Message(format!("Invalid {label} ID")))
+}
+
+pub fn parse_uuid_response(
+    id: &str,
+    label: &str,
+    headers: &HeaderMap,
+) -> std::result::Result<Uuid, Box<Response>> {
+    Uuid::parse_str(id).map_err(|_| {
+        Box::new(error_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            headers,
+            ErrorSpec {
+                error: format!("Invalid {label} ID"),
+                code: "BAD_REQUEST",
+                details: None,
+            },
+        ))
+    })
 }
 
 /// Normalize an S3 object prefix: strip leading `/`, ensure trailing `/`,

--- a/backend/src/api/events/service.rs
+++ b/backend/src/api/events/service.rs
@@ -105,17 +105,7 @@ pub(in crate::api) async fn load_event(
     headers: &HeaderMap,
     id: &str,
 ) -> std::result::Result<(Event, Uuid), HandlerError> {
-    let event_uuid = Uuid::parse_str(id).map_err(|_| {
-        Box::new(error_response(
-            axum::http::StatusCode::BAD_REQUEST,
-            headers,
-            ErrorSpec {
-                error: "Invalid event ID".to_string(),
-                code: "BAD_REQUEST",
-                details: None,
-            },
-        ))
-    })?;
+    let event_uuid = crate::api::parse_uuid_response(id, "event", headers)?;
 
     let mut conn = crate::db::conn()
         .await

--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -20,7 +20,8 @@ use axum::{
 use chrono::Utc;
 use uuid::Uuid;
 
-use super::state::{require_auth_db, DataResponse, MatchingQuery};
+use crate::api::auth_or_respond;
+use super::state::{DataResponse, MatchingQuery};
 use crate::db::models::events::Event;
 use crate::db::models::profiles::Profile;
 use matching_assembler::build_recommendations_response;
@@ -35,10 +36,7 @@ pub(super) async fn profiles_recommendations(
     Query(query): Query<MatchingQuery>,
 ) -> Result<Response> {
     let repo = MatchingRepository;
-    let (_session, user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, user) = auth_or_respond!(headers);
 
     let limit = query.limit.unwrap_or(10).clamp(1, 50) as usize;
 
@@ -93,10 +91,7 @@ pub(super) async fn events_recommendations(
     Query(query): Query<MatchingQuery>,
 ) -> Result<Response> {
     let repo = MatchingRepository;
-    let (_session, user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, user) = auth_or_respond!(headers);
 
     let limit = query.limit.unwrap_or(20).clamp(1, 100) as usize;
 

--- a/backend/src/api/matrix/operations.rs
+++ b/backend/src/api/matrix/operations.rs
@@ -136,7 +136,9 @@ impl<'a> MatrixClient<'a> {
             "invite": invited_user_ids,
         });
         if let Some(name) = room_name {
-            payload["name"] = json!(name);
+            if let Some(obj) = payload.as_object_mut() {
+                obj.insert("name".to_string(), json!(name));
+            }
         }
         let body: MatrixCreateRoomResponse = execute_matrix_json_request(
             self.http_client

--- a/backend/src/api/matrix/session.rs
+++ b/backend/src/api/matrix/session.rs
@@ -8,7 +8,7 @@ use axum::{extract::State, http::HeaderMap, Json};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
-use super::super::state::require_auth_db;
+use crate::api::auth_or_respond;
 use super::{chat_bootstrap_error, matrix_service, MatrixSessionRequest};
 use crate::db::models::profiles::Profile;
 use crate::db::schema::profiles;
@@ -19,10 +19,7 @@ pub(super) async fn create_session(
     Json(payload): Json<MatrixSessionRequest>,
 ) -> Result<Response> {
     let (user_pid, user_name, profile_picture) = {
-        let (_session, user) = match require_auth_db(&headers).await {
-            Ok(auth) => auth,
-            Err(response) => return Ok(*response),
-        };
+        let (_session, user) = auth_or_respond!(headers);
         let pic = {
             let mut conn = crate::db::conn().await.ok();
             match conn.as_mut() {

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -23,8 +23,8 @@ mod state;
 mod uploads;
 
 pub(crate) use common::{
-    ErrorSpec, env_non_empty, error_response, extract_filename, resolve_image_url,
-    resolve_image_urls, resolve_thumbhashes,
+    ErrorSpec, auth_or_respond, env_non_empty, error_response, extract_filename, parse_uuid,
+    parse_uuid_response, resolve_image_url, resolve_image_urls, resolve_thumbhashes,
 };
 
 fn cache_layer(value: &'static str) -> SetResponseHeaderLayer<HeaderValue> {

--- a/backend/src/api/profiles/mod.rs
+++ b/backend/src/api/profiles/mod.rs
@@ -21,9 +21,8 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use uuid::Uuid;
-
-use super::state::{require_auth_db, DataResponse};
+use crate::api::auth_or_respond;
+use super::state::DataResponse;
 use profiles_http::not_found_profile;
 pub(super) use profiles_http::validation_error;
 use profiles_repo::{load_profile_by_user_id, load_profile_with_owner_pid};
@@ -36,10 +35,7 @@ pub(super) async fn profile_me(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    let (_session, user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, user) = auth_or_respond!(headers);
 
     let profile = load_profile_by_user_id(user.id).await?;
 
@@ -56,13 +52,9 @@ pub(super) async fn profile_get(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let (_session, _user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, _user) = auth_or_respond!(headers);
 
-    let profile_uuid = Uuid::parse_str(&id)
-        .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
+    let profile_uuid = super::parse_uuid(&id, "profile")?;
 
     let Some((profile, user_pid)) = load_profile_with_owner_pid(profile_uuid).await? else {
         return Ok(not_found_profile(&headers, &id));
@@ -77,13 +69,9 @@ pub(super) async fn profile_get_full(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let (_session, _user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, _user) = auth_or_respond!(headers);
 
-    let profile_uuid = Uuid::parse_str(&id)
-        .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
+    let profile_uuid = super::parse_uuid(&id, "profile")?;
 
     let Some((profile, user_pid)) = load_profile_with_owner_pid(profile_uuid).await? else {
         return Ok(not_found_profile(&headers, &id));

--- a/backend/src/api/profiles/view.rs
+++ b/backend/src/api/profiles/view.rs
@@ -18,7 +18,7 @@ fn decode_profile_images(profile: &Profile) -> Vec<String> {
 
 async fn lookup_thumbhash(profile_picture: Option<&String>) -> Option<String> {
     let pic = profile_picture?;
-    let map = resolve_thumbhashes(&[pic.clone()]).await;
+    let map = resolve_thumbhashes(std::slice::from_ref(pic)).await;
     map.into_values().next()
 }
 

--- a/backend/src/api/profiles/write_service.rs
+++ b/backend/src/api/profiles/write_service.rs
@@ -244,17 +244,7 @@ pub(super) async fn load_and_verify_profile(
     id: &str,
 ) -> std::result::Result<(Profile, crate::db::models::users::User), Box<Response>> {
     let (_session, user) = require_auth_db(headers).await?;
-    let profile_uuid = Uuid::parse_str(id).map_err(|_| {
-        Box::new(error_response(
-            axum::http::StatusCode::BAD_REQUEST,
-            headers,
-            ErrorSpec {
-                error: "Invalid profile ID".to_string(),
-                code: "BAD_REQUEST",
-                details: None,
-            },
-        ))
-    })?;
+    let profile_uuid = crate::api::parse_uuid_response(id, "profile", headers)?;
 
     let mut conn = crate::db::conn().await.map_err(|_| {
         Box::new(error_response(

--- a/backend/src/api/push_gateway.rs
+++ b/backend/src/api/push_gateway.rs
@@ -88,13 +88,12 @@ fn bearer_token(headers: &HeaderMap) -> Option<String> {
 fn query_token_fallback_enabled() -> bool {
     std::env::var("PUSH_GATEWAY_QUERY_TOKEN_FALLBACK")
         .ok()
-        .map(|value| {
+        .is_none_or(|value| {
             matches!(
                 value.to_ascii_lowercase().as_str(),
                 "1" | "true" | "yes" | "on"
             )
         })
-        .unwrap_or(true)
 }
 
 fn provided_gateway_token(headers: &HeaderMap, query: &PushGatewayAuthQuery) -> Option<String> {

--- a/backend/src/api/root.rs
+++ b/backend/src/api/root.rs
@@ -132,6 +132,7 @@ mod tests {
     use super::redact_push_gateway_url;
 
     #[test]
+    #[allow(clippy::expect_used)]
     fn redact_push_gateway_url_strips_query_and_fragment() {
         let raw = "https://user:pass@push.example/_matrix/push/v1/notify?token=secret#frag";
         let redacted = redact_push_gateway_url(raw).expect("valid url");

--- a/backend/src/api/search.rs
+++ b/backend/src/api/search.rs
@@ -9,7 +9,8 @@ use axum::{
 use serde::Deserialize;
 use std::collections::HashMap;
 
-use super::state::{require_auth_db, DataResponse};
+use crate::api::auth_or_respond;
+use super::state::DataResponse;
 
 const PRIVATE_CACHE_SHORT: HeaderValue = HeaderValue::from_static("private, max-age=60");
 type Result<T> = crate::error::AppResult<T>;
@@ -104,10 +105,7 @@ pub(super) async fn search_messages(
     headers: HeaderMap,
     Query(query): Query<MessageSearchQuery>,
 ) -> Result<Response> {
-    let (_session, user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, user) = auth_or_respond!(headers);
 
     let limit = usize::from(query.limit.unwrap_or(20).clamp(1, 50));
     let q = query.q.trim().to_string();
@@ -143,10 +141,7 @@ pub(super) async fn search(
     headers: HeaderMap,
     Query(query): Query<SearchQuery>,
 ) -> Result<Response> {
-    let (_session, _user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, _user) = auth_or_respond!(headers);
 
     let limit = usize::from(query.limit.unwrap_or(10).clamp(1, 50));
     let q = query.q.trim().to_string();

--- a/backend/src/api/settings.rs
+++ b/backend/src/api/settings.rs
@@ -8,7 +8,8 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
-use super::state::{require_auth_db, DataResponse};
+use crate::api::auth_or_respond;
+use super::state::DataResponse;
 use crate::db::models::user_settings::{NewUserSetting, UserSetting, UserSettingChangeset};
 use crate::db::schema::user_settings;
 
@@ -70,10 +71,7 @@ pub(super) async fn settings_get(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    let (_session, user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, user) = auth_or_respond!(headers);
 
     let mut conn = crate::db::conn().await?;
     let settings = user_settings::table
@@ -93,10 +91,7 @@ pub(super) async fn settings_update(
     headers: HeaderMap,
     Json(body): Json<UpdateSettingsBody>,
 ) -> Result<Response> {
-    let (_session, user) = match require_auth_db(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    let (_session, user) = auth_or_respond!(headers);
 
     let mut conn = crate::db::conn().await?;
     let existing = user_settings::table

--- a/backend/src/api/state/auth.rs
+++ b/backend/src/api/state/auth.rs
@@ -84,9 +84,7 @@ async fn cache_auth_get(hashed_token: &str) -> Option<(Session, User)> {
         let guard = auth_cache().read().await;
         guard.get(hashed_token).cloned()
     };
-    let Some(entry) = cached else {
-        return None;
-    };
+    let entry = cached?;
     if entry.cached_until <= now || entry.session.expires_at <= now {
         auth_cache().write().await.remove(hashed_token);
         return None;
@@ -146,7 +144,10 @@ pub(in crate::api) async fn require_auth_context(
     let hashed = session_token_hash(&token);
 
     if let Some((session, user)) = cache_auth_get(&hashed).await {
-        maybe_renew_session(&session).await;
+        let elapsed = Utc::now() - session.updated_at;
+        if elapsed >= Duration::seconds(SESSION_UPDATE_AGE_SECS) {
+            maybe_renew_session(&session).await;
+        }
         return Ok(AuthContext { session, user });
     }
 

--- a/backend/src/api/state/event_requests.rs
+++ b/backend/src/api/state/event_requests.rs
@@ -21,7 +21,6 @@ pub(in crate::api) struct EventsQuery {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub(in crate::api) struct CreateEventBody {
     pub(in crate::api) title: String,
     #[serde(default)]
@@ -45,7 +44,7 @@ pub(in crate::api) struct CreateEventBody {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(clippy::option_option, dead_code)]
+#[allow(clippy::option_option)]
 pub(in crate::api) struct UpdateEventBody {
     #[serde(default)]
     pub(in crate::api) title: Option<String>,


### PR DESCRIPTION
**Fix all clippy errors and clean up backend code**

Makes `cargo clippy --lib` pass again and tidies up repeated patterns in API handlers.

- [x] clippy and tests pass
- [x] auth works correctly through the new macro
- [x] account deletion rolls back on partial failure