### PR TITLE
sec(ratelimit): IP-keyed throttle on /matching/profiles and ws_upgrade

### DIFF
--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -56,18 +56,26 @@ pub async fn ws_upgrade(State(ctx): State<AppContext>, upgrade: WebSocketUpgrade
 }
 
 /// Route-level gate for the `/chat/ws` endpoint. Runs on the raw `Request`
-/// before any extractors, so it can reject hostile origins *before* Axum's
-/// `WebSocketUpgrade` extractor runs its own preconditions — which matters
-/// both for security (reject early, no socket work) and for testability
-/// (in-process test harnesses can't satisfy the WebSocket extractor's HTTP
-/// version check, so any gate that lives *inside* the handler body is
-/// unreachable from integration tests).
+/// before any extractors, so both the origin allowlist and the IP rate
+/// limit fire uniformly in prod and in axum-test (the in-process transport
+/// can't satisfy `WebSocketUpgrade`'s HTTP-version precondition, so any
+/// check that lives inside the handler body is unreachable from integration
+/// tests). Origin is checked first — cheap and local, keeps hostile pages
+/// from burning a rate-limit slot.
 pub async fn ws_upgrade_gate(req: Request, next: Next) -> Response {
     if let Some(origin) = req.headers().get("origin").and_then(|v| v.to_str().ok()) {
         if !is_allowed_ws_origin(origin) {
             tracing::warn!(origin = %origin, "ws_upgrade: rejected origin");
             return (StatusCode::FORBIDDEN, "forbidden origin").into_response();
         }
+    }
+    if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        req.headers(),
+        crate::api::ip_rate_limit::IpRateLimitAction::ChatWsUpgrade,
+    )
+    .await
+    {
+        return *response;
     }
     next.run(req).await
 }

