### PR TITLE
sec(ratelimit): IP throttle on /xp/scan and /xp/task

### DIFF
--- a/backend/src/api/ip_rate_limit.rs
+++ b/backend/src/api/ip_rate_limit.rs
@@ -35,6 +35,7 @@ use super::{error_response, ErrorSpec};
 const IP_RATE_LIMIT_WINDOW_SECS: i64 = 60;
 const MATCHING_PROFILES_MAX_PER_MIN: u32 = 30;
 const CHAT_WS_UPGRADE_MAX_PER_MIN: u32 = 60;
+const XP_ACTION_MAX_PER_MIN: u32 = 30;
 
 /// Bucket name used when no trustworthy client IP can be parsed from the
 /// proxy headers. A shared bucket still caps the endpoint, so missing
@@ -45,6 +46,7 @@ const UNKNOWN_BUCKET: &str = "unknown";
 pub enum IpRateLimitAction {
     MatchingProfiles,
     ChatWsUpgrade,
+    XpAction,
 }
 
 impl IpRateLimitAction {
@@ -52,6 +54,7 @@ impl IpRateLimitAction {
         match self {
             Self::MatchingProfiles => MATCHING_PROFILES_MAX_PER_MIN,
             Self::ChatWsUpgrade => CHAT_WS_UPGRADE_MAX_PER_MIN,
+            Self::XpAction => XP_ACTION_MAX_PER_MIN,
         }
     }
 
@@ -59,6 +62,7 @@ impl IpRateLimitAction {
         match self {
             Self::MatchingProfiles => "ip_matching_profiles",
             Self::ChatWsUpgrade => "ip_chat_ws_upgrade",
+            Self::XpAction => "ip_xp_action",
         }
     }
 }
@@ -361,5 +365,12 @@ mod tests {
         let h = headers_with("x-real-ip", "2001:db8:abcd:0012:aaaa:bbbb:cccc:dddd");
         let key = rate_key_for(IpRateLimitAction::MatchingProfiles, &h);
         assert_eq!(key, "ip_matching_profiles:2001:db8:abcd:12::/64");
+    }
+
+    #[test]
+    fn rate_key_scopes_xp_action_per_action() {
+        let h = headers_with("x-real-ip", "198.51.100.7");
+        let key = rate_key_for(IpRateLimitAction::XpAction, &h);
+        assert_eq!(key, "ip_xp_action:198.51.100.7");
     }
 }

--- a/backend/src/api/xp/handler.rs
+++ b/backend/src/api/xp/handler.rs
@@ -52,6 +52,15 @@ struct ClaimTaskResponse {
 }
 
 async fn claim_task(headers: HeaderMap, Json(body): Json<ClaimTaskBody>) -> Result<Response> {
+    if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::XpAction,
+    )
+    .await
+    {
+        return Ok(*response);
+    }
+
     let profile = match service::load_profile_for(&headers).await {
         Ok(p) => p,
         Err(response) => return Ok(*response),
@@ -123,6 +132,15 @@ pub(in crate::api) async fn scan_token(
     headers: HeaderMap,
     Json(body): Json<ScanBody>,
 ) -> Result<Response> {
+    if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::XpAction,
+    )
+    .await
+    {
+        return Ok(*response);
+    }
+
     let scanner = match service::load_profile_for(&headers).await {
         Ok(p) => p,
         Err(response) => return Ok(*response),


### PR DESCRIPTION
**Rate-limit XP earning actions**

Caps XP-awarding endpoints at 30 req/min per IP to limit point farming. Separate from the tighter \`/xp/token\` limit because scan/task are end-user actions and should be a bit looser.

- [ ] smoke-test 31 scans → 31st returns 429 with \`Retry-After\`
- [ ] confirm normal scan/task flow still works under the cap

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add IP rate limit of 30 requests/min to `/xp/scan` and `/xp/task` endpoints
> Adds a new `IpRateLimitAction::XpAction` variant in [ip_rate_limit.rs](https://github.com/poziomki-app/poziomki/pull/172/files#diff-b24a2d1728b014ee0e49e0c1191930457a5d5de97252671fc82f4c34b3444819) capped at 30 attempts per minute, keyed by `ip_xp_action`. Both the `scan_token` and `claim_task` handlers in [xp/handler.rs](https://github.com/poziomki-app/poziomki/pull/172/files#diff-952bfdfa8e523e782cbb1d0d2d34dadb45d1ac46f263d2b912970687d8732e82) now check this limit early and short-circuit with a rate-limit response when exceeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a03f12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->