### PR TITLE
sec(rls): viewer context helpers and SECURITY DEFINER auth lookups

### DIFF
--- a/backend/migrations/2026-04-18-010000_auth_security_definer/down.sql
+++ b/backend/migrations/2026-04-18-010000_auth_security_definer/down.sql
@@ -1,0 +1,3 @@
+DROP FUNCTION IF EXISTS app.resolve_session(text);
+DROP FUNCTION IF EXISTS app.find_user_for_login(text);
+-- Schema intentionally retained for future app.* helpers.

--- a/backend/migrations/2026-04-18-010000_auth_security_definer/up.sql
+++ b/backend/migrations/2026-04-18-010000_auth_security_definer/up.sql
@@ -1,0 +1,85 @@
+-- SECURITY DEFINER helpers used by the authentication path.
+--
+-- Login and session resolution must look up users/sessions BEFORE a viewer
+-- context has been established, so once RLS is enabled on those tables
+-- (Tier A) the normal SELECTs will return zero rows. These functions run as
+-- the owner (BYPASSRLS) and are locked to exact-match inputs, so the API
+-- role can call them to authenticate without being granted broad read on the
+-- underlying tables.
+
+CREATE SCHEMA IF NOT EXISTS app;
+
+COMMENT ON SCHEMA app IS
+    'Internal helpers invoked from the API layer (viewer context, auth lookups).';
+
+-- Exact-match user lookup by email. Used by the login/signup flow to load a
+-- row plus password hash for verification. Never expose fuzzy matching here.
+CREATE OR REPLACE FUNCTION app.find_user_for_login(p_email text)
+RETURNS TABLE (
+    id int,
+    pid uuid,
+    name varchar,
+    email varchar,
+    password varchar,
+    email_verified_at timestamptz,
+    is_review_stub bool
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT u.id, u.pid, u.name, u.email, u.password, u.email_verified_at, u.is_review_stub
+    FROM users u
+    WHERE u.email = p_email
+    LIMIT 1
+$$;
+
+COMMENT ON FUNCTION app.find_user_for_login(text) IS
+    'Exact-match user lookup for the login path. Runs as owner (bypasses RLS) because it is called before a viewer context is established.';
+
+-- Exact-match session resolution by hashed bearer token.
+CREATE OR REPLACE FUNCTION app.resolve_session(p_token_hash text)
+RETURNS TABLE (
+    session_id uuid,
+    user_id int,
+    user_pid uuid,
+    token varchar,
+    ip_address varchar,
+    user_agent varchar,
+    expires_at timestamptz,
+    created_at timestamptz,
+    updated_at timestamptz,
+    is_review_stub bool
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT s.id, s.user_id, u.pid, s.token, s.ip_address, s.user_agent,
+           s.expires_at, s.created_at, s.updated_at, u.is_review_stub
+    FROM sessions s
+    JOIN users u ON u.id = s.user_id
+    WHERE s.token = p_token_hash
+    LIMIT 1
+$$;
+
+COMMENT ON FUNCTION app.resolve_session(text) IS
+    'Exact-match session resolution by hashed token. Runs as owner so the bearer-token middleware can authenticate before any viewer context exists.';
+
+REVOKE EXECUTE ON FUNCTION app.find_user_for_login(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.resolve_session(text) FROM PUBLIC;
+
+-- Grant to the API role if it exists. The role is created by
+-- infra/ops/postgres/setup-roles.sh; pristine dev clones that have not run
+-- that step will skip these grants and the owner retains default EXECUTE.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_user_for_login(text) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.resolve_session(text) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/migrations/2026-04-18-010000_auth_security_definer/up.sql
+++ b/backend/migrations/2026-04-18-010000_auth_security_definer/up.sql
@@ -71,15 +71,22 @@ COMMENT ON FUNCTION app.resolve_session(text) IS
 REVOKE EXECUTE ON FUNCTION app.find_user_for_login(text) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.resolve_session(text) FROM PUBLIC;
 
--- Grant to the API role if it exists. The role is created by
--- infra/ops/postgres/setup-roles.sh; pristine dev clones that have not run
+-- Grant to the API role if it exists now. The role is created by
+-- infra/ops/postgres/setup-roles.sh; pristine dev clones that haven't run
 -- that step will skip these grants and the owner retains default EXECUTE.
+-- setup-roles.sh is forward-compatible: re-running it after this migration
+-- applies catches up USAGE/EXECUTE on the app schema, so bootstrap ordering
+-- doesn't matter in either direction.
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
         EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_user_for_login(text) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.resolve_session(text) TO poziomki_api';
+        -- Any future function added to `app` by a later migration is
+        -- auto-granted EXECUTE to poziomki_api.
+        EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE poziomki IN SCHEMA app '
+             || 'GRANT EXECUTE ON FUNCTIONS TO poziomki_api';
     END IF;
 END
 $$;

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1,5 +1,11 @@
 pub mod models;
 pub mod schema;
+pub mod viewer;
+
+pub use viewer::{
+    find_user_for_login, resolve_session, set_anon_context, set_viewer_context, with_anon_tx,
+    with_viewer_tx, AuthSessionRow, AuthUserRow, DbViewer,
+};
 
 use deadpool::managed::Timeouts;
 use deadpool::Runtime;

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -1,0 +1,174 @@
+//! Viewer context for row-level security.
+//!
+//! Every per-user request sets a few session-local GUCs (`app.user_id`,
+//! `app.is_stub`, `app.role`) that RLS policies consult. Because pgdog runs
+//! in transaction-pool mode, the server backend is reattached after each
+//! `COMMIT`; session-level `SET` would leak into the next request. All
+//! helpers here use `SET LOCAL` inside an explicit transaction so the
+//! context lives and dies with that transaction.
+//!
+//! `app.role` is descriptive only — the real trust boundary is the DB role
+//! itself (`poziomki_api` vs `poziomki_worker`). A GUC can be overridden
+//! from within any query, so it cannot gate privilege.
+
+use diesel::deserialize::QueryableByName;
+use diesel::sql_types::{Bool, Integer, Nullable, Text, Timestamptz, Uuid as SqlUuid, VarChar};
+use diesel::OptionalExtension;
+use diesel_async::scoped_futures::ScopedBoxFuture;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl, SimpleAsyncConnection};
+
+/// Identity of the authenticated caller whose visibility scopes the current
+/// transaction. Constructed from the session row after authentication.
+#[derive(Clone, Copy, Debug)]
+pub struct DbViewer {
+    pub user_id: i32,
+    pub is_review_stub: bool,
+}
+
+/// Apply the viewer as `SET LOCAL` GUCs.
+///
+/// Must run inside an explicit transaction. `with_viewer_tx` does that for
+/// you; prefer this lower-level form only when an existing call site already
+/// opens its own transaction (e.g. `build_transaction().serializable()`).
+pub async fn set_viewer_context(
+    conn: &mut AsyncPgConnection,
+    viewer: DbViewer,
+) -> Result<(), diesel::result::Error> {
+    // Safe interpolation: user_id is i32, is_review_stub is bool.
+    let sql = format!(
+        "SET LOCAL app.user_id = '{}'; SET LOCAL app.is_stub = '{}'; SET LOCAL app.role = 'user'",
+        viewer.user_id, viewer.is_review_stub
+    );
+    conn.batch_execute(&sql).await
+}
+
+/// Anonymous / pre-auth context. `app.user_id = 0`, `app.role = 'anon'`.
+pub async fn set_anon_context(conn: &mut AsyncPgConnection) -> Result<(), diesel::result::Error> {
+    conn.batch_execute(
+        "SET LOCAL app.user_id = '0'; SET LOCAL app.is_stub = 'false'; SET LOCAL app.role = 'anon'",
+    )
+    .await
+}
+
+/// Run `f` inside a transaction that has `set_viewer_context(viewer)` as its
+/// first statement. Use for the common case where the handler doesn't need
+/// custom isolation.
+pub async fn with_viewer_tx<'a, F, T>(viewer: DbViewer, f: F) -> Result<T, diesel::result::Error>
+where
+    F: for<'c> FnOnce(
+            &'c mut AsyncPgConnection,
+        ) -> ScopedBoxFuture<'a, 'c, Result<T, diesel::result::Error>>
+        + Send
+        + 'a,
+    T: Send + 'a,
+{
+    let mut conn = crate::db::conn()
+        .await
+        .map_err(|_| diesel::result::Error::BrokenTransactionManager)?;
+    conn.transaction::<T, diesel::result::Error, _>(move |conn| {
+        Box::pin(async move {
+            set_viewer_context(conn, viewer).await?;
+            f(conn).await
+        })
+    })
+    .await
+}
+
+/// `with_viewer_tx` but for anonymous / pre-auth endpoints.
+pub async fn with_anon_tx<'a, F, T>(f: F) -> Result<T, diesel::result::Error>
+where
+    F: for<'c> FnOnce(
+            &'c mut AsyncPgConnection,
+        ) -> ScopedBoxFuture<'a, 'c, Result<T, diesel::result::Error>>
+        + Send
+        + 'a,
+    T: Send + 'a,
+{
+    let mut conn = crate::db::conn()
+        .await
+        .map_err(|_| diesel::result::Error::BrokenTransactionManager)?;
+    conn.transaction::<T, diesel::result::Error, _>(move |conn| {
+        Box::pin(async move {
+            set_anon_context(conn).await?;
+            f(conn).await
+        })
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// SECURITY DEFINER lookups
+//
+// Authentication queries `users` by email and `sessions` by hashed token
+// before any viewer context exists. Once Tier-A policies are enabled, those
+// plain SELECTs will return zero rows. The `app.*` functions defined in the
+// auth_security_definer migration run as the owner and are tightly scoped to
+// exact-match inputs, so the API role can authenticate without being granted
+// broad read on the underlying tables.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, QueryableByName)]
+pub struct AuthUserRow {
+    #[diesel(sql_type = Integer)]
+    pub id: i32,
+    #[diesel(sql_type = SqlUuid)]
+    pub pid: uuid::Uuid,
+    #[diesel(sql_type = VarChar)]
+    pub name: String,
+    #[diesel(sql_type = VarChar)]
+    pub email: String,
+    #[diesel(sql_type = VarChar)]
+    pub password: String,
+    #[diesel(sql_type = Nullable<Timestamptz>)]
+    pub email_verified_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[diesel(sql_type = Bool)]
+    pub is_review_stub: bool,
+}
+
+/// Exact-match user lookup by email. Bypasses RLS via SECURITY DEFINER.
+pub async fn find_user_for_login(
+    conn: &mut AsyncPgConnection,
+    email: &str,
+) -> Result<Option<AuthUserRow>, diesel::result::Error> {
+    diesel::sql_query("SELECT * FROM app.find_user_for_login($1)")
+        .bind::<Text, _>(email)
+        .get_result::<AuthUserRow>(conn)
+        .await
+        .optional()
+}
+
+#[derive(Debug, Clone, QueryableByName)]
+pub struct AuthSessionRow {
+    #[diesel(sql_type = SqlUuid)]
+    pub session_id: uuid::Uuid,
+    #[diesel(sql_type = Integer)]
+    pub user_id: i32,
+    #[diesel(sql_type = SqlUuid)]
+    pub user_pid: uuid::Uuid,
+    #[diesel(sql_type = VarChar)]
+    pub token: String,
+    #[diesel(sql_type = Nullable<VarChar>)]
+    pub ip_address: Option<String>,
+    #[diesel(sql_type = Nullable<VarChar>)]
+    pub user_agent: Option<String>,
+    #[diesel(sql_type = Timestamptz)]
+    pub expires_at: chrono::DateTime<chrono::Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    #[diesel(sql_type = Bool)]
+    pub is_review_stub: bool,
+}
+
+/// Exact-match session lookup by hashed token. Bypasses RLS via SECURITY DEFINER.
+pub async fn resolve_session(
+    conn: &mut AsyncPgConnection,
+    token_hash: &str,
+) -> Result<Option<AuthSessionRow>, diesel::result::Error> {
+    diesel::sql_query("SELECT * FROM app.resolve_session($1)")
+        .bind::<Text, _>(token_hash)
+        .get_result::<AuthSessionRow>(conn)
+        .await
+        .optional()
+}

--- a/backend/tests/requests/db_viewer.rs
+++ b/backend/tests/requests/db_viewer.rs
@@ -1,0 +1,249 @@
+//! Integration tests for the `db::viewer` module — `DbViewer`,
+//! `set_viewer_context`, `with_viewer_tx`/`with_anon_tx`, and the SECURITY
+//! DEFINER auth lookups.
+
+use chrono::{Duration, Utc};
+use diesel::prelude::*;
+use diesel::sql_types::Text;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::RunQueryDsl;
+use poziomki_backend::app::{build_test_app_context, reset_test_database};
+use poziomki_backend::db::models::users::{NewUser, User};
+use poziomki_backend::db::schema::{sessions, users};
+use poziomki_backend::db::{
+    self, find_user_for_login, resolve_session, set_anon_context, set_viewer_context, with_anon_tx,
+    with_viewer_tx, DbViewer,
+};
+use serial_test::serial;
+use uuid::Uuid;
+
+async fn setup() {
+    let _ = dotenvy::dotenv();
+    let _ = build_test_app_context().expect("build test app context");
+    reset_test_database().await.expect("truncate test tables");
+}
+
+async fn insert_user(email: &str, is_review_stub: bool) -> User {
+    let mut conn = db::conn().await.expect("pool");
+    let new_user = NewUser {
+        pid: Uuid::new_v4(),
+        email: email.to_string(),
+        password: "hash".to_string(),
+        api_key: Uuid::new_v4().to_string(),
+        name: "Test".to_string(),
+    };
+    let inserted: User = diesel::insert_into(users::table)
+        .values(&new_user)
+        .returning(User::as_select())
+        .get_result(&mut conn)
+        .await
+        .expect("insert user");
+
+    if is_review_stub {
+        diesel::update(users::table.find(inserted.id))
+            .set(users::is_review_stub.eq(true))
+            .execute(&mut conn)
+            .await
+            .expect("mark stub");
+        users::table
+            .find(inserted.id)
+            .select(User::as_select())
+            .first(&mut conn)
+            .await
+            .expect("reload")
+    } else {
+        inserted
+    }
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct CurrentSetting {
+    #[diesel(sql_type = Text)]
+    value: String,
+}
+
+#[tokio::test]
+#[serial]
+async fn set_viewer_context_exposes_gucs_inside_transaction() {
+    setup().await;
+    let user = insert_user("viewer_ctx_test@example.com", false).await;
+    let viewer = DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+
+    let got = with_viewer_tx(viewer, |conn| {
+        async move {
+            let row: CurrentSetting =
+                diesel::sql_query("SELECT current_setting('app.user_id', true) AS value")
+                    .get_result(conn)
+                    .await?;
+            let role: CurrentSetting =
+                diesel::sql_query("SELECT current_setting('app.role', true) AS value")
+                    .get_result(conn)
+                    .await?;
+            Ok((row.value, role.value))
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("viewer tx");
+
+    assert_eq!(got.0, user.id.to_string());
+    assert_eq!(got.1, "user");
+}
+
+#[tokio::test]
+#[serial]
+async fn set_local_does_not_leak_across_transactions() {
+    // pgdog pool is in transaction mode, but diesel holds the same underlying
+    // connection across queries until it's dropped. The important property is
+    // that SET LOCAL clears at COMMIT, so a second transaction on the *same*
+    // connection object should see an empty app.user_id.
+    setup().await;
+    let user = insert_user("leak_test@example.com", false).await;
+    let viewer = DbViewer {
+        user_id: user.id,
+        is_review_stub: false,
+    };
+
+    with_viewer_tx(viewer, |_| {
+        async { Ok::<_, diesel::result::Error>(()) }.scope_boxed()
+    })
+    .await
+    .expect("first tx");
+
+    let after: String = with_anon_tx(|conn| {
+        async move {
+            let row: CurrentSetting =
+                diesel::sql_query("SELECT current_setting('app.user_id', true) AS value")
+                    .get_result(conn)
+                    .await?;
+            Ok(row.value)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("second tx");
+    // Inside the anon tx, user_id was reset to '0'.
+    assert_eq!(after, "0");
+}
+
+#[tokio::test]
+#[serial]
+async fn with_anon_tx_sets_anon_role() {
+    setup().await;
+    let role: String = with_anon_tx(|conn| {
+        async move {
+            let row: CurrentSetting =
+                diesel::sql_query("SELECT current_setting('app.role', true) AS value")
+                    .get_result(conn)
+                    .await?;
+            Ok(row.value)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("anon tx");
+    assert_eq!(role, "anon");
+}
+
+#[tokio::test]
+#[serial]
+async fn find_user_for_login_returns_known_and_none() {
+    setup().await;
+    let user = insert_user("login_lookup@example.com", true).await;
+
+    let mut conn = db::conn().await.expect("pool");
+    let hit = find_user_for_login(&mut conn, "login_lookup@example.com")
+        .await
+        .expect("lookup");
+    let row = hit.expect("row present");
+    assert_eq!(row.id, user.id);
+    assert!(row.is_review_stub);
+
+    let miss = find_user_for_login(&mut conn, "nobody@example.com")
+        .await
+        .expect("lookup");
+    assert!(miss.is_none());
+}
+
+#[tokio::test]
+#[serial]
+async fn resolve_session_returns_known_and_none() {
+    setup().await;
+    let user = insert_user("session_lookup@example.com", false).await;
+
+    let mut conn = db::conn().await.expect("pool");
+    let token = format!("hashed-{}", Uuid::new_v4());
+    let expires_at = Utc::now() + Duration::days(7);
+    diesel::insert_into(sessions::table)
+        .values((
+            sessions::user_id.eq(user.id),
+            sessions::token.eq(&token),
+            sessions::expires_at.eq(expires_at),
+        ))
+        .execute(&mut conn)
+        .await
+        .expect("insert session");
+
+    let hit = resolve_session(&mut conn, &token)
+        .await
+        .expect("lookup")
+        .expect("row present");
+    assert_eq!(hit.user_id, user.id);
+    assert_eq!(hit.user_pid, user.pid);
+
+    let miss = resolve_session(&mut conn, "no-such-token")
+        .await
+        .expect("lookup");
+    assert!(miss.is_none());
+}
+
+#[tokio::test]
+#[serial]
+async fn set_viewer_context_without_wrapper_also_works_inside_explicit_tx() {
+    // set_viewer_context is a primitive used inside existing
+    // build_transaction()... call sites. Confirm it's composable.
+    use diesel_async::AsyncConnection;
+    setup().await;
+    let user = insert_user("primitive_ctx@example.com", false).await;
+    let viewer = DbViewer {
+        user_id: user.id,
+        is_review_stub: false,
+    };
+
+    let mut conn = db::conn().await.expect("pool");
+    let got: String = conn
+        .transaction::<String, diesel::result::Error, _>(|conn| {
+            async move {
+                set_viewer_context(conn, viewer).await?;
+                let row: CurrentSetting =
+                    diesel::sql_query("SELECT current_setting('app.user_id', true) AS value")
+                        .get_result(conn)
+                        .await?;
+                Ok(row.value)
+            }
+            .scope_boxed()
+        })
+        .await
+        .expect("tx");
+    assert_eq!(got, user.id.to_string());
+
+    // Anon primitive also works on a fresh transaction.
+    let got_anon: String = conn
+        .transaction::<String, diesel::result::Error, _>(|conn| {
+            async move {
+                set_anon_context(conn).await?;
+                let row: CurrentSetting =
+                    diesel::sql_query("SELECT current_setting('app.user_id', true) AS value")
+                        .get_result(conn)
+                        .await?;
+                Ok(row.value)
+            }
+            .scope_boxed()
+        })
+        .await
+        .expect("anon tx");
+    assert_eq!(got_anon, "0");
+}

--- a/backend/tests/requests/mod.rs
+++ b/backend/tests/requests/mod.rs
@@ -1,1 +1,2 @@
+mod db_viewer;
 mod migration_contract;


### PR DESCRIPTION
**Viewer context helpers and auth lookups for the RLS rollout**

Adds the Rust plumbing and two SECURITY DEFINER SQL functions that subsequent PRs will use to set a per-request identity without breaking the sign-in path.

- [ ] wait for PR #174 to merge and deploy, then rebase
- [x] migration applies cleanly (CI, run 24600080695)
- [x] `find_user_for_login` and `resolve_session` return expected rows against a real session (CI integration tests)