### PR TITLE
feat(review): sandboxed reviewer account + stubs for Google Play

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ result-*
 # OS
 .DS_Store
 Thumbs.db
+play-store/

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -90,6 +90,10 @@ required-features = []
 name = "worker"
 path = "src/bin/worker.rs"
 
+[[bin]]
+name = "seed_reviewer"
+path = "src/bin/seed_reviewer.rs"
+
 [dev-dependencies]
 serial_test = { version = "=3.4.0" }
 axum-test = { version = "=19.0.0" }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=planner /app/backend/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . /app/
-RUN cargo build --release --bin poziomki_backend-cli --bin worker
+RUN cargo build --release --bin poziomki_backend-cli --bin worker --bin seed_reviewer
 
 # debian:bookworm-slim
 FROM debian@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS runtime-deps
@@ -48,6 +48,7 @@ WORKDIR /app
 COPY --from=runtime-deps /staging/ /
 COPY --from=builder /app/backend/target/release/poziomki_backend-cli /usr/local/bin/poziomki_backend-cli
 COPY --from=builder /app/backend/target/release/worker /usr/local/bin/worker
+COPY --from=builder /app/backend/target/release/seed_reviewer /usr/local/bin/seed_reviewer
 
 USER nonroot
 EXPOSE 5150

--- a/backend/migrations/2026-04-17-000000_review_stub_flag/down.sql
+++ b/backend/migrations/2026-04-17-000000_review_stub_flag/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS users_is_review_stub_idx;
+ALTER TABLE users DROP COLUMN is_review_stub;

--- a/backend/migrations/2026-04-17-000000_review_stub_flag/up.sql
+++ b/backend/migrations/2026-04-17-000000_review_stub_flag/up.sql
@@ -1,0 +1,6 @@
+-- Flag users that exist solely to support Google Play reviewer QA. Profiles
+-- and DMs owned by these accounts are visible only between other stub users,
+-- so they never leak into normal users' matching feed or chat list.
+ALTER TABLE users ADD COLUMN is_review_stub BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX users_is_review_stub_idx ON users (is_review_stub) WHERE is_review_stub = true;

