### PR TITLE
test(uploads): variant-file IDOR regression test

### DIFF
--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -797,6 +797,59 @@ async fn uploads_auth_check_accepts_owned_variant_url() {
 
 #[tokio::test]
 #[serial]
+async fn uploads_auth_check_rejects_other_users_variant_url() {
+    request(|request, _ctx| async move {
+        let (owner_key, owner_value) =
+            create_user_with_profile(&request, "idor-owner@example.com", "Owner").await;
+        let (attacker_key, attacker_value) =
+            create_user_with_profile(&request, "idor-attacker@example.com", "Attacker").await;
+
+        let upload_payload = upload_png(&request, &owner_key, &owner_value).await;
+        let owner_filename = upload_payload["data"]["filename"]
+            .as_str()
+            .map(ToOwned::to_owned)
+            .expect("filename should be present");
+        let thumb_filename = upload_payload["data"]["thumbnail_url"]
+            .as_str()
+            .and_then(|url| url.strip_prefix("/api/v1/uploads/"))
+            .map(ToOwned::to_owned)
+            .expect("dev thumbnail URL shape");
+
+        // Attacker tries to auth-check the original: must not succeed.
+        let auth_check_original = request
+            .get("/api/v1/uploads/auth-check")
+            .add_header(attacker_key.clone(), attacker_value.clone())
+            .add_header(
+                HeaderName::from_static("x-original-uri"),
+                HeaderValue::from_str(&format!("/uploads/{owner_filename}")).expect("valid header"),
+            )
+            .await;
+        assert_ne!(
+            auth_check_original.status_code(),
+            200,
+            "attacker must not auth-check owner's original file"
+        );
+
+        // Attacker tries to auth-check the thumb variant: must not succeed.
+        let auth_check_variant = request
+            .get("/api/v1/uploads/auth-check")
+            .add_header(attacker_key, attacker_value)
+            .add_header(
+                HeaderName::from_static("x-original-uri"),
+                HeaderValue::from_str(&format!("/uploads/{thumb_filename}")).expect("valid header"),
+            )
+            .await;
+        assert_ne!(
+            auth_check_variant.status_code(),
+            200,
+            "attacker must not auth-check owner's variant file"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
 async fn upload_returns_error_when_upload_row_insert_fails() {
     request(|request, _ctx| async move {
         use diesel_async::RunQueryDsl;


### PR DESCRIPTION
**Regression test for upload ownership**

Adds a test that asserts user B cannot auth-check user A's original or variant filenames. Protects against future refactors that accidentally leak variant ownership.

- [ ] ensure CI is green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add IDOR regression test for variant file auth-check in uploads
> Adds a test in [migration_contract.rs](https://github.com/poziomki-app/poziomki/pull/154/files#diff-461eaef6bf3981b134937e871fd2baef0d22bf4ae43a878a78cfdb6da58190fd) that verifies `GET /api/v1/uploads/auth-check` rejects cross-user access to both original and thumbnail variant files. The test creates an owner and attacker, uploads a PNG as the owner, then asserts that auth-check returns non-200 when the attacker requests the owner's file URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b363a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->