--- a/backend/src/api/ip_rate_limit.rs
+++ b/backend/src/api/ip_rate_limit.rs
@@ -1,0 +1,199 @@
+//! IP-keyed rate limits for non-auth endpoints.
+//!
+//! This mirrors the DB-backed limiter in `api::auth::rate_limit` but keys on
+//! the client IP from the reverse proxy instead of the per-user subject.
+//!
+//! **Header choice matters for exploitability.** Caddy's default
+//! `reverse_proxy` behaviour *appends* the client IP to any existing
+//! `X-Forwarded-For`, which means an attacker who sends
+//! `X-Forwarded-For: 1.2.3.4` can control the first hop. So we prefer
+//! `X-Real-IP`, which Caddy sets authoritatively on the API hosts
+//! (`infra/caddy/Caddyfile.prod` configures `header_up X-Real-IP
+//! {client_ip}`). We still read XFF as a fallback, but take the *last* hop —
+//! the one Caddy appended — rather than the first, so a spoofed XFF value
+//! can't bypass the limit.
+use axum::http::HeaderMap;
+use axum::response::Response;
+use diesel::deserialize::QueryableByName;
+use diesel::sql_types::Integer;
+use diesel_async::RunQueryDsl;
+
+use super::{error_response, ErrorSpec};
+
+const IP_RATE_LIMIT_WINDOW_SECS: i64 = 60;
+const MATCHING_PROFILES_MAX_PER_MIN: u32 = 30;
+const CHAT_WS_UPGRADE_MAX_PER_MIN: u32 = 60;
+
+#[derive(Clone, Copy, Debug)]
+pub enum IpRateLimitAction {
+    MatchingProfiles,
+    ChatWsUpgrade,
+}
+
+impl IpRateLimitAction {
+    const fn max_attempts(self) -> u32 {
+        match self {
+            Self::MatchingProfiles => MATCHING_PROFILES_MAX_PER_MIN,
+            Self::ChatWsUpgrade => CHAT_WS_UPGRADE_MAX_PER_MIN,
+        }
+    }
+
+    const fn key_prefix(self) -> &'static str {
+        match self {
+            Self::MatchingProfiles => "ip_matching_profiles",
+            Self::ChatWsUpgrade => "ip_chat_ws_upgrade",
+        }
+    }
+}
+
+/// Resolve the client IP from proxy headers, in order of trustworthiness:
+///
+/// 1. `X-Real-IP` — Caddy sets this authoritatively; no client input can
+///    forge it past the proxy boundary.
+/// 2. `X-Forwarded-For` last hop — Caddy appends, so the rightmost value is
+///    what Caddy saw. Reading the first hop would be spoofable.
+/// 3. `"unknown"` — a single shared bucket, so the endpoint is still capped
+///    when headers are missing.
+fn client_ip(headers: &HeaderMap) -> String {
+    if let Some(value) = headers.get("x-real-ip").and_then(|v| v.to_str().ok()) {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    if let Some(value) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
+        if let Some(last) = value.split(',').next_back() {
+            let trimmed = last.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    "unknown".to_string()
+}
+
+fn rate_limit_response(headers: &HeaderMap) -> Response {
+    error_response(
+        axum::http::StatusCode::TOO_MANY_REQUESTS,
+        headers,
+        ErrorSpec {
+            error: "Too many requests, try again later".to_string(),
+            code: "RATE_LIMITED",
+            details: None,
+        },
+    )
+}
+
+#[derive(QueryableByName)]
+struct AttemptRow {
+    #[diesel(sql_type = Integer)]
+    attempts: i32,
+}
+
+async fn upsert_attempt(
+    key: &str,
+    window_secs: i64,
+) -> std::result::Result<i64, Box<dyn std::error::Error + Send + Sync>> {
+    let mut conn = crate::db::conn().await?;
+    let row = diesel::sql_query(
+        r"
+        INSERT INTO auth_rate_limits (id, rate_key, window_start, attempts, updated_at)
+        VALUES (gen_random_uuid(), $1, NOW(), 1, NOW())
+        ON CONFLICT (rate_key) DO UPDATE
+        SET
+            window_start = CASE
+                WHEN auth_rate_limits.window_start <= NOW() - make_interval(secs => $2)
+                    THEN NOW()
+                ELSE auth_rate_limits.window_start
+            END,
+            attempts = CASE
+                WHEN auth_rate_limits.window_start <= NOW() - make_interval(secs => $2)
+                    THEN 1
+                ELSE auth_rate_limits.attempts + 1
+            END,
+            updated_at = NOW()
+        RETURNING attempts
+        ",
+    )
+    .bind::<diesel::sql_types::Text, _>(key)
+    .bind::<diesel::sql_types::BigInt, _>(window_secs)
+    .get_result::<AttemptRow>(&mut conn)
+    .await?;
+
+    Ok(i64::from(row.attempts))
+}
+
+/// Throttle requests by (action, client IP).
+///
+/// Returns `Err(response)` with a 429 body when the caller exceeds the
+/// action's per-minute cap. Fails open on DB errors so a database hiccup
+/// doesn't take the API offline.
+pub async fn enforce_ip_rate_limit(
+    headers: &HeaderMap,
+    action: IpRateLimitAction,
+) -> std::result::Result<(), Box<Response>> {
+    let ip = client_ip(headers);
+    let key = format!("{}:{ip}", action.key_prefix());
+
+    let attempts = match upsert_attempt(&key, IP_RATE_LIMIT_WINDOW_SECS).await {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(%error, rate_key = %key, "ip rate limiter unavailable; allowing request");
+            return Ok(());
+        }
+    };
+
+    if attempts > i64::from(action.max_attempts()) {
+        Err(Box::new(rate_limit_response(headers)))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::client_ip;
+    use axum::http::HeaderMap;
+
+    fn headers_with(name: &'static str, value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(name, value.parse().expect("valid header value"));
+        h
+    }
+
+    #[test]
+    fn prefers_x_real_ip_over_xff() {
+        // If Caddy sets both (which it does), X-Real-IP wins because it
+        // isn't appended to by convention and can't be spoofed past Caddy.
+        let mut h = HeaderMap::new();
+        h.insert(
+            "x-real-ip",
+            "198.51.100.7".parse().expect("valid header value"),
+        );
+        h.insert(
+            "x-forwarded-for",
+            "1.2.3.4, 10.0.0.1".parse().expect("valid header value"),
+        );
+        assert_eq!(client_ip(&h), "198.51.100.7");
+    }
+
+    #[test]
+    fn uses_xff_last_hop_when_no_real_ip() {
+        // A malicious client sending X-Forwarded-For: 1.2.3.4 gets appended
+        // to by Caddy, so the last hop is the one the proxy observed.
+        let h = headers_with("x-forwarded-for", "1.2.3.4, 203.0.113.9");
+        assert_eq!(client_ip(&h), "203.0.113.9");
+    }
+
+    #[test]
+    fn handles_single_xff_hop() {
+        let h = headers_with("x-forwarded-for", "203.0.113.5");
+        assert_eq!(client_ip(&h), "203.0.113.5");
+    }
+
+    #[test]
+    fn falls_back_to_unknown_bucket() {
+        assert_eq!(client_ip(&HeaderMap::new()), "unknown");
+    }
+}

--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -49,6 +49,17 @@ pub(super) async fn profiles_recommendations(
     headers: HeaderMap,
     Query(query): Query<MatchingQuery>,
 ) -> Result<Response> {
+    // IP-keyed limit runs before auth so unauthenticated scrape attempts
+    // don't touch the DB auth path.
+    if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::MatchingProfiles,
+    )
+    .await
+    {
+        return Ok(*response);
+    }
+
     let repo = MatchingRepository;
     let (_session, user) = auth_or_respond!(headers);
 

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod chat;
 mod common;
 mod events;
 pub(crate) mod imgproxy_signing;
+pub mod ip_rate_limit;
 mod matching;
 mod profiles;
 mod root;

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -607,6 +607,62 @@ async fn ws_upgrade_rejects_foreign_origin() {
 
 #[tokio::test]
 #[serial]
+async fn ws_upgrade_is_rate_limited_per_ip() {
+    request(|request, _ctx| async move {
+        // Cap is 60/min (CHAT_WS_UPGRADE_MAX_PER_MIN). The rate-limit gate
+        // sits in the same route-layer middleware as the origin check, so
+        // a plain GET from the same IP 61 times yields 429 on the last one.
+        let ip_header = (
+            HeaderName::from_static("x-real-ip"),
+            HeaderValue::from_static("203.0.113.200"),
+        );
+
+        let mut last_status = 0;
+        for _ in 0..61 {
+            let response = request
+                .get("/api/v1/chat/ws")
+                .add_header(ip_header.0.clone(), ip_header.1.clone())
+                .await;
+            last_status = response.status_code().as_u16();
+        }
+        assert_eq!(
+            last_status, 429,
+            "expected the 61st ws_upgrade to be rate-limited"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn matching_profiles_is_rate_limited_per_ip() {
+    request(|request, _ctx| async move {
+        // Cap is 30/min (MATCHING_PROFILES_MAX_PER_MIN). The rate-limit
+        // check fires before auth, so no session is needed. The 31st
+        // request from the same forwarded IP should receive 429.
+        let ip_header = (
+            HeaderName::from_static("x-real-ip"),
+            HeaderValue::from_static("203.0.113.201"),
+        );
+
+        let mut last_status = 0;
+        for _ in 0..31 {
+            let response = request
+                .get("/api/v1/matching/profiles?limit=1")
+                .add_header(ip_header.0.clone(), ip_header.1.clone())
+                .await;
+            last_status = response.status_code().as_u16();
+        }
+        assert_eq!(
+            last_status, 429,
+            "expected the 31st /matching/profiles to be rate-limited"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
 async fn sign_in_verifies_hashed_password() {
     request(|request, _ctx| async move {
         let sign_up = request

--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -48,6 +48,12 @@ mobile.poziomki.app {
 
 	handle {
 		reverse_proxy localhost:5150 {
+			# Set an authoritative client-IP header the backend rate
+			# limiter can trust. We also replace X-Forwarded-For
+			# (Caddy would otherwise append, letting a client forge
+			# the first hop).
+			header_up X-Real-IP {client_ip}
+			header_up X-Forwarded-For {client_ip}
 			header_down -X-Powered-By
 		}
 	}
@@ -109,6 +115,10 @@ rs.poziomki.app {
 
 	handle {
 		reverse_proxy localhost:5150 {
+			# See comment on mobile.poziomki.app for rationale —
+			# authoritative client IP for the backend limiter.
+			header_up X-Real-IP {client_ip}
+			header_up X-Forwarded-For {client_ip}
 			header_down -X-Powered-By
 		}
 	}


### PR DESCRIPTION
**Per-IP rate limit on non-auth endpoints**

Reuses the existing \`auth_rate_limits\` table with an IP-keyed action set. No new dependency, 60s fixed window, fails open on DB error.

- \`/matching/profiles\` — 30/min per IP (CPU-heavy and scrapable)
- \`chat/ws\` upgrade — 60/min per IP (accepts socket before auth runs)

- [ ] confirm CI rate-limit test fires 429 on request #61

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add IP-keyed rate limiting to `/matching/profiles` and WebSocket upgrade endpoints
> - Adds a new [`ip_rate_limit`](https://github.com/poziomki-app/poziomki/pull/163/files#diff-b24a2d1728b014ee0e49e0c1191930457a5d5de97252671fc82f4c34b3444819) module that resolves client IP from `X-Real-IP` or `X-Forwarded-For` headers and enforces per-IP per-action limits via a DB upsert into `auth_rate_limits`, resetting counters after a 1-minute window.
> - Caps `/matching/profiles` at 30 requests/min and `/api/v1/chat/ws` upgrade attempts at 60/min per IP; exceeding either returns a 429 with code `RATE_LIMITED`.
> - Updates the [Caddy config](https://github.com/poziomki-app/poziomki/pull/163/files#diff-507ac62fa8220af2d08c3d8f2ef5aee0806600e1d1085fc4c641c643ea9f4e36) to forward an authoritative `X-Real-IP` and non-appended `X-Forwarded-For` to the backend.
> - DB errors fail open (requests are allowed through) with a warning log.
> - Risk: rate limit checks run before authentication on `/matching/profiles`, meaning unauthenticated requests consume the same per-IP quota.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6e9045.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->