--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -193,6 +193,14 @@ pub async fn list_for_user(
 
     let mut conn = crate::db::conn().await?;
 
+    let viewer_is_stub = users::table
+        .filter(users::id.eq(user_id))
+        .select(users::is_review_stub)
+        .first::<bool>(&mut conn)
+        .await
+        .optional()?
+        .unwrap_or(false);
+
     let conv_ids: Vec<Uuid> = conversation_members::table
         .filter(conversation_members::user_id.eq(user_id))
         .select(conversation_members::conversation_id)
@@ -203,10 +211,59 @@ pub async fn list_for_user(
         return Ok(Vec::new());
     }
 
-    let convs: Vec<Conversation> = conversations::table
+    let all_convs: Vec<Conversation> = conversations::table
         .filter(conversations::id.eq_any(&conv_ids))
         .load(&mut conn)
         .await?;
+
+    // Collect the "other participant" id for every DM so we can batch-load
+    // their is_review_stub flags in a single query.
+    let other_ids: Vec<i32> = all_convs
+        .iter()
+        .filter(|c| c.kind == "dm")
+        .filter_map(|c| {
+            if c.user_low_id == Some(user_id) {
+                c.user_high_id
+            } else {
+                c.user_low_id
+            }
+        })
+        .collect();
+
+    let stub_flags: std::collections::HashMap<i32, bool> = if other_ids.is_empty() {
+        std::collections::HashMap::new()
+    } else {
+        users::table
+            .filter(users::id.eq_any(&other_ids))
+            .select((users::id, users::is_review_stub))
+            .load::<(i32, bool)>(&mut conn)
+            .await?
+            .into_iter()
+            .collect()
+    };
+
+    // Hide DMs where the other participant has a different is_review_stub
+    // value so stub accounts stay invisible to real users (and vice versa).
+    let convs: Vec<Conversation> = all_convs
+        .into_iter()
+        .filter(|conv| {
+            if conv.kind != "dm" {
+                return true;
+            }
+            let other_id = if conv.user_low_id == Some(user_id) {
+                conv.user_high_id
+            } else {
+                conv.user_low_id
+            };
+            other_id
+                .is_none_or(|id| stub_flags.get(&id).copied().unwrap_or(false) == viewer_is_stub)
+        })
+        .collect();
+
+    let conv_ids: Vec<Uuid> = convs.iter().map(|c| c.id).collect();
+    if conv_ids.is_empty() {
+        return Ok(Vec::new());
+    }
 
     // Batch-load latest message per conversation (DISTINCT ON)
     let latest_messages: Vec<crate::db::models::messages::Message> = diesel::sql_query(

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -56,18 +56,26 @@ pub async fn ws_upgrade(State(ctx): State<AppContext>, upgrade: WebSocketUpgrade
 }
 
 /// Route-level gate for the `/chat/ws` endpoint. Runs on the raw `Request`
-/// before any extractors, so it can reject hostile origins *before* Axum's
-/// `WebSocketUpgrade` extractor runs its own preconditions — which matters
-/// both for security (reject early, no socket work) and for testability
-/// (in-process test harnesses can't satisfy the WebSocket extractor's HTTP
-/// version check, so any gate that lives *inside* the handler body is
-/// unreachable from integration tests).
+/// before any extractors, so both the origin allowlist and the IP rate
+/// limit fire uniformly in prod and in axum-test (the in-process transport
+/// can't satisfy `WebSocketUpgrade`'s HTTP-version precondition, so any
+/// check that lives inside the handler body is unreachable from integration
+/// tests). Origin is checked first — cheap and local, keeps hostile pages
+/// from burning a rate-limit slot.
 pub async fn ws_upgrade_gate(req: Request, next: Next) -> Response {
     if let Some(origin) = req.headers().get("origin").and_then(|v| v.to_str().ok()) {
         if !is_allowed_ws_origin(origin) {
             tracing::warn!(origin = %origin, "ws_upgrade: rejected origin");
             return (StatusCode::FORBIDDEN, "forbidden origin").into_response();
         }
+    }
+    if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        req.headers(),
+        crate::api::ip_rate_limit::IpRateLimitAction::ChatWsUpgrade,
+    )
+    .await
+    {
+        return *response;
     }
     next.run(req).await
 }

--- a/backend/src/api/ip_rate_limit.rs
+++ b/backend/src/api/ip_rate_limit.rs
@@ -1,0 +1,199 @@
+//! IP-keyed rate limits for non-auth endpoints.
+//!
+//! This mirrors the DB-backed limiter in `api::auth::rate_limit` but keys on
+//! the client IP from the reverse proxy instead of the per-user subject.
+//!
+//! **Header choice matters for exploitability.** Caddy's default
+//! `reverse_proxy` behaviour *appends* the client IP to any existing
+//! `X-Forwarded-For`, which means an attacker who sends
+//! `X-Forwarded-For: 1.2.3.4` can control the first hop. So we prefer
+//! `X-Real-IP`, which Caddy sets authoritatively on the API hosts
+//! (`infra/caddy/Caddyfile.prod` configures `header_up X-Real-IP
+//! {client_ip}`). We still read XFF as a fallback, but take the *last* hop —
+//! the one Caddy appended — rather than the first, so a spoofed XFF value
+//! can't bypass the limit.
+use axum::http::HeaderMap;
+use axum::response::Response;
+use diesel::deserialize::QueryableByName;
+use diesel::sql_types::Integer;
+use diesel_async::RunQueryDsl;
+
+use super::{error_response, ErrorSpec};
+
+const IP_RATE_LIMIT_WINDOW_SECS: i64 = 60;
+const MATCHING_PROFILES_MAX_PER_MIN: u32 = 30;
+const CHAT_WS_UPGRADE_MAX_PER_MIN: u32 = 60;
+
+#[derive(Clone, Copy, Debug)]
+pub enum IpRateLimitAction {
+    MatchingProfiles,
+    ChatWsUpgrade,
+}
+
+impl IpRateLimitAction {
+    const fn max_attempts(self) -> u32 {
+        match self {
+            Self::MatchingProfiles => MATCHING_PROFILES_MAX_PER_MIN,
+            Self::ChatWsUpgrade => CHAT_WS_UPGRADE_MAX_PER_MIN,
+        }
+    }
+
+    const fn key_prefix(self) -> &'static str {
+        match self {
+            Self::MatchingProfiles => "ip_matching_profiles",
+            Self::ChatWsUpgrade => "ip_chat_ws_upgrade",
+        }
+    }
+}
+
+/// Resolve the client IP from proxy headers, in order of trustworthiness:
+///
+/// 1. `X-Real-IP` — Caddy sets this authoritatively; no client input can
+///    forge it past the proxy boundary.
+/// 2. `X-Forwarded-For` last hop — Caddy appends, so the rightmost value is
+///    what Caddy saw. Reading the first hop would be spoofable.
+/// 3. `"unknown"` — a single shared bucket, so the endpoint is still capped
+///    when headers are missing.
+fn client_ip(headers: &HeaderMap) -> String {
+    if let Some(value) = headers.get("x-real-ip").and_then(|v| v.to_str().ok()) {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    if let Some(value) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
+        if let Some(last) = value.split(',').next_back() {
+            let trimmed = last.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    "unknown".to_string()
+}
+
+fn rate_limit_response(headers: &HeaderMap) -> Response {
+    error_response(
+        axum::http::StatusCode::TOO_MANY_REQUESTS,
+        headers,
+        ErrorSpec {
+            error: "Too many requests, try again later".to_string(),
+            code: "RATE_LIMITED",
+            details: None,
+        },
+    )
+}
+
+#[derive(QueryableByName)]
+struct AttemptRow {
+    #[diesel(sql_type = Integer)]
+    attempts: i32,
+}
+
+async fn upsert_attempt(
+    key: &str,
+    window_secs: i64,
+) -> std::result::Result<i64, Box<dyn std::error::Error + Send + Sync>> {
+    let mut conn = crate::db::conn().await?;
+    let row = diesel::sql_query(
+        r"
+        INSERT INTO auth_rate_limits (id, rate_key, window_start, attempts, updated_at)
+        VALUES (gen_random_uuid(), $1, NOW(), 1, NOW())
+        ON CONFLICT (rate_key) DO UPDATE
+        SET
+            window_start = CASE
+                WHEN auth_rate_limits.window_start <= NOW() - make_interval(secs => $2)
+                    THEN NOW()
+                ELSE auth_rate_limits.window_start
+            END,
+            attempts = CASE
+                WHEN auth_rate_limits.window_start <= NOW() - make_interval(secs => $2)
+                    THEN 1
+                ELSE auth_rate_limits.attempts + 1
+            END,
+            updated_at = NOW()
+        RETURNING attempts
+        ",
+    )
+    .bind::<diesel::sql_types::Text, _>(key)
+    .bind::<diesel::sql_types::BigInt, _>(window_secs)
+    .get_result::<AttemptRow>(&mut conn)
+    .await?;
+
+    Ok(i64::from(row.attempts))
+}
+
+/// Throttle requests by (action, client IP).
+///
+/// Returns `Err(response)` with a 429 body when the caller exceeds the
+/// action's per-minute cap. Fails open on DB errors so a database hiccup
+/// doesn't take the API offline.
+pub async fn enforce_ip_rate_limit(
+    headers: &HeaderMap,
+    action: IpRateLimitAction,
+) -> std::result::Result<(), Box<Response>> {
+    let ip = client_ip(headers);
+    let key = format!("{}:{ip}", action.key_prefix());
+
+    let attempts = match upsert_attempt(&key, IP_RATE_LIMIT_WINDOW_SECS).await {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(%error, rate_key = %key, "ip rate limiter unavailable; allowing request");
+            return Ok(());
+        }
+    };
+
+    if attempts > i64::from(action.max_attempts()) {
+        Err(Box::new(rate_limit_response(headers)))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::client_ip;
+    use axum::http::HeaderMap;
+
+    fn headers_with(name: &'static str, value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(name, value.parse().expect("valid header value"));
+        h
+    }
+
+    #[test]
+    fn prefers_x_real_ip_over_xff() {
+        // If Caddy sets both (which it does), X-Real-IP wins because it
+        // isn't appended to by convention and can't be spoofed past Caddy.
+        let mut h = HeaderMap::new();
+        h.insert(
+            "x-real-ip",
+            "198.51.100.7".parse().expect("valid header value"),
+        );
+        h.insert(
+            "x-forwarded-for",
+            "1.2.3.4, 10.0.0.1".parse().expect("valid header value"),
+        );
+        assert_eq!(client_ip(&h), "198.51.100.7");
+    }
+
+    #[test]
+    fn uses_xff_last_hop_when_no_real_ip() {
+        // A malicious client sending X-Forwarded-For: 1.2.3.4 gets appended
+        // to by Caddy, so the last hop is the one the proxy observed.
+        let h = headers_with("x-forwarded-for", "1.2.3.4, 203.0.113.9");
+        assert_eq!(client_ip(&h), "203.0.113.9");
+    }
+
+    #[test]
+    fn handles_single_xff_hop() {
+        let h = headers_with("x-forwarded-for", "203.0.113.5");
+        assert_eq!(client_ip(&h), "203.0.113.5");
+    }
+
+    #[test]
+    fn falls_back_to_unknown_bucket() {
+        assert_eq!(client_ip(&HeaderMap::new()), "unknown");
+    }
+}

--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -49,6 +49,17 @@ pub(super) async fn profiles_recommendations(
     headers: HeaderMap,
     Query(query): Query<MatchingQuery>,
 ) -> Result<Response> {
+    // IP-keyed limit runs before auth so unauthenticated scrape attempts
+    // don't touch the DB auth path.
+    if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::MatchingProfiles,
+    )
+    .await
+    {
+        return Ok(*response);
+    }
+
     let repo = MatchingRepository;
     let (_session, user) = auth_or_respond!(headers);
 

--- a/backend/src/api/matching/repo.rs
+++ b/backend/src/api/matching/repo.rs
@@ -184,9 +184,19 @@ impl MatchingRepository {
         limit: i64,
         conn: &mut crate::db::DbConn,
     ) -> std::result::Result<Vec<Profile>, crate::error::AppError> {
+        let viewer_is_stub = users::table
+            .filter(users::id.eq(user_id))
+            .select(users::is_review_stub)
+            .first::<bool>(conn)
+            .await
+            .optional()?
+            .unwrap_or(false);
+
         profiles::table
+            .inner_join(users::table.on(users::id.eq(profiles::user_id)))
             .left_join(user_settings::table.on(user_settings::user_id.eq(profiles::user_id)))
             .filter(profiles::user_id.ne(user_id))
+            .filter(users::is_review_stub.eq(viewer_is_stub))
             .filter(
                 user_settings::privacy_discoverable
                     .eq(true)

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod chat;
 mod common;
 mod events;
 pub(crate) mod imgproxy_signing;
+pub mod ip_rate_limit;
 mod matching;
 mod profiles;
 mod root;

--- a/backend/src/api/uploads/mod.rs
+++ b/backend/src/api/uploads/mod.rs
@@ -40,7 +40,6 @@ use super::state::{
     DirectUploadPresignBody, DirectUploadPresignResponse, SuccessResponse, UploadResponse,
     UploadStatusResponse,
 };
-use super::{error_response, ErrorSpec};
 use crate::db::models::uploads::{NewUpload, UploadChangeset};
 use crate::jobs::enqueue_upload_variants_generation;
 use uploads_auth_service::{
@@ -53,7 +52,9 @@ use uploads_http::{
 use uploads_multipart::HandlerError;
 pub(super) use uploads_read_handler::{auth_check, file_get, file_status};
 use uploads_url_service::{encode_thumbhash, fallback_variant_urls, public_upload_url};
-use uploads_validation_service::{extract_filename_from_original_uri, validate_presign_payload};
+use uploads_validation_service::{
+    extract_filename_from_original_uri, validate_completed_upload_bytes, validate_presign_payload,
+};
 pub(super) use uploads_write_handler::{
     file_delete, file_upload, file_upload_complete, file_upload_presign,
 };

--- a/backend/src/api/uploads/storage.rs
+++ b/backend/src/api/uploads/storage.rs
@@ -1,5 +1,6 @@
 use axum::http::{header, HeaderMap, HeaderValue};
 use s3::{creds::Credentials, error::S3Error, Bucket, Region};
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use url::Url;
 
@@ -8,8 +9,14 @@ const DEFAULT_PRESIGN_EXPIRY_SECS: u64 = 3600;
 const MAX_PRESIGN_EXPIRY_SECS: u32 = 604_800;
 
 #[derive(Clone)]
+enum StorageBackend {
+    S3(Box<Bucket>),
+    Local { root: PathBuf },
+}
+
+#[derive(Clone)]
 struct StorageConfig {
-    bucket: Box<Bucket>,
+    backend: StorageBackend,
     public_url: Option<String>,
     presign_expiry_secs: u64,
     object_prefix: String,
@@ -70,7 +77,41 @@ fn object_path(object_prefix: &str, filename: &str) -> String {
     format!("/{object_prefix}{filename}")
 }
 
-fn build_bucket() -> Result<StorageConfig, String> {
+fn local_storage_root() -> Option<PathBuf> {
+    env_any(&["UPLOAD_STORAGE_DIR"])
+        .map(PathBuf::from)
+        .or_else(|| {
+            let is_test_database = std::env::var("DATABASE_URL")
+                .ok()
+                .is_some_and(|url| url.contains("poziomki-backend_development"));
+            if cfg!(debug_assertions) && is_test_database {
+                Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/test-uploads"))
+            } else {
+                None
+            }
+        })
+}
+
+fn local_object_path(root: &Path, object_prefix: &str, filename: &str) -> PathBuf {
+    root.join(object_prefix.trim_matches('/')).join(filename)
+}
+
+fn build_storage() -> Result<StorageConfig, String> {
+    let object_prefix = normalize_prefix(
+        env_any(&["IMGPROXY_ALLOWED_PREFIX"])
+            .as_deref()
+            .unwrap_or("uploads/"),
+    )?;
+
+    if let Some(root) = local_storage_root() {
+        return Ok(StorageConfig {
+            backend: StorageBackend::Local { root },
+            public_url: None,
+            presign_expiry_secs: parse_presign_expiry_secs(),
+            object_prefix,
+        });
+    }
+
     let endpoint = env_any(&["GARAGE_S3_ENDPOINT"])
         .ok_or_else(|| "Missing S3 endpoint. Set GARAGE_S3_ENDPOINT.".to_string())?;
     let bucket_name = env_any(&["GARAGE_S3_BUCKET"])
@@ -82,11 +123,6 @@ fn build_bucket() -> Result<StorageConfig, String> {
     let region_name = env_any(&["GARAGE_S3_REGION"]).unwrap_or_else(|| DEFAULT_REGION.to_string());
     let public_url = env_any(&["GARAGE_S3_PUBLIC_URL"]);
     let virtual_host = parse_bool_env("GARAGE_S3_VIRTUAL_HOST_STYLE", false);
-    let object_prefix = normalize_prefix(
-        env_any(&["IMGPROXY_ALLOWED_PREFIX"])
-            .as_deref()
-            .unwrap_or("uploads/"),
-    )?;
 
     let region = Region::Custom {
         region: region_name,
@@ -103,7 +139,7 @@ fn build_bucket() -> Result<StorageConfig, String> {
     };
 
     Ok(StorageConfig {
-        bucket,
+        backend: StorageBackend::S3(bucket),
         public_url,
         presign_expiry_secs: parse_presign_expiry_secs(),
         object_prefix,
@@ -111,7 +147,7 @@ fn build_bucket() -> Result<StorageConfig, String> {
 }
 
 fn load_storage() -> Result<StorageConfig, String> {
-    build_bucket()
+    build_storage()
 }
 
 fn storage() -> Result<&'static StorageConfig, String> {
@@ -164,53 +200,101 @@ pub(super) async fn upload(
     mime_type: &str,
 ) -> Result<(), StorageError> {
     let config = storage().map_err(|_message| storage_error(None))?;
-    let response = config
-        .bucket
-        .put_object_with_content_type(
-            object_path(&config.object_prefix, filename),
-            bytes,
-            mime_type,
-        )
-        .await
-        .map_err(|err| map_s3_error(&err))?;
-    ensure_ok_status(response.status_code())
+    match &config.backend {
+        StorageBackend::S3(bucket) => {
+            let response = bucket
+                .put_object_with_content_type(
+                    object_path(&config.object_prefix, filename),
+                    bytes,
+                    mime_type,
+                )
+                .await
+                .map_err(|err| map_s3_error(&err))?;
+            ensure_ok_status(response.status_code())
+        }
+        StorageBackend::Local { root } => {
+            let path = local_object_path(root, &config.object_prefix, filename);
+            if let Some(parent) = path.parent() {
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .map_err(|_err| storage_error(None))?;
+            }
+            tokio::fs::write(path, bytes)
+                .await
+                .map_err(|_err| storage_error(None))
+        }
+    }
 }
 
 pub(in crate::api) async fn read(filename: &str) -> Result<Vec<u8>, StorageError> {
     let config = storage().map_err(|_message| storage_error(None))?;
-    let response = config
-        .bucket
-        .get_object(object_path(&config.object_prefix, filename))
-        .await
-        .map_err(|err| map_s3_error(&err))?;
-    ensure_ok_status(response.status_code())?;
-    Ok(response.to_vec())
+    match &config.backend {
+        StorageBackend::S3(bucket) => {
+            let response = bucket
+                .get_object(object_path(&config.object_prefix, filename))
+                .await
+                .map_err(|err| map_s3_error(&err))?;
+            ensure_ok_status(response.status_code())?;
+            Ok(response.to_vec())
+        }
+        StorageBackend::Local { root } => {
+            tokio::fs::read(local_object_path(root, &config.object_prefix, filename))
+                .await
+                .map_err(|err| {
+                    if err.kind() == std::io::ErrorKind::NotFound {
+                        storage_error(Some(StorageErrorKind::NotFound))
+                    } else {
+                        storage_error(None)
+                    }
+                })
+        }
+    }
 }
 
 pub(in crate::api) async fn exists(filename: &str) -> Result<bool, StorageError> {
     let config = storage().map_err(|_message| storage_error(None))?;
-    let (_head, status_code) = config
-        .bucket
-        .head_object(object_path(&config.object_prefix, filename))
-        .await
-        .map_err(|err| map_s3_error(&err))?;
-    if (200..300).contains(&status_code) {
-        return Ok(true);
+    match &config.backend {
+        StorageBackend::S3(bucket) => {
+            let (_head, status_code) = bucket
+                .head_object(object_path(&config.object_prefix, filename))
+                .await
+                .map_err(|err| map_s3_error(&err))?;
+            if (200..300).contains(&status_code) {
+                return Ok(true);
+            }
+            if status_code == 404 {
+                return Ok(false);
+            }
+            Err(storage_error(None))
+        }
+        StorageBackend::Local { root } => {
+            tokio::fs::try_exists(local_object_path(root, &config.object_prefix, filename))
+                .await
+                .map_err(|_err| storage_error(None))
+        }
     }
-    if status_code == 404 {
-        return Ok(false);
-    }
-    Err(storage_error(None))
 }
 
 pub(super) async fn delete(filename: &str) -> Result<(), StorageError> {
     let config = storage().map_err(|_message| storage_error(None))?;
-    let response = config
-        .bucket
-        .delete_object(object_path(&config.object_prefix, filename))
-        .await
-        .map_err(|err| map_s3_error(&err))?;
-    ensure_ok_status(response.status_code())
+    match &config.backend {
+        StorageBackend::S3(bucket) => {
+            let response = bucket
+                .delete_object(object_path(&config.object_prefix, filename))
+                .await
+                .map_err(|err| map_s3_error(&err))?;
+            ensure_ok_status(response.status_code())
+        }
+        StorageBackend::Local { root } => {
+            match tokio::fs::remove_file(local_object_path(root, &config.object_prefix, filename))
+                .await
+            {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(_err) => Err(storage_error(None)),
+            }
+        }
+    }
 }
 
 pub(in crate::api) async fn signed_put_url(
@@ -218,6 +302,9 @@ pub(in crate::api) async fn signed_put_url(
     mime_type: &str,
 ) -> Result<String, StorageError> {
     let config = storage().map_err(|_message| storage_error(None))?;
+    let StorageBackend::S3(bucket) = &config.backend else {
+        return Err(storage_error(None));
+    };
     let mut headers = HeaderMap::new();
     let content_type = HeaderValue::from_str(mime_type).map_err(|_err| storage_error(None))?;
     headers.insert(header::CONTENT_TYPE, content_type);
@@ -226,8 +313,7 @@ pub(in crate::api) async fn signed_put_url(
         HeaderValue::from_static("private, max-age=31536000"),
     );
 
-    let signed = config
-        .bucket
+    let signed = bucket
         .presign_put(
             object_path(&config.object_prefix, filename),
             presign_expiry_secs_u32(config.presign_expiry_secs),

--- a/backend/src/api/uploads/validation_service.rs
+++ b/backend/src/api/uploads/validation_service.rs
@@ -4,7 +4,8 @@ use super::uploads_http::bad_request;
 use super::uploads_multipart::HandlerError;
 use crate::api::state::{
     allowed_upload_mime, is_chat_context, is_s3_storage_configured, max_upload_size_bytes,
-    parse_upload_context, validate_filename, DirectUploadPresignBody, UploadContext,
+    parse_upload_context, validate_filename, validate_image_dimensions, validate_magic_bytes,
+    DirectUploadPresignBody, UploadContext,
 };
 
 pub(super) fn extract_filename_from_original_uri(
@@ -93,4 +94,21 @@ pub(super) fn check_upload_constraints(
         )));
     }
     Ok(())
+}
+
+pub(super) fn validate_completed_upload_bytes(
+    headers: &HeaderMap,
+    mime_type: &str,
+    bytes: &[u8],
+) -> std::result::Result<(), HandlerError> {
+    check_upload_constraints(headers, mime_type, bytes.len())?;
+    if !validate_magic_bytes(bytes, mime_type) {
+        return Err(Box::new(bad_request(
+            headers,
+            "INVALID_FILE_CONTENT",
+            "Content does not match type",
+        )));
+    }
+    validate_image_dimensions(bytes, mime_type)
+        .map_err(|message| Box::new(bad_request(headers, "IMAGE_TOO_LARGE", message)))
 }

--- a/backend/src/api/uploads/write_handler.rs
+++ b/backend/src/api/uploads/write_handler.rs
@@ -1,12 +1,11 @@
 use super::{
-    bad_request, create_upload_filename, enqueue_upload_variants_generation, error_response,
-    fallback_variant_urls, internal_upload_error, load_owned_upload, not_found, public_upload_url,
-    require_auth_profile, storage_delete, storage_signed_put_url, storage_upload,
-    uploads_multipart, uploads_resize, uploads_storage, validate_filename,
-    validate_presign_payload, AppContext, DataResponse, DirectUploadCompleteBody,
-    DirectUploadPresignBody, DirectUploadPresignResponse, ErrorSpec, HandlerError, HeaderMap, Json,
-    Multipart, NewUpload, Path, Response, Result, State, SuccessResponse, UploadChangeset,
-    UploadResponse, Utc, Uuid,
+    bad_request, create_upload_filename, enqueue_upload_variants_generation, fallback_variant_urls,
+    internal_upload_error, load_owned_upload, not_found, public_upload_url, require_auth_profile,
+    storage_delete, storage_signed_put_url, storage_upload, uploads_multipart, uploads_resize,
+    uploads_storage, validate_completed_upload_bytes, validate_filename, validate_presign_payload,
+    AppContext, DataResponse, DirectUploadCompleteBody, DirectUploadPresignBody,
+    DirectUploadPresignResponse, HandlerError, HeaderMap, Json, Multipart, NewUpload, Path,
+    Response, Result, State, SuccessResponse, UploadChangeset, UploadResponse, Utc, Uuid,
 };
 use axum::response::IntoResponse;
 
@@ -148,22 +147,16 @@ pub(in crate::api) async fn file_upload_complete(
         let profile = require_auth_profile(&headers).await?;
         let upload = load_owned_upload(&headers, &payload.filename, profile.id).await?;
 
-        let exists = uploads_storage::exists(&payload.filename)
-            .await
-            .map_err(|_error| {
-                Box::new(error_response(
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    &headers,
-                    ErrorSpec {
-                        error: "Upload storage is unavailable".to_string(),
-                        code: "INTERNAL_ERROR",
-                        details: None,
-                    },
-                )) as HandlerError
-            })?;
-        if !exists {
-            return Err(Box::new(not_found(&headers)));
-        }
+        let bytes =
+            uploads_storage::read(&payload.filename)
+                .await
+                .map_err(|error| match error.kind {
+                    Some(uploads_storage::StorageErrorKind::NotFound) => {
+                        Box::new(not_found(&headers)) as HandlerError
+                    }
+                    _ => internal_upload_error(&headers, "Upload storage is unavailable"),
+                })?;
+        validate_completed_upload_bytes(&headers, &upload.mime_type, &bytes)?;
 
         if let Err(error) = enqueue_upload_variants_generation(&upload.id).await {
             tracing::warn!(
@@ -182,7 +175,7 @@ pub(in crate::api) async fn file_upload_complete(
                 id: upload.id.to_string(),
                 url,
                 filename: upload.filename,
-                size: 0,
+                size: bytes.len(),
                 mime_type: upload.mime_type,
                 thumbnail_url,
                 standard_url,

--- a/backend/src/bin/seed_reviewer.rs
+++ b/backend/src/bin/seed_reviewer.rs
@@ -1,0 +1,388 @@
+//! One-shot CLI to provision the Google Play reviewer test account plus a
+//! small constellation of stub profiles and DMs. Safe to re-run: exits early
+//! if the reviewer account already exists.
+//!
+//! Prereq: upload the stub photos to S3 first (keys listed in `PHOTOS`).
+
+use argon2::password_hash::rand_core::{OsRng, RngCore};
+use chrono::{Duration, Utc};
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use poziomki_backend::db::schema::{
+    conversation_members, conversations, messages, profiles, uploads, user_settings, users,
+};
+use poziomki_backend::security;
+use uuid::Uuid;
+
+const REVIEWER_EMAIL: &str = "reviewer@poziomki.app";
+
+struct StubSpec {
+    email: &'static str,
+    name: &'static str,
+    bio: &'static str,
+    program: &'static str,
+    photo_key: &'static str,
+}
+
+const REVIEWER: StubSpec = StubSpec {
+    email: REVIEWER_EMAIL,
+    name: "Reviewer",
+    bio: "Konto recenzenta Google Play.",
+    program: "Informatyka",
+    photo_key: "review/reviewer.webp",
+};
+
+const STUBS: &[StubSpec] = &[
+    StubSpec {
+        email: "stub01@poziomki.app",
+        name: "Ola",
+        bio: "Kocham planszówki i długie spacery po Krakowie.",
+        program: "Psychologia",
+        photo_key: "review/stub01.webp",
+    },
+    StubSpec {
+        email: "stub02@poziomki.app",
+        name: "Kuba",
+        bio: "Bieganie o świcie, kawa o ósmej, kod do wieczora.",
+        program: "Informatyka",
+        photo_key: "review/stub02.webp",
+    },
+    StubSpec {
+        email: "stub03@poziomki.app",
+        name: "Marta",
+        bio: "Studentka architektury, fanka kina i jazzu.",
+        program: "Architektura",
+        photo_key: "review/stub03.webp",
+    },
+    StubSpec {
+        email: "stub04@poziomki.app",
+        name: "Piotr",
+        bio: "Wspinaczka, fotografia analogowa, dobre pierogi.",
+        program: "Fizyka",
+        photo_key: "review/stub04.webp",
+    },
+    StubSpec {
+        email: "stub05@poziomki.app",
+        name: "Zosia",
+        bio: "Szukam kogoś do nauki języka włoskiego.",
+        program: "Filologia włoska",
+        photo_key: "review/stub05.webp",
+    },
+    StubSpec {
+        email: "stub06@poziomki.app",
+        name: "Jan",
+        bio: "Muzyka elektroniczna, koty, góry.",
+        program: "Matematyka",
+        photo_key: "review/stub06.webp",
+    },
+    StubSpec {
+        email: "stub07@poziomki.app",
+        name: "Ania",
+        bio: "Miłośniczka teatru i eksperymentalnej kuchni.",
+        program: "Teatrologia",
+        photo_key: "review/stub07.webp",
+    },
+    StubSpec {
+        email: "stub08@poziomki.app",
+        name: "Mateusz",
+        bio: "Programowanie, rower, gry planszowe.",
+        program: "Informatyka",
+        photo_key: "review/stub08.webp",
+    },
+];
+
+/// Scripted DM messages between reviewer and stubs 01..03. Even index =
+/// from reviewer, odd = from stub.
+const CHAT_SCRIPTS: &[(&str, &[&str])] = &[
+    (
+        "stub01@poziomki.app",
+        &[
+            "Cześć! Widziałam, że też lubisz planszówki :)",
+            "Hej! Tak, ostatnio gram w Terraformację Marsa. A Ty?",
+            "Uwielbiam! Może w sobotę zagramy?",
+            "Jasne, może u mnie około 18?",
+            "Pasuje. Przynieść coś słodkiego?",
+            "Zawsze miło widziane!",
+        ],
+    ),
+    (
+        "stub02@poziomki.app",
+        &[
+            "Hej, biegasz po Plantach?",
+            "Tak, codziennie rano o 6:30.",
+            "Dołączę jutro, jeśli ok?",
+            "Pewnie, spotkajmy się przy Barbakanie.",
+            "Super, do jutra!",
+        ],
+    ),
+    (
+        "stub03@poziomki.app",
+        &[
+            "Widziałam Twój profil, też interesujesz się kinem?",
+            "Tak, szczególnie Bergmana i Kieślowskiego.",
+            "O, mam plakat Dekalogu w pokoju :)",
+            "Kiedyś musisz mi pokazać!",
+            "Jasne, może przy kawie?",
+            "Chętnie. Znasz kawiarnię na Kazimierzu „Alchemia\"?",
+            "Tak! Ulubione miejsce. Sobota 15:00?",
+        ],
+    ),
+];
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = users)]
+struct SeedUser {
+    pid: Uuid,
+    email: String,
+    password: String,
+    api_key: String,
+    name: String,
+    email_verified_at: chrono::DateTime<Utc>,
+    is_review_stub: bool,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = user_settings)]
+struct SeedUserSettings {
+    id: Uuid,
+    user_id: i32,
+    theme: String,
+    language: String,
+    notifications_enabled: bool,
+    privacy_show_program: bool,
+    privacy_discoverable: bool,
+}
+
+fn random_password() -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%^&*";
+    let mut bytes = [0u8; 20];
+    OsRng.fill_bytes(&mut bytes);
+    bytes
+        .iter()
+        .map(|b| {
+            let idx = (*b as usize) % CHARSET.len();
+            CHARSET.get(idx).copied().unwrap_or(b'x') as char
+        })
+        .collect()
+}
+
+async fn user_exists(
+    email: &str,
+    conn: &mut poziomki_backend::db::DbConn,
+) -> Result<Option<i32>, Box<dyn std::error::Error + Send + Sync>> {
+    let row = users::table
+        .filter(users::email.eq(email))
+        .select(users::id)
+        .first::<i32>(conn)
+        .await
+        .optional()?;
+    Ok(row)
+}
+
+async fn create_seed_user(
+    spec: &StubSpec,
+    password_hash: &str,
+    conn: &mut poziomki_backend::db::DbConn,
+) -> Result<(i32, Uuid), Box<dyn std::error::Error + Send + Sync>> {
+    let new_user = SeedUser {
+        pid: Uuid::new_v4(),
+        email: spec.email.to_string(),
+        password: password_hash.to_string(),
+        api_key: format!("rv-{}", Uuid::new_v4()),
+        name: spec.name.to_string(),
+        email_verified_at: Utc::now(),
+        is_review_stub: true,
+    };
+    let user_id: i32 = diesel::insert_into(users::table)
+        .values(&new_user)
+        .returning(users::id)
+        .get_result(conn)
+        .await?;
+
+    // user_settings
+    let settings = SeedUserSettings {
+        id: Uuid::new_v4(),
+        user_id,
+        theme: "system".to_string(),
+        language: "pl".to_string(),
+        notifications_enabled: true,
+        privacy_show_program: true,
+        privacy_discoverable: true,
+    };
+    diesel::insert_into(user_settings::table)
+        .values(&settings)
+        .execute(conn)
+        .await?;
+
+    // upload row for the profile photo
+    let upload_id = Uuid::new_v4();
+    let now = Utc::now();
+    diesel::insert_into(uploads::table)
+        .values((
+            uploads::id.eq(upload_id),
+            uploads::filename.eq(spec.photo_key),
+            uploads::owner_id.eq::<Option<Uuid>>(None),
+            uploads::context.eq("profile"),
+            uploads::context_id.eq::<Option<String>>(None),
+            uploads::mime_type.eq("image/webp"),
+            uploads::deleted.eq(false),
+            uploads::thumbhash.eq::<Option<Vec<u8>>>(None),
+            uploads::has_variants.eq(false),
+            uploads::created_at.eq(now),
+            uploads::updated_at.eq(now),
+        ))
+        .execute(conn)
+        .await?;
+
+    // profile
+    let profile_id = Uuid::new_v4();
+    diesel::insert_into(profiles::table)
+        .values((
+            profiles::id.eq(profile_id),
+            profiles::user_id.eq(user_id),
+            profiles::name.eq(spec.name),
+            profiles::bio.eq::<Option<&str>>(Some(spec.bio)),
+            profiles::profile_picture.eq::<Option<&str>>(Some(spec.photo_key)),
+            profiles::images.eq::<Option<serde_json::Value>>(None),
+            profiles::program.eq::<Option<&str>>(Some(spec.program)),
+            profiles::gradient_start.eq::<Option<&str>>(None),
+            profiles::gradient_end.eq::<Option<&str>>(None),
+            profiles::created_at.eq(now),
+            profiles::updated_at.eq(now),
+        ))
+        .execute(conn)
+        .await?;
+
+    Ok((user_id, profile_id))
+}
+
+async fn seed_dm(
+    reviewer_id: i32,
+    stub_id: i32,
+    script: &[&str],
+    conn: &mut poziomki_backend::db::DbConn,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let (low, high) = if reviewer_id < stub_id {
+        (reviewer_id, stub_id)
+    } else {
+        (stub_id, reviewer_id)
+    };
+    let now = Utc::now();
+    let conv_id = Uuid::new_v4();
+    diesel::insert_into(conversations::table)
+        .values((
+            conversations::id.eq(conv_id),
+            conversations::kind.eq("dm"),
+            conversations::title.eq::<Option<&str>>(None),
+            conversations::event_id.eq::<Option<Uuid>>(None),
+            conversations::user_low_id.eq::<Option<i32>>(Some(low)),
+            conversations::user_high_id.eq::<Option<i32>>(Some(high)),
+            conversations::created_at.eq(now),
+            conversations::updated_at.eq(now),
+        ))
+        .execute(conn)
+        .await?;
+
+    for user in [reviewer_id, stub_id] {
+        diesel::insert_into(conversation_members::table)
+            .values((
+                conversation_members::conversation_id.eq(conv_id),
+                conversation_members::user_id.eq(user),
+                conversation_members::joined_at.eq(now),
+            ))
+            .execute(conn)
+            .await?;
+    }
+
+    // Space messages over the last ~7 days so the chat looks organic.
+    let base = now - Duration::days(7);
+    let step_minutes = if script.is_empty() {
+        0
+    } else {
+        let total_minutes = 7 * 24 * 60_i64;
+        total_minutes / i64::try_from(script.len()).unwrap_or(1).max(1)
+    };
+    for (idx, body) in script.iter().enumerate() {
+        let sender = if idx % 2 == 0 { reviewer_id } else { stub_id };
+        let idx_i64 = i64::try_from(idx).unwrap_or(0);
+        let created_at = base + Duration::minutes(step_minutes * idx_i64);
+        diesel::insert_into(messages::table)
+            .values((
+                messages::id.eq(Uuid::new_v4()),
+                messages::conversation_id.eq(conv_id),
+                messages::sender_id.eq(sender),
+                messages::body.eq(*body),
+                messages::kind.eq("text"),
+                messages::reply_to_id.eq::<Option<Uuid>>(None),
+                messages::client_id.eq::<Option<String>>(None),
+                messages::created_at.eq(created_at),
+            ))
+            .execute(conn)
+            .await?;
+    }
+
+    Ok(())
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let database_url =
+        std::env::var("DATABASE_URL").map_err(|_| "DATABASE_URL must be set".to_string())?;
+    poziomki_backend::db::init_pool(&database_url)?;
+
+    let mut conn = poziomki_backend::db::conn().await?;
+
+    if user_exists(REVIEWER_EMAIL, &mut conn).await?.is_some() {
+        tracing::info!(
+            "Reviewer account already exists ({}). Nothing to do.",
+            REVIEWER_EMAIL
+        );
+        return Ok(());
+    }
+
+    // Reviewer
+    let reviewer_password = random_password();
+    let reviewer_hash = security::hash_password(&reviewer_password)
+        .map_err(|e| format!("Argon2 hash failed: {e}"))?;
+    let (reviewer_id, _reviewer_profile_id) =
+        create_seed_user(&REVIEWER, &reviewer_hash, &mut conn).await?;
+    tracing::info!("Created reviewer user id={}", reviewer_id);
+
+    // Stubs
+    let stub_hash = security::hash_password("stub-unused-password-0000")
+        .map_err(|e| format!("Argon2 hash failed: {e}"))?;
+    let mut stub_ids_by_email: std::collections::HashMap<&str, i32> =
+        std::collections::HashMap::new();
+    for stub in STUBS {
+        let (id, _pid) = create_seed_user(stub, &stub_hash, &mut conn).await?;
+        stub_ids_by_email.insert(stub.email, id);
+        tracing::info!("Created stub user {} (id={})", stub.email, id);
+    }
+
+    // DMs (reviewer <-> stub01/02/03)
+    for (email, script) in CHAT_SCRIPTS {
+        if let Some(&stub_id) = stub_ids_by_email.get(*email) {
+            seed_dm(reviewer_id, stub_id, script, &mut conn).await?;
+            tracing::info!("Seeded DM reviewer <-> {}", email);
+        }
+    }
+
+    tracing::info!("========================================");
+    tracing::info!("REVIEWER EMAIL:    {}", REVIEWER_EMAIL);
+    tracing::info!("REVIEWER PASSWORD: {}", reviewer_password);
+    tracing::info!("Save it now; it will not be shown again.");
+    tracing::info!("========================================");
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+    let _ = dotenvy::dotenv();
+    run().await
+}

--- a/backend/src/db/models/users.rs
+++ b/backend/src/db/models/users.rs
@@ -22,6 +22,7 @@ pub struct User {
     pub magic_link_expiration: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub is_review_stub: bool,
 }
 
 #[derive(Debug, Insertable)]

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -316,6 +316,7 @@ diesel::table! {
         magic_link_expiration -> Nullable<Timestamptz>,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        is_review_stub -> Bool,
     }
 }
 

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -607,6 +607,62 @@ async fn ws_upgrade_rejects_foreign_origin() {
 
 #[tokio::test]
 #[serial]
+async fn ws_upgrade_is_rate_limited_per_ip() {
+    request(|request, _ctx| async move {
+        // Cap is 60/min (CHAT_WS_UPGRADE_MAX_PER_MIN). The rate-limit gate
+        // sits in the same route-layer middleware as the origin check, so
+        // a plain GET from the same IP 61 times yields 429 on the last one.
+        let ip_header = (
+            HeaderName::from_static("x-real-ip"),
+            HeaderValue::from_static("203.0.113.200"),
+        );
+
+        let mut last_status = 0;
+        for _ in 0..61 {
+            let response = request
+                .get("/api/v1/chat/ws")
+                .add_header(ip_header.0.clone(), ip_header.1.clone())
+                .await;
+            last_status = response.status_code().as_u16();
+        }
+        assert_eq!(
+            last_status, 429,
+            "expected the 61st ws_upgrade to be rate-limited"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn matching_profiles_is_rate_limited_per_ip() {
+    request(|request, _ctx| async move {
+        // Cap is 30/min (MATCHING_PROFILES_MAX_PER_MIN). The rate-limit
+        // check fires before auth, so no session is needed. The 31st
+        // request from the same forwarded IP should receive 429.
+        let ip_header = (
+            HeaderName::from_static("x-real-ip"),
+            HeaderValue::from_static("203.0.113.201"),
+        );
+
+        let mut last_status = 0;
+        for _ in 0..31 {
+            let response = request
+                .get("/api/v1/matching/profiles?limit=1")
+                .add_header(ip_header.0.clone(), ip_header.1.clone())
+                .await;
+            last_status = response.status_code().as_u16();
+        }
+        assert_eq!(
+            last_status, 429,
+            "expected the 31st /matching/profiles to be rate-limited"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
 async fn sign_in_verifies_hashed_password() {
     request(|request, _ctx| async move {
         let sign_up = request

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -5,7 +5,7 @@ POSTGRES_DB=poziomki
 
 # API / Worker
 JWT_SECRET=
-SERVER_HOST=https://rs.poziomki.app
+SERVER_HOST=https://api.poziomki.app
 ALLOWED_EMAIL_DOMAIN=*
 
 # Garage S3

--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -89,10 +89,10 @@ cdn.poziomki.app {
 	respond 404
 }
 
-rs.poziomki.app {
+api.poziomki.app {
 	import secure_headers
 	log {
-		output file /var/log/caddy/rs-access.log {
+		output file /var/log/caddy/api-access.log {
 			roll_size 50MiB
 			roll_keep 3
 			roll_keep_for 720h

--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -48,6 +48,12 @@ mobile.poziomki.app {
 
 	handle {
 		reverse_proxy localhost:5150 {
+			# Set an authoritative client-IP header the backend rate
+			# limiter can trust. We also replace X-Forwarded-For
+			# (Caddy would otherwise append, letting a client forge
+			# the first hop).
+			header_up X-Real-IP {client_ip}
+			header_up X-Forwarded-For {client_ip}
 			header_down -X-Powered-By
 		}
 	}
@@ -109,6 +115,10 @@ rs.poziomki.app {
 
 	handle {
 		reverse_proxy localhost:5150 {
+			# See comment on mobile.poziomki.app for rationale —
+			# authoritative client IP for the backend limiter.
+			header_up X-Real-IP {client_ip}
+			header_up X-Forwarded-For {client_ip}
 			header_down -X-Powered-By
 		}
 	}

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -112,7 +112,7 @@ services:
       PORT: 5150
       METRICS_PORT: 9092
       SERVER_BINDING: 0.0.0.0
-      SERVER_HOST: ${SERVER_HOST:-https://rs.poziomki.app}
+      SERVER_HOST: ${SERVER_HOST:-https://api.poziomki.app}
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki}:${POSTGRES_PASSWORD}@pgdog:6432/${POSTGRES_DB:-poziomki}
       DB_POOL_MAX_SIZE: ${API_DB_POOL_MAX_SIZE:-16}
       DB_POOL_WAIT_TIMEOUT_MS: ${API_DB_POOL_WAIT_TIMEOUT_MS:-3000}
@@ -171,7 +171,7 @@ services:
     environment:
       RUST_ENV: production
       METRICS_PORT: 9093
-      SERVER_HOST: ${SERVER_HOST:-https://rs.poziomki.app}
+      SERVER_HOST: ${SERVER_HOST:-https://api.poziomki.app}
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki}:${POSTGRES_PASSWORD}@pgdog:6432/${POSTGRES_DB:-poziomki}
       DB_POOL_MAX_SIZE: ${WORKER_DB_POOL_MAX_SIZE:-8}
       DB_POOL_WAIT_TIMEOUT_MS: ${WORKER_DB_POOL_WAIT_TIMEOUT_MS:-3000}

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -20,11 +20,11 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.poziomki.rs.app"
+        applicationId = "app.poziomki"
         minSdk = 24
         targetSdk = 36
-        versionCode = 42
-        versionName = "0.18.1"
+        versionCode = 43
+        versionName = "0.18.2"
 
         val apiUrl = project.findProperty("apiBaseUrl")?.toString() ?: "http://localhost:5150"
         buildConfigField("String", "API_BASE_URL", "\"$apiUrl\"")


### PR DESCRIPTION
**Reviewer test account + 8 stub profiles + 3 pre-populated DMs for Google Play submission.**

Stub accounts carry a new `is_review_stub` flag. Matching feed and DM list queries filter by the viewer's flag so stubs are visible only between review accounts and never leak into real users' experience.

- [ ] merge to main
- [ ] deploy on `poziomki` (rebuild `api` + `worker`, new `seed_reviewer` bin)
- [ ] upload 9 DiceBear avatars to Garage under `review/*.webp`
- [ ] run `seed_reviewer` once — save printed password
- [ ] paste creds into Play Console App access

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sandboxed reviewer account with stub users and IP-based rate limiting for app store review
> - Adds `is_review_stub` flag to the `users` table; stub users only see other stubs in matching candidates and DMs, isolating app store reviewers from real users.
> - Adds a `seed_reviewer` binary that provisions a reviewer account, multiple stub users with profiles/photos, and scripted DM conversations for app store review.
> - Adds IP-based rate limiting (via [ip_rate_limit.rs](https://github.com/poziomki-app/poziomki/pull/164/files#diff-b24a2d1728b014ee0e49e0c1191930457a5d5de97252671fc82f4c34b3444819)) to `/matching/profiles` (30 req/min) and `/chat/ws` upgrades (60 req/min), returning 429 on excess.
> - Adds a local filesystem storage backend for uploads, activated in development or via `UPLOAD_STORAGE_DIR`, so the reviewer setup works without S3.
> - Completed direct uploads now validate file content, MIME type, and image dimensions before acceptance.
> - Caddy config updated to forward `X-Real-IP` and normalize `X-Forwarded-For` so rate limiting keys on the correct client IP.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6ad0be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->