### PR TITLE
sec(push): validate NTFY_SERVER against host allowlist

### DIFF
--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -333,8 +333,7 @@ pub async fn push_unregister(
 pub async fn chat_config(State(_ctx): State<AppContext>, headers: HeaderMap) -> Result<Response> {
     let _ = auth_or_respond!(headers);
 
-    let ntfy_server = crate::api::common::env_non_empty("NTFY_SERVER")
-        .unwrap_or_else(|| "https://ntfy.poziomki.app".to_string());
+    let ntfy_server = crate::api::chat::push::resolved_ntfy_server();
 
     Ok((
         StatusCode::OK,

--- a/backend/src/api/chat/push.rs
+++ b/backend/src/api/chat/push.rs
@@ -4,6 +4,34 @@ use uuid::Uuid;
 
 use crate::db::schema::push_subscriptions;
 
+const ALLOWED_NTFY_HOSTS: &[&str] = &["ntfy.poziomki.app"];
+const DEFAULT_NTFY_SERVER: &str = "https://ntfy.poziomki.app";
+
+fn is_allowed_ntfy_server(url: &str) -> bool {
+    let Some(rest) = url.strip_prefix("https://") else {
+        return false;
+    };
+    let host = rest.split('/').next().unwrap_or("");
+    ALLOWED_NTFY_HOSTS.contains(&host)
+}
+
+/// Return the configured ntfy server if it passes the allowlist, otherwise the
+/// safe default. A poisoned `NTFY_SERVER` env must not redirect push traffic to
+/// an attacker-controlled host.
+pub fn resolved_ntfy_server() -> String {
+    match crate::api::common::env_non_empty("NTFY_SERVER") {
+        Some(configured) if is_allowed_ntfy_server(&configured) => configured,
+        Some(configured) => {
+            tracing::warn!(
+                configured = %configured,
+                "NTFY_SERVER rejected by allowlist; falling back to default"
+            );
+            DEFAULT_NTFY_SERVER.to_string()
+        }
+        None => DEFAULT_NTFY_SERVER.to_string(),
+    }
+}
+
 fn push_client() -> &'static reqwest::Client {
     use std::sync::OnceLock;
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -75,8 +103,7 @@ async fn resolve_ntfy_topics(
         return Ok(Vec::new());
     }
 
-    let ntfy_server = crate::api::common::env_non_empty("NTFY_SERVER")
-        .unwrap_or_else(|| "https://ntfy.poziomki.app".to_string());
+    let ntfy_server = resolved_ntfy_server();
 
     let mut conn = crate::db::conn().await?;
     let topics: Vec<String> = push_subscriptions::table
@@ -89,4 +116,39 @@ async fn resolve_ntfy_topics(
         .into_iter()
         .map(|topic| (topic, ntfy_server.clone()))
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_allowed_ntfy_server;
+
+    #[test]
+    fn accepts_allowlisted_host() {
+        assert!(is_allowed_ntfy_server("https://ntfy.poziomki.app"));
+        assert!(is_allowed_ntfy_server("https://ntfy.poziomki.app/"));
+        assert!(is_allowed_ntfy_server("https://ntfy.poziomki.app/topic"));
+    }
+
+    #[test]
+    fn rejects_non_https() {
+        assert!(!is_allowed_ntfy_server("http://ntfy.poziomki.app"));
+    }
+
+    #[test]
+    fn rejects_other_hosts() {
+        assert!(!is_allowed_ntfy_server("https://evil.example.com"));
+        assert!(!is_allowed_ntfy_server(
+            "https://ntfy.poziomki.app.evil.com"
+        ));
+        assert!(!is_allowed_ntfy_server(
+            "https://evil.com/ntfy.poziomki.app"
+        ));
+    }
+
+    #[test]
+    fn rejects_userinfo_smuggling() {
+        assert!(!is_allowed_ntfy_server(
+            "https://ntfy.poziomki.app@evil.com"
+        ));
+    }
 }


### PR DESCRIPTION
**Backend-side ntfy allowlist**

Mirrors mobile PR #148 — if `NTFY_SERVER` env is set to a host outside the allowlist, fall back to the safe default instead of blindly using it.

- [ ] verify push still works after merge + redeploy

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate NTFY_SERVER against an https host allowlist in push notification resolution
> - Adds `is_allowed_ntfy_server` in [push.rs](https://github.com/poziomki-app/poziomki/pull/152/files#diff-5a16ddcb5511893a2ee2de2ae966387c71b125fb504d5b0ca15cc7b1d3b59de6) that requires `https://` scheme and checks the host against a hardcoded allowlist (`ntfy.poziomki.app`), rejecting userinfo and host prefix/suffix attacks.
> - Adds `resolved_ntfy_server` that reads `NTFY_SERVER` from the environment and falls back to `https://ntfy.poziomki.app` with a warning if the value is absent or rejected.
> - Updates `resolve_ntfy_topics` and the `chat_config` handler to use `resolved_ntfy_server()` instead of reading the env var directly.
> - Behavioral Change: a previously accepted custom `NTFY_SERVER` with a non-allowlisted host will now be silently replaced by the default server.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d6c946.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->