### PR TITLE
fix: backend security and logic issues from code review

### DIFF
--- a/backend/migrations/2026-03-13-000000_drop_redundant_interactions_index/down.sql
+++ b/backend/migrations/2026-03-13-000000_drop_redundant_interactions_index/down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_event_interactions_profile_id ON event_interactions (profile_id);

--- a/backend/migrations/2026-03-13-000000_drop_redundant_interactions_index/up.sql
+++ b/backend/migrations/2026-03-13-000000_drop_redundant_interactions_index/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_event_interactions_profile_id;

--- a/backend/src/api/events/tags_service.rs
+++ b/backend/src/api/events/tags_service.rs
@@ -53,7 +53,10 @@ pub(in crate::api) async fn resolve_event_tag_ids_with_conn(
         ids.sort_unstable();
         ids.dedup();
         if !ids.is_empty() {
-            let matched = load_existing_event_tag_ids(conn, &ids).await?;
+            let matched: std::collections::HashSet<Uuid> = load_existing_event_tag_ids(conn, &ids)
+                .await?
+                .into_iter()
+                .collect();
             if matched.len() != ids.len() {
                 return Err(crate::error::AppError::Validation(
                     "All tagIds must reference existing event tags".to_string(),
@@ -114,9 +117,11 @@ async fn validate_event_tag_ids(
     let mut conn = crate::db::conn()
         .await
         .map_err(|e| Box::new(crate::error::AppError::from(e).into_response()))?;
-    let matched = load_existing_event_tag_ids(&mut conn, &parsed)
+    let matched: std::collections::HashSet<Uuid> = load_existing_event_tag_ids(&mut conn, &parsed)
         .await
-        .map_err(|e| Box::new(e.into_response()))?;
+        .map_err(|e| Box::new(e.into_response()))?
+        .into_iter()
+        .collect();
 
     if matched.len() != parsed.len() {
         return Err(Box::new(validation_error(

--- a/backend/src/api/events/tags_service.rs
+++ b/backend/src/api/events/tags_service.rs
@@ -52,6 +52,14 @@ pub(in crate::api) async fn resolve_event_tag_ids_with_conn(
         ids.truncate(MAX_EVENT_TAGS);
         ids.sort_unstable();
         ids.dedup();
+        if !ids.is_empty() {
+            let matched = load_existing_event_tag_ids(conn, &ids).await?;
+            if matched.len() != ids.len() {
+                return Err(crate::error::AppError::Validation(
+                    "All tagIds must reference existing event tags".to_string(),
+                ));
+            }
+        }
         return Ok(ids);
     }
 

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -155,10 +155,11 @@ pub(in crate::api) async fn event_update(
     Path(id): Path<String>,
     Json(payload): Json<UpdateEventBody>,
 ) -> Result<Response> {
-    let (changeset, event_uuid, profile) = match event_update_inner(&headers, &id, &payload).await {
-        Ok(data) => data,
-        Err(response) => return Ok(*response),
-    };
+    let (changeset, event_uuid, profile, current_event) =
+        match event_update_inner(&headers, &id, &payload).await {
+            Ok(data) => data,
+            Err(response) => return Ok(*response),
+        };
 
     let tag_names = payload.tags.clone();
     let validated_tag_ids = if payload.tag_ids.is_some() {
@@ -170,9 +171,14 @@ pub(in crate::api) async fn event_update(
         None
     };
 
+    let disabling_approval =
+        current_event.requires_approval && changeset.requires_approval == Some(false);
+
     let mut conn = crate::db::conn().await?;
-    let updated = conn
-        .transaction(|conn| {
+    let (updated, auto_approved) = conn
+        .build_transaction()
+        .serializable()
+        .run(|conn| {
             let changeset = crate::db::models::events::EventChangeset {
                 title: changeset.title.clone(),
                 description: changeset.description.clone(),
@@ -192,11 +198,32 @@ pub(in crate::api) async fn event_update(
             Box::pin(async move {
                 let updated =
                     events_write_repo::update_event_with_conn(conn, event_uuid, &changeset).await?;
+                let auto_approved = if disabling_approval {
+                    events_write_repo::auto_approve_pending_with_conn(
+                        conn,
+                        event_uuid,
+                        updated.max_attendees,
+                    )
+                    .await?
+                } else {
+                    vec![]
+                };
                 maybe_sync_tags_with_conn(conn, event_uuid, tag_names, validated_tag_ids).await?;
-                Ok::<Event, crate::error::AppError>(updated)
+                Ok::<(Event, Vec<Uuid>), crate::error::AppError>((updated, auto_approved))
             })
         })
         .await?;
+
+    for pid in &auto_approved {
+        if let Err(error) = enqueue_matrix_event_membership_sync(&updated.id, pid, false).await {
+            tracing::warn!(
+                %error,
+                event_id = %updated.id,
+                profile_id = %pid,
+                "failed to enqueue matrix membership sync for auto-approved attendee"
+            );
+        }
+    }
 
     let data = build_event_response(&updated, &profile.id).await?;
     Ok(Json(DataResponse { data }).into_response())
@@ -252,10 +279,9 @@ fn resolve_attend_status(payload: Option<Json<AttendEventBody>>) -> &'static str
         .and_then(|Json(body)| body.status)
         .unwrap_or(AttendeeStatus::Going)
     {
-        AttendeeStatus::Going => ATTENDEE_GOING,
+        AttendeeStatus::Going | AttendeeStatus::Pending => ATTENDEE_GOING,
         AttendeeStatus::Interested => ATTENDEE_INTERESTED,
         AttendeeStatus::Invited => ATTENDEE_INVITED,
-        AttendeeStatus::Pending => "pending",
     }
 }
 
@@ -289,15 +315,16 @@ pub(in crate::api) async fn event_attend(
             status_str
         };
 
-    let accepted = events_write_repo::check_capacity_and_upsert(
+    let outcome = events_write_repo::check_capacity_and_upsert(
         event_uuid,
         profile.id,
         effective_status,
         event.max_attendees,
         already_going,
+        None,
     )
     .await?;
-    if !accepted {
+    if outcome == events_write_repo::UpsertOutcome::Full {
         return Ok(validation_error(&headers, "Event is full"));
     }
 
@@ -359,16 +386,27 @@ pub(in crate::api) async fn event_approve_attendee(
     let target_profile_id = Uuid::parse_str(&profile_id_str)
         .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
 
-    let existing = events_write_repo::find_attendee_status(event_uuid, target_profile_id).await?;
-    if existing.as_deref() != Some("pending") {
-        return Ok(super::events_service::validation_error(
-            &headers,
-            "Attendee is not pending approval",
-        ));
+    let outcome = events_write_repo::check_capacity_and_upsert(
+        event_uuid,
+        target_profile_id,
+        "going",
+        event.max_attendees,
+        false,
+        Some("pending"),
+    )
+    .await?;
+    match outcome {
+        events_write_repo::UpsertOutcome::Full => {
+            return Ok(validation_error(&headers, "Event is full"));
+        }
+        events_write_repo::UpsertOutcome::StatusMismatch => {
+            return Ok(super::events_service::validation_error(
+                &headers,
+                "Attendee is not pending approval",
+            ));
+        }
+        events_write_repo::UpsertOutcome::Accepted => {}
     }
-
-    // upsert_attendee records the "joined" interaction inside the same transaction
-    events_write_repo::upsert_attendee(event_uuid, target_profile_id, "going").await?;
 
     if let Err(error) =
         enqueue_matrix_event_membership_sync(&event.id, &target_profile_id, false).await
@@ -409,15 +447,13 @@ pub(in crate::api) async fn event_reject_attendee(
     let target_profile_id = Uuid::parse_str(&profile_id_str)
         .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
 
-    let existing = events_write_repo::find_attendee_status(event_uuid, target_profile_id).await?;
-    if existing.as_deref() != Some("pending") {
+    let deleted = events_write_repo::delete_pending_attendee(event_uuid, target_profile_id).await?;
+    if !deleted {
         return Ok(super::events_service::validation_error(
             &headers,
             "Attendee is not pending approval",
         ));
     }
-
-    events_write_repo::delete_event_attendee(event_uuid, target_profile_id).await?;
 
     Ok(Json(DataResponse {
         data: SuccessResponse { success: true },

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -337,7 +337,6 @@ pub(in crate::api) async fn event_attend(
         profile.id,
         effective_status,
         event.max_attendees,
-        already_going,
         None,
     )
     .await?;
@@ -414,7 +413,6 @@ pub(in crate::api) async fn event_approve_attendee(
         target_profile_id,
         "going",
         event.max_attendees,
-        false,
         Some("pending"),
     )
     .await?;

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -176,9 +176,10 @@ pub(in crate::api) async fn event_update(
 
     // Use the more restrictive of old / new cap so approval cannot
     // exceed what the organizer intended with this update.
-    let effective_max = match changeset.max_attendees.flatten() {
-        Some(new_max) => Some(new_max.min(current_event.max_attendees.unwrap_or(new_max))),
+    let effective_max = match changeset.max_attendees {
         None => current_event.max_attendees,
+        Some(None) => None,
+        Some(Some(new_max)) => Some(new_max.min(current_event.max_attendees.unwrap_or(new_max))),
     };
     let mut conn = crate::db::conn().await?;
     let mut attempts = 0;

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -221,7 +221,7 @@ pub(in crate::api) async fn event_update(
         match result {
             Ok(val) => break val,
             Err(ref e)
-                if attempts < events_write_repo::MAX_SERIALIZATION_RETRIES
+                if attempts < events_write_repo::MAX_ATTEMPTS
                     && events_write_repo::is_serialization_failure_app(e) =>
             {
                 tokio::time::sleep(std::time::Duration::from_millis(attempts as u64 * 5)).await;
@@ -317,37 +317,30 @@ pub(in crate::api) async fn event_attend(
 
     // Approval gate only applies to "going" — "interested" is a soft signal that
     // intentionally bypasses approval so users can bookmark events without creator action.
-    let effective_status =
-        if event.requires_approval && status_str == "going" && event.creator_id != profile.id {
-            let existing = events_write_repo::load_attendee(event_uuid, profile.id).await?;
-            if existing.is_some_and(|a| a.status == "going") {
-                "going"
-            } else {
-                "pending"
-            }
-        } else {
-            status_str
-        };
+    let requires_approval =
+        event.requires_approval && status_str == "going" && event.creator_id != profile.id;
 
     let outcome = events_write_repo::check_capacity_and_upsert(
         event_uuid,
         profile.id,
-        effective_status,
+        status_str,
         event.max_attendees,
         None,
+        requires_approval,
     )
     .await?;
-    match outcome {
+    let written_status = match outcome {
         events_write_repo::UpsertOutcome::Full => {
             return Ok(validation_error(&headers, "Event is full"));
         }
-        events_write_repo::UpsertOutcome::Accepted => {}
+        events_write_repo::UpsertOutcome::Accepted(s) => s,
         events_write_repo::UpsertOutcome::StatusMismatch => {
             debug_assert!(false, "StatusMismatch returned with require_status = None");
+            return Ok(validation_error(&headers, "Unexpected status mismatch"));
         }
-    }
+    };
 
-    if effective_status != "pending" {
+    if written_status != "pending" {
         if let Err(error) =
             enqueue_matrix_event_membership_sync(&event.id, &profile.id, false).await
         {
@@ -411,6 +404,7 @@ pub(in crate::api) async fn event_approve_attendee(
         "going",
         event.max_attendees,
         Some("pending"),
+        false,
     )
     .await?;
     match outcome {
@@ -423,7 +417,7 @@ pub(in crate::api) async fn event_approve_attendee(
                 "Attendee is not pending approval",
             ));
         }
-        events_write_repo::UpsertOutcome::Accepted => {}
+        events_write_repo::UpsertOutcome::Accepted(_) => {}
     }
 
     if let Err(error) =

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -325,8 +325,12 @@ pub(in crate::api) async fn event_attend(
         None,
     )
     .await?;
-    if outcome == events_write_repo::UpsertOutcome::Full {
-        return Ok(validation_error(&headers, "Event is full"));
+    match outcome {
+        events_write_repo::UpsertOutcome::Full => {
+            return Ok(validation_error(&headers, "Event is full"));
+        }
+        events_write_repo::UpsertOutcome::Accepted
+        | events_write_repo::UpsertOutcome::StatusMismatch => {}
     }
 
     if effective_status != "pending" {

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -9,7 +9,8 @@ use axum::{
     Json,
 };
 use chrono::Utc;
-use diesel_async::AsyncConnection;
+use diesel::QueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::api::state::{
@@ -155,7 +156,7 @@ pub(in crate::api) async fn event_update(
     Path(id): Path<String>,
     Json(payload): Json<UpdateEventBody>,
 ) -> Result<Response> {
-    let (changeset, event_uuid, profile, current_event) =
+    let (changeset, event_uuid, profile, _current_event) =
         match event_update_inner(&headers, &id, &payload).await {
             Ok(data) => data,
             Err(response) => return Ok(*response),
@@ -171,8 +172,7 @@ pub(in crate::api) async fn event_update(
         None
     };
 
-    let disabling_approval =
-        current_event.requires_approval && changeset.requires_approval == Some(false);
+    let sets_approval_false = changeset.requires_approval == Some(false);
 
     let mut conn = crate::db::conn().await?;
     let mut attempts = 0;
@@ -199,10 +199,17 @@ pub(in crate::api) async fn event_update(
                 let tag_names = tag_names.clone();
                 let validated_tag_ids = validated_tag_ids.clone();
                 Box::pin(async move {
+                    // Read requires_approval inside the txn so retries see fresh state
+                    let was_requiring = sets_approval_false
+                        && crate::db::schema::events::table
+                            .find(event_uuid)
+                            .select(crate::db::schema::events::requires_approval)
+                            .first::<bool>(conn)
+                            .await?;
                     let updated =
                         events_write_repo::update_event_with_conn(conn, event_uuid, &changeset)
                             .await?;
-                    let auto_approved = if disabling_approval {
+                    let auto_approved = if was_requiring {
                         events_write_repo::auto_approve_pending_with_conn(
                             conn,
                             event_uuid,

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -314,16 +314,13 @@ pub(in crate::api) async fn event_attend(
     };
 
     let status_str = resolve_attend_status(payload);
-    let existing_attendee = events_write_repo::load_attendee(event_uuid, profile.id).await?;
-    let already_going = existing_attendee
-        .as_ref()
-        .is_some_and(|attendee| attendee.status == "going");
 
     // Approval gate only applies to "going" — "interested" is a soft signal that
     // intentionally bypasses approval so users can bookmark events without creator action.
     let effective_status =
         if event.requires_approval && status_str == "going" && event.creator_id != profile.id {
-            if already_going {
+            let existing = events_write_repo::load_attendee(event_uuid, profile.id).await?;
+            if existing.is_some_and(|a| a.status == "going") {
                 "going"
             } else {
                 "pending"

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -174,13 +174,9 @@ pub(in crate::api) async fn event_update(
     let disabling_approval =
         current_event.requires_approval && changeset.requires_approval == Some(false);
 
-    // Use the more restrictive of old / new cap so approval cannot
-    // exceed what the organizer intended with this update.
-    let effective_max = match changeset.max_attendees {
-        None => current_event.max_attendees,
-        Some(None) => None,
-        Some(Some(new_max)) => Some(new_max.min(current_event.max_attendees.unwrap_or(new_max))),
-    };
+    let effective_max = changeset
+        .max_attendees
+        .unwrap_or(current_event.max_attendees);
     let mut conn = crate::db::conn().await?;
     let mut attempts = 0;
     let (updated, auto_approved) = loop {

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -174,7 +174,12 @@ pub(in crate::api) async fn event_update(
     let disabling_approval =
         current_event.requires_approval && changeset.requires_approval == Some(false);
 
-    let pre_update_max_attendees = current_event.max_attendees;
+    // Use the more restrictive of old / new cap so approval cannot
+    // exceed what the organizer intended with this update.
+    let effective_max = match changeset.max_attendees.flatten() {
+        Some(new_max) => Some(new_max.min(current_event.max_attendees.unwrap_or(new_max))),
+        None => current_event.max_attendees,
+    };
     let mut conn = crate::db::conn().await?;
     let mut attempts = 0;
     let (updated, auto_approved) = loop {
@@ -207,7 +212,7 @@ pub(in crate::api) async fn event_update(
                         events_write_repo::auto_approve_pending_with_conn(
                             conn,
                             event_uuid,
-                            pre_update_max_attendees,
+                            effective_max,
                         )
                         .await?
                     } else {

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -174,45 +174,62 @@ pub(in crate::api) async fn event_update(
     let disabling_approval =
         current_event.requires_approval && changeset.requires_approval == Some(false);
 
+    let pre_update_max_attendees = current_event.max_attendees;
     let mut conn = crate::db::conn().await?;
-    let (updated, auto_approved) = conn
-        .build_transaction()
-        .serializable()
-        .run(|conn| {
-            let changeset = crate::db::models::events::EventChangeset {
-                title: changeset.title.clone(),
-                description: changeset.description.clone(),
-                cover_image: changeset.cover_image.clone(),
-                location: changeset.location.clone(),
-                starts_at: changeset.starts_at,
-                ends_at: changeset.ends_at,
-                conversation_id: changeset.conversation_id.clone(),
-                latitude: changeset.latitude,
-                longitude: changeset.longitude,
-                max_attendees: changeset.max_attendees,
-                updated_at: changeset.updated_at,
-                requires_approval: changeset.requires_approval,
-            };
-            let tag_names = tag_names.clone();
-            let validated_tag_ids = validated_tag_ids.clone();
-            Box::pin(async move {
-                let updated =
-                    events_write_repo::update_event_with_conn(conn, event_uuid, &changeset).await?;
-                let auto_approved = if disabling_approval {
-                    events_write_repo::auto_approve_pending_with_conn(
-                        conn,
-                        event_uuid,
-                        updated.max_attendees,
-                    )
-                    .await?
-                } else {
-                    vec![]
+    let mut attempts = 0;
+    let (updated, auto_approved) = loop {
+        attempts += 1;
+        let result = conn
+            .build_transaction()
+            .serializable()
+            .run(|conn| {
+                let changeset = crate::db::models::events::EventChangeset {
+                    title: changeset.title.clone(),
+                    description: changeset.description.clone(),
+                    cover_image: changeset.cover_image.clone(),
+                    location: changeset.location.clone(),
+                    starts_at: changeset.starts_at,
+                    ends_at: changeset.ends_at,
+                    conversation_id: changeset.conversation_id.clone(),
+                    latitude: changeset.latitude,
+                    longitude: changeset.longitude,
+                    max_attendees: changeset.max_attendees,
+                    updated_at: changeset.updated_at,
+                    requires_approval: changeset.requires_approval,
                 };
-                maybe_sync_tags_with_conn(conn, event_uuid, tag_names, validated_tag_ids).await?;
-                Ok::<(Event, Vec<Uuid>), crate::error::AppError>((updated, auto_approved))
+                let tag_names = tag_names.clone();
+                let validated_tag_ids = validated_tag_ids.clone();
+                Box::pin(async move {
+                    let updated =
+                        events_write_repo::update_event_with_conn(conn, event_uuid, &changeset)
+                            .await?;
+                    let auto_approved = if disabling_approval {
+                        events_write_repo::auto_approve_pending_with_conn(
+                            conn,
+                            event_uuid,
+                            pre_update_max_attendees,
+                        )
+                        .await?
+                    } else {
+                        vec![]
+                    };
+                    maybe_sync_tags_with_conn(conn, event_uuid, tag_names, validated_tag_ids)
+                        .await?;
+                    Ok::<(Event, Vec<Uuid>), crate::error::AppError>((updated, auto_approved))
+                })
             })
-        })
-        .await?;
+            .await;
+        match result {
+            Ok(val) => break val,
+            Err(ref e)
+                if attempts < events_write_repo::MAX_SERIALIZATION_RETRIES
+                    && events_write_repo::is_serialization_failure_app(e) =>
+            {
+                tokio::time::sleep(std::time::Duration::from_millis(attempts as u64 * 5)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    };
 
     for pid in &auto_approved {
         if let Err(error) = enqueue_matrix_event_membership_sync(&updated.id, pid, false).await {

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -279,6 +279,7 @@ fn resolve_attend_status(payload: Option<Json<AttendEventBody>>) -> &'static str
         .and_then(|Json(body)| body.status)
         .unwrap_or(AttendeeStatus::Going)
     {
+        // Clients cannot self-assign pending; the approval gate below handles downgrade
         AttendeeStatus::Going | AttendeeStatus::Pending => ATTENDEE_GOING,
         AttendeeStatus::Interested => ATTENDEE_INTERESTED,
         AttendeeStatus::Invited => ATTENDEE_INVITED,

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -174,9 +174,6 @@ pub(in crate::api) async fn event_update(
     let disabling_approval =
         current_event.requires_approval && changeset.requires_approval == Some(false);
 
-    let effective_max = changeset
-        .max_attendees
-        .unwrap_or(current_event.max_attendees);
     let mut conn = crate::db::conn().await?;
     let mut attempts = 0;
     let (updated, auto_approved) = loop {
@@ -209,7 +206,7 @@ pub(in crate::api) async fn event_update(
                         events_write_repo::auto_approve_pending_with_conn(
                             conn,
                             event_uuid,
-                            effective_max,
+                            updated.max_attendees,
                         )
                         .await?
                     } else {
@@ -348,8 +345,10 @@ pub(in crate::api) async fn event_attend(
         events_write_repo::UpsertOutcome::Full => {
             return Ok(validation_error(&headers, "Event is full"));
         }
-        events_write_repo::UpsertOutcome::Accepted
-        | events_write_repo::UpsertOutcome::StatusMismatch => {}
+        events_write_repo::UpsertOutcome::Accepted => {}
+        events_write_repo::UpsertOutcome::StatusMismatch => {
+            debug_assert!(false, "StatusMismatch returned with require_status = None");
+        }
     }
 
     if effective_status != "pending" {

--- a/backend/src/api/events/write_repo.rs
+++ b/backend/src/api/events/write_repo.rs
@@ -46,7 +46,6 @@ pub(in crate::api) async fn check_capacity_and_upsert(
     profile_id: Uuid,
     status: &str,
     max_attendees: Option<i32>,
-    already_going: bool,
     require_status: Option<&str>,
 ) -> std::result::Result<UpsertOutcome, crate::error::AppError> {
     let status = status.to_string();
@@ -63,21 +62,25 @@ pub(in crate::api) async fn check_capacity_and_upsert(
                 let status = status.clone();
                 let require_status = require_status.clone();
                 Box::pin(async move {
-                    // Precondition: verify attendee has required status (inside txn)
+                    // Read current status inside the txn so retries see fresh state
+                    let current_status = event_attendees::table
+                        .filter(event_attendees::event_id.eq(event_id))
+                        .filter(event_attendees::profile_id.eq(profile_id))
+                        .select(event_attendees::status)
+                        .first::<String>(conn)
+                        .await
+                        .optional()?;
+
+                    // Precondition: verify attendee has required status
                     if let Some(required) = &require_status {
-                        let current = event_attendees::table
-                            .filter(event_attendees::event_id.eq(event_id))
-                            .filter(event_attendees::profile_id.eq(profile_id))
-                            .select(event_attendees::status)
-                            .first::<String>(conn)
-                            .await
-                            .optional()?;
-                        if current.as_deref() != Some(required.as_str()) {
+                        if current_status.as_deref() != Some(required.as_str()) {
                             return Ok::<UpsertOutcome, diesel::result::Error>(
                                 UpsertOutcome::StatusMismatch,
                             );
                         }
                     }
+
+                    let already_going = current_status.as_deref() == Some("going");
 
                     // Capacity gate: only enforce when switching to "going"
                     if status == "going" && !already_going {

--- a/backend/src/api/events/write_repo.rs
+++ b/backend/src/api/events/write_repo.rs
@@ -8,7 +8,7 @@ use crate::db::models::event_interactions::EventInteraction;
 use crate::db::models::events::{Event, EventChangeset, NewEvent};
 use crate::db::schema::{event_attendees, event_interactions, events};
 
-pub(in crate::api) const MAX_SERIALIZATION_RETRIES: usize = 3;
+pub(in crate::api) const MAX_ATTEMPTS: usize = 3;
 
 const fn is_serialization_failure(err: &diesel::result::Error) -> bool {
     matches!(
@@ -30,7 +30,10 @@ pub(in crate::api) fn is_serialization_failure_app(err: &crate::error::AppError)
 }
 
 pub(in crate::api) enum UpsertOutcome {
-    Accepted,
+    /// The upsert succeeded. Contains the status that was actually written,
+    /// which may differ from the requested status when the approval gate
+    /// downgrades "going" → "pending".
+    Accepted(String),
     Full,
     StatusMismatch,
 }
@@ -41,12 +44,18 @@ pub(in crate::api) enum UpsertOutcome {
 ///
 /// When `require_status` is `Some`, the attendee's current status is verified
 /// inside the transaction before proceeding, preventing TOCTOU races.
+///
+/// When `requires_approval` is true and the requested status is "going",
+/// the approval gate is evaluated inside the transaction: if the attendee
+/// is not already "going", the written status is downgraded to "pending".
+/// The actual written status is returned in `UpsertOutcome::Accepted`.
 pub(in crate::api) async fn check_capacity_and_upsert(
     event_id: Uuid,
     profile_id: Uuid,
     status: &str,
     max_attendees: Option<i32>,
     require_status: Option<&str>,
+    requires_approval: bool,
 ) -> std::result::Result<UpsertOutcome, crate::error::AppError> {
     let status = status.to_string();
     let require_status = require_status.map(String::from);
@@ -82,8 +91,16 @@ pub(in crate::api) async fn check_capacity_and_upsert(
 
                     let already_going = current_status.as_deref() == Some("going");
 
+                    // Approval gate: downgrade "going" → "pending" unless already going
+                    let effective_status =
+                        if requires_approval && status == "going" && !already_going {
+                            "pending".to_string()
+                        } else {
+                            status
+                        };
+
                     // Capacity gate: only enforce when switching to "going"
-                    if status == "going" && !already_going {
+                    if effective_status == "going" && !already_going {
                         if let Some(max) = max_attendees {
                             let current_going = event_attendees::table
                                 .filter(event_attendees::event_id.eq(event_id))
@@ -109,7 +126,7 @@ pub(in crate::api) async fn check_capacity_and_upsert(
                     let attendee = EventAttendee {
                         event_id,
                         profile_id,
-                        status: status.clone(),
+                        status: effective_status.clone(),
                     };
                     diesel::insert_into(event_attendees::table)
                         .values(&attendee)
@@ -117,19 +134,19 @@ pub(in crate::api) async fn check_capacity_and_upsert(
                         .await?;
 
                     // Track "joined" interaction atomically with the attendee change
-                    if status == "going" {
+                    if effective_status == "going" {
                         upsert_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
                     } else {
                         delete_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
                     }
 
-                    Ok(UpsertOutcome::Accepted)
+                    Ok(UpsertOutcome::Accepted(effective_status))
                 })
             })
             .await;
         match result {
             Ok(val) => return Ok(val),
-            Err(ref e) if attempts < MAX_SERIALIZATION_RETRIES && is_serialization_failure(e) => {
+            Err(ref e) if attempts < MAX_ATTEMPTS && is_serialization_failure(e) => {
                 tokio::time::sleep(std::time::Duration::from_millis(attempts as u64 * 5)).await;
             }
             Err(e) => return Err(e.into()),
@@ -201,20 +218,6 @@ pub(in crate::api) async fn delete_event_attendee_with_conn(
     .execute(conn)
     .await?;
     Ok(())
-}
-
-pub(in crate::api) async fn load_attendee(
-    event_id: Uuid,
-    profile_id: Uuid,
-) -> std::result::Result<Option<EventAttendee>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-    let attendee = event_attendees::table
-        .filter(event_attendees::event_id.eq(event_id))
-        .filter(event_attendees::profile_id.eq(profile_id))
-        .first::<EventAttendee>(&mut conn)
-        .await
-        .optional()?;
-    Ok(attendee)
 }
 
 /// Auto-approve pending attendees for an event, respecting `max_attendees`.

--- a/backend/src/api/events/write_repo.rs
+++ b/backend/src/api/events/write_repo.rs
@@ -8,7 +8,6 @@ use crate::db::models::event_interactions::EventInteraction;
 use crate::db::models::events::{Event, EventChangeset, NewEvent};
 use crate::db::schema::{event_attendees, event_interactions, events};
 
-#[derive(PartialEq, Eq)]
 pub(in crate::api) enum UpsertOutcome {
     Accepted,
     Full,
@@ -193,7 +192,7 @@ pub(in crate::api) async fn auto_approve_pending_with_conn(
     conn: &mut AsyncPgConnection,
     event_id: Uuid,
     max_attendees: Option<i32>,
-) -> std::result::Result<Vec<Uuid>, diesel::result::Error> {
+) -> std::result::Result<Vec<Uuid>, crate::error::AppError> {
     let pending_ids: Vec<Uuid> = event_attendees::table
         .filter(event_attendees::event_id.eq(event_id))
         .filter(event_attendees::status.eq("pending"))

--- a/backend/src/api/events/write_repo.rs
+++ b/backend/src/api/events/write_repo.rs
@@ -8,6 +8,27 @@ use crate::db::models::event_interactions::EventInteraction;
 use crate::db::models::events::{Event, EventChangeset, NewEvent};
 use crate::db::schema::{event_attendees, event_interactions, events};
 
+pub(in crate::api) const MAX_SERIALIZATION_RETRIES: usize = 3;
+
+const fn is_serialization_failure(err: &diesel::result::Error) -> bool {
+    matches!(
+        err,
+        diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::SerializationFailure,
+            _
+        )
+    )
+}
+
+pub(in crate::api) fn is_serialization_failure_app(err: &crate::error::AppError) -> bool {
+    match err {
+        crate::error::AppError::Any(boxed) => boxed
+            .downcast_ref::<diesel::result::Error>()
+            .is_some_and(is_serialization_failure),
+        _ => false,
+    }
+}
+
 pub(in crate::api) enum UpsertOutcome {
     Accepted,
     Full,
@@ -32,74 +53,85 @@ pub(in crate::api) async fn check_capacity_and_upsert(
     let require_status = require_status.map(String::from);
     let mut conn = crate::db::conn().await?;
 
-    conn.build_transaction()
-        .serializable()
-        .run(|conn| {
-            let status = status.clone();
-            let require_status = require_status.clone();
-            Box::pin(async move {
-                // Precondition: verify attendee has required status (inside txn)
-                if let Some(required) = &require_status {
-                    let current = event_attendees::table
-                        .filter(event_attendees::event_id.eq(event_id))
-                        .filter(event_attendees::profile_id.eq(profile_id))
-                        .select(event_attendees::status)
-                        .first::<String>(conn)
-                        .await
-                        .optional()?;
-                    if current.as_deref() != Some(required.as_str()) {
-                        return Ok::<UpsertOutcome, diesel::result::Error>(
-                            UpsertOutcome::StatusMismatch,
-                        );
-                    }
-                }
-
-                // Capacity gate: only enforce when switching to "going"
-                if status == "going" && !already_going {
-                    if let Some(max) = max_attendees {
-                        let current_going = event_attendees::table
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        let result = conn
+            .build_transaction()
+            .serializable()
+            .run(|conn| {
+                let status = status.clone();
+                let require_status = require_status.clone();
+                Box::pin(async move {
+                    // Precondition: verify attendee has required status (inside txn)
+                    if let Some(required) = &require_status {
+                        let current = event_attendees::table
                             .filter(event_attendees::event_id.eq(event_id))
-                            .filter(event_attendees::status.eq("going"))
-                            .count()
-                            .get_result::<i64>(conn)
-                            .await?;
-                        if current_going >= i64::from(max) {
-                            return Ok(UpsertOutcome::Full);
+                            .filter(event_attendees::profile_id.eq(profile_id))
+                            .select(event_attendees::status)
+                            .first::<String>(conn)
+                            .await
+                            .optional()?;
+                        if current.as_deref() != Some(required.as_str()) {
+                            return Ok::<UpsertOutcome, diesel::result::Error>(
+                                UpsertOutcome::StatusMismatch,
+                            );
                         }
                     }
-                }
 
-                // Upsert attendee: delete-then-insert
-                diesel::delete(
-                    event_attendees::table
-                        .filter(event_attendees::event_id.eq(event_id))
-                        .filter(event_attendees::profile_id.eq(profile_id)),
-                )
-                .execute(conn)
-                .await?;
+                    // Capacity gate: only enforce when switching to "going"
+                    if status == "going" && !already_going {
+                        if let Some(max) = max_attendees {
+                            let current_going = event_attendees::table
+                                .filter(event_attendees::event_id.eq(event_id))
+                                .filter(event_attendees::status.eq("going"))
+                                .count()
+                                .get_result::<i64>(conn)
+                                .await?;
+                            if current_going >= i64::from(max) {
+                                return Ok(UpsertOutcome::Full);
+                            }
+                        }
+                    }
 
-                let attendee = EventAttendee {
-                    event_id,
-                    profile_id,
-                    status: status.clone(),
-                };
-                diesel::insert_into(event_attendees::table)
-                    .values(&attendee)
+                    // Upsert attendee: delete-then-insert
+                    diesel::delete(
+                        event_attendees::table
+                            .filter(event_attendees::event_id.eq(event_id))
+                            .filter(event_attendees::profile_id.eq(profile_id)),
+                    )
                     .execute(conn)
                     .await?;
 
-                // Track "joined" interaction atomically with the attendee change
-                if status == "going" {
-                    upsert_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
-                } else {
-                    delete_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
-                }
+                    let attendee = EventAttendee {
+                        event_id,
+                        profile_id,
+                        status: status.clone(),
+                    };
+                    diesel::insert_into(event_attendees::table)
+                        .values(&attendee)
+                        .execute(conn)
+                        .await?;
 
-                Ok(UpsertOutcome::Accepted)
+                    // Track "joined" interaction atomically with the attendee change
+                    if status == "going" {
+                        upsert_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
+                    } else {
+                        delete_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
+                    }
+
+                    Ok(UpsertOutcome::Accepted)
+                })
             })
-        })
-        .await
-        .map_err(Into::into)
+            .await;
+        match result {
+            Ok(val) => return Ok(val),
+            Err(ref e) if attempts < MAX_SERIALIZATION_RETRIES && is_serialization_failure(e) => {
+                tokio::time::sleep(std::time::Duration::from_millis(attempts as u64 * 5)).await;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
 }
 
 pub(in crate::api) async fn insert_event_with_conn(

--- a/backend/src/api/events/write_repo.rs
+++ b/backend/src/api/events/write_repo.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::event_attendees::EventAttendee;
@@ -8,25 +8,53 @@ use crate::db::models::event_interactions::EventInteraction;
 use crate::db::models::events::{Event, EventChangeset, NewEvent};
 use crate::db::schema::{event_attendees, event_interactions, events};
 
+#[derive(PartialEq, Eq)]
+pub(in crate::api) enum UpsertOutcome {
+    Accepted,
+    Full,
+    StatusMismatch,
+}
+
 /// Atomically check capacity, upsert the attendee, and track the interaction
 /// inside a serializable transaction so that two concurrent requests cannot
 /// exceed `max_attendees` and the interaction stays consistent.
-/// Returns `true` when the upsert succeeded, `false` when the event is full.
+///
+/// When `require_status` is `Some`, the attendee's current status is verified
+/// inside the transaction before proceeding, preventing TOCTOU races.
 pub(in crate::api) async fn check_capacity_and_upsert(
     event_id: Uuid,
     profile_id: Uuid,
     status: &str,
     max_attendees: Option<i32>,
     already_going: bool,
-) -> std::result::Result<bool, crate::error::AppError> {
+    require_status: Option<&str>,
+) -> std::result::Result<UpsertOutcome, crate::error::AppError> {
     let status = status.to_string();
+    let require_status = require_status.map(String::from);
     let mut conn = crate::db::conn().await?;
 
     conn.build_transaction()
         .serializable()
         .run(|conn| {
             let status = status.clone();
+            let require_status = require_status.clone();
             Box::pin(async move {
+                // Precondition: verify attendee has required status (inside txn)
+                if let Some(required) = &require_status {
+                    let current = event_attendees::table
+                        .filter(event_attendees::event_id.eq(event_id))
+                        .filter(event_attendees::profile_id.eq(profile_id))
+                        .select(event_attendees::status)
+                        .first::<String>(conn)
+                        .await
+                        .optional()?;
+                    if current.as_deref() != Some(required.as_str()) {
+                        return Ok::<UpsertOutcome, diesel::result::Error>(
+                            UpsertOutcome::StatusMismatch,
+                        );
+                    }
+                }
+
                 // Capacity gate: only enforce when switching to "going"
                 if status == "going" && !already_going {
                     if let Some(max) = max_attendees {
@@ -37,7 +65,7 @@ pub(in crate::api) async fn check_capacity_and_upsert(
                             .get_result::<i64>(conn)
                             .await?;
                         if current_going >= i64::from(max) {
-                            return Ok::<bool, diesel::result::Error>(false);
+                            return Ok(UpsertOutcome::Full);
                         }
                     }
                 }
@@ -68,7 +96,7 @@ pub(in crate::api) async fn check_capacity_and_upsert(
                     delete_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
                 }
 
-                Ok(true)
+                Ok(UpsertOutcome::Accepted)
             })
         })
         .await
@@ -108,52 +136,22 @@ pub(in crate::api) async fn delete_event(
     Ok(())
 }
 
-/// Upsert attendee status inside a transaction. When the new status is "going",
-/// also records a "joined" interaction for the recommendation system.
-pub(in crate::api) async fn upsert_attendee(
+/// Atomically delete an attendee only if their status is "pending".
+/// Returns `true` when the row was deleted, `false` when no pending row existed.
+pub(in crate::api) async fn delete_pending_attendee(
     event_id: Uuid,
     profile_id: Uuid,
-    status: &str,
-) -> std::result::Result<(), crate::error::AppError> {
-    let status = status.to_string();
+) -> std::result::Result<bool, crate::error::AppError> {
     let mut conn = crate::db::conn().await?;
-    conn.transaction(|conn| {
-        let status = status.clone();
-        Box::pin(async move {
-            diesel::delete(
-                event_attendees::table
-                    .filter(event_attendees::event_id.eq(event_id))
-                    .filter(event_attendees::profile_id.eq(profile_id)),
-            )
-            .execute(conn)
-            .await?;
-
-            let attendee = EventAttendee {
-                event_id,
-                profile_id,
-                status: status.clone(),
-            };
-            diesel::insert_into(event_attendees::table)
-                .values(&attendee)
-                .execute(conn)
-                .await?;
-
-            if status == "going" {
-                upsert_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
-            }
-
-            Ok::<(), crate::error::AppError>(())
-        })
-    })
-    .await
-}
-
-pub(in crate::api) async fn delete_event_attendee(
-    event_id: Uuid,
-    profile_id: Uuid,
-) -> std::result::Result<(), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-    delete_event_attendee_with_conn(&mut conn, event_id, profile_id).await
+    let deleted = diesel::delete(
+        event_attendees::table
+            .filter(event_attendees::event_id.eq(event_id))
+            .filter(event_attendees::profile_id.eq(profile_id))
+            .filter(event_attendees::status.eq("pending")),
+    )
+    .execute(&mut conn)
+    .await?;
+    Ok(deleted > 0)
 }
 
 pub(in crate::api) async fn delete_event_attendee_with_conn(
@@ -171,21 +169,6 @@ pub(in crate::api) async fn delete_event_attendee_with_conn(
     Ok(())
 }
 
-pub(in crate::api) async fn find_attendee_status(
-    event_id: Uuid,
-    profile_id: Uuid,
-) -> std::result::Result<Option<String>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-    let status = event_attendees::table
-        .filter(event_attendees::event_id.eq(event_id))
-        .filter(event_attendees::profile_id.eq(profile_id))
-        .select(event_attendees::status)
-        .first::<String>(&mut conn)
-        .await
-        .optional()?;
-    Ok(status)
-}
-
 pub(in crate::api) async fn load_attendee(
     event_id: Uuid,
     profile_id: Uuid,
@@ -198,6 +181,79 @@ pub(in crate::api) async fn load_attendee(
         .await
         .optional()?;
     Ok(attendee)
+}
+
+/// Auto-approve pending attendees for an event, respecting `max_attendees`.
+/// Must be called inside a serializable transaction to prevent capacity races.
+/// Returns the profile IDs that were promoted so the caller can enqueue
+/// Matrix membership syncs.
+pub(in crate::api) async fn auto_approve_pending_with_conn(
+    conn: &mut AsyncPgConnection,
+    event_id: Uuid,
+    max_attendees: Option<i32>,
+) -> std::result::Result<Vec<Uuid>, diesel::result::Error> {
+    let pending_ids: Vec<Uuid> = event_attendees::table
+        .filter(event_attendees::event_id.eq(event_id))
+        .filter(event_attendees::status.eq("pending"))
+        .select(event_attendees::profile_id)
+        .order(event_attendees::profile_id.asc())
+        .load::<Uuid>(conn)
+        .await?;
+
+    if pending_ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let to_approve: Vec<Uuid> = if let Some(max) = max_attendees {
+        let current_going = event_attendees::table
+            .filter(event_attendees::event_id.eq(event_id))
+            .filter(event_attendees::status.eq("going"))
+            .count()
+            .get_result::<i64>(conn)
+            .await?;
+        let remaining = usize::try_from((i64::from(max) - current_going).max(0)).unwrap_or(0);
+        pending_ids.into_iter().take(remaining).collect()
+    } else {
+        pending_ids
+    };
+
+    if to_approve.is_empty() {
+        return Ok(vec![]);
+    }
+
+    diesel::update(
+        event_attendees::table
+            .filter(event_attendees::event_id.eq(event_id))
+            .filter(event_attendees::profile_id.eq_any(&to_approve)),
+    )
+    .set(event_attendees::status.eq("going"))
+    .execute(conn)
+    .await?;
+
+    let now = Utc::now();
+    let interactions: Vec<EventInteraction> = to_approve
+        .iter()
+        .map(|&pid| EventInteraction {
+            profile_id: pid,
+            event_id,
+            kind: "joined".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .collect();
+    diesel::insert_into(event_interactions::table)
+        .values(&interactions)
+        .on_conflict((
+            event_interactions::profile_id,
+            event_interactions::event_id,
+            event_interactions::kind,
+        ))
+        .do_update()
+        .set(event_interactions::updated_at.eq(now))
+        .execute(conn)
+        .await?;
+
+    Ok(to_approve)
 }
 
 async fn upsert_interaction_with_conn(

--- a/backend/src/api/events/write_repo.rs
+++ b/backend/src/api/events/write_repo.rs
@@ -263,7 +263,8 @@ pub(in crate::api) async fn auto_approve_pending_with_conn(
     diesel::update(
         event_attendees::table
             .filter(event_attendees::event_id.eq(event_id))
-            .filter(event_attendees::profile_id.eq_any(&to_approve)),
+            .filter(event_attendees::profile_id.eq_any(&to_approve))
+            .filter(event_attendees::status.eq("pending")),
     )
     .set(event_attendees::status.eq("going"))
     .execute(conn)

--- a/backend/src/api/events/write_repo.rs
+++ b/backend/src/api/events/write_repo.rs
@@ -185,6 +185,8 @@ pub(in crate::api) async fn load_attendee(
 
 /// Auto-approve pending attendees for an event, respecting `max_attendees`.
 /// Must be called inside a serializable transaction to prevent capacity races.
+/// Promotion order is deterministic (by UUID) but not FIFO — the table has no
+/// `created_at` column, so arrival-time ordering is unavailable.
 /// Returns the profile IDs that were promoted so the caller can enqueue
 /// Matrix membership syncs.
 pub(in crate::api) async fn auto_approve_pending_with_conn(

--- a/backend/src/api/events/write_service.rs
+++ b/backend/src/api/events/write_service.rs
@@ -134,12 +134,12 @@ pub(in crate::api) async fn event_update_inner(
     headers: &HeaderMap,
     id: &str,
     payload: &UpdateEventBody,
-) -> std::result::Result<(EventChangeset, Uuid, Profile), Box<axum::response::Response>> {
+) -> std::result::Result<(EventChangeset, Uuid, Profile, Event), Box<axum::response::Response>> {
     let (profile, _user_pid) = require_auth_profile(headers).await?;
     let (event, event_uuid) = load_event(headers, id).await?;
     validate_creator(headers, &event, profile.id)?;
     validate_event_basic_fields(headers, payload)?;
     let dates = parse_event_dates(headers, &event, payload)?;
     let changeset = build_update_changeset(payload, dates);
-    Ok((changeset, event_uuid, profile))
+    Ok((changeset, event_uuid, profile, event))
 }

--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -148,12 +148,12 @@ pub(super) async fn events_recommendations(
     let all_history_tags = repo
         .batch_load_event_tag_ids(&all_history_ids, &mut conn)
         .await?;
-    // Deduplicate: if an event is both saved (1.0) and joined (0.5), keep max weight
+    // Deduplicate: if an event is both joined (1.0) and saved (0.5), keep max weight
     let mut event_weights: HashMap<Uuid, f64> = HashMap::new();
-    for &id in &saved_event_ids {
+    for &id in &joined_event_ids {
         event_weights.insert(id, 1.0);
     }
-    for &id in &joined_event_ids {
+    for &id in &saved_event_ids {
         event_weights.entry(id).or_insert(0.5);
     }
     let history_affinity = build_affinity_map(

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -24,7 +24,7 @@ impl IntoResponse for AppError {
         if let Self::Validation(msg) = &self {
             return (
                 axum::http::StatusCode::UNPROCESSABLE_ENTITY,
-                axum::Json(serde_json::json!({ "message": msg })),
+                axum::Json(serde_json::json!({ "error": msg, "code": "VALIDATION_ERROR" })),
             )
                 .into_response();
         }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -7,6 +7,8 @@ pub enum AppError {
     #[error("{0}")]
     Message(String),
     #[error("{0}")]
+    Validation(String),
+    #[error("{0}")]
     Any(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
@@ -19,6 +21,13 @@ impl AppError {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
+        if let Self::Validation(msg) = &self {
+            return (
+                axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+                axum::Json(serde_json::json!({ "message": msg })),
+            )
+                .into_response();
+        }
         tracing::error!(error = %self, "internal application error");
         (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
**Backend review fixes**

Addresses remaining Greptile findings from PRs #57-#71 — capacity check on approve, pending status bypass, tag ID validation in transactions, auto-approve stranded attendees, recommendation weight correction, redundant index cleanup.

- [ ] verify approve returns 422 when event is full
- [ ] verify pending attendees get auto-approved when requires_approval toggled off
- [ ] verify tag ID validation rejects unknown IDs in create/update