### PR TITLE
sec(rls): add least-privilege DB roles for API and worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,23 @@
 DATABASE_URL=postgres://poziomki:poziomki@localhost:5432/poziomki-backend_development
 JWT_SECRET=change-me-in-production
 
+# Least-privilege DB roles (Phase 1 of RLS rollout).
+#
+# In production the owner role in DATABASE_URL should only be used for
+# migrations. The API pool uses API_DATABASE_URL (role: poziomki_api, no
+# BYPASSRLS) and the worker uses WORKER_DATABASE_URL (role: poziomki_worker,
+# BYPASSRLS).
+#
+# Leave these empty until you've run infra/ops/postgres/setup-roles.sh;
+# the Rust pool falls back to DATABASE_URL when unset.
+#
+# POSTGRES_API_PASSWORD and POSTGRES_WORKER_PASSWORD are consumed by the
+# bootstrap script and by pgdog (to register both roles in its user table).
+POSTGRES_API_PASSWORD=
+POSTGRES_WORKER_PASSWORD=
+API_DATABASE_URL=
+WORKER_DATABASE_URL=
+
 # DB pool
 # DB_POOL_MAX_SIZE=10
 # DB_POOL_WAIT_TIMEOUT_MS=3000

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -120,24 +120,47 @@ fn load_runtime_config() -> crate::error::AppResult<RuntimeConfig> {
     Ok(RuntimeConfig { binding, port })
 }
 
