### PR TITLE
fix(chat): allow api.poziomki.app as WS origin

### DIFF
--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -35,6 +35,7 @@ const ALLOWED_WS_ORIGINS: &[&str] = &[
     "https://poziomki.app",
     "https://www.poziomki.app",
     "https://mobile.poziomki.app",
+    "https://api.poziomki.app",
     "http://localhost",
     "http://127.0.0.1",
 ];
@@ -80,6 +81,7 @@ mod origin_tests {
     fn accepts_allowlisted() {
         assert!(is_allowed_ws_origin("https://poziomki.app"));
         assert!(is_allowed_ws_origin("https://mobile.poziomki.app"));
+        assert!(is_allowed_ws_origin("https://api.poziomki.app"));
         assert!(is_allowed_ws_origin("http://localhost:5173"));
         assert!(is_allowed_ws_origin("http://127.0.0.1:3000"));
     }


### PR DESCRIPTION
Native Android client sends Origin: https://api.poziomki.app on WebSocket handshake; the allowlist from #162 rejected it with 403, so chat was broken for all native clients since that PR merged.

Two-line fix: add the API domain to the allowlist + a matching test assertion.

- [ ] merge
- [ ] deploy (rebuild api)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `https://api.poziomki.app` as a valid WebSocket origin
> Adds `https://api.poziomki.app` to `ALLOWED_WS_ORIGINS` in [mod.rs](https://github.com/poziomki-app/poziomki/pull/168/files#diff-5e07944cd52759fed0f90311e982e992339a7f7aa1a48ecacd35d11e547d1a4e) so WebSocket upgrade requests from that origin are no longer rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7939142.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->