### PR TITLE
sec(caddy): harden secure_headers snippet

### DIFF
--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -3,6 +3,21 @@
 		Strict-Transport-Security "max-age=31536000"
 		X-Content-Type-Options "nosniff"
 		Referrer-Policy "strict-origin-when-cross-origin"
+		# Clickjacking: refuse to be framed, in both the legacy and
+		# modern dialects so older clients respect at least one.
+		X-Frame-Options "DENY"
+		Content-Security-Policy "frame-ancestors 'none'"
+		# Deny sensor / payment capabilities the web app doesn't use.
+		# The mobile clients call native APIs directly, so this has no
+		# effect on them.
+		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"
+		# COOP isolates the top-level browsing context; CORP keeps
+		# assets opt-in-loadable within the poziomki.app family (any
+		# *.poziomki.app subdomain — so cdn.poziomki.app images still
+		# render in the poziomki.app web shell) but blocks fetches
+		# from unrelated origins.
+		Cross-Origin-Opener-Policy "same-origin"
+		Cross-Origin-Resource-Policy "same-site"
 		-Server
 	}
 }


### PR DESCRIPTION
**Clickjacking and feature-policy defaults**

Extends the shared \`secure_headers\` snippet so every fronted host ships X-Frame-Options, frame-ancestors CSP, Permissions-Policy, and COOP/CORP. CORP set to \`same-site\` so cdn.poziomki.app images still render in the web shell.

- [ ] curl -I each host after redeploy to confirm new headers
- [ ] verify web shell still loads cdn.poziomki.app images

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `secure_headers` snippet in Caddy with stricter browser security policies
> Adds several HTTP security headers to [Caddyfile.prod](https://github.com/poziomki-app/poziomki/pull/161/files#diff-507ac62fa8220af2d08c3d8f2ef5aee0806600e1d1085fc4c641c643ea9f4e36) to tighten browser-enforced protections:
> - Adds `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'` to block all framing
> - Adds `Permissions-Policy` disabling camera, microphone, geolocation, payment, USB, and motion sensors
> - Adds `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Resource-Policy: same-site` to restrict cross-origin access
> - Behavioral Change: browsers enforcing these headers will now block embedding, cross-origin isolation, and access to listed device APIs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01cde59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->