### PR TITLE
sec(rls): route session resolution and login lookups through app.* helpers

### DIFF
--- a/backend/src/api/auth/service.rs
+++ b/backend/src/api/auth/service.rs
@@ -13,13 +13,15 @@ use diesel_async::AsyncConnection;
 use super::super::{
     error_response,
     state::{
-        create_session_db, normalize_email, session_model_to_view, upsert_otp, user_model_to_view,
-        validate_signup_payload, verify_otp_db, DataResponse, SignUpBody,
+        auth_user_row_to_view, create_session_db, normalize_email, session_model_to_view,
+        upsert_otp, user_model_to_view, validate_signup_payload, verify_otp_db, DataResponse,
+        SignUpBody,
     },
     ErrorSpec,
 };
 use crate::db::models::users::{NewUser, User, UserChangeset};
 use crate::db::schema::{sessions, users};
+use crate::db::{self, AuthUserRow};
 use crate::jobs::enqueue_otp_email;
 
 pub(super) const OTP_RESEND_COOLDOWN_SECS: i64 = 30;
@@ -149,15 +151,10 @@ pub(super) async fn create_user_or_error(
 async fn find_authenticated_user(
     email: &str,
     password: &str,
-) -> std::result::Result<Option<User>, crate::error::AppError> {
+) -> std::result::Result<Option<AuthUserRow>, crate::error::AppError> {
     let mut conn = crate::db::conn().await?;
-    let user = users::table
-        .filter(users::email.eq(email))
-        .first::<User>(&mut conn)
-        .await
-        .optional()?;
-
-    Ok(user.filter(|u| crate::security::verify_password(password, &u.password)))
+    let row = db::find_user_for_login(&mut conn, email).await?;
+    Ok(row.filter(|u| crate::security::verify_password(password, &u.password)))
 }
 
 pub(super) async fn sign_in_success_or_unauthorized(
@@ -189,7 +186,7 @@ pub(super) async fn sign_in_success_or_unauthorized(
 
     let session = create_session_db(headers, user.id).await?;
     let data = serde_json::json!({
-        "user": user_model_to_view(&user),
+        "user": auth_user_row_to_view(&user),
         "token": session.token,
         "session": session_model_to_view(&session.model),
     });
@@ -198,13 +195,9 @@ pub(super) async fn sign_in_success_or_unauthorized(
 
 pub(super) async fn find_user_by_email(
     email: &str,
-) -> std::result::Result<Option<User>, crate::error::AppError> {
+) -> std::result::Result<Option<AuthUserRow>, crate::error::AppError> {
     let mut conn = crate::db::conn().await?;
-    Ok(users::table
-        .filter(users::email.eq(email))
-        .first::<User>(&mut conn)
-        .await
-        .optional()?)
+    Ok(db::find_user_for_login(&mut conn, email).await?)
 }
 
 pub(super) async fn verify_otp_inner(
@@ -238,7 +231,7 @@ pub(super) async fn verify_otp_inner(
     let session = create_session_db(headers, verified_user.id).await?;
     Ok(Json(DataResponse {
         data: serde_json::json!({
-            "user": user_model_to_view(&verified_user),
+            "user": auth_user_row_to_view(&verified_user),
             "token": session.token,
             "session": session_model_to_view(&session.model),
             "status": true,

--- a/backend/src/api/auth/session.rs
+++ b/backend/src/api/auth/session.rs
@@ -5,15 +5,17 @@ use axum::response::Response;
 use axum::{extract::State, http::HeaderMap, response::IntoResponse, Json};
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 
 use super::super::state::{
-    extract_bearer_token, resolve_session_by_token, session_model_to_view, user_model_to_view,
+    extract_bearer_token, hash_session_token, session_model_to_view, user_model_to_view,
     SessionResponse,
 };
 use crate::db::models::sessions::Session;
 use crate::db::models::users::User;
 use crate::db::schema::users;
+use crate::db::{self, DbViewer};
 
 fn empty_session_response() -> Response {
     Json(SessionResponse {
@@ -29,22 +31,50 @@ async fn resolve_session_and_user(
     let Some(token) = extract_bearer_token(headers) else {
         return Ok(None);
     };
+    let hashed = hash_session_token(&token);
 
-    let session = resolve_session_by_token(&token).await?;
-
-    let session = session.filter(|s| s.expires_at > Utc::now());
-    let Some(session) = session else {
-        return Ok(None);
-    };
-
+    // Single transaction: SECURITY DEFINER session resolution, then viewer
+    // context, then the User SELECT under that context. Matches the pattern
+    // used by the require_auth_context middleware so both stay RLS-ready.
     let mut conn = crate::db::conn().await?;
-    let user = users::table
-        .find(session.user_id)
-        .first::<User>(&mut conn)
-        .await
-        .optional()?;
-
-    Ok(user.map(|u| (session, u)))
+    let result = conn
+        .transaction::<Option<(Session, User)>, diesel::result::Error, _>(|conn| {
+            async move {
+                let Some(row) = db::resolve_session(conn, &hashed).await? else {
+                    return Ok(None);
+                };
+                if row.expires_at <= Utc::now() {
+                    return Ok(None);
+                }
+                db::set_viewer_context(
+                    conn,
+                    DbViewer {
+                        user_id: row.user_id,
+                        is_review_stub: row.is_review_stub,
+                    },
+                )
+                .await?;
+                let user = users::table
+                    .find(row.user_id)
+                    .first::<User>(conn)
+                    .await
+                    .optional()?;
+                let session = Session {
+                    id: row.session_id,
+                    user_id: row.user_id,
+                    token: row.token,
+                    ip_address: row.ip_address,
+                    user_agent: row.user_agent,
+                    expires_at: row.expires_at,
+                    created_at: row.created_at,
+                    updated_at: row.updated_at,
+                };
+                Ok(user.map(|u| (session, u)))
+            }
+            .scope_boxed()
+        })
+        .await?;
+    Ok(result)
 }
 
 pub(in crate::api) async fn get_session(

--- a/backend/src/api/state/auth.rs
+++ b/backend/src/api/state/auth.rs
@@ -1,7 +1,8 @@
 use axum::http::HeaderMap;
 use chrono::{DateTime, Duration, Utc};
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::env;
@@ -15,6 +16,7 @@ use super::{SessionView, UserView};
 use crate::db::models::sessions::{NewSession, Session, SessionUpdate};
 use crate::db::models::users::User;
 use crate::db::schema::{sessions, users};
+use crate::db::{self, DbViewer};
 
 const SESSION_DURATION_SECS: i64 = 60 * 60 * 24 * 7;
 const SESSION_UPDATE_AGE_SECS: i64 = 60 * 60 * 24;
@@ -148,18 +150,6 @@ pub(in crate::api) async fn invalidate_auth_cache_for_user_id(user_id: i32) {
         .retain(|_, entry| entry.user.id != user_id);
 }
 
-pub(in crate::api) async fn resolve_session_by_token(
-    token: &str,
-) -> std::result::Result<Option<Session>, crate::error::AppError> {
-    let hashed = session_token_hash(token);
-    let mut conn = crate::db::conn().await?;
-    Ok(sessions::table
-        .filter(sessions::token.eq(&hashed))
-        .first::<Session>(&mut conn)
-        .await
-        .optional()?)
-}
-
 pub(in crate::api) async fn require_auth_db(
     headers: &HeaderMap,
 ) -> std::result::Result<(Session, User), Box<axum::response::Response>> {
@@ -177,60 +167,115 @@ pub(in crate::api) async fn require_auth_context(
     if let Some((session, user)) = cache_auth_get(&hashed).await {
         let elapsed = Utc::now() - session.updated_at;
         if elapsed >= Duration::seconds(SESSION_UPDATE_AGE_SECS) {
-            maybe_renew_session(&session).await;
+            maybe_renew_session(&session, user.is_review_stub).await;
         }
         tracing::Span::current().record("user_id", user.id);
         return Ok(AuthContext { session, user });
     }
 
+    // The SECURITY DEFINER `app.resolve_session` bypasses RLS so we can
+    // authenticate a bearer token before a viewer context exists. Once we
+    // know the user, we set `app.user_id` / `app.is_stub` inside the same
+    // transaction so the follow-up User SELECT and session renewal run under
+    // the correct RLS scope.
     let mut conn = crate::db::conn()
         .await
         .map_err(|_| Box::new(unauthorized_response(headers)))?;
-    let (session, user) = sessions::table
-        .inner_join(users::table.on(users::id.eq(sessions::user_id)))
-        .filter(sessions::token.eq(&hashed))
-        .select((Session::as_select(), User::as_select()))
-        .first::<(Session, User)>(&mut conn)
-        .await
-        .optional()
-        .map_err(|_| Box::new(unauthorized_response(headers)))?
-        .ok_or_else(|| Box::new(unauthorized_response(headers)))?;
-
     let now = Utc::now();
-    if session.expires_at <= now || is_past_absolute_cap(&session, now) {
-        let _ = diesel::delete(sessions::table.find(session.id))
-            .execute(&mut conn)
-            .await;
-        return Err(Box::new(unauthorized_response(headers)));
-    }
 
-    let session = maybe_renew_session_on_conn(session, &mut conn).await;
+    let hashed_for_tx = hashed.clone();
+    let result = conn
+        .transaction::<Option<(Session, User)>, diesel::result::Error, _>(|conn| {
+            async move {
+                let Some(row) = db::resolve_session(conn, &hashed_for_tx).await? else {
+                    return Ok(None);
+                };
+                let session = session_from_row(&row);
+                if session.expires_at <= now || is_past_absolute_cap(&session, now) {
+                    let _ = diesel::delete(sessions::table.find(session.id))
+                        .execute(conn)
+                        .await;
+                    return Ok(None);
+                }
+                db::set_viewer_context(
+                    conn,
+                    DbViewer {
+                        user_id: row.user_id,
+                        is_review_stub: row.is_review_stub,
+                    },
+                )
+                .await?;
+                let user = users::table
+                    .find(row.user_id)
+                    .select(User::as_select())
+                    .first::<User>(conn)
+                    .await?;
+                let session = maybe_renew_session_on_conn(session, conn).await;
+                Ok(Some((session, user)))
+            }
+            .scope_boxed()
+        })
+        .await
+        .map_err(|_| Box::new(unauthorized_response(headers)))?;
+
+    let (session, user) = result.ok_or_else(|| Box::new(unauthorized_response(headers)))?;
     cache_auth_put(hashed, &session, &user).await;
     tracing::Span::current().record("user_id", user.id);
     Ok(AuthContext { session, user })
 }
 
-async fn maybe_renew_session(session: &Session) {
-    let now = Utc::now();
-    let elapsed = now - session.updated_at;
-    if elapsed >= Duration::seconds(SESSION_UPDATE_AGE_SECS) {
-        let new_expires = capped_expiry(
-            session.created_at,
-            now + Duration::seconds(SESSION_DURATION_SECS),
-        );
-        if let Ok(mut conn) = crate::db::conn().await {
-            let _ = diesel::update(sessions::table.find(session.id))
-                .set(&SessionUpdate {
-                    updated_at: Some(now),
-                    expires_at: Some(new_expires),
-                })
-                .execute(&mut conn)
-                .await;
-        }
+fn session_from_row(row: &db::AuthSessionRow) -> Session {
+    Session {
+        id: row.session_id,
+        user_id: row.user_id,
+        token: row.token.clone(),
+        ip_address: row.ip_address.clone(),
+        user_agent: row.user_agent.clone(),
+        expires_at: row.expires_at,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
     }
 }
 
-async fn maybe_renew_session_on_conn(session: Session, conn: &mut crate::db::DbConn) -> Session {
+async fn maybe_renew_session(session: &Session, is_review_stub: bool) {
+    let now = Utc::now();
+    let elapsed = now - session.updated_at;
+    if elapsed < Duration::seconds(SESSION_UPDATE_AGE_SECS) {
+        return;
+    }
+    let new_expires = capped_expiry(
+        session.created_at,
+        now + Duration::seconds(SESSION_DURATION_SECS),
+    );
+    let session_id = session.id;
+    // Renewal is a mutation on the sessions row; run under the caller's
+    // viewer context so it obeys RLS once Tier-A policies land.
+    let _ = db::with_viewer_tx(
+        DbViewer {
+            user_id: session.user_id,
+            is_review_stub,
+        },
+        move |conn| {
+            async move {
+                diesel::update(sessions::table.find(session_id))
+                    .set(&SessionUpdate {
+                        updated_at: Some(now),
+                        expires_at: Some(new_expires),
+                    })
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            }
+            .scope_boxed()
+        },
+    )
+    .await;
+}
+
+async fn maybe_renew_session_on_conn(
+    session: Session,
+    conn: &mut diesel_async::AsyncPgConnection,
+) -> Session {
     let now = Utc::now();
     if now - session.updated_at < Duration::seconds(SESSION_UPDATE_AGE_SECS) {
         return session;
@@ -305,6 +350,15 @@ pub(in crate::api) fn user_model_to_view(user: &User) -> UserView {
         email: user.email.clone(),
         name: user.name.clone(),
         email_verified: user.email_verified_at.is_some(),
+    }
+}
+
+pub(in crate::api) fn auth_user_row_to_view(row: &db::AuthUserRow) -> UserView {
+    UserView {
+        id: row.pid.to_string(),
+        email: row.email.clone(),
+        name: row.name.clone(),
+        email_verified: row.email_verified_at.is_some(),
     }
 }
 


### PR DESCRIPTION
**Migrate the auth module's critical reads to the viewer-aware path**

The session middleware and `GET /get-session` handler now go through `app.resolve_session` + `set_viewer_context`, and login lookups go through `app.find_user_for_login`. Follow-up PRs will migrate the write paths (OTP, reset, signup dup check, account).

- [x] CI green
- [x] sign-up, sign-in, OTP, and `GET /get-session` exercised against the deployed build
- [x] confirm `pg_stat_activity` shows authenticated queries running as `poziomki_api` with `app.user_id` set