### PR TITLE
chore: security scans, and local git hooks

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+# Only run backend checks if backend files are staged
+if git diff --cached --name-only | grep -q '^backend/'; then
+    echo "Running cargo fmt check..."
+    (cd backend && cargo fmt --all -- --check)
+
+    echo "Running cargo clippy..."
+    (cd backend && cargo clippy --all-targets --all-features -- -D warnings)
+fi

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+# Only run if backend files changed vs remote
+remote="$1"
+url="$2"
+
+if git diff --name-only HEAD @{u} 2>/dev/null | grep -q '^backend/'; then
+    echo "Running cargo audit..."
+    (cd backend && cargo audit)
+fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,15 +12,6 @@ permissions:
   security-events: write
 
 jobs:
-  cargo-audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          working-directory: backend
-
   trivy-backend:
     runs-on: ubuntu-latest
     steps:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,6 +18,19 @@ cp .env.example .env
 
 Potrzebujesz co najmniej `DATABASE_URL` i `JWT_SECRET`. Przykładowe wartości znajdziesz w `.env.example`.
 
+### Git hooks
+
+Po sklonowaniu repozytorium ustaw ścieżkę hooków:
+
+```sh
+git config core.hooksPath .github/hooks
+```
+
+Hooki uruchamiają automatycznie:
+
+- **pre-commit** — `cargo fmt --check` + `cargo clippy` (tylko przy zmianach w `backend/`)
+- **pre-push** — `cargo audit` (tylko przy zmianach w `backend/`)
+
 ### Backend
 
 ```sh


### PR DESCRIPTION
Add GitHub funding config, improve CI security scanning (trivy + clippy SARIF), and move cargo-audit to a local pre-push hook. Pre-commit hook runs fmt + clippy on backend changes.

- [x] contributors run `git config core.hooksPath .github/hooks` after cloning