### PR TITLE
sec(deps): wire cargo-deny into CI and triage advisories

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,3 +47,13 @@ jobs:
         with:
           sarif_file: trivy-mobile.sarif
           category: trivy-mobile
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: backend/Cargo.toml
+          command: check advisories licenses bans sources
+          arguments: ""

--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -1,5 +1,21 @@
 [advisories]
 version = 2
+ignore = [
+    # RUSTSEC-2023-0071: Marvin timing side-channel in the `rsa` crate
+    # (pulled in transitively by lettre for SMTP). Exploitation requires an
+    # attacker able to observe RSA signing timing over the network — which
+    # applies to servers exposing RSA endpoints, not an SMTP *client*
+    # performing TLS to a trusted provider. No patched `rsa` release
+    # exists; re-evaluate when RustCrypto/RSA lands constant-time fixes
+    # or when lettre drops the rsa dependency.
+    "RUSTSEC-2023-0071",
+    # RUSTSEC-2026-0097: rand 0.8 is unsound when a custom logger calls
+    # `rand::rng()`. We do not install a custom logger that calls into rand,
+    # and the dependency is only transitively pulled in by lettre → rsa →
+    # num-bigint-dig for email crypto. Re-evaluate when lettre ships an
+    # update that no longer depends on rand 0.8.
+    "RUSTSEC-2026-0097",
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
**Advisory gate in CI**

Adds a \`cargo-deny\` job to the Security workflow and documents triage rationale for two transitive advisories from \`lettre → rsa\`.

- [ ] confirm cargo-deny job runs green in CI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire cargo-deny into CI and triage advisories for backend dependencies
> - Adds a `cargo-deny` job to [security.yml](.github/workflows/security.yml) that runs on every CI build, checking advisories, licenses, bans, and sources against [backend/Cargo.toml](https://github.com/poziomki-app/poziomki/pull/155/files#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1).
> - Introduces [backend/deny.toml](https://github.com/poziomki-app/poziomki/pull/155/files#diff-69d451b15b98b99acc2765158eecfbfd80089037eb487d1cdba9b2f1062eb982) with an ignore list for `RUSTSEC-2023-0071` and `RUSTSEC-2026-0097`, which are acknowledged but not yet actionable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d8c3b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->