### PR TITLE
sec(auth): close OTP verification timing oracle

### DIFF
--- a/backend/src/api/state/mod.rs
+++ b/backend/src/api/state/mod.rs
@@ -111,16 +111,38 @@ async fn load_valid_otp(email: &str) -> Option<(OtpCode, crate::db::DbConn)> {
 
 /// Verify an OTP code against the database. Returns true if valid.
 /// On success, deletes the OTP row. On failure, increments attempts.
+///
+/// All failure branches perform the same constant-time comparison and an
+/// equivalent DB round-trip so an attacker cannot distinguish "email has no
+/// OTP row" (i.e. unknown account) from "bad code" via timing.
 pub(super) async fn verify_otp_db(email: &str, otp: &str) -> bool {
     use subtle::ConstantTimeEq;
 
-    let Some((saved, mut conn)) = load_valid_otp(email).await else {
+    let loaded = load_valid_otp(email).await;
+
+    // Always compare in constant time against something of the requested
+    // length — even when no OTP exists — so CPU-side timing is uniform.
+    let ct_match = if let Some((saved, _)) = loaded.as_ref() {
+        saved.code.len() == otp.len() && bool::from(saved.code.as_bytes().ct_eq(otp.as_bytes()))
+    } else {
+        let dummy = vec![0u8; otp.len()];
+        let _ = bool::from(dummy.as_slice().ct_eq(otp.as_bytes()));
+        false
+    };
+
+    let Some((saved, mut conn)) = loaded else {
+        // No valid OTP row. Issue a no-op write to match the DB round-trip
+        // of the "bad code" path, then fail.
+        if let Ok(mut conn) = crate::db::conn().await {
+            let _ = diesel::update(otp_codes::table.find(Uuid::nil()))
+                .set(otp_codes::attempts.eq(0))
+                .execute(&mut conn)
+                .await;
+        }
         return false;
     };
 
-    // Constant-time comparison
-    if saved.code.len() != otp.len() || !bool::from(saved.code.as_bytes().ct_eq(otp.as_bytes())) {
-        // Increment attempts
+    if !ct_match {
         let new_attempts = saved.attempts.saturating_add(1);
         let _ = diesel::update(otp_codes::table.find(saved.id))
             .set(otp_codes::attempts.eq(new_attempts))


### PR DESCRIPTION
**Mask timing between unknown email and bad code**

\`verify_otp_db\` used to short-circuit when no OTP row existed, skipping both the constant-time compare and the DB write the bad-code path performs. Attacker could distinguish the two via response timing — a weak account-enumeration oracle. Both failure paths now look alike.

- [ ] confirm OTP verify latency is still acceptable

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close timing oracle in `state::verify_otp_db` OTP verification
> Previously, when no OTP row existed for an email, `verify_otp_db` returned `false` immediately, leaking timing information compared to the slower bad-code path. Now it performs a constant-time dummy comparison and a no-op DB update against `otp_codes::table.find(Uuid::nil())` to equalize timing across all failure paths. Risk: the no-op DB write is best-effort and may still introduce minor timing variance under load.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized eb08675. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->