### PR TITLE
Switch backend runtime to distroless

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,21 +15,40 @@ COPY --from=planner /app/backend/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . /app/
-RUN cargo build --release --bin poziomki_backend-cli --bin worker
+RUN cargo build --release --bin poziomki_backend-cli --bin worker \
+    && strip /app/backend/target/release/poziomki_backend-cli /app/backend/target/release/worker
 
-FROM debian:bookworm-slim AS runtime
-WORKDIR /app
-
+FROM debian:bookworm-slim AS runtime-deps
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends ca-certificates curl libpq5 libwebp7 \
+    && apt-get install -y --no-install-recommends libpq5 libwebp7 ca-certificates \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
-    && groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser \
-    && chown appuser:appuser /app
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
+RUN set -eux; \
+    mkdir -p /staging/usr/lib/x86_64-linux-gnu /staging/etc/ssl/certs; \
+    cp -aL /etc/ssl/certs/ca-certificates.crt /staging/etc/ssl/certs/; \
+    for lib in /usr/lib/x86_64-linux-gnu/libpq.so* \
+               /usr/lib/x86_64-linux-gnu/libwebp.so* \
+               /usr/lib/x86_64-linux-gnu/libsharpyuv.so*; do \
+        [ -e "$lib" ] && cp -aL "$lib" /staging/usr/lib/x86_64-linux-gnu/ || true; \
+    done; \
+    for root in /staging/usr/lib/x86_64-linux-gnu/libpq.so* \
+                /staging/usr/lib/x86_64-linux-gnu/libwebp.so*; do \
+        [ -e "$root" ] || continue; \
+        ldd "$root" | awk '/=>/ && $3 ~ /^\// { print $3 }'; \
+    done | sort -u | while read -r dep; do \
+        [ -f "$dep" ] && cp -aL "$dep" /staging/usr/lib/x86_64-linux-gnu/ || true; \
+    done
+
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+WORKDIR /app
+
+COPY --from=runtime-deps /staging/ /
+COPY --from=ghcr.io/tarampampam/curl:8.6.0 /bin/curl /usr/local/bin/curl
 COPY --from=builder /app/backend/target/release/poziomki_backend-cli /usr/local/bin/poziomki_backend-cli
 COPY --from=builder /app/backend/target/release/worker /usr/local/bin/worker
-USER appuser
+
+USER nonroot
 EXPOSE 5150
