### PR TITLE
sec(ratelimit): IP throttle on /uploads write paths

### DIFF
--- a/backend/src/api/ip_rate_limit.rs
+++ b/backend/src/api/ip_rate_limit.rs
@@ -35,6 +35,7 @@ use super::{error_response, ErrorSpec};
 const IP_RATE_LIMIT_WINDOW_SECS: i64 = 60;
 const MATCHING_PROFILES_MAX_PER_MIN: u32 = 30;
 const CHAT_WS_UPGRADE_MAX_PER_MIN: u32 = 60;
+const UPLOAD_WRITE_MAX_PER_MIN: u32 = 30;
 
 /// Bucket name used when no trustworthy client IP can be parsed from the
 /// proxy headers. A shared bucket still caps the endpoint, so missing
@@ -45,6 +46,7 @@ const UNKNOWN_BUCKET: &str = "unknown";
 pub enum IpRateLimitAction {
     MatchingProfiles,
     ChatWsUpgrade,
+    UploadWrite,
 }
 
 impl IpRateLimitAction {
@@ -52,6 +54,7 @@ impl IpRateLimitAction {
         match self {
             Self::MatchingProfiles => MATCHING_PROFILES_MAX_PER_MIN,
             Self::ChatWsUpgrade => CHAT_WS_UPGRADE_MAX_PER_MIN,
+            Self::UploadWrite => UPLOAD_WRITE_MAX_PER_MIN,
         }
     }
 
@@ -59,6 +62,7 @@ impl IpRateLimitAction {
         match self {
             Self::MatchingProfiles => "ip_matching_profiles",
             Self::ChatWsUpgrade => "ip_chat_ws_upgrade",
+            Self::UploadWrite => "ip_upload_write",
         }
     }
 }
@@ -361,5 +365,12 @@ mod tests {
         let h = headers_with("x-real-ip", "2001:db8:abcd:0012:aaaa:bbbb:cccc:dddd");
         let key = rate_key_for(IpRateLimitAction::MatchingProfiles, &h);
         assert_eq!(key, "ip_matching_profiles:2001:db8:abcd:12::/64");
+    }
+
+    #[test]
+    fn rate_key_scopes_upload_write_per_action() {
+        let h = headers_with("x-real-ip", "198.51.100.7");
+        let key = rate_key_for(IpRateLimitAction::UploadWrite, &h);
+        assert_eq!(key, "ip_upload_write:198.51.100.7");
     }
 }

--- a/backend/src/api/uploads/write_handler.rs
+++ b/backend/src/api/uploads/write_handler.rs
@@ -20,6 +20,12 @@ pub(in crate::api) async fn file_upload(
     multipart: Multipart,
 ) -> Result<Response> {
     let response: std::result::Result<Response, HandlerError> = async {
+        crate::api::ip_rate_limit::enforce_ip_rate_limit(
+            &headers,
+            crate::api::ip_rate_limit::IpRateLimitAction::UploadWrite,
+        )
+        .await?;
+
         let profile = require_auth_profile(&headers).await?;
 
         let parsed = uploads_multipart::read_multipart(&headers, multipart).await?;
@@ -90,6 +96,12 @@ pub(in crate::api) async fn file_upload_presign(
     Json(payload): Json<DirectUploadPresignBody>,
 ) -> Result<Response> {
     let response: std::result::Result<Response, HandlerError> = async {
+        crate::api::ip_rate_limit::enforce_ip_rate_limit(
+            &headers,
+            crate::api::ip_rate_limit::IpRateLimitAction::UploadWrite,
+        )
+        .await?;
+
         let context = validate_presign_payload(&headers, &payload)?;
         let profile = require_auth_profile(&headers).await?;
 
@@ -141,6 +153,12 @@ pub(in crate::api) async fn file_upload_complete(
     Json(payload): Json<DirectUploadCompleteBody>,
 ) -> Result<Response> {
     let response: std::result::Result<Response, HandlerError> = async {
+        crate::api::ip_rate_limit::enforce_ip_rate_limit(
+            &headers,
+            crate::api::ip_rate_limit::IpRateLimitAction::UploadWrite,
+        )
+        .await?;
+
         if let Err(message) = validate_filename(&payload.filename) {
             return Err(Box::new(bad_request(&headers, "INVALID_FILENAME", message)));
         }


### PR DESCRIPTION
**Rate-limit the upload write paths**

Each upload triggers S3 writes + imgproxy variant generation — highest per-request cost in the API. Extends the existing IP-keyed limiter (PRs #163, #169) with a new `UploadWrite` action at 30 req/min, applied to `/uploads/presign`, `/uploads/complete`, and `POST /uploads/`.

- [ ] smoke-test 31 presign calls → last one returns 429 with `Retry-After`
- [ ] confirm a single upload still works for a real user

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-IP rate limiting (30 req/min) to upload write endpoints
> Applies `IpRateLimitAction::UploadWrite` rate limiting to the `file_upload`, `file_upload_presign`, and `file_upload_complete` handlers in [write_handler.rs](https://github.com/poziomki-app/poziomki/pull/170/files#diff-fe37b1660668b738d2e667d0b9bc967035d78d1eda334da04db54a10e601ad0c). The limit check runs before authentication or payload processing, so requests over 30/min per IP are rejected early with no further work done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8e4982.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->