### PR TITLE
feat(review): is_review_stub flag to isolate reviewer and test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ result-*
 # OS
 .DS_Store
 Thumbs.db
+play-store/
+backend/seed/

--- a/backend/migrations/2026-04-17-000000_review_stub_flag/down.sql
+++ b/backend/migrations/2026-04-17-000000_review_stub_flag/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS users_is_review_stub_idx;
+ALTER TABLE users DROP COLUMN is_review_stub;

--- a/backend/migrations/2026-04-17-000000_review_stub_flag/up.sql
+++ b/backend/migrations/2026-04-17-000000_review_stub_flag/up.sql
@@ -1,0 +1,6 @@
+-- Flag users that exist solely to support Google Play reviewer QA. Profiles
+-- and DMs owned by these accounts are visible only between other stub users,
+-- so they never leak into normal users' matching feed or chat list.
+ALTER TABLE users ADD COLUMN is_review_stub BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX users_is_review_stub_idx ON users (is_review_stub) WHERE is_review_stub = true;

--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -193,6 +193,14 @@ pub async fn list_for_user(
 
     let mut conn = crate::db::conn().await?;
 
+    let viewer_is_stub = users::table
+        .filter(users::id.eq(user_id))
+        .select(users::is_review_stub)
+        .first::<bool>(&mut conn)
+        .await
+        .optional()?
+        .unwrap_or(false);
+
     let conv_ids: Vec<Uuid> = conversation_members::table
         .filter(conversation_members::user_id.eq(user_id))
         .select(conversation_members::conversation_id)
@@ -203,10 +211,59 @@ pub async fn list_for_user(
         return Ok(Vec::new());
     }
 
-    let convs: Vec<Conversation> = conversations::table
+    let all_convs: Vec<Conversation> = conversations::table
         .filter(conversations::id.eq_any(&conv_ids))
         .load(&mut conn)
         .await?;
+
+    // Collect the "other participant" id for every DM so we can batch-load
+    // their is_review_stub flags in a single query.
+    let other_ids: Vec<i32> = all_convs
+        .iter()
+        .filter(|c| c.kind == "dm")
+        .filter_map(|c| {
+            if c.user_low_id == Some(user_id) {
+                c.user_high_id
+            } else {
+                c.user_low_id
+            }
+        })
+        .collect();
+
+    let stub_flags: std::collections::HashMap<i32, bool> = if other_ids.is_empty() {
+        std::collections::HashMap::new()
+    } else {
+        users::table
+            .filter(users::id.eq_any(&other_ids))
+            .select((users::id, users::is_review_stub))
+            .load::<(i32, bool)>(&mut conn)
+            .await?
+            .into_iter()
+            .collect()
+    };
+
+    // Hide DMs where the other participant has a different is_review_stub
+    // value so stub accounts stay invisible to real users (and vice versa).
+    let convs: Vec<Conversation> = all_convs
+        .into_iter()
+        .filter(|conv| {
+            if conv.kind != "dm" {
+                return true;
+            }
+            let other_id = if conv.user_low_id == Some(user_id) {
+                conv.user_high_id
+            } else {
+                conv.user_low_id
+            };
+            other_id
+                .is_none_or(|id| stub_flags.get(&id).copied().unwrap_or(false) == viewer_is_stub)
+        })
+        .collect();
+
+    let conv_ids: Vec<Uuid> = convs.iter().map(|c| c.id).collect();
+    if conv_ids.is_empty() {
+        return Ok(Vec::new());
+    }
 
     // Batch-load latest message per conversation (DISTINCT ON)
     let latest_messages: Vec<crate::db::models::messages::Message> = diesel::sql_query(

--- a/backend/src/api/matching/repo.rs
+++ b/backend/src/api/matching/repo.rs
@@ -184,9 +184,19 @@ impl MatchingRepository {
         limit: i64,
         conn: &mut crate::db::DbConn,
     ) -> std::result::Result<Vec<Profile>, crate::error::AppError> {
+        let viewer_is_stub = users::table
+            .filter(users::id.eq(user_id))
+            .select(users::is_review_stub)
+            .first::<bool>(conn)
+            .await
+            .optional()?
+            .unwrap_or(false);
+
         profiles::table
+            .inner_join(users::table.on(users::id.eq(profiles::user_id)))
             .left_join(user_settings::table.on(user_settings::user_id.eq(profiles::user_id)))
             .filter(profiles::user_id.ne(user_id))
+            .filter(users::is_review_stub.eq(viewer_is_stub))
             .filter(
                 user_settings::privacy_discoverable
                     .eq(true)

--- a/backend/src/db/models/users.rs
+++ b/backend/src/db/models/users.rs
@@ -22,6 +22,7 @@ pub struct User {
     pub magic_link_expiration: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub is_review_stub: bool,
 }
 
 #[derive(Debug, Insertable)]

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -316,6 +316,7 @@ diesel::table! {
         magic_link_expiration -> Nullable<Timestamptz>,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        is_review_stub -> Bool,
     }
 }
 


### PR DESCRIPTION
**Privacy-preserving isolation for Google Play reviewer test data.**

Adds a boolean flag on users. Matching feed and DM list filter by the viewer's flag, so reviewer/stub accounts never leak into real users' view.

Seed data lives in a local-only SQL script (gitignored) — nothing reviewer-specific ships in the image.

- [ ] merge
- [ ] deploy on poziomki (rebuild api + worker)
- [ ] upload 5 avatars to Garage under review/*.webp
- [ ] run backend/seed/review.sql against prod db
- [ ] paste creds into Play Console App access

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `is_review_stub` flag to isolate reviewer test accounts from real users in matching and chat
> - Adds an `is_review_stub` boolean column to the `users` table (default `false`) with a partial index on stub accounts via [migration](https://github.com/poziomki-app/poziomki/pull/165/files#diff-1b20e222341b721fb7e2051db6b882500a9ce9e0a652e586da2e8a6ce7368fb7).
> - Filters candidate profiles in `MatchingRepository.load_candidate_profiles` so users only see candidates whose `is_review_stub` value matches their own.
> - Filters DM conversations in `list_for_user` so only conversations with participants sharing the same stub status are returned.
> - Behavioral Change: stub and non-stub users are now fully isolated in both matching and DM conversation views.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a252f23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->