### PR TITLE
Remove debug println from release builds, secure avatar download

### DIFF
--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
@@ -7,7 +7,9 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
-import java.net.URL
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 class NotificationHelper(
@@ -80,8 +82,14 @@ class NotificationHelper(
 
         if (avatarUrl != null) {
             runCatching {
-                val bitmap = URL(avatarUrl).openStream().use { BitmapFactory.decodeStream(it) }
-                if (bitmap != null) builder.setLargeIcon(bitmap)
+                val request = Request.Builder().url(avatarUrl).build()
+                avatarClient.newCall(request).execute().use { response ->
+                    if (response.isSuccessful) {
+                        val bytes = response.body.byteStream().readNBytes(MAX_AVATAR_BYTES)
+                        val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                        if (bitmap != null) builder.setLargeIcon(bitmap)
+                    }
+                }
             }
         }
 
@@ -124,8 +132,16 @@ class NotificationHelper(
 
     companion object {
         private const val GROUP_SUMMARY_BASE = 500
+        private const val MAX_AVATAR_BYTES = 512 * 1024
         const val CHANNEL_MESSAGES = "poz_messages"
         const val CHANNEL_SERVICE = "poz_push_service"
         const val SERVICE_NOTIFICATION_ID = 900
+
+        private val avatarClient =
+            OkHttpClient
+                .Builder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(5, TimeUnit.SECONDS)
+                .build()
     }
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt
@@ -52,7 +52,7 @@ class SqlDelightRoomTimelineCacheStore(
                     .decodeFromString(ListSerializer(CachedTimelineItem.serializer()), row.payload_json)
                     .map(CachedTimelineItem::toDomain)
             }.getOrElse {
-                println("[TimelineCache] WARN: timeline cache corrupted for $roomId, clearing")
+                // cache corrupted, clearing
                 runCatching { db.roomTimelineCacheQueries.deleteByRoomId(roomId) }
                 emptyList()
             }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsConnection.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsConnection.kt
@@ -76,9 +76,9 @@ class WsConnection(
                     } catch (_: CancellationException) {
                         break
                     } catch (
-                        @Suppress("TooGenericExceptionCaught") e: Exception,
+                        @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
                     ) {
-                        println("[WsConnection] error: ${e.message}")
+                        // connection error, will reconnect
                     }
                     _isConnected.value = false
                     sendChannel = null
@@ -150,7 +150,7 @@ class WsConnection(
                         }
                         delay(10_000L)
                         if (!pongReceived.value) {
-                            println("[WsConnection] pong timeout, reconnecting")
+                            // pong timeout, reconnecting
                             close()
                             break
                         }
@@ -175,13 +175,10 @@ class WsConnection(
                         }
 
                         is Frame.Close -> {
-                            println("[WsConnection] received close frame")
                             break
                         }
 
-                        is Frame.Binary -> {
-                            println("[WsConnection] unexpected binary frame, ignoring")
-                        }
+                        is Frame.Binary -> {}
 
                         else -> {}
                     }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/mapper/EventMapper.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/mapper/EventMapper.kt
@@ -46,7 +46,7 @@ private fun parseAttendeesPreview(jsonStr: String?): List<EventAttendeePreview> 
         emptyList()
     } else {
         runCatching { json.decodeFromString<List<EventAttendeePreview>>(jsonStr) }
-            .onFailure { println("ERROR/EventMapper: failed to parse attendees_preview — ${it.message}") }
+            .onFailure { /* parse error, return empty */ }
             .getOrDefault(emptyList())
     }
 
@@ -55,7 +55,7 @@ private fun parseTags(jsonStr: String?): List<Tag> =
         emptyList()
     } else {
         runCatching { json.decodeFromString<List<Tag>>(jsonStr) }
-            .onFailure { println("ERROR/EventMapper: failed to parse tags — ${it.message}") }
+            .onFailure { /* parse error, return empty */ }
             .getOrDefault(emptyList())
     }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
@@ -137,10 +137,7 @@ class SyncEngine(
             val delayIndex = minOf(op.retry_count.toInt(), BACKOFF_DELAYS.size - 1)
             delay(BACKOFF_DELAYS[delayIndex])
         } else if (!success) {
-            println(
-                "ERROR/SyncEngine: permanently retiring ${op.type}" +
-                    " (entity=${op.entity_id}) after $MAX_RETRIES retries",
-            )
+            // permanently retiring op after max retries
             revertOptimisticState(op)
             _permanentFailures.tryEmit(op)
             pendingOps.complete(op.id)


### PR DESCRIPTION
**Security hardening for beta launch**

Strip 8 println() calls that leaked debug info to logcat in release APKs. Replace raw java.net.URL avatar download in notifications with OkHttp (5s timeout, 512KB cap).

- [ ] verify notifications still show avatars
- [ ] confirm no logcat output from WsConnection/SyncEngine/EventMapper in release build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove debug `println` calls and secure avatar downloads in push notifications
> - Replaces `URL.openStream`-based avatar loading in [`NotificationHelper`](https://github.com/poziomki-app/poziomki/pull/147/files#diff-780aa9be733464b5a29a61b9c31a2e5f966f1f37392a195e43be193c3fe781c0) with OkHttp, adding 5-second timeouts and a 512 KiB download cap; the icon is only set on a successful response with a non-null bitmap.
> - Removes `println` debug logging across [`WsConnection`](https://github.com/poziomki-app/poziomki/pull/147/files#diff-95867c84c72495320cd3c57542186a7c8ae1970d9a35f4da92e57356a5ad637c), [`SyncEngine`](https://github.com/poziomki-app/poziomki/pull/147/files#diff-e6e4cc4cb173ab48c430ada0073bebdffe92a571a84b27b93241dc925e932fd6), [`EventMapper`](https://github.com/poziomki-app/poziomki/pull/147/files#diff-9706ece9cc84eb37387be3e7217183c522966246d8e9e8e4532121bc486a11d3), and [`SqlDelightRoomTimelineCacheStore`](https://github.com/poziomki-app/poziomki/pull/147/files#diff-0828598ef38a3e52fb5f7e4605d8d40d6b368da52a35229e584e6e7b69e4fe66); all original control flow and error handling is preserved.
> - Behavioral Change: avatar fetch now fails silently (no large icon set) if the server returns a non-2xx response or the response exceeds 512 KiB.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 955ff38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->