### PR TITLE
fix: remove .expect() on TestServer::new()

### DIFF
--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -35,8 +35,7 @@ where
     poziomki_backend::app::reset_test_database()
         .await
         .expect("truncate test tables");
-    let server = TestServer::new(poziomki_backend::app::build_router_with_state(ctx.clone()))
-        .expect("create axum test server");
+    let server = TestServer::new(poziomki_backend::app::build_router_with_state(ctx.clone()));
     f(server, ctx).await;
 }
 


### PR DESCRIPTION
TestServer::new() in axum_test v19 returns TestServer directly, the .expect() call causes a compile error (E0599). 

Fixes https://github.com/poziomki-app/poziomki/security/code-scanning/2