-CMD ["poziomki_backend-cli"]
+ENTRYPOINT ["/usr/local/bin/poziomki_backend-cli"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,8 +21,10 @@ FROM debian:bookworm-slim AS runtime
 WORKDIR /app
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends ca-certificates curl libpq5 libwebp7 \
-    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
     && groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser \
     && chown appuser:appuser /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.93-bookworm AS chef
+# rust:1.93-bookworm
+FROM rust@sha256:7c4ae649a84014c467d79319bbf17ce2632ae8b8be123ac2fb2ea5be46823f31 AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app/backend
 
@@ -15,12 +16,11 @@ COPY --from=planner /app/backend/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . /app/
-RUN cargo build --release --bin poziomki_backend-cli --bin worker \
-    && strip /app/backend/target/release/poziomki_backend-cli /app/backend/target/release/worker
+RUN cargo build --release --bin poziomki_backend-cli --bin worker
 
-FROM debian:bookworm-slim AS runtime-deps
+# debian:bookworm-slim
+FROM debian@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS runtime-deps
 RUN apt-get update \
-    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends libpq5 libwebp7 ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
@@ -28,24 +28,24 @@ RUN apt-get update \
 RUN set -eux; \
     mkdir -p /staging/usr/lib/x86_64-linux-gnu /staging/etc/ssl/certs; \
     cp -aL /etc/ssl/certs/ca-certificates.crt /staging/etc/ssl/certs/; \
-    for lib in /usr/lib/x86_64-linux-gnu/libpq.so* \
-               /usr/lib/x86_64-linux-gnu/libwebp.so* \
-               /usr/lib/x86_64-linux-gnu/libsharpyuv.so*; do \
-        [ -e "$lib" ] && cp -aL "$lib" /staging/usr/lib/x86_64-linux-gnu/ || true; \
+    for soname in libpq.so.5 libwebp.so.7 libsharpyuv.so.0; do \
+        cp -aL /usr/lib/x86_64-linux-gnu/${soname}* /staging/usr/lib/x86_64-linux-gnu/; \
     done; \
-    for root in /staging/usr/lib/x86_64-linux-gnu/libpq.so* \
-                /staging/usr/lib/x86_64-linux-gnu/libwebp.so*; do \
-        [ -e "$root" ] || continue; \
+    for root in /staging/usr/lib/x86_64-linux-gnu/libpq.so.5 \
+                /staging/usr/lib/x86_64-linux-gnu/libwebp.so.7; do \
         ldd "$root" | awk '/=>/ && $3 ~ /^\// { print $3 }'; \
     done | sort -u | while read -r dep; do \
-        [ -f "$dep" ] && cp -aL "$dep" /staging/usr/lib/x86_64-linux-gnu/ || true; \
+        dest="/staging${dep}"; \
+        [ -e "$dest" ] && continue; \
+        mkdir -p "$(dirname "$dest")"; \
+        cp -aL "$dep" "$dest"; \
     done
 
-FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+# gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/cc-debian12@sha256:e2d29aec8061843706b7e484c444f78fafb05bfe47745505252b1769a05d14f1 AS runtime
 WORKDIR /app
 
 COPY --from=runtime-deps /staging/ /
-COPY --from=ghcr.io/tarampampam/curl:8.6.0 /bin/curl /usr/local/bin/curl
 COPY --from=builder /app/backend/target/release/poziomki_backend-cli /usr/local/bin/poziomki_backend-cli
 COPY --from=builder /app/backend/target/release/worker /usr/local/bin/worker
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
 RUN set -eux; \
     mkdir -p /staging/usr/lib/x86_64-linux-gnu /staging/etc/ssl/certs; \
     cp -aL /etc/ssl/certs/ca-certificates.crt /staging/etc/ssl/certs/; \
-    for soname in libpq.so.5 libwebp.so.7 libsharpyuv.so.0; do \
+    for soname in libpq.so.5 libwebp.so.7; do \
         cp -aL /usr/lib/x86_64-linux-gnu/${soname}* /staging/usr/lib/x86_64-linux-gnu/; \
     done; \
     for root in /staging/usr/lib/x86_64-linux-gnu/libpq.so.5 \

--- a/backend/src/bin/main.rs
+++ b/backend/src/bin/main.rs
@@ -1,5 +1,8 @@
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if std::env::args().nth(1).as_deref() == Some("healthcheck") {
+        poziomki_backend::healthcheck::api_healthcheck().await;
+    }
     poziomki_backend::app::run_api_server()
         .await
         .map_err(Into::into)

--- a/backend/src/bin/worker.rs
+++ b/backend/src/bin/worker.rs
@@ -1,5 +1,8 @@
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if std::env::args().nth(1).as_deref() == Some("healthcheck") {
+        poziomki_backend::healthcheck::worker_healthcheck();
+    }
     poziomki_backend::app::run_outbox_worker_process()
         .await
         .map_err(Into::into)

--- a/backend/src/healthcheck.rs
+++ b/backend/src/healthcheck.rs
@@ -1,0 +1,34 @@
+use std::process::exit;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::jobs::outbox::OUTBOX_WORKER_HEARTBEAT_PATH;
+
+const HTTP_TIMEOUT: Duration = Duration::from_secs(3);
+const WORKER_HEARTBEAT_STALE_AFTER_SECS: u64 = 30;
+const DEFAULT_API_PORT: &str = "5150";
+
+pub async fn api_healthcheck() -> ! {
+    let port = std::env::var("PORT").unwrap_or_else(|_| DEFAULT_API_PORT.to_string());
+    let url = format!("http://127.0.0.1:{port}/health");
+
+    let Ok(client) = reqwest::Client::builder().timeout(HTTP_TIMEOUT).build() else {
+        exit(1);
+    };
+
+    let ok = matches!(client.get(url).send().await, Ok(resp) if resp.status().is_success());
+    exit(i32::from(!ok));
+}
+
+pub fn worker_healthcheck() -> ! {
+    let Ok(contents) = std::fs::read_to_string(OUTBOX_WORKER_HEARTBEAT_PATH) else {
+        exit(1);
+    };
+    let Ok(ts_secs) = contents.trim().parse::<u64>() else {
+        exit(1);
+    };
+    let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+        exit(1);
+    };
+    let age_secs = now.as_secs().saturating_sub(ts_secs);
+    exit(i32::from(age_secs >= WORKER_HEARTBEAT_STALE_AFTER_SECS))
+}

--- a/backend/src/jobs/outbox/mod.rs
+++ b/backend/src/jobs/outbox/mod.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 static OUTBOX_WORKER_STARTED: AtomicBool = AtomicBool::new(false);
 pub(super) const OUTBOX_LOCK_TIMEOUT_SECS: i64 = 300;
 const OUTBOX_DEFAULT_MAX_ATTEMPTS: i32 = 10;
