### PR TITLE
Structured JSON logging and request tracing

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3164,6 +3164,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3223,6 +3224,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,12 +3243,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -47,7 +47,7 @@ tokio = { version = "=1.50.0", default-features = false, features = [
 ] }
 axum = { version = "=0.8.8", features = ["multipart"] }
 tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 chrono = { version = "=0.4.44", default-features = false, features = ["clock", "serde"] }
 validator = { version = "=0.20.0", features = ["derive"] }
 uuid = { version = "=1.21.0", features = ["v4"] }
@@ -65,7 +65,7 @@ fast_image_resize = "=6.0.0"
 webp = "=0.3.1"
 thumbhash = "=0.1.0"
 base64 = "=0.22.1"
-tower-http = { version = "=0.6.8", features = ["set-header"] }
+tower-http = { version = "=0.6.8", features = ["set-header", "trace"] }
 argon2 = { version = "=0.5.3", features = ["rand"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 jsonwebtoken = "=10.3.0"

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -4,6 +4,7 @@ use axum::{
     Router,
 };
 use tower_http::set_header::SetResponseHeaderLayer;
+use tower_http::trace::TraceLayer;
 
 use crate::app::AppContext;
 
@@ -148,6 +149,26 @@ fn push_gateway_routes() -> Router<AppContext> {
     Router::new().route("/notify", post(push_gateway::notify))
 }
 
+#[derive(Clone)]
+struct StatusAwareOnResponse;
+
+impl<B> tower_http::trace::OnResponse<B> for StatusAwareOnResponse {
+    fn on_response(
+        self,
+        response: &axum::http::Response<B>,
+        latency: std::time::Duration,
+        span: &tracing::Span,
+    ) {
+        let status = response.status().as_u16();
+        let latency_ms = latency.as_millis();
+        if status >= 500 {
+            tracing::error!(parent: span, status, latency_ms, "response");
+        } else {
+            tracing::info!(parent: span, status, latency_ms, "response");
+        }
+    }
+}
+
 fn ops_routes() -> Router<AppContext> {
     Router::new()
         .route("/outbox/status", get(root::outbox_status))
@@ -172,6 +193,32 @@ pub fn router() -> Router<AppContext> {
         .nest("/api/v1/matrix", matrix_room_routes())
         .nest("/_matrix/push/v1", push_gateway_routes())
         .nest("/api/v1/ops", ops_routes())
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(|req: &axum::http::Request<_>| {
+                    if req.uri().path() == "/health" {
+                        return tracing::Span::none();
+                    }
+                    let request_id = req
+                        .headers()
+                        .get("x-request-id")
+                        .and_then(|v| v.to_str().ok())
+                        .map_or_else(
+                            || {
+                                let (hi, _) = uuid::Uuid::new_v4().as_u64_pair();
+                                format!("{:08x}", (hi >> 32) as u32)
+                            },
+                            String::from,
+                        );
+                    tracing::info_span!(
+                        "request",
+                        method = %req.method(),
+                        path = %req.uri().path(),
+                        request_id = %request_id,
+                    )
+                })
+                .on_response(StatusAwareOnResponse),
+        )
 }
 
 pub(crate) async fn deliver_otp_email_job(to: &str, code: &str) {

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -163,6 +163,8 @@ impl<B> tower_http::trace::OnResponse<B> for StatusAwareOnResponse {
         let latency_ms = latency.as_millis();
         if status >= 500 {
             tracing::error!(parent: span, status, latency_ms, "response");
+        } else if status >= 400 {
+            tracing::warn!(parent: span, status, latency_ms, "response");
         } else {
             tracing::info!(parent: span, status, latency_ms, "response");
         }

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -212,10 +212,14 @@ pub fn router() -> Router<AppContext> {
                             },
                             String::from,
                         );
+                    let path = req
+                        .extensions()
+                        .get::<axum::extract::MatchedPath>()
+                        .map_or_else(|| req.uri().path().to_owned(), |mp| mp.as_str().to_owned());
                     tracing::info_span!(
                         "request",
                         method = %req.method(),
-                        path = %req.uri().path(),
+                        path = %path,
                         request_id = %request_id,
                     )
                 })

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -159,6 +159,9 @@ impl<B> tower_http::trace::OnResponse<B> for StatusAwareOnResponse {
         latency: std::time::Duration,
         span: &tracing::Span,
     ) {
+        if span.is_disabled() {
+            return;
+        }
         let status = response.status().as_u16();
         let latency_ms = latency.as_millis();
         if status >= 500 {
@@ -195,7 +198,7 @@ pub fn router() -> Router<AppContext> {
         .nest("/api/v1/matrix", matrix_room_routes())
         .nest("/_matrix/push/v1", push_gateway_routes())
         .nest("/api/v1/ops", ops_routes())
-        .layer(
+        .route_layer(
             TraceLayer::new_for_http()
                 .make_span_with(|req: &axum::http::Request<_>| {
                     if req.uri().path() == "/health" {

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -198,7 +198,7 @@ pub fn router() -> Router<AppContext> {
         .nest("/api/v1/matrix", matrix_room_routes())
         .nest("/_matrix/push/v1", push_gateway_routes())
         .nest("/api/v1/ops", ops_routes())
-        .route_layer(
+        .layer(
             TraceLayer::new_for_http()
                 .make_span_with(|req: &axum::http::Request<_>| {
                     if req.uri().path() == "/health" {
@@ -215,14 +215,10 @@ pub fn router() -> Router<AppContext> {
                             },
                             String::from,
                         );
-                    let path = req
-                        .extensions()
-                        .get::<axum::extract::MatchedPath>()
-                        .map_or_else(|| req.uri().path().to_owned(), |mp| mp.as_str().to_owned());
                     tracing::info_span!(
                         "request",
                         method = %req.method(),
-                        path = %path,
+                        path = %req.uri().path(),
                         request_id = %request_id,
                     )
                 })

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -37,15 +37,28 @@ fn init_tracing_once() -> crate::error::AppResult<()> {
         return Ok(());
     }
 
-    let level = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
-    let filter = tracing_subscriber::EnvFilter::try_new(level)
-        .map_err(|e| crate::error::AppError::Any(e.into()))?;
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
 
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_target(true)
-        .try_init()
-        .map_err(|e| crate::error::AppError::Message(format!("logger init failed: {e}")))?;
+    let is_production = std::env::var("RUST_ENV").unwrap_or_default() == "production";
+
+    if is_production {
+        tracing_subscriber::fmt()
+            .json()
+            .flatten_event(true)
+            .with_env_filter(filter)
+            .with_target(true)
+            .with_current_span(true)
+            .with_span_list(true)
+            .try_init()
+            .map_err(|e| crate::error::AppError::Message(format!("logger init: {e}")))?;
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(true)
+            .try_init()
+            .map_err(|e| crate::error::AppError::Message(format!("logger init: {e}")))?;
+    }
 
     let _ = TRACING_INIT.set(());
     Ok(())

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -37,8 +37,15 @@ fn init_tracing_once() -> crate::error::AppResult<()> {
         return Ok(());
     }
 
-    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let filter = match tracing_subscriber::EnvFilter::try_from_default_env() {
+        Ok(f) => f,
+        Err(e) if std::env::var("RUST_LOG").is_ok() => {
+            return Err(crate::error::AppError::Message(format!(
+                "invalid RUST_LOG: {e}"
+            )));
+        }
+        Err(_) => tracing_subscriber::EnvFilter::new("info"),
+    };
 
     let is_production = std::env::var("RUST_ENV").unwrap_or_default() == "production";
 

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -128,6 +128,7 @@ pub fn init_pool(database_url: &str) -> Result<(), String> {
 /// # Errors
 /// Returns an error when the pool is not yet initialised or when obtaining a
 /// connection from the pool fails.
+#[tracing::instrument(skip_all)]
 pub async fn conn() -> Result<DbConn, diesel_async::pooled_connection::deadpool::PoolError> {
     POOL.get()
         .ok_or(diesel_async::pooled_connection::deadpool::PoolError::NoRuntimeSpecified)?

--- a/backend/src/jobs/outbox/outbox_dispatch.rs
+++ b/backend/src/jobs/outbox/outbox_dispatch.rs
@@ -149,14 +149,6 @@ pub(super) async fn mark_job_failed(
         .await?;
     }
 
-    tracing::warn!(
-        job_id = %job.id,
-        topic = %job.topic,
-        attempts = job.attempts,
-        max_attempts = job.max_attempts,
-        error = %error_message,
-        "outbox job failed"
-    );
     Ok(())
 }
 

--- a/backend/src/jobs/outbox/outbox_dispatch.rs
+++ b/backend/src/jobs/outbox/outbox_dispatch.rs
@@ -33,6 +33,7 @@ struct UploadVariantsGenerationJobPayload {
     upload_id: String,
 }
 
+#[tracing::instrument(skip(job), fields(job_id = %job.id, job_topic = %job.topic))]
 pub(super) async fn dispatch_job(job: &OutboxJob) -> std::result::Result<(), String> {
     match job.topic.as_str() {
         OUTBOX_TOPIC_OTP_EMAIL => dispatch_otp_email(&job.payload_json).await,

--- a/backend/src/jobs/outbox/outbox_worker.rs
+++ b/backend/src/jobs/outbox/outbox_worker.rs
@@ -65,7 +65,12 @@ async fn process_one_job() -> std::result::Result<bool, String> {
             mark_job_done(&job.id).await.map_err(|e| e.to_string())?;
         }
         Err(ref error) => {
-            tracing::error!(%error, job_id = %job.id, job_topic = %job.topic, attempts = job.attempts, max_attempts = job.max_attempts, "job dispatch failed");
+            let is_terminal = job.attempts >= job.max_attempts;
+            if is_terminal {
+                tracing::error!(%error, job_id = %job.id, job_topic = %job.topic, attempts = job.attempts, max_attempts = job.max_attempts, "job permanently failed");
+            } else {
+                tracing::warn!(%error, job_id = %job.id, job_topic = %job.topic, attempts = job.attempts, max_attempts = job.max_attempts, "job dispatch failed, will retry");
+            }
             mark_job_failed(&job, error)
                 .await
                 .map_err(|e| e.to_string())?;

--- a/backend/src/jobs/outbox/outbox_worker.rs
+++ b/backend/src/jobs/outbox/outbox_worker.rs
@@ -65,7 +65,7 @@ async fn process_one_job() -> std::result::Result<bool, String> {
             mark_job_done(&job.id).await.map_err(|e| e.to_string())?;
         }
         Err(ref error) => {
-            tracing::error!(%error, job_id = %job.id, job_topic = %job.topic, "job dispatch failed");
+            tracing::error!(%error, job_id = %job.id, job_topic = %job.topic, attempts = job.attempts, max_attempts = job.max_attempts, "job dispatch failed");
             mark_job_failed(&job, error)
                 .await
                 .map_err(|e| e.to_string())?;

--- a/backend/src/jobs/outbox/outbox_worker.rs
+++ b/backend/src/jobs/outbox/outbox_worker.rs
@@ -65,15 +65,15 @@ async fn process_one_job() -> std::result::Result<bool, String> {
             mark_job_done(&job.id).await.map_err(|e| e.to_string())?;
         }
         Err(ref error) => {
+            mark_job_failed(&job, error)
+                .await
+                .map_err(|e| e.to_string())?;
             let is_terminal = job.attempts >= job.max_attempts;
             if is_terminal {
                 tracing::error!(%error, job_id = %job.id, job_topic = %job.topic, attempts = job.attempts, max_attempts = job.max_attempts, "job permanently failed");
             } else {
                 tracing::warn!(%error, job_id = %job.id, job_topic = %job.topic, attempts = job.attempts, max_attempts = job.max_attempts, "job dispatch failed, will retry");
             }
-            mark_job_failed(&job, error)
-                .await
-                .map_err(|e| e.to_string())?;
         }
     }
 

--- a/backend/src/jobs/outbox/outbox_worker.rs
+++ b/backend/src/jobs/outbox/outbox_worker.rs
@@ -53,6 +53,7 @@ struct OutboxJobRow {
     max_attempts: i32,
 }
 
+#[tracing::instrument(skip_all)]
 async fn process_one_job() -> std::result::Result<bool, String> {
     let Some(job) = claim_next_job().await.map_err(|e| e.to_string())? else {
         return Ok(false);
@@ -63,8 +64,9 @@ async fn process_one_job() -> std::result::Result<bool, String> {
         Ok(()) => {
             mark_job_done(&job.id).await.map_err(|e| e.to_string())?;
         }
-        Err(error) => {
-            mark_job_failed(&job, &error)
+        Err(ref error) => {
+            tracing::error!(%error, job_id = %job.id, job_topic = %job.topic, "job dispatch failed");
+            mark_job_failed(&job, error)
                 .await
                 .map_err(|e| e.to_string())?;
         }
@@ -73,6 +75,7 @@ async fn process_one_job() -> std::result::Result<bool, String> {
     Ok(true)
 }
 
+#[tracing::instrument(skip_all)]
 async fn claim_next_job() -> std::result::Result<Option<OutboxJob>, crate::error::AppError> {
     let mut conn = crate::db::conn().await?;
 

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -145,6 +145,7 @@ services:
     ports:
       - "127.0.0.1:5150:5150"
     environment:
+      RUST_ENV: production
       PORT: 5150
       SERVER_BINDING: 0.0.0.0
       SERVER_HOST: ${SERVER_HOST:-https://rs.poziomki.app}
@@ -218,6 +219,7 @@ services:
       stalwart:
         condition: service_started
     environment:
+      RUST_ENV: production
       SERVER_HOST: ${SERVER_HOST:-https://rs.poziomki.app}
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki}:${POSTGRES_PASSWORD}@pgdog:6432/${POSTGRES_DB:-poziomki}
       DB_POOL_MAX_SIZE: ${WORKER_DB_POOL_MAX_SIZE:-8}

--- a/infra/ops/vector/compose.yaml
+++ b/infra/ops/vector/compose.yaml
@@ -1,0 +1,37 @@
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+    compress: "true"
+
+services:
+  vector:
+    image: timberio/vector:0.54.0-alpine
+    restart: unless-stopped
+    environment:
+      PARSEABLE_PASSWORD: ${PARSEABLE_PASSWORD}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./vector.yaml:/etc/vector/vector.yaml:ro
+      - vector-data:/var/lib/vector
+    command: ["--config", "/etc/vector/vector.yaml"]
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: '0.5'
+    logging: *default-logging
+    networks: [app]
+
+volumes:
+  vector-data:
+
+networks:
+  app:
+    external: true
+    name: poziomki-rs_app

--- a/infra/ops/vector/parseable-setup.sh
+++ b/infra/ops/vector/parseable-setup.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Run on the server after deploying Vector + structured logging backend.
+# Requires: PARSEABLE_PASSWORD env var set, Parseable running on localhost:8100.
+set -euo pipefail
+
+PASS="${PARSEABLE_PASSWORD:?Set PARSEABLE_PASSWORD}"
+BASE="http://localhost:8100"
+
+NETRC="$(mktemp)"
+trap 'rm -f "$NETRC"' EXIT
+chmod 600 "$NETRC"
+printf 'machine localhost\nlogin admin\npassword %s\n' "$PASS" > "$NETRC"
+
+echo "==> Deleting old docker stream..."
+curl -sS --netrc-file "$NETRC" -X DELETE "${BASE}/api/v1/logstream/docker" || true
+
+echo "==> Setting 30-day retention on streams..."
+for stream in api worker infra; do
+  curl -sSf --netrc-file "$NETRC" -X PUT \
+    "${BASE}/api/v1/logstream/${stream}/retention" \
+    -H 'Content-Type: application/json' \
+    -d '[{"description":"30 day retention","action":"delete","duration":"30d"}]'
+  echo ""
+done
+
+echo "==> Creating API error alert -> ntfy..."
+curl -sSf --netrc-file "$NETRC" -X PUT \
+  "${BASE}/api/v1/logstream/api/alert" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "version": "v1",
+    "alerts": [{
+      "name": "api-errors",
+      "message": "API error spike detected — check the api stream",
+      "rule": {
+        "type": "column",
+        "config": {
+          "column": "level",
+          "operator": "=",
+          "value": "ERROR",
+          "repeats": 3
+        }
+      },
+      "targets": [{
+        "type": "webhook",
+        "endpoint": "https://ntfy.poziomki.app/poziomki-ops",
+        "repeat": { "interval": "5m", "times": 3 }
+      }]
+    }]
+  }'
+echo ""
+
+echo "==> Creating worker outbox failure alert -> ntfy..."
+curl -sSf --netrc-file "$NETRC" -X PUT \
+  "${BASE}/api/v1/logstream/worker/alert" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "version": "v1",
+    "alerts": [{
+      "name": "outbox-failures",
+      "message": "Outbox job failure detected",
+      "rule": {
+        "type": "column",
+        "config": {
+          "column": "level",
+          "operator": "=",
+          "value": "ERROR",
+          "repeats": 1
+        }
+      },
+      "targets": [{
+        "type": "webhook",
+        "endpoint": "https://ntfy.poziomki.app/poziomki-ops",
+        "repeat": { "interval": "10m", "times": 3 }
+      }]
+    }]
+  }'
+echo ""
+
+echo "==> Done. Verify at ${BASE} (tunnel: ssh -L 8100:localhost:8100 poziomki)"

--- a/infra/ops/vector/vector.yaml
+++ b/infra/ops/vector/vector.yaml
@@ -21,6 +21,8 @@ transforms:
             ts, ts_err = parse_timestamp(.timestamp, format: "%+")
             if ts_err == null { .timestamp = ts }
           }
+        } else {
+          .level = "RAW"
         }
       }
 

--- a/infra/ops/vector/vector.yaml
+++ b/infra/ops/vector/vector.yaml
@@ -1,0 +1,102 @@
+sources:
+  docker_logs:
+    type: docker_logs
+    exclude_containers:
+      - "poziomki-rs-garage-1"
+      - "parseable"
+      - "vector-vector-1"
+
+transforms:
+  parse_json:
+    type: remap
+    inputs: ["docker_logs"]
+    source: |-
+      name = string(.container_name) ?? ""
+      if starts_with(name, "poziomki-rs-api-") || starts_with(name, "poziomki-rs-worker-") {
+        parsed, err = parse_json(.message)
+        if err == null {
+          merged, merge_err = merge(., parsed)
+          if merge_err == null {
+            . = merged
+            ts, ts_err = parse_timestamp(.timestamp, format: "%+")
+            if ts_err == null { .timestamp = ts }
+          }
+        }
+      }
+
+  route_streams:
+    type: route
+    inputs: ["parse_json"]
+    route:
+      api: 'starts_with(string(.container_name) ?? "", "poziomki-rs-api-")'
+      worker: 'starts_with(string(.container_name) ?? "", "poziomki-rs-worker-")'
+
+sinks:
+  parseable_api:
+    type: http
+    inputs: ["route_streams.api"]
+    uri: http://parseable:8000/api/v1/ingest
+    method: post
+    encoding:
+      codec: json
+    auth:
+      strategy: basic
+      user: admin
+      password: "${PARSEABLE_PASSWORD}"
+    request:
+      headers:
+        X-P-Stream: api
+    compression: gzip
+    batch:
+      max_events: 100
+      timeout_secs: 2
+    buffer:
+      type: disk
+      max_size: 268435488
+      when_full: block
+
+  parseable_worker:
+    type: http
+    inputs: ["route_streams.worker"]
+    uri: http://parseable:8000/api/v1/ingest
+    method: post
+    encoding:
+      codec: json
+    auth:
+      strategy: basic
+      user: admin
+      password: "${PARSEABLE_PASSWORD}"
+    request:
+      headers:
+        X-P-Stream: worker
+    compression: gzip
+    batch:
+      max_events: 100
+      timeout_secs: 2
+    buffer:
+      type: disk
+      max_size: 268435488
+      when_full: block
+
+  parseable_infra:
+    type: http
+    inputs: ["route_streams._unmatched"]
+    uri: http://parseable:8000/api/v1/ingest
+    method: post
+    encoding:
+      codec: json
+    auth:
+      strategy: basic
+      user: admin
+      password: "${PARSEABLE_PASSWORD}"
+    request:
+      headers:
+        X-P-Stream: infra
+    compression: gzip
+    batch:
+      max_events: 100
+      timeout_secs: 5
+    buffer:
+      type: disk
+      max_size: 268435488
+      when_full: block


### PR DESCRIPTION
**Structured logging for Parseable with Vector**

Backend now emits structured JSON logs in production and traces every HTTP request with method, path, latency, and status. Vector replaces Fluent Bit for log collection — tested side-by-side on prod, Vector wins on config ergonomics, auto container metadata, and stream routing.

- `RUST_ENV=production` switches tracing to JSON output, dev stays pretty-printed
- TraceLayer middleware logs every request with method, path, request_id, status, latency
- `#[instrument]` on `conn()`, `dispatch_job()`, `process_one_job()`, `claim_next_job()`
- Vector config: excludes Garage feedback loop, routes to api/worker/infra Parseable streams, parses JSON fields from tracing-subscriber output
- Parseable setup script: deletes old docker stream, sets 30d retention, creates error alerts to ntfy

- [ ] deploy structured logging backend (rebuild api + worker)
- [ ] run parseable-setup.sh to configure retention and alerts
- [ ] delete old docker stream from Parseable