### PR TITLE
sec(logs): redact emails in auth-flow tracing

### DIFF
--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -63,7 +63,7 @@ pub(super) async fn sign_up(
         let code = generate_otp_code();
         upsert_otp(&normalized_email, &code).await?;
         if let Err(error) = enqueue_otp_email(&normalized_email, &code).await {
-            tracing::error!(%error, email = %normalized_email, "failed to enqueue OTP email after sign up");
+            tracing::error!(%error, email = %crate::api::redact_email(&normalized_email), "failed to enqueue OTP email after sign up");
         }
     }
 
@@ -125,7 +125,7 @@ async fn maybe_resend_otp(email: &str) -> crate::error::AppResult<()> {
     let code = generate_otp_code();
     upsert_otp(email, &code).await?;
     if let Err(error) = enqueue_otp_email(email, &code).await {
-        tracing::error!(%error, email = %email, "failed to enqueue OTP email after resend");
+        tracing::error!(%error, email = %crate::api::redact_email(email), "failed to enqueue OTP email after resend");
     }
     Ok(())
 }
@@ -166,7 +166,7 @@ pub(super) async fn forgot_password(
             let code = generate_otp_code();
             if upsert_otp(&email, &code).await.is_ok() {
                 if let Err(error) = enqueue_otp_email(&email, &code).await {
-                    tracing::error!(%error, email = %email, "failed to enqueue OTP for forgot password");
+                    tracing::error!(%error, email = %crate::api::redact_email(&email), "failed to enqueue OTP for forgot password");
                 }
             }
         }
@@ -202,7 +202,7 @@ async fn maybe_resend_forgot_password_otp(email: &str) -> crate::error::AppResul
     let code = generate_otp_code();
     upsert_otp(email, &code).await?;
     if let Err(error) = enqueue_otp_email(email, &code).await {
-        tracing::error!(%error, email = %email, "failed to enqueue OTP for forgot password resend");
+        tracing::error!(%error, email = %crate::api::redact_email(email), "failed to enqueue OTP for forgot password resend");
     }
     Ok(())
 }

--- a/backend/src/api/auth/otp_email.rs
+++ b/backend/src/api/auth/otp_email.rs
@@ -171,7 +171,10 @@ fn build_otp_email(from_mbox: Mailbox, to_mbox: Mailbox, code: &str) -> Option<M
 
 pub(in crate::api) async fn send_otp_email(to: &str, code: &str) -> Result<(), String> {
     if !super::env_truthy("SMTP_ENABLE") {
-        tracing::debug!("Mail disabled, skipping OTP email to {to}");
+        tracing::debug!(
+            "Mail disabled, skipping OTP email to {}",
+            crate::api::redact_email(to)
+        );
         return Ok(());
     }
 
@@ -212,7 +215,10 @@ pub(in crate::api) async fn send_otp_email(to: &str, code: &str) -> Result<(), S
             .build();
         match mailer.send_raw(&envelope, &body).await {
             Ok(_) => {
-                tracing::info!("OTP email delivered to {to} via {mx_host}");
+                tracing::info!(
+                    "OTP email delivered to {} via {mx_host}",
+                    crate::api::redact_email(to)
+                );
                 return Ok(());
             }
             Err(e) => last_err = format!("{mx_host}: {e}"),

--- a/backend/src/api/auth/service.rs
+++ b/backend/src/api/auth/service.rs
@@ -173,7 +173,7 @@ pub(super) async fn sign_in_success_or_unauthorized(
         let code = generate_otp_code();
         upsert_otp(email, &code).await?;
         if let Err(error) = enqueue_otp_email(email, &code).await {
-            tracing::error!(%error, email = %email, "failed to enqueue OTP email for unverified sign in");
+            tracing::error!(%error, email = %crate::api::redact_email(email), "failed to enqueue OTP email for unverified sign in");
         }
 
         return Ok(error_response(

--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -38,6 +38,21 @@ pub fn env_non_empty(key: &str) -> Option<String> {
     std::env::var(key).ok().filter(|v| !v.trim().is_empty())
 }
 
+/// Render an email for log output as `abc***@domain`, keeping the domain
+/// (useful when triaging deployment-specific issues) while dropping most of
+/// the local-part. Malformed addresses collapse to `***` so nothing sneaks
+/// through in raw form.
+pub fn redact_email(email: &str) -> String {
+    let Some((local, domain)) = email.split_once('@') else {
+        return "***".to_string();
+    };
+    let prefix: String = local.chars().take(3).collect();
+    if prefix.is_empty() {
+        return format!("***@{domain}");
+    }
+    format!("{prefix}***@{domain}")
+}
+
 fn request_id(headers: &HeaderMap) -> String {
     headers
         .get("x-request-id")
@@ -189,4 +204,29 @@ pub async fn resolve_thumbhashes(
     rows.into_iter()
         .map(|(name, raw)| (name, base64::engine::general_purpose::STANDARD.encode(&raw)))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_email;
+
+    #[test]
+    fn keeps_three_char_prefix_and_domain() {
+        assert_eq!(redact_email("adam@ibims.pl"), "ada***@ibims.pl");
+    }
+
+    #[test]
+    fn handles_short_local_part() {
+        assert_eq!(redact_email("ab@example.com"), "ab***@example.com");
+    }
+
+    #[test]
+    fn collapses_malformed_address() {
+        assert_eq!(redact_email("no-at-sign"), "***");
+    }
+
+    #[test]
+    fn handles_empty_local_part() {
+        assert_eq!(redact_email("@example.com"), "***@example.com");
+    }
 }

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -28,8 +28,8 @@ mod xp;
 
 pub(crate) use common::{
     auth_or_respond, env_non_empty, error_response, extract_filename, parse_uuid,
-    parse_uuid_response, resolve_bio_image_urls, resolve_image_url, resolve_image_urls,
-    resolve_thumbhashes, ErrorSpec,
+    parse_uuid_response, redact_email, resolve_bio_image_urls, resolve_image_url,
+    resolve_image_urls, resolve_thumbhashes, ErrorSpec,
 };
 fn cache_layer(value: &'static str) -> SetResponseHeaderLayer<HeaderValue> {
     SetResponseHeaderLayer::if_not_present(header::CACHE_CONTROL, HeaderValue::from_static(value))


### PR DESCRIPTION
**Stop logging full email addresses**

Seven log sites across the auth flow emitted full emails — usable for account enumeration from a log dump. Replace with \`ada***@ibims.pl\` form (first 3 chars of local part + domain).

- [ ] confirm CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redact emails in auth-flow tracing logs
> Adds a `redact_email` helper in [`api/common.rs`](https://github.com/poziomki-app/poziomki/pull/160/files#diff-99a3d74e3f87b04ff9678c9452acdbe0f481cf9658ef5724e4fbccfb6e8cdcbb) that masks the local-part of an email (keeping up to 3 chars followed by `***`) while preserving the domain. All `tracing::error`/`info`/`debug` calls across sign-up, sign-in, OTP resend, and forgot-password flows are updated to use this helper instead of logging raw email addresses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63151d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->