### PR TITLE
Validate ntfy server URL against allowlist

### DIFF
--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/PushManager.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/PushManager.kt
@@ -45,6 +45,7 @@ class PushManager(
             }
 
         val ntfyServer = config.ntfyServer ?: return
+        if (!isAllowedNtfyServer(ntfyServer)) return
         val ntfyTopic = "poz_$deviceId"
 
         // Register push subscription with backend
@@ -61,5 +62,15 @@ class PushManager(
     private fun stopPushService() {
         val intent = Intent(appContext, NtfyPushService::class.java)
         appContext.stopService(intent)
+    }
+
+    companion object {
+        private val ALLOWED_NTFY_HOSTS = setOf("ntfy.poziomki.app")
+
+        private fun isAllowedNtfyServer(url: String): Boolean =
+            url.startsWith("https://") &&
+                ALLOWED_NTFY_HOSTS.any { host ->
+                    url == "https://$host" || url.startsWith("https://$host/")
+                }
     }
 }


### PR DESCRIPTION
**Security hardening for beta launch**

Only connect to ntfy push servers matching a trusted host allowlist (ntfy.poziomki.app) over HTTPS. Prevents a compromised backend config response from redirecting push notification traffic to an attacker-controlled server.

- [ ] verify push notifications still work

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate ntfy server URL against an allowlist in `PushManager`
> Adds a server-side allowlist check before registering push subscriptions. The ntfy server URL must use HTTPS and match a host in `ALLOWED_NTFY_HOSTS` (currently `ntfy.poziomki.app`); if not, `PushManager` returns early without registering. The check is implemented in a new `Companion` object on [`PushManager.kt`](https://github.com/poziomki-app/poziomki/pull/148/files#diff-b2828217385a3d9f1015573e28be987242d2146ee9524d30f62697886fa5e5c5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe0aacc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->