### PR TITLE
sec(ws): origin allowlist + server-side heartbeat

### DIFF
--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -25,8 +25,64 @@ type Result<T> = crate::error::AppResult<T>;
 // WebSocket upgrade
 // ---------------------------------------------------------------------------
 
-pub async fn ws_upgrade(State(ctx): State<AppContext>, upgrade: WebSocketUpgrade) -> Response {
+/// Origins the browser-side app is allowed to open a chat socket from.
+/// Native mobile clients typically omit `Origin`; that is accepted. Any
+/// *present* Origin that doesn't match the allowlist is rejected with 403
+/// before we even start the upgrade, so a malicious page can't hold the
+/// socket open during the 5s auth window.
+const ALLOWED_WS_ORIGINS: &[&str] = &[
+    "https://poziomki.app",
+    "https://www.poziomki.app",
+    "https://mobile.poziomki.app",
+    "http://localhost",
+    "http://127.0.0.1",
+];
+
+fn is_allowed_ws_origin(origin: &str) -> bool {
+    ALLOWED_WS_ORIGINS.iter().any(|allowed| {
+        // Exact match (`https://poziomki.app`) *or* a localhost-with-port
+        // prefix (`http://localhost:5173`). We deliberately don't match
+        // other schemes or subdomain suffixes.
+        origin == *allowed
+            || ((allowed.starts_with("http://localhost")
+                || allowed.starts_with("http://127.0.0.1"))
+                && origin.starts_with(&format!("{allowed}:")))
+    })
+}
+
+pub async fn ws_upgrade(
+    State(ctx): State<AppContext>,
+    headers: HeaderMap,
+    upgrade: WebSocketUpgrade,
+) -> Response {
+    if let Some(origin) = headers.get("origin").and_then(|v| v.to_str().ok()) {
+        if !is_allowed_ws_origin(origin) {
+            tracing::warn!(origin = %origin, "ws_upgrade: rejected origin");
+            return (StatusCode::FORBIDDEN, "forbidden origin").into_response();
+        }
+    }
     upgrade.on_upgrade(move |socket| ws::handle_socket(socket, ctx.chat_hub))
+}
+
+#[cfg(test)]
+mod origin_tests {
+    use super::is_allowed_ws_origin;
+
+    #[test]
+    fn accepts_allowlisted() {
+        assert!(is_allowed_ws_origin("https://poziomki.app"));
+        assert!(is_allowed_ws_origin("https://mobile.poziomki.app"));
+        assert!(is_allowed_ws_origin("http://localhost:5173"));
+        assert!(is_allowed_ws_origin("http://127.0.0.1:3000"));
+    }
+
+    #[test]
+    fn rejects_unrelated() {
+        assert!(!is_allowed_ws_origin("https://evil.com"));
+        assert!(!is_allowed_ws_origin("https://poziomki.app.evil.com"));
+        assert!(!is_allowed_ws_origin("http://poziomki.app"));
+        assert!(!is_allowed_ws_origin("capacitor://localhost"));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -8,8 +8,9 @@ pub mod report_repo;
 pub mod ws;
 
 use axum::{
-    extract::{ws::WebSocketUpgrade, Path, State},
+    extract::{ws::WebSocketUpgrade, Path, Request, State},
     http::{HeaderMap, StatusCode},
+    middleware::Next,
     response::{IntoResponse, Response},
     Json,
 };
@@ -50,18 +51,25 @@ fn is_allowed_ws_origin(origin: &str) -> bool {
     })
 }
 
-pub async fn ws_upgrade(
-    State(ctx): State<AppContext>,
-    headers: HeaderMap,
-    upgrade: WebSocketUpgrade,
-) -> Response {
-    if let Some(origin) = headers.get("origin").and_then(|v| v.to_str().ok()) {
+pub async fn ws_upgrade(State(ctx): State<AppContext>, upgrade: WebSocketUpgrade) -> Response {
+    upgrade.on_upgrade(move |socket| ws::handle_socket(socket, ctx.chat_hub))
+}
+
+/// Route-level gate for the `/chat/ws` endpoint. Runs on the raw `Request`
+/// before any extractors, so it can reject hostile origins *before* Axum's
+/// `WebSocketUpgrade` extractor runs its own preconditions — which matters
+/// both for security (reject early, no socket work) and for testability
+/// (in-process test harnesses can't satisfy the WebSocket extractor's HTTP
+/// version check, so any gate that lives *inside* the handler body is
+/// unreachable from integration tests).
+pub async fn ws_upgrade_gate(req: Request, next: Next) -> Response {
+    if let Some(origin) = req.headers().get("origin").and_then(|v| v.to_str().ok()) {
         if !is_allowed_ws_origin(origin) {
             tracing::warn!(origin = %origin, "ws_upgrade: rejected origin");
             return (StatusCode::FORBIDDEN, "forbidden origin").into_response();
         }
     }
-    upgrade.on_upgrade(move |socket| ws::handle_socket(socket, ctx.chat_hub))
+    next.run(req).await
 }
 
 #[cfg(test)]

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -15,6 +15,11 @@ const AUTH_TIMEOUT_SECS: u64 = 5;
 const DEFAULT_HISTORY_LIMIT: i64 = 50;
 const MAX_HISTORY_LIMIT: i64 = 200;
 const SEND_RATE_LIMIT: u32 = 10;
+/// Interval at which the server pings idle sockets so half-open TCP
+/// connections are reaped without waiting on kernel keepalive.
+const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+/// Close the socket if no frame (including pong) arrives within this window.
+const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
 
 /// Handle a WebSocket connection after Axum upgrade.
 pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
@@ -62,41 +67,64 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
         }
     });
 
