### PR TITLE
sec(auth): cap absolute session age at 30 days

### DIFF
--- a/backend/src/api/state/auth.rs
+++ b/backend/src/api/state/auth.rs
@@ -18,6 +18,27 @@ use crate::db::schema::{sessions, users};
 
 const SESSION_DURATION_SECS: i64 = 60 * 60 * 24 * 7;
 const SESSION_UPDATE_AGE_SECS: i64 = 60 * 60 * 24;
+/// Hard cap from session creation: renewals cannot extend a session past this
+/// absolute age, even if the user stays active. Limits how long a stolen
+/// token can be kept alive by an attacker touching the API once a day.
+const SESSION_MAX_ABSOLUTE_SECS: i64 = 60 * 60 * 24 * 30;
+
+fn session_hard_expiry(created_at: DateTime<Utc>) -> DateTime<Utc> {
+    created_at + Duration::seconds(SESSION_MAX_ABSOLUTE_SECS)
+}
+
+fn is_past_absolute_cap(session: &Session, now: DateTime<Utc>) -> bool {
+    now >= session_hard_expiry(session.created_at)
+}
+
+fn capped_expiry(session_created_at: DateTime<Utc>, sliding: DateTime<Utc>) -> DateTime<Utc> {
+    let hard = session_hard_expiry(session_created_at);
+    if sliding < hard {
+        sliding
+    } else {
+        hard
+    }
+}
 const AUTH_CACHE_TTL_DEFAULT_SECS: i64 = 15;
 const SESSION_TOKEN_HASH_PREFIX: &str = "st2:";
 
@@ -85,7 +106,10 @@ async fn cache_auth_get(hashed_token: &str) -> Option<(Session, User)> {
         guard.get(hashed_token).cloned()
     };
     let entry = cached?;
-    if entry.cached_until <= now || entry.session.expires_at <= now {
+    if entry.cached_until <= now
+        || entry.session.expires_at <= now
+        || is_past_absolute_cap(&entry.session, now)
+    {
         auth_cache().write().await.remove(hashed_token);
         return None;
     }
@@ -173,7 +197,7 @@ pub(in crate::api) async fn require_auth_context(
         .ok_or_else(|| Box::new(unauthorized_response(headers)))?;
 
     let now = Utc::now();
-    if session.expires_at <= now {
+    if session.expires_at <= now || is_past_absolute_cap(&session, now) {
         let _ = diesel::delete(sessions::table.find(session.id))
             .execute(&mut conn)
             .await;
@@ -190,7 +214,10 @@ async fn maybe_renew_session(session: &Session) {
     let now = Utc::now();
     let elapsed = now - session.updated_at;
     if elapsed >= Duration::seconds(SESSION_UPDATE_AGE_SECS) {
-        let new_expires = now + Duration::seconds(SESSION_DURATION_SECS);
+        let new_expires = capped_expiry(
+            session.created_at,
+            now + Duration::seconds(SESSION_DURATION_SECS),
+        );
         if let Ok(mut conn) = crate::db::conn().await {
             let _ = diesel::update(sessions::table.find(session.id))
                 .set(&SessionUpdate {
@@ -209,7 +236,10 @@ async fn maybe_renew_session_on_conn(session: Session, conn: &mut crate::db::DbC
         return session;
     }
 
-    let new_expires = now + Duration::seconds(SESSION_DURATION_SECS);
+    let new_expires = capped_expiry(
+        session.created_at,
+        now + Duration::seconds(SESSION_DURATION_SECS),
+    );
     let _ = diesel::update(sessions::table.find(session.id))
         .set(&SessionUpdate {
             updated_at: Some(now),


### PR DESCRIPTION
**Absolute session expiry**

Sliding renewal previously let a session live indefinitely as long as it was touched every 24h. Adds a hard 30-day ceiling anchored at \`created_at\`, enforced on both cache hits and DB auth checks, with renewal clamped so expiry can't exceed the cap.

- [ ] confirm users reauthenticate after 30 days rather than being silently logged out mid-session

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap absolute session age at 30 days in authentication middleware
> - Adds `SESSION_MAX_ABSOLUTE_SECS` (30 days) as a hard upper bound on session lifetime, regardless of sliding window renewals.
> - Session validation in `require_auth_context` now rejects and deletes sessions older than 30 days; previously only `expires_at` was checked.
> - Cache eviction in `cache_auth_get` also treats sessions past the hard cap as invalid.
> - Renewal logic in `maybe_renew_session` and `maybe_renew_session_on_conn` caps new `expires_at` to the hard expiry derived from `created_at`.
> - Behavioral Change: sessions created more than 30 days ago are now rejected and deleted on next request, even if `expires_at` has not elapsed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 732922a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->