### PR TITLE
chore: CodeQL matrix for java-kotlin + bump to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,12 +45,12 @@ jobs:
         if: matrix.language == 'java-kotlin'
         uses: android-actions/setup-android@v3
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
-      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/autobuild@v4
         if: matrix.build-mode == 'autobuild'
 
       - name: Build mobile
@@ -58,4 +58,4 @@ jobs:
         working-directory: mobile
         run: ./gradlew --no-daemon testClasses
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
           format: sarif
           output: trivy-backend.sarif
 
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: trivy-backend.sarif
@@ -44,7 +44,7 @@ jobs:
           format: sarif
           output: trivy-mobile.sarif
 
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: trivy-mobile.sarif
@@ -102,7 +102,7 @@ jobs:
           | sarif-fmt
         continue-on-error: true
 
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: clippy-results.sarif


### PR DESCRIPTION
Add java-kotlin to CodeQL analysis with proper Android SDK setup, and bump all codeql-action references from v3 to v4.