### PR TITLE
fix: mobile reliability issues from code review

### DIFF
--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/mapper/EventMapper.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/mapper/EventMapper.kt
@@ -5,40 +5,9 @@ import com.poziomki.app.network.EventAttendee
 import com.poziomki.app.network.EventAttendeePreview
 import com.poziomki.app.network.EventCreator
 import com.poziomki.app.network.Tag
-import kotlinx.datetime.Clock
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 private val json = Json { ignoreUnknownKeys = true }
-
-fun Event.toDbParams(): List<Any?> =
-    listOf(
-        id,
-        title,
-        description,
-        coverImage,
-        location,
-        startsAt,
-        endsAt,
-        creatorId,
-        creator?.name,
-        creator?.profilePicture,
-        attendeesCount.toLong(),
-        maxAttendees?.toLong(),
-        if (isAttending) 1L else 0L,
-        if (isSaved) 1L else 0L,
-        json.encodeToString(attendeesPreview),
-        json.encodeToString(tags),
-        createdAt,
-        conversationId,
-        score,
-        Clock.System.now().toEpochMilliseconds(),
-        0L,
-        latitude,
-        longitude,
-        if (requiresApproval) 1L else 0L,
-        if (isPending) 1L else 0L,
-    )
 
 fun com.poziomki.app.db.Event.toApiModel(): Event =
     Event(
@@ -88,17 +57,6 @@ private fun parseTags(jsonStr: String?): List<Tag> =
         runCatching { json.decodeFromString<List<Tag>>(jsonStr) }
             .getOrDefault(emptyList())
     }
