### PR TITLE
sec(ratelimit): IP throttle on /xp/token

### DIFF
--- a/backend/src/api/ip_rate_limit.rs
+++ b/backend/src/api/ip_rate_limit.rs
@@ -35,6 +35,7 @@ use super::{error_response, ErrorSpec};
 const IP_RATE_LIMIT_WINDOW_SECS: i64 = 60;
 const MATCHING_PROFILES_MAX_PER_MIN: u32 = 30;
 const CHAT_WS_UPGRADE_MAX_PER_MIN: u32 = 60;
+const XP_TOKEN_GEN_MAX_PER_MIN: u32 = 10;
 
 /// Bucket name used when no trustworthy client IP can be parsed from the
 /// proxy headers. A shared bucket still caps the endpoint, so missing
@@ -45,6 +46,7 @@ const UNKNOWN_BUCKET: &str = "unknown";
 pub enum IpRateLimitAction {
     MatchingProfiles,
     ChatWsUpgrade,
+    XpTokenGen,
 }
 
 impl IpRateLimitAction {
@@ -52,6 +54,7 @@ impl IpRateLimitAction {
         match self {
             Self::MatchingProfiles => MATCHING_PROFILES_MAX_PER_MIN,
             Self::ChatWsUpgrade => CHAT_WS_UPGRADE_MAX_PER_MIN,
+            Self::XpTokenGen => XP_TOKEN_GEN_MAX_PER_MIN,
         }
     }
 
@@ -59,6 +62,7 @@ impl IpRateLimitAction {
         match self {
             Self::MatchingProfiles => "ip_matching_profiles",
             Self::ChatWsUpgrade => "ip_chat_ws_upgrade",
+            Self::XpTokenGen => "ip_xp_token_gen",
         }
     }
 }
@@ -361,5 +365,12 @@ mod tests {
         let h = headers_with("x-real-ip", "2001:db8:abcd:0012:aaaa:bbbb:cccc:dddd");
         let key = rate_key_for(IpRateLimitAction::MatchingProfiles, &h);
         assert_eq!(key, "ip_matching_profiles:2001:db8:abcd:12::/64");
+    }
+
+    #[test]
+    fn rate_key_scopes_xp_token_gen_per_action() {
+        let h = headers_with("x-real-ip", "198.51.100.7");
+        let key = rate_key_for(IpRateLimitAction::XpTokenGen, &h);
+        assert_eq!(key, "ip_xp_token_gen:198.51.100.7");
     }
 }

--- a/backend/src/api/xp/handler.rs
+++ b/backend/src/api/xp/handler.rs
@@ -91,6 +91,15 @@ async fn claim_task(headers: HeaderMap, Json(body): Json<ClaimTaskBody>) -> Resu
 }
 
 pub(in crate::api) async fn get_token(headers: HeaderMap) -> Result<Response> {
+    if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::XpTokenGen,
+    )
+    .await
+    {
+        return Ok(*response);
+    }
+
     let profile = match service::load_profile_for(&headers).await {
         Ok(p) => p,
         Err(response) => return Ok(*response),


### PR DESCRIPTION
**Rate-limit XP token generation**

XP is an in-app currency; unlimited `/xp/token` makes farming trivial. Adds an `XpTokenGen` action at 10 req/min to the existing IP-keyed limiter.

- [ ] smoke-test 11 token calls → 11th returns 429 with \`Retry-After\`
- [ ] confirm normal QR flow still works under the cap

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add IP rate limit of 10 requests/min to the `/xp/token` endpoint
> Adds a new `IpRateLimitAction::XpTokenGen` variant in [ip_rate_limit.rs](https://github.com/poziomki-app/poziomki/pull/171/files#diff-b24a2d1728b014ee0e49e0c1191930457a5d5de97252671fc82f4c34b3444819) with a cap of 10 requests per minute and key prefix `ip_xp_token_gen`. The [get_token handler](https://github.com/poziomki-app/poziomki/pull/171/files#diff-952bfdfa8e523e782cbb1d0d2d34dadb45d1ac46f263d2b912970687d8732e82) enforces this limit before loading the profile or generating a token, returning the rate limit error response immediately if exceeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d662635.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->