-fn init_diesel_pool() -> crate::error::AppResult<()> {
-    let url = std::env::var("DATABASE_URL")
-        .map_err(|_| crate::error::AppError::message("DATABASE_URL must be set"))?;
+#[derive(Clone, Copy)]
+enum PoolRole {
+    Api,
+    Worker,
+}
+
+// The pool URL is chosen per-process so the API and worker can connect as
+// least-privilege roles (poziomki_api / poziomki_worker) while migrations
+// keep using the owner role via DATABASE_URL. When the role-specific var is
+// unset we fall back to DATABASE_URL, which preserves current dev behaviour.
+fn resolve_pool_url(role: PoolRole) -> crate::error::AppResult<String> {
+    let primary = match role {
+        PoolRole::Api => "API_DATABASE_URL",
+        PoolRole::Worker => "WORKER_DATABASE_URL",
+    };
+    if let Ok(value) = std::env::var(primary) {
+        if !value.trim().is_empty() {
+            return Ok(value);
+        }
+    }
+    std::env::var("DATABASE_URL")
+        .map_err(|_| crate::error::AppError::message("DATABASE_URL must be set"))
+}
+
+fn init_diesel_pool(role: PoolRole) -> crate::error::AppResult<()> {
+    let url = resolve_pool_url(role)?;
     crate::db::init_pool(&url).map_err(crate::error::AppError::Message)
 }
 
-fn build_app_context() -> crate::error::AppResult<AppContext> {
-    let url = std::env::var("DATABASE_URL")
+fn build_app_context(role: PoolRole) -> crate::error::AppResult<AppContext> {
+    let migration_url = std::env::var("DATABASE_URL")
         .map_err(|_| crate::error::AppError::message("DATABASE_URL must be set"))?;
-    crate::db::run_migrations(&url).map_err(crate::error::AppError::Message)?;
-    init_diesel_pool()?;
+    crate::db::run_migrations(&migration_url).map_err(crate::error::AppError::Message)?;
+    init_diesel_pool(role)?;
     Ok(AppContext {
         chat_hub: crate::api::chat::hub::ChatHub::new(),
     })
 }
 
 pub fn build_test_app_context() -> crate::error::AppResult<AppContext> {
-    build_app_context()
+    build_app_context(PoolRole::Api)
 }
 
 pub async fn reset_test_database() -> crate::error::AppResult<()> {
@@ -153,7 +176,7 @@ pub async fn run_api_server() -> crate::error::AppResult<()> {
     init_tracing_once()?;
     crate::telemetry::init_metrics_exporter(crate::telemetry::ProcessKind::Api)?;
     let cfg = load_runtime_config()?;
-    let ctx = build_app_context()?;
+    let ctx = build_app_context(PoolRole::Api)?;
     let router = build_router_with_state(ctx);
 
     let listener = tokio::net::TcpListener::bind((cfg.binding.as_str(), cfg.port))
@@ -178,7 +201,7 @@ pub async fn run_outbox_worker_process() -> crate::error::AppResult<()> {
     init_tracing_once()?;
     crate::telemetry::init_metrics_exporter(crate::telemetry::ProcessKind::Worker)?;
     let _cfg = load_runtime_config()?;
-    let ctx = build_app_context()?;
+    let ctx = build_app_context(PoolRole::Worker)?;
 
     crate::jobs::start_background_workers(&ctx)?;
     tracing::info!("Poziomki outbox worker process started");

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -65,6 +65,10 @@ services:
       DB_NAME: ${POSTGRES_DB:-poziomki}
       DB_USER: ${POSTGRES_USER:-poziomki}
       DB_PASSWORD: ${POSTGRES_PASSWORD}
+      API_DB_USER: ${POSTGRES_API_USER:-poziomki_api}
+      API_DB_PASSWORD: ${POSTGRES_API_PASSWORD:-}
+      WORKER_DB_USER: ${POSTGRES_WORKER_USER:-poziomki_worker}
+      WORKER_DB_PASSWORD: ${POSTGRES_WORKER_PASSWORD:-}
       DEFAULT_POOL_SIZE: ${PGDOG_POOL_SIZE:-20}
       POOL_MODE: transaction
       LISTEN_PORT: 6432
@@ -113,7 +117,12 @@ services:
       METRICS_PORT: 9092
       SERVER_BINDING: 0.0.0.0
       SERVER_HOST: ${SERVER_HOST:-https://rs.poziomki.app}
+      # Owner URL used ONLY for migrations (schema changes need the owner role).
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki}:${POSTGRES_PASSWORD}@pgdog:6432/${POSTGRES_DB:-poziomki}
+      # Least-privilege URL the API pool connects as. Leave unset in .env until
+      # roles have been bootstrapped via infra/ops/postgres/setup-roles.sh; the
+      # Rust pool falls back to DATABASE_URL when this is empty.
+      API_DATABASE_URL: ${API_DATABASE_URL:-}
       DB_POOL_MAX_SIZE: ${API_DB_POOL_MAX_SIZE:-16}
       DB_POOL_WAIT_TIMEOUT_MS: ${API_DB_POOL_WAIT_TIMEOUT_MS:-3000}
       DB_POOL_CREATE_TIMEOUT_MS: ${API_DB_POOL_CREATE_TIMEOUT_MS:-5000}
@@ -172,7 +181,13 @@ services:
       RUST_ENV: production
       METRICS_PORT: 9093
       SERVER_HOST: ${SERVER_HOST:-https://rs.poziomki.app}
+      # Owner URL used ONLY for migrations (worker also runs pending migrations
+      # on boot via build_app_context).
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki}:${POSTGRES_PASSWORD}@pgdog:6432/${POSTGRES_DB:-poziomki}
+      # Worker pool URL. Worker has BYPASSRLS because outbox dispatch and
+      # cleanup legitimately act across users. Leave unset in .env until roles
+      # have been bootstrapped; Rust falls back to DATABASE_URL when empty.
+      WORKER_DATABASE_URL: ${WORKER_DATABASE_URL:-}
       DB_POOL_MAX_SIZE: ${WORKER_DB_POOL_MAX_SIZE:-8}
       DB_POOL_WAIT_TIMEOUT_MS: ${WORKER_DB_POOL_WAIT_TIMEOUT_MS:-3000}
       DB_POOL_CREATE_TIMEOUT_MS: ${WORKER_DB_POOL_CREATE_TIMEOUT_MS:-5000}

--- a/infra/ops/pgdog/entrypoint.sh
+++ b/infra/ops/pgdog/entrypoint.sh
@@ -93,6 +93,30 @@ database = "${DB_NAME}"
 password = "${DB_PASSWORD}"
 EOF
 
+# Additional least-privilege roles. Each is optional; when both name and
+# password are set, we register the user with pgdog so clients can connect
+# as that role directly. Added for the RLS rollout (Phase 1) so the API and
+# worker stop running as the cluster owner.
+if [ -n "${API_DB_USER:-}" ] && [ -n "${API_DB_PASSWORD:-}" ]; then
+  cat >> "${CFG_DIR}/users.toml" <<EOF
+
+[[users]]
+name = "${API_DB_USER}"
+database = "${DB_NAME}"
+password = "${API_DB_PASSWORD}"
+EOF
+fi
+
+if [ -n "${WORKER_DB_USER:-}" ] && [ -n "${WORKER_DB_PASSWORD:-}" ]; then
+  cat >> "${CFG_DIR}/users.toml" <<EOF
+
+[[users]]
+name = "${WORKER_DB_USER}"
+database = "${DB_NAME}"
+password = "${WORKER_DB_PASSWORD}"
+EOF
+fi
+
 exec /usr/local/bin/pgdog \
   --config "${CFG_DIR}/pgdog.toml" \
   --users "${CFG_DIR}/users.toml"

--- a/infra/ops/postgres/setup-roles.sh
+++ b/infra/ops/postgres/setup-roles.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# One-time bootstrap: create least-privilege Postgres roles for the API and worker.
+#
+# Run this once per environment. It's idempotent, but re-running rotates the
+# role passwords to whatever is currently in the env vars below.
+#
+# Required env vars:
+#   POSTGRES_API_PASSWORD      Password for the poziomki_api role.
+#   POSTGRES_WORKER_PASSWORD   Password for the poziomki_worker role.
+#
+# Optional (all default to values already used by docker-compose.prod.yml):
+#   POSTGRES_CONTAINER  Container name (default: poziomki-rs-postgres-1).
+#   POSTGRES_USER       Owner role to connect as (default: poziomki).
+#   POSTGRES_DB         Database to bootstrap in (default: poziomki-rs).
+#
+# Example (local):
+#   POSTGRES_API_PASSWORD=... POSTGRES_WORKER_PASSWORD=... \
+#     ./infra/ops/postgres/setup-roles.sh
+#
+# Example (prod, via SSH):
+#   ssh poziomki 'cd /home/ubuntu/poziomki-rs && \
+#     POSTGRES_API_PASSWORD=... POSTGRES_WORKER_PASSWORD=... \
+#     ./infra/ops/postgres/setup-roles.sh'
+
+set -eu
+
+: "${POSTGRES_API_PASSWORD:?Set POSTGRES_API_PASSWORD}"
+: "${POSTGRES_WORKER_PASSWORD:?Set POSTGRES_WORKER_PASSWORD}"
+
+CONTAINER="${POSTGRES_CONTAINER:-poziomki-rs-postgres-1}"
+OWNER_USER="${POSTGRES_USER:-poziomki}"
+DB_NAME="${POSTGRES_DB:-poziomki-rs}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SQL_FILE="${SCRIPT_DIR}/setup-roles.sql"
+
+if [ ! -f "${SQL_FILE}" ]; then
+  echo "Missing ${SQL_FILE}" >&2
+  exit 1
+fi
+
+echo "Bootstrapping roles in ${CONTAINER} / ${DB_NAME} as ${OWNER_USER}..."
+
+docker exec -i \
+  -e PGPASSWORD \
+  "${CONTAINER}" \
+  psql -v ON_ERROR_STOP=1 \
+       -v "api_password=${POSTGRES_API_PASSWORD}" \
+       -v "worker_password=${POSTGRES_WORKER_PASSWORD}" \
+       -U "${OWNER_USER}" \
+       -d "${DB_NAME}" \
+  < "${SQL_FILE}"
+
+echo "Done. Verify with:"
+echo "  docker exec ${CONTAINER} psql -U ${OWNER_USER} -d ${DB_NAME} -c '\\du'"

--- a/infra/ops/postgres/setup-roles.sql
+++ b/infra/ops/postgres/setup-roles.sql
@@ -69,3 +69,28 @@ ALTER DEFAULT PRIVILEGES FOR ROLE poziomki IN SCHEMA public
 ALTER DEFAULT PRIVILEGES FOR ROLE poziomki IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES
   TO poziomki_api, poziomki_worker;
+
+-- ---------------------------------------------------------------------------
+-- Catch-up grants for the `app` schema
+--
+-- The `app` schema is created by later migrations (SECURITY DEFINER helpers
+-- for the auth path). When setup-roles.sh runs AFTER those migrations have
+-- applied, we still need to grant USAGE + EXECUTE on everything the API role
+-- should call. The DO block is a no-op on pristine databases where the
+-- schema doesn't exist yet — the corresponding migration does the grants on
+-- first run, and re-running this script after any future app.* function
+-- lands picks up the new grants.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'app') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA app TO poziomki_api';
+        -- Prospective: any function added to `app` by a future migration
+        -- auto-grants EXECUTE to poziomki_api without operator intervention.
+        EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE poziomki IN SCHEMA app '
+             || 'GRANT EXECUTE ON FUNCTIONS TO poziomki_api';
+    END IF;
+END
+$$;

--- a/infra/ops/postgres/setup-roles.sql
+++ b/infra/ops/postgres/setup-roles.sql
@@ -1,0 +1,71 @@
+-- One-time role + privilege bootstrap for Poziomki.
+--
+-- Creates the least-privilege roles the API and worker will connect as, so the
+-- application is no longer the cluster superuser. This is the Phase 1 baseline
+-- for Row-Level Security: no policies yet, just role separation.
+--
+-- Run as the database owner (the existing `poziomki` superuser) against the
+-- application database (`poziomki-rs` in production). The wrapper script
+-- `setup-roles.sh` invokes this with the right -v variables.
+--
+-- Safe to re-run: all statements are idempotent. Re-running rotates passwords
+-- to whatever you pass in.
+--
+-- Variables (passed via `psql -v`):
+--   api_password      -- password for poziomki_api
+--   worker_password   -- password for poziomki_worker
+
+\set ON_ERROR_STOP on
+
+-- ---------------------------------------------------------------------------
+-- Roles
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+    CREATE ROLE poziomki_api LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_worker') THEN
+    -- Worker legitimately crosses user boundaries (outbox dispatch, cleanup).
+    -- Give it BYPASSRLS so it isn't tripped by the policies we add in Phase 3.
+    CREATE ROLE poziomki_worker LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE BYPASSRLS;
+  END IF;
+END
+$$;
+
+-- Passwords come from psql variables; quoted via :'...' to escape safely.
+ALTER ROLE poziomki_api     WITH PASSWORD :'api_password';
+ALTER ROLE poziomki_worker  WITH PASSWORD :'worker_password';
+
+-- Bound the worst-case query cost for an exploited or buggy API endpoint.
+ALTER ROLE poziomki_api SET statement_timeout = '5s';
+
+-- ---------------------------------------------------------------------------
+-- Privileges on the current schema
+-- ---------------------------------------------------------------------------
+
+GRANT USAGE ON SCHEMA public TO poziomki_api, poziomki_worker;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON ALL TABLES IN SCHEMA public
+  TO poziomki_api, poziomki_worker;
+
+GRANT USAGE, SELECT
+  ON ALL SEQUENCES IN SCHEMA public
+  TO poziomki_api, poziomki_worker;
+
+-- ---------------------------------------------------------------------------
+-- Default privileges for future migrations
+--
+-- Applies whenever the owner (`poziomki`) creates a new table or sequence in
+-- `public`, so we don't have to re-run grants after every migration.
+-- ---------------------------------------------------------------------------
+
+ALTER DEFAULT PRIVILEGES FOR ROLE poziomki IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES
+  TO poziomki_api, poziomki_worker;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE poziomki IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES
+  TO poziomki_api, poziomki_worker;


### PR DESCRIPTION
**Least-privilege DB roles for API and worker**

The app stops connecting as the cluster owner. API and worker get dedicated roles; migrations keep using the owner URL.

- [x] set role passwords in prod `.env`
- [x] run `infra/ops/postgres/setup-roles.sh` on the server
- [x] rebuild pgdog + api + worker
- [x] verify the new roles exist and the API cannot `CREATE TABLE`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add least-privilege DB roles for API and worker processes
> - Introduces `poziomki_api` and `poziomki_worker` Postgres roles with DML-only privileges, bootstrapped via [`setup-roles.sql`](https://github.com/poziomki-app/poziomki/pull/174/files#diff-854fbe6f4777497285b931bc4564cc120b5fdc252bdb1e5b1095902d6c546ad4) and [`setup-roles.sh`](https://github.com/poziomki-app/poziomki/pull/174/files#diff-4a0811193f23950ef05a2ee5cdcc97b142fed69cbb82078380bfdfa80cb40296).
> - Adds a `PoolRole` enum in [`app.rs`](https://github.com/poziomki-app/poziomki/pull/174/files#diff-b702b9211732f0e35064d2bc6290fe5f2f607f79ce8acc6c8caa211fa89d2b1c) so the API server uses `API_DATABASE_URL` and the outbox worker uses `WORKER_DATABASE_URL`, both falling back to `DATABASE_URL`.
> - Migrations always run under the owner role via `DATABASE_URL`; runtime connection pools use the role-specific URL when set.
> - Extends the pgdog entrypoint to register the API and worker users in `users.toml` when credentials are supplied via environment variables.
> - Behavioral Change: existing deployments using only `DATABASE_URL` are unaffected, but setting the new role-specific vars causes each process to connect with reduced privileges.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d7db1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->