### PR TITLE
sec(gdpr): add user_audit_log table for account actions

### DIFF
--- a/backend/migrations/2026-04-16-000000_user_audit_log/down.sql
+++ b/backend/migrations/2026-04-16-000000_user_audit_log/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE user_audit_log;

--- a/backend/migrations/2026-04-16-000000_user_audit_log/up.sql
+++ b/backend/migrations/2026-04-16-000000_user_audit_log/up.sql
@@ -1,0 +1,13 @@
+-- GDPR audit trail for user-initiated account actions (deletion, export,
+-- password change). Intentionally stores only the user's public id so the
+-- row survives the user's row being deleted. This is the record of
+-- processing activity required by GDPR Art. 30.
+CREATE TABLE user_audit_log (
+    id         UUID PRIMARY KEY,
+    user_pid   UUID NOT NULL,
+    action     TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX user_audit_log_user_pid_idx ON user_audit_log (user_pid);
+CREATE INDEX user_audit_log_created_at_idx ON user_audit_log (created_at);

--- a/backend/src/api/auth/account.rs
+++ b/backend/src/api/auth/account.rs
@@ -21,10 +21,34 @@ type Result<T> = crate::error::AppResult<T>;
 
 use crate::app::AppContext;
 use crate::db::models::profiles::Profile;
+use crate::db::models::user_audit_log::NewUserAuditLog;
 use crate::db::schema::{
     conversations, event_attendees, events, profile_tags, profiles, sessions, uploads,
-    user_settings, users,
+    user_audit_log, user_settings, users,
 };
+
+/// Record a GDPR-relevant action on an account (deletion, export, password
+/// change). Best-effort: logs a warning on failure but never blocks the
+/// originating operation.
+async fn write_audit(user_pid: uuid::Uuid, action: &'static str) {
+    let Ok(mut conn) = crate::db::conn().await else {
+        tracing::warn!(action, "audit log skipped: no DB conn");
+        return;
+    };
+    let entry = NewUserAuditLog {
+        id: uuid::Uuid::new_v4(),
+        user_pid,
+        action: action.to_string(),
+        created_at: Utc::now(),
+    };
+    if let Err(e) = diesel::insert_into(user_audit_log::table)
+        .values(&entry)
+        .execute(&mut conn)
+        .await
+    {
+        tracing::warn!(action, error = %e, "audit log insert failed");
+    }
+}
 
 async fn delete_user_data(user_id: i32) -> std::result::Result<(), crate::error::AppError> {
     let mut conn = crate::db::conn().await?;
@@ -171,6 +195,9 @@ pub(in crate::api) async fn delete_account(
         return Ok(unauthorized_error(&headers, "Invalid password"));
     }
 
+    // Record deletion request before wiping the user record so the audit
+    // entry survives the cascade.
+    write_audit(user.pid, "account_delete").await;
     delete_user_data(user.id).await?;
     invalidate_auth_cache_for_user_id(user.id).await;
 
@@ -224,6 +251,7 @@ pub(in crate::api) async fn change_password(
     .await?;
 
     invalidate_auth_cache_for_user_id(user.id).await;
+    write_audit(user.pid, "password_change").await;
 
     Ok(Json(DataResponse {
         data: SuccessResponse { success: true },
@@ -326,6 +354,8 @@ pub(in crate::api) async fn export_data(
         .finish()
         .map_err(|e| crate::error::AppError::message(format!("zip finish error: {e}")))?;
     let zip_bytes = cursor.into_inner();
+
+    write_audit(user.pid, "data_export").await;
 
     Ok((
         [

--- a/backend/src/db/models/mod.rs
+++ b/backend/src/db/models/mod.rs
@@ -21,5 +21,6 @@ pub mod reports;
 pub mod sessions;
 pub mod tags;
 pub mod uploads;
+pub mod user_audit_log;
 pub mod user_settings;
 pub mod users;

--- a/backend/src/db/models/user_audit_log.rs
+++ b/backend/src/db/models/user_audit_log.rs
@@ -1,0 +1,14 @@
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use crate::db::schema::user_audit_log;
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = user_audit_log)]
+pub struct NewUserAuditLog {
+    pub id: Uuid,
+    pub user_pid: Uuid,
+    pub action: String,
+    pub created_at: DateTime<Utc>,
+}

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -234,6 +234,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    user_audit_log (id) {
+        id -> Uuid,
+        user_pid -> Uuid,
+        action -> Text,
+        created_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     sessions (id) {
         id -> Uuid,
         user_id -> Int4,
@@ -359,5 +368,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     user_settings,
     users,
     task_completions,
+    user_audit_log,
     xp_scans,
 );


### PR DESCRIPTION
**GDPR audit trail**

Minimal audit log — user pid, action, timestamp — written on account delete, data export, and password change. Supports Art. 30 records-of-processing and lets us demonstrate Art. 15/17 fulfillment.

- [ ] run migration on prod

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `user_audit_log` table to record account delete, password change, and data export actions
> - Adds a `user_audit_log` DB table (migration in [up.sql](https://github.com/poziomki-app/poziomki/pull/156/files#diff-bb962967b9f684319f578ca1e04919391a87ad09fbafe06e7c508f5e0ce91c8d)) with columns for `id`, `user_pid`, `action`, and `created_at`, indexed on `user_pid` and `created_at`.
> - Adds a `write_audit` helper in [account.rs](https://github.com/poziomki-app/poziomki/pull/156/files#diff-bbdfd4575cacec32ca674d1d737611e5809c5d10e496ab08f3a49a6964cbe60a) that inserts a row best-effort — failures log a warning and never propagate to the caller.
> - Calls `write_audit` in the `delete_account`, `change_password`, and `export_data` handlers with action strings `"account_delete"`, `"password_change"`, and `"data_export"` respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4facd0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->