### PR TITLE
sec(ratelimit): IP throttle on /search and /messages/search

### DIFF
--- a/backend/src/api/ip_rate_limit.rs
+++ b/backend/src/api/ip_rate_limit.rs
@@ -35,6 +35,7 @@ use super::{error_response, ErrorSpec};
 const IP_RATE_LIMIT_WINDOW_SECS: i64 = 60;
 const MATCHING_PROFILES_MAX_PER_MIN: u32 = 30;
 const CHAT_WS_UPGRADE_MAX_PER_MIN: u32 = 60;
+const SEARCH_MAX_PER_MIN: u32 = 20;
 
 /// Bucket name used when no trustworthy client IP can be parsed from the
 /// proxy headers. A shared bucket still caps the endpoint, so missing
@@ -45,6 +46,7 @@ const UNKNOWN_BUCKET: &str = "unknown";
 pub enum IpRateLimitAction {
     MatchingProfiles,
     ChatWsUpgrade,
+    Search,
 }
 
 impl IpRateLimitAction {
@@ -52,6 +54,7 @@ impl IpRateLimitAction {
         match self {
             Self::MatchingProfiles => MATCHING_PROFILES_MAX_PER_MIN,
             Self::ChatWsUpgrade => CHAT_WS_UPGRADE_MAX_PER_MIN,
+            Self::Search => SEARCH_MAX_PER_MIN,
         }
     }
 
@@ -59,6 +62,7 @@ impl IpRateLimitAction {
         match self {
             Self::MatchingProfiles => "ip_matching_profiles",
             Self::ChatWsUpgrade => "ip_chat_ws_upgrade",
+            Self::Search => "ip_search",
         }
     }
 }
@@ -361,5 +365,12 @@ mod tests {
         let h = headers_with("x-real-ip", "2001:db8:abcd:0012:aaaa:bbbb:cccc:dddd");
         let key = rate_key_for(IpRateLimitAction::MatchingProfiles, &h);
         assert_eq!(key, "ip_matching_profiles:2001:db8:abcd:12::/64");
+    }
+
+    #[test]
+    fn rate_key_scopes_search_per_action() {
+        let h = headers_with("x-real-ip", "198.51.100.7");
+        let key = rate_key_for(IpRateLimitAction::Search, &h);
+        assert_eq!(key, "ip_search:198.51.100.7");
     }
 }

--- a/backend/src/api/search.rs
+++ b/backend/src/api/search.rs
@@ -106,6 +106,15 @@ pub(super) async fn search_messages(
     headers: HeaderMap,
     Query(query): Query<MessageSearchQuery>,
 ) -> Result<Response> {
+    if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::Search,
+    )
+    .await
+    {
+        return Ok(*response);
+    }
+
     let (_session, user) = auth_or_respond!(headers);
 
     let limit = usize::from(query.limit.unwrap_or(20).clamp(1, 50));
@@ -140,6 +149,15 @@ pub(super) async fn search(
     headers: HeaderMap,
     Query(query): Query<SearchQuery>,
 ) -> Result<Response> {
+    if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::Search,
+    )
+    .await
+    {
+        return Ok(*response);
+    }
+
     let (_session, user) = auth_or_respond!(headers);
 
     let limit = usize::from(query.limit.unwrap_or(10).clamp(1, 50));


### PR DESCRIPTION
**Rate-limit search endpoints**

Search runs expensive DB queries (full-text across profiles/events/tags, plus message rooms). Adds a \`Search\` action at 20 req/min to the existing IP-keyed limiter to cap query cost per caller.

- [ ] smoke-test 21 search calls → 21st returns 429 with \`Retry-After\`
- [ ] confirm normal search still works under the cap

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add IP rate limiting to `/search` and `/messages/search` endpoints
> Introduces a `Search` variant to `IpRateLimitAction` with a limit of 20 requests per minute, scoped under the `ip_search` key prefix. Both the `search` and `search_messages` handlers in [search.rs](https://github.com/poziomki-app/poziomki/pull/173/files#diff-1a03cc14fc820270327ee5f287c5b2c69f468bf7d5e1f3cbb069b1440c93de0b) now call `enforce_ip_rate_limit` at the start and return early with the rate limiter's response when the limit is exceeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1776c2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->