### PR TITLE
sec(events): cap max_attendees at 10 000

### DIFF
--- a/backend/src/api/events/service.rs
+++ b/backend/src/api/events/service.rs
@@ -160,13 +160,17 @@ pub(in crate::api) fn validate_event_category(
     }
 }
 
-pub(in crate::api) fn validate_max_attendees(
+pub(in crate::api) const MAX_ATTENDEES_UPPER_BOUND: i32 = 10_000;
+
+pub(in crate::api) const fn validate_max_attendees(
     value: Option<i32>,
 ) -> std::result::Result<(), &'static str> {
-    if value.is_some_and(|limit| limit <= 0) {
-        Err("Attendee limit must be greater than 0")
-    } else {
-        Ok(())
+    match value {
+        Some(limit) if limit <= 0 => Err("Attendee limit must be greater than 0"),
+        Some(limit) if limit > MAX_ATTENDEES_UPPER_BOUND => {
+            Err("Attendee limit must be at most 10000")
+        }
+        _ => Ok(()),
     }
 }
 

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -254,6 +254,18 @@ async fn events_flow_matches_phase_3_contract() {
             .await;
         assert_eq!(invalid_tag_create.status_code(), 400);
 
+        // Absurdly high max_attendees is rejected — 10 000 is the upper bound.
+        let over_cap_create = request
+            .post("/api/v1/events")
+            .add_header(owner_auth_key.clone(), owner_auth_value.clone())
+            .json(&serde_json::json!({
+                "title": "Stadium event",
+                "startsAt": "2030-01-02T14:00:00Z",
+                "maxAttendees": 10_001,
+            }))
+            .await;
+        assert_eq!(over_cap_create.status_code(), 400);
+
         let owner_list_after_invalid = request
             .get("/api/v1/events")
             .add_header(owner_auth_key.clone(), owner_auth_value.clone())


### PR DESCRIPTION
**Upper bound on attendee limit**

Validator rejected non-positive values but accepted up to i32::MAX. Adds a 10 000 ceiling — generous for any realistic event and well below where attendee-count queries or UI paging would misbehave.

- [ ] confirm CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap `max_attendees` at 10,000 when creating events
> Adds a `MAX_ATTENDEES_UPPER_BOUND` constant (10,000) in [service.rs](https://github.com/poziomki-app/poziomki/pull/158/files#diff-5c19eb3696d6aaa06a22e8d350d43170596e41e78f2cfa7aebf496dee42c916f) and updates `validate_max_attendees` to reject values above it with a 400 error. A contract test verifies that submitting `maxAttendees: 10001` returns HTTP 400.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f15bfd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->