-    // Reader loop: process incoming client messages
+    // Reader loop: process incoming client messages + server heartbeat.
     let mut send_count: u32 = 0;
     let mut send_window = tokio::time::Instant::now();
+    let mut last_seen = tokio::time::Instant::now();
+    let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
+    // First tick fires immediately — skip it so we don't ping a freshly-
+    // opened socket before the client has settled.
+    heartbeat.tick().await;
 
-    while let Some(Ok(frame)) = ws_rx.next().await {
-        match frame {
-            Message::Text(text) => {
-                let parsed: Result<ClientMessage, _> = serde_json::from_str(&text);
-                match parsed {
-                    Ok(client_msg) => {
-                        // Rate-limit Send messages (10/sec)
-                        if matches!(&client_msg, ClientMessage::Send { .. }) {
-                            if send_window.elapsed() >= std::time::Duration::from_secs(1) {
-                                send_count = 0;
-                                send_window = tokio::time::Instant::now();
+    loop {
+        tokio::select! {
+            frame = ws_rx.next() => {
+                let Some(Ok(frame)) = frame else { break };
+                last_seen = tokio::time::Instant::now();
+                match frame {
+                    Message::Text(text) => {
+                        let parsed: Result<ClientMessage, _> = serde_json::from_str(&text);
+                        match parsed {
+                            Ok(client_msg) => {
+                                // Rate-limit Send messages (10/sec)
+                                if matches!(&client_msg, ClientMessage::Send { .. }) {
+                                    if send_window.elapsed() >= std::time::Duration::from_secs(1) {
+                                        send_count = 0;
+                                        send_window = tokio::time::Instant::now();
+                                    }
+                                    send_count += 1;
+                                    if send_count > SEND_RATE_LIMIT {
+                                        let _ = outbound_tx.send(ServerMessage::Error {
+                                            message: "rate limited: too many messages".to_string(),
+                                        });
+                                        continue;
+                                    }
+                                }
+                                handle_client_message(client_msg, user_id, &hub, &outbound_tx).await;
                             }
-                            send_count += 1;
-                            if send_count > SEND_RATE_LIMIT {
+                            Err(e) => {
                                 let _ = outbound_tx.send(ServerMessage::Error {
-                                    message: "rate limited: too many messages".to_string(),
+                                    message: format!("invalid message: {e}"),
                                 });
-                                continue;
                             }
                         }
-                        handle_client_message(client_msg, user_id, &hub, &outbound_tx).await;
                     }
-                    Err(e) => {
-                        let _ = outbound_tx.send(ServerMessage::Error {
-                            message: format!("invalid message: {e}"),
-                        });
-                    }
+                    Message::Close(_) => break,
+                    // Pong / Ping / Binary all count as "still alive" via the
+                    // last_seen update above; we don't otherwise act on them.
+                    _ => {}
                 }
             }
-            Message::Close(_) => break,
-            _ => {}
+            _ = heartbeat.tick() => {
+                if last_seen.elapsed() > IDLE_TIMEOUT {
+                    tracing::info!(user_id, "ws idle timeout; closing");
+                    break;
+                }
+                // Nudge the client to prove liveness. We route through the
+                // same outbound channel the writer drains, so we don't need
+                // to share the sink.
+                let _ = outbound_tx.send(ServerMessage::Pong);
+            }
         }
     }
 

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -33,6 +33,11 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
     // --- Step 2: Register in hub ---
     let mut hub_rx = hub.register(user_id);
     let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<ServerMessage>();
+    // Separate channel for WS protocol-level Ping frames. Using the standard
+    // control frame (rather than an app-level Pong JSON) means the client's
+    // WebSocket stack auto-responds at the framing layer and no app code
+    // sees the heartbeat.
+    let (ping_tx, mut ping_rx) = mpsc::unbounded_channel::<()>();
 
     // Send initial conversation list
     let conv_list = conversations::list_for_user(user_id)
@@ -48,7 +53,9 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
     }
 
     // --- Step 3: Main loop ---
-    // Spawn a writer task that drains hub messages + outbound messages
+    // Spawn a writer task that drains hub messages, outbound messages, and
+    // heartbeat pings. It owns `ws_tx` so all writes go through a single
+    // place.
     let writer_task = tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -59,6 +66,11 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
                 }
                 Some(msg) = outbound_rx.recv() => {
                     if send_json(&mut ws_tx, &msg).await.is_err() {
+                        break;
+                    }
+                }
+                Some(()) = ping_rx.recv() => {
+                    if ws_tx.send(Message::Ping(Vec::new().into())).await.is_err() {
                         break;
                     }
                 }
@@ -120,10 +132,11 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
                     tracing::info!(user_id, "ws idle timeout; closing");
                     break;
                 }
-                // Nudge the client to prove liveness. We route through the
-                // same outbound channel the writer drains, so we don't need
-                // to share the sink.
-                let _ = outbound_tx.send(ServerMessage::Pong);
+                // Signal the writer task to send a WS-level Ping. The
+                // client's WebSocket library replies with Pong at the
+                // framing layer, which resets `last_seen` via the reader
+                // arm above without surfacing to app code.
+                let _ = ping_tx.send(());
             }
         }
     }

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -159,7 +159,10 @@ fn search_routes() -> Router<AppContext> {
 
 fn chat_routes() -> Router<AppContext> {
     Router::new()
-        .route("/ws", get(chat::ws_upgrade))
+        .route(
+            "/ws",
+            get(chat::ws_upgrade).route_layer(middleware::from_fn(chat::ws_upgrade_gate)),
+        )
         .route("/config", get(chat::chat_config))
         .route("/dms", post(chat::resolve_dm))
         .route(

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -575,6 +575,25 @@ async fn matching_and_uploads_endpoints_available() {
 
 #[tokio::test]
 #[serial]
+async fn ws_upgrade_rejects_foreign_origin() {
+    request(|request, _ctx| async move {
+        // No Bearer token needed — the origin check fires before we look at
+        // auth. The upgrade handshake itself isn't completed by TestServer,
+        // but Axum still runs the handler and the returned 403 lands here.
+        let response = request
+            .get("/api/v1/chat/ws")
+            .add_header(
+                HeaderName::from_static("origin"),
+                HeaderValue::from_static("https://evil.example.com"),
+            )
+            .await;
+        assert_eq!(response.status_code(), 403);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
 async fn sign_in_verifies_hashed_password() {
     request(|request, _ctx| async move {
         let sign_up = request

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -573,20 +573,42 @@ async fn matching_and_uploads_endpoints_available() {
     .await;
 }
 
+/// Add the minimal set of RFC 6455 headers that make `WebSocketUpgrade`
+/// satisfy its extractor requirements so the handler body actually runs.
+/// Without these the extractor rejects with 400 before our Origin / rate
+/// limit checks fire, giving the tests a false green.
+fn attach_ws_upgrade_headers(req: axum_test::TestRequest) -> axum_test::TestRequest {
+    req.add_header(
+        HeaderName::from_static("upgrade"),
+        HeaderValue::from_static("websocket"),
+    )
+    .add_header(
+        HeaderName::from_static("connection"),
+        HeaderValue::from_static("Upgrade"),
+    )
+    .add_header(
+        HeaderName::from_static("sec-websocket-version"),
+        HeaderValue::from_static("13"),
+    )
+    .add_header(
+        HeaderName::from_static("sec-websocket-key"),
+        HeaderValue::from_static("dGhlIHNhbXBsZSBub25jZQ=="),
+    )
+}
+
 #[tokio::test]
 #[serial]
 async fn ws_upgrade_rejects_foreign_origin() {
     request(|request, _ctx| async move {
         // No Bearer token needed — the origin check fires before we look at
-        // auth. The upgrade handshake itself isn't completed by TestServer,
-        // but Axum still runs the handler and the returned 403 lands here.
-        let response = request
-            .get("/api/v1/chat/ws")
-            .add_header(
-                HeaderName::from_static("origin"),
-                HeaderValue::from_static("https://evil.example.com"),
-            )
-            .await;
+        // auth. We also don't finish the WS handshake, but with the RFC 6455
+        // headers attached the handler body does run and returns 403 before
+        // any upgrade is attempted.
+        let response = attach_ws_upgrade_headers(request.get("/api/v1/chat/ws").add_header(
+            HeaderName::from_static("origin"),
+            HeaderValue::from_static("https://evil.example.com"),
+        ))
+        .await;
         assert_eq!(response.status_code(), 403);
     })
     .await;

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -573,42 +573,21 @@ async fn matching_and_uploads_endpoints_available() {
     .await;
 }
 
-/// Add the minimal set of RFC 6455 headers that make `WebSocketUpgrade`
-/// satisfy its extractor requirements so the handler body actually runs.
-/// Without these the extractor rejects with 400 before our Origin / rate
-/// limit checks fire, giving the tests a false green.
-fn attach_ws_upgrade_headers(req: axum_test::TestRequest) -> axum_test::TestRequest {
-    req.add_header(
-        HeaderName::from_static("upgrade"),
-        HeaderValue::from_static("websocket"),
-    )
-    .add_header(
-        HeaderName::from_static("connection"),
-        HeaderValue::from_static("Upgrade"),
-    )
-    .add_header(
-        HeaderName::from_static("sec-websocket-version"),
-        HeaderValue::from_static("13"),
-    )
-    .add_header(
-        HeaderName::from_static("sec-websocket-key"),
-        HeaderValue::from_static("dGhlIHNhbXBsZSBub25jZQ=="),
-    )
-}
-
 #[tokio::test]
 #[serial]
 async fn ws_upgrade_rejects_foreign_origin() {
     request(|request, _ctx| async move {
-        // No Bearer token needed — the origin check fires before we look at
-        // auth. We also don't finish the WS handshake, but with the RFC 6455
-        // headers attached the handler body does run and returns 403 before
-        // any upgrade is attempted.
-        let response = attach_ws_upgrade_headers(request.get("/api/v1/chat/ws").add_header(
-            HeaderName::from_static("origin"),
-            HeaderValue::from_static("https://evil.example.com"),
-        ))
-        .await;
+        // The origin gate is a route-layer middleware, so it runs on the
+        // raw Request before Axum's WebSocketUpgrade extractor performs
+        // its own HTTP-version check. A plain GET with a foreign Origin
+        // therefore reaches the gate and returns 403.
+        let response = request
+            .get("/api/v1/chat/ws")
+            .add_header(
+                HeaderName::from_static("origin"),
+                HeaderValue::from_static("https://evil.example.com"),
+            )
+            .await;
         assert_eq!(response.status_code(), 403);
     })
     .await;


### PR DESCRIPTION
**WebSocket hardening**

Two fixes in chat/ws:

- ws_upgrade rejects unknown Origin headers with 403 before completing the handshake, so a malicious page can't hold a socket open during the 5s auth window. Missing Origin (native clients) is still accepted.
- Reader loop now has a 30s server heartbeat and a 90s idle timeout so half-open TCP sockets are reaped promptly.

- [ ] smoke-test mobile chat after deploy (heartbeat should be invisible)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add WebSocket origin allowlist and server-side heartbeat to chat endpoint
> - Adds `ws_upgrade_gate` middleware to `/api/v1/chat/ws` that returns 403 for requests with a non-allowlisted `Origin` header; requests with no `Origin` or an allowlisted one proceed normally.
> - Allowlisted origins include production domains and `localhost`/`127.0.0.1` with any port.
> - Adds server-side heartbeat: the server sends a WebSocket `Ping` every 30 seconds and closes connections idle for more than 90 seconds.
> - Behavioral Change: existing WebSocket clients connecting from non-allowlisted origins will receive 403 instead of upgrading.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 158f3fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->