-pub(super) const OUTBOX_WORKER_HEARTBEAT_PATH: &str = "/tmp/poziomki-outbox-worker-heartbeat";
+pub const OUTBOX_WORKER_HEARTBEAT_PATH: &str = "/tmp/poziomki-outbox-worker-heartbeat";
 
 #[derive(Debug, Clone)]
 pub(super) struct OutboxJob {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,6 +3,7 @@ pub mod app;
 mod app_support;
 pub mod db;
 pub mod error;
+pub mod healthcheck;
 pub mod jobs;
 pub mod search;
 pub mod security;

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -136,7 +136,7 @@ services:
       IMGPROXY_BASE_URL: ${IMGPROXY_BASE_URL:-}
       IMGPROXY_URL_EXPIRY_SECS: ${IMGPROXY_URL_EXPIRY_SECS:-120}
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:5150/health"]
+      test: ["CMD", "/usr/local/bin/curl", "-fsS", "http://localhost:5150/health"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -253,7 +253,7 @@ services:
       GARAGE_S3_REGION: ${GARAGE_S3_REGION:-garage}
       IMGPROXY_PURGE_SECRET: ${IMGPROXY_PURGE_SECRET:-}
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:3080/health"]
+      test: ["CMD", "/usr/local/bin/curl", "-fsS", "http://localhost:3080/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -161,7 +161,7 @@ services:
     build:
       context: ..
       dockerfile: backend/Dockerfile
-    command: ["worker"]
+    entrypoint: ["/usr/local/bin/worker"]
     restart: unless-stopped
     depends_on:
       postgres:

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -136,7 +136,7 @@ services:
       IMGPROXY_BASE_URL: ${IMGPROXY_BASE_URL:-}
       IMGPROXY_URL_EXPIRY_SECS: ${IMGPROXY_URL_EXPIRY_SECS:-120}
     healthcheck:
-      test: ["CMD", "/usr/local/bin/curl", "-fsS", "http://localhost:5150/health"]
+      test: ["CMD", "/usr/local/bin/poziomki_backend-cli", "healthcheck"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -199,11 +199,7 @@ services:
     volumes:
       - ./ops/dkim/private.key:/etc/dkim/private.key:ro
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "test -f /tmp/poziomki-outbox-worker-heartbeat && test $(( $(date +%s) - $(cat /tmp/poziomki-outbox-worker-heartbeat) )) -lt 30",
-        ]
+      test: ["CMD", "/usr/local/bin/worker", "healthcheck"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -253,7 +249,7 @@ services:
       GARAGE_S3_REGION: ${GARAGE_S3_REGION:-garage}
       IMGPROXY_PURGE_SECRET: ${IMGPROXY_PURGE_SECRET:-}
     healthcheck:
-      test: ["CMD", "/usr/local/bin/curl", "-fsS", "http://localhost:3080/health"]
+      test: ["CMD", "/usr/local/bin/healthcheck"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:5150/health"]
+      test: ["CMD", "/usr/local/bin/poziomki_backend-cli", "healthcheck"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
**Smaller, shell-free runtime image for api + worker**

Move runtime to distroless/cc-debian12:nonroot, add a Rust `healthcheck` subcommand on both binaries (drops the third-party curl dependency), and digest-pin all base images.

- [ ] rebuild + restart api + worker on server after merge
- [ ] confirm both services transition to healthy on first boot

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch backend runtime to distroless and replace curl-based healthchecks with binary healthcheck mode
> - Replaces the final Docker image stage with `gcr.io/distroless/cc-debian12:nonroot`, staging only required shared libraries (`libpq5`, `libwebp7`) and CA certificates. No shell or curl is present in the final image.
> - Adds a `healthcheck` subcommand to [poziomki_backend-cli](https://github.com/poziomki-app/poziomki/pull/151/files#diff-d2d8f829b00e44852334cdb2eb29b9af4eb51d7ed4965134bac6ea5c96760a2a) and [worker](https://github.com/poziomki-app/poziomki/pull/151/files#diff-e07a10ec4216b7b285c5b038fc9a842e8832f736961903b4cdaa10786dca5e8a) binaries, implemented in the new [healthcheck.rs](https://github.com/poziomki-app/poziomki/pull/151/files#diff-7f0731d11f9179f4d90ff16efde21c6fdb05d70370e038d66886c2e9ae1ae086) module. The API binary performs an HTTP GET to `/health` with a 3s timeout; the worker binary checks heartbeat file freshness against a 30s threshold.
> - Updates both [docker-compose.yml](https://github.com/poziomki-app/poziomki/pull/151/files#diff-6636069cba3e1b359b84b30d2c70cbf96e6119237bbc67acc21ec03d1893ab21) and [docker-compose.prod.yml](https://github.com/poziomki-app/poziomki/pull/151/files#diff-2eeee385263c859a8fc9d0a455c48137ba77b00bde682f9a7208b0aad1d3f864) to use binary healthcheck mode instead of curl.
> - Risk: the distroless image contains no shell, so any exec-based debug access or shell-dependent tooling in the container will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67cfd81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->