### PR TITLE
Strip message content from ntfy push notifications

### DIFF
--- a/backend/src/api/chat/push.rs
+++ b/backend/src/api/chat/push.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
-use crate::db::schema::{profiles, push_subscriptions, users};
+use crate::db::schema::push_subscriptions;
 
 fn push_client() -> &'static reqwest::Client {
     use std::sync::OnceLock;
@@ -19,16 +19,11 @@ fn push_client() -> &'static reqwest::Client {
 }
 
 /// Send push notifications to conversation members for a new message.
-pub async fn notify_push(user_ids: Vec<i32>, conversation_id: Uuid, sender_id: i32, body: &str) {
-    // Resolve sender name + avatar
-    let Some((sender_name, sender_avatar)) = resolve_sender_profile(sender_id).await else {
-        tracing::warn!(
-            sender_id,
-            "push: could not resolve sender profile, skipping"
-        );
-        return;
-    };
-
+///
+/// Only the conversation ID is sent through ntfy — no message content, sender
+/// names, or avatar URLs. The client uses this as a wake-up signal and fetches
+/// actual message data through the authenticated WebSocket/API.
+pub async fn notify_push(user_ids: Vec<i32>, conversation_id: Uuid, _sender_id: i32, _body: &str) {
     // Resolve ntfy topics for target users
     let topics = match resolve_ntfy_topics(&user_ids).await {
         Ok(t) => t,
@@ -41,23 +36,8 @@ pub async fn notify_push(user_ids: Vec<i32>, conversation_id: Uuid, sender_id: i
     let client = push_client();
     let ntfy_token = crate::api::common::env_non_empty("NTFY_TOKEN");
 
-    // Truncate body for push
-    let push_body = if body.chars().count() > 200 {
-        let truncated: String = body.chars().take(197).collect();
-        format!("{truncated}...")
-    } else {
-        body.to_string()
-    };
-
-    let avatar_url = sender_avatar
-        .as_ref()
-        .and_then(|filename| crate::api::imgproxy_signing::signed_avatar_url(filename));
-
     let push_data = serde_json::json!({
         "room_id": conversation_id.to_string(),
-        "sender": sender_name,
-        "body": push_body,
-        "avatar": avatar_url,
     });
 
     for (ntfy_topic, ntfy_server) in &topics {
@@ -65,7 +45,7 @@ pub async fn notify_push(user_ids: Vec<i32>, conversation_id: Uuid, sender_id: i
         let url = format!("{ntfy_server}/{ntfy_topic}");
         let mut req = client
             .post(&url)
-            .header("Title", &sender_name)
+            .header("Title", "new_message")
             .json(&push_data);
         if let Some(ref token) = ntfy_token {
             req = req.header("Authorization", format!("Bearer {token}"));
@@ -86,17 +66,6 @@ pub async fn notify_push(user_ids: Vec<i32>, conversation_id: Uuid, sender_id: i
             }
         }
     }
-}
-
-async fn resolve_sender_profile(sender_id: i32) -> Option<(String, Option<String>)> {
-    let mut conn = crate::db::conn().await.ok()?;
-    profiles::table
-        .inner_join(users::table.on(users::id.eq(profiles::user_id)))
-        .filter(users::id.eq(sender_id))
-        .select((profiles::name, profiles::profile_picture))
-        .first::<(String, Option<String>)>(&mut conn)
-        .await
-        .ok()
 }
 
 async fn resolve_ntfy_topics(

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NtfyPushService.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NtfyPushService.kt
@@ -115,12 +115,7 @@ class NtfyPushService :
                 json.decodeFromString<JsonObject>(message)
             }.getOrNull()
 
-        val sender =
-            parsed["title"]?.jsonPrimitive?.content
-                ?: pushData?.get("sender")?.jsonPrimitive?.content
         val roomId = pushData?.get("room_id")?.jsonPrimitive?.content
-        val body = pushData?.get("body")?.jsonPrimitive?.content
-        val avatar = pushData?.get("avatar")?.jsonPrimitive?.content
         val timestampMs =
             parsed["time"]
                 ?.jsonPrimitive
@@ -132,10 +127,10 @@ class NtfyPushService :
         if (roomId != null && roomId == ActiveChat.roomId) return
 
         notificationHelper.showMessageNotification(
-            sender = sender,
+            sender = null,
             roomId = roomId,
-            body = body,
-            avatarUrl = avatar,
+            body = null,
+            avatarUrl = null,
             timestampMs = timestampMs,
         )
     }


### PR DESCRIPTION
**Security hardening for beta launch**

Ntfy push now sends only the conversation ID as a wake-up signal — no message body, sender name, or avatar URL. Client shows a generic "New message" notification; actual content comes through the authenticated WebSocket.

Previously, anyone who knew a device's ntfy topic could subscribe and read message previews. Now the push channel leaks nothing except "a message arrived in room X".

- [ ] verify push notifications still trigger on new messages
- [ ] verify tapping notification still opens correct chat

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip message content from ntfy push notifications
> - The ntfy push payload now contains only `room_id`, with the notification title hardcoded to `"new_message"`. Sender name, message body, and avatar URL are no longer sent.
> - On the backend ([push.rs](https://github.com/poziomki-app/poziomki/pull/149/files#diff-5a16ddcb5511893a2ee2de2ae966387c71b125fb504d5b0ca15cc7b1d3b59de6)), the `notify_push` function drops the `sender_id` and `body` parameters, removes the database query for sender profile, and removes body truncation logic. The `resolve_sender_profile` function is deleted entirely.
> - On Android ([NtfyPushService.kt](https://github.com/poziomki-app/poziomki/pull/149/files#diff-6b465d8f458ee8fa31d748cf0540eee4477742aaf83b3f7252bef065f127c59f)), the notification handler now passes `null` for sender, body, and avatar when calling `showMessageNotification`.
> - Behavioral Change: Push notifications no longer display message previews or sender details.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2f8ab1f. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->