-
-fun EventAttendee.toDbParams(eventId: String): List<Any?> =
-    listOf(
-        eventId,
-        profileId,
-        userId,
-        name,
-        profilePicture,
-        status,
-        if (isCreator) 1L else 0L,
-    )
 
 fun com.poziomki.app.db.Event_attendee.toApiModel(): EventAttendee =
     EventAttendee(

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventMutationRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventMutationRepository.kt
@@ -30,6 +30,7 @@ internal class EventMutationRepository(
 ) {
     companion object {
         private const val CREATE_EVENT_ONLINE_TIMEOUT_MS = 1500L
+        private const val MUTATION_TIMEOUT_MS = 10_000L
         private const val NETWORK_STATUS_CODE = 0
         private const val REQUEST_TIMEOUT_STATUS_CODE = 408
         private const val TOO_MANY_REQUESTS_STATUS_CODE = 429
@@ -86,7 +87,7 @@ internal class EventMutationRepository(
             }
         }
 
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     suspend fun updateEvent(
         id: String,
         request: UpdateEventRequest,
@@ -139,7 +140,17 @@ internal class EventMutationRepository(
                 optimisticEvent?.let { ApiResult.Success(it) }
                     ?: ApiResult.Error("Offline and no cached data", "OFFLINE", 0)
             } else {
-                updateEventOnline(id, request, optimisticEvent)
+                withTimeoutOrNull(MUTATION_TIMEOUT_MS) {
+                    updateEventOnline(id, request, optimisticEvent)
+                } ?: run {
+                    pendingOps.enqueue(
+                        type = "update_event",
+                        entityId = id,
+                        payload = json.encodeToString(request),
+                    )
+                    optimisticEvent?.let { ApiResult.Success(it) }
+                        ?: ApiResult.Error("Timeout", "TIMEOUT", 0)
+                }
             }
         }
 
@@ -169,7 +180,8 @@ internal class EventMutationRepository(
             }
 
             if (connectivityMonitor.isOnline.value) {
-                when (val result = api.attendEvent(id)) {
+                val result = withTimeoutOrNull(MUTATION_TIMEOUT_MS) { api.attendEvent(id) }
+                when (result) {
                     is ApiResult.Success -> {
                         upsertEvent(result.data, Clock.System.now().toEpochMilliseconds())
                         eventRoomManager.reconcileMembershipAfterAttend(result.data.conversationId)
@@ -188,6 +200,11 @@ internal class EventMutationRepository(
                             )
                             result
                         }
+                    }
+
+                    null -> {
+                        pendingOps.enqueue("attend_event", id, "{}")
+                        ApiResult.Success(Unit)
                     }
                 }
             } else {
@@ -210,7 +227,8 @@ internal class EventMutationRepository(
             }
 
             if (connectivityMonitor.isOnline.value) {
-                when (val result = api.leaveEvent(id)) {
+                val result = withTimeoutOrNull(MUTATION_TIMEOUT_MS) { api.leaveEvent(id) }
+                when (result) {
                     is ApiResult.Success -> {
                         upsertEvent(result.data, Clock.System.now().toEpochMilliseconds())
                         eventRoomManager.reconcileMembershipAfterLeave()
@@ -230,6 +248,11 @@ internal class EventMutationRepository(
                             result
                         }
                     }
+
+                    null -> {
+                        pendingOps.enqueue("leave_event", id, "{}")
+                        ApiResult.Success(Unit)
+                    }
                 }
             } else {
                 pendingOps.enqueue("leave_event", id, "{}")
@@ -242,7 +265,8 @@ internal class EventMutationRepository(
             val current = db.eventQueries.selectById(id).executeAsOneOrNull()
             db.eventQueries.deleteById(id)
             if (connectivityMonitor.isOnline.value) {
-                when (val result = api.deleteEvent(id)) {
+                val result = withTimeoutOrNull(MUTATION_TIMEOUT_MS) { api.deleteEvent(id) }
+                when (result) {
                     is ApiResult.Success -> {
                         ApiResult.Success(Unit)
                     }
@@ -255,6 +279,11 @@ internal class EventMutationRepository(
                             current?.let(::restoreEvent)
                             result
                         }
+                    }
+
+                    null -> {
+                        pendingOps.enqueue("delete_event", id, "{}")
+                        ApiResult.Success(Unit)
                     }
                 }
             } else {
@@ -280,7 +309,10 @@ internal class EventMutationRepository(
             db.eventQueries.updateSaved(is_saved = if (saved) 1L else 0L, id = id)
 
             if (connectivityMonitor.isOnline.value) {
-                val result = if (saved) api.saveEvent(id) else api.unsaveEvent(id)
+                val result =
+                    withTimeoutOrNull(MUTATION_TIMEOUT_MS) {
+                        if (saved) api.saveEvent(id) else api.unsaveEvent(id)
+                    }
                 when (result) {
                     is ApiResult.Success -> {
                         upsertEvent(result.data, Clock.System.now().toEpochMilliseconds())
@@ -299,6 +331,11 @@ internal class EventMutationRepository(
                             db.eventQueries.updateSaved(is_saved = previousSaved, id = id)
                             result
                         }
+                    }
+
+                    null -> {
+                        pendingOps.enqueue(if (saved) "save_event" else "unsave_event", id, "{}")
+                        ApiResult.Success(Unit)
                     }
                 }
             } else {

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/TagRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/TagRepository.kt
@@ -21,7 +21,9 @@ class TagRepository(
     private val api: ApiService,
 ) {
     companion object {
-        private const val TAGS_CACHE_KEY = "tags_catalog"
+        private const val CACHE_PREFIX = "tags_catalog"
+
+        private fun cacheKey(scope: String?): String = if (scope != null) "${CACHE_PREFIX}_$scope" else CACHE_PREFIX
     }
 
     fun observeTags(scope: String? = null): Flow<List<Tag>> {
@@ -45,9 +47,10 @@ class TagRepository(
             if (scope == "interest") {
                 ensureInterestSeedIfEmpty()
             }
+            val key = cacheKey(scope)
             val lastRefreshMs =
                 db.cacheStateQueries
-                    .selectByKey(TAGS_CACHE_KEY)
+                    .selectByKey(key)
                     .executeAsOneOrNull()
                     ?.cached_at ?: 0L
             if (!forceRefresh && !CachePolicy.isCatalogStale(lastRefreshMs)) return@withContext true
@@ -65,7 +68,7 @@ class TagRepository(
                                 parent_id = tag.parentId,
                             )
                         }
-                        db.cacheStateQueries.upsert(TAGS_CACHE_KEY, now)
+                        db.cacheStateQueries.upsert(key, now)
                     }
                     true
                 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/TagRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/TagRepository.kt
@@ -53,6 +53,7 @@ class TagRepository(
             if (!forceRefresh && !CachePolicy.isCatalogStale(lastRefreshMs)) return@withContext true
             when (val result = api.getTags(scope)) {
                 is ApiResult.Success -> {
+                    val now = Clock.System.now().toEpochMilliseconds()
                     db.transaction {
                         result.data.forEach { tag ->
                             db.tagQueries.upsert(
@@ -64,9 +65,8 @@ class TagRepository(
                                 parent_id = tag.parentId,
                             )
                         }
+                        db.cacheStateQueries.upsert(TAGS_CACHE_KEY, now)
                     }
-                    val now = Clock.System.now().toEpochMilliseconds()
-                    db.cacheStateQueries.upsert(TAGS_CACHE_KEY, now)
                     true
                 }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/TagRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/TagRepository.kt
@@ -20,7 +20,9 @@ class TagRepository(
     private val db: PoziomkiDatabase,
     private val api: ApiService,
 ) {
-    private var lastRefreshMs: Long = 0L
+    companion object {
+        private const val TAGS_CACHE_KEY = "tags_catalog"
+    }
 
     fun observeTags(scope: String? = null): Flow<List<Tag>> {
         val query =
@@ -43,6 +45,11 @@ class TagRepository(
             if (scope == "interest") {
                 ensureInterestSeedIfEmpty()
             }
+            val lastRefreshMs =
+                db.cacheStateQueries
+                    .selectByKey(TAGS_CACHE_KEY)
+                    .executeAsOneOrNull()
+                    ?.cached_at ?: 0L
             if (!forceRefresh && !CachePolicy.isCatalogStale(lastRefreshMs)) return@withContext true
             when (val result = api.getTags(scope)) {
                 is ApiResult.Success -> {
@@ -58,7 +65,8 @@ class TagRepository(
                             )
                         }
                     }
-                    lastRefreshMs = Clock.System.now().toEpochMilliseconds()
+                    val now = Clock.System.now().toEpochMilliseconds()
+                    db.cacheStateQueries.upsert(TAGS_CACHE_KEY, now)
                     true
                 }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
@@ -133,6 +133,7 @@ class SyncEngine(
             val delayIndex = minOf(op.retry_count.toInt(), BACKOFF_DELAYS.size - 1)
             delay(BACKOFF_DELAYS[delayIndex])
         } else if (!success) {
+            println("[SyncEngine] permanently retiring ${op.type} (entity=${op.entity_id}) after $MAX_RETRIES retries")
             pendingOps.complete(op.id)
         }
     }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
@@ -133,7 +133,10 @@ class SyncEngine(
             val delayIndex = minOf(op.retry_count.toInt(), BACKOFF_DELAYS.size - 1)
             delay(BACKOFF_DELAYS[delayIndex])
         } else if (!success) {
-            println("[SyncEngine] permanently retiring ${op.type} (entity=${op.entity_id}) after $MAX_RETRIES retries")
+            println(
+                "ERROR/SyncEngine: permanently retiring ${op.type}" +
+                    " (entity=${op.entity_id}) after $MAX_RETRIES retries",
+            )
             pendingOps.complete(op.id)
         }
     }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
@@ -133,7 +133,7 @@ class SyncEngine(
             val delayIndex = minOf(op.retry_count.toInt(), BACKOFF_DELAYS.size - 1)
             delay(BACKOFF_DELAYS[delayIndex])
         } else if (!success) {
-            pendingOps.fail(op.id)
+            pendingOps.complete(op.id)
         }
     }
 


### PR DESCRIPTION
**Mobile review fixes**

Addresses remaining Greptile findings from PRs #57-#71 — infinite retry loop, missing mutation timeouts, non-persistent tag cache, dead code cleanup.

- [ ] verify exhausted sync operations get cleaned up after 5 retries
- [ ] verify mutation calls time out after 10s and fall back to offline queue
- [ ] verify tag cache survives app restart