### PR TITLE
sec(rls): route remaining auth write paths through viewer-aware helpers

### DIFF
--- a/backend/migrations/2026-04-18-020000_auth_writes_security_definer/down.sql
+++ b/backend/migrations/2026-04-18-020000_auth_writes_security_definer/down.sql
@@ -1,0 +1,5 @@
+DROP FUNCTION IF EXISTS app.complete_password_reset(int, text, timestamptz);
+DROP FUNCTION IF EXISTS app.find_user_for_password_reset(text, text, timestamptz);
+DROP FUNCTION IF EXISTS app.set_password_reset_token(int, text, timestamptz);
+DROP FUNCTION IF EXISTS app.mark_email_verified(int, timestamptz);
+DROP FUNCTION IF EXISTS app.create_user_for_signup(uuid, text, text, text, text);

--- a/backend/migrations/2026-04-18-020000_auth_writes_security_definer/down.sql
+++ b/backend/migrations/2026-04-18-020000_auth_writes_security_definer/down.sql
@@ -1,3 +1,5 @@
+DROP FUNCTION IF EXISTS app.delete_session_by_token(text);
+DROP FUNCTION IF EXISTS app.create_session_for_user(uuid, int, text, varchar, varchar, timestamptz, timestamptz);
 DROP FUNCTION IF EXISTS app.complete_password_reset(int, text, timestamptz);
 DROP FUNCTION IF EXISTS app.find_user_for_password_reset(text, text, timestamptz);
 DROP FUNCTION IF EXISTS app.set_password_reset_token(int, text, timestamptz);

--- a/backend/migrations/2026-04-18-020000_auth_writes_security_definer/up.sql
+++ b/backend/migrations/2026-04-18-020000_auth_writes_security_definer/up.sql
@@ -131,12 +131,78 @@ $$;
 COMMENT ON FUNCTION app.complete_password_reset(int, text, timestamptz) IS
     'Rotate password hash, clear reset token, and invalidate all sessions for a user.';
 
+-- Create a session row for a user who has just been authenticated (sign-in,
+-- OTP verify, password reset). Called before the caller has set a viewer
+-- context. The caller provides the session id so it can embed it in the
+-- bearer token without an extra round-trip. Returns the inserted row.
+CREATE OR REPLACE FUNCTION app.create_session_for_user(
+    p_id uuid,
+    p_user_id int,
+    p_token_hash text,
+    p_ip_address varchar,
+    p_user_agent varchar,
+    p_now timestamptz,
+    p_expires_at timestamptz
+)
+RETURNS TABLE (
+    id uuid,
+    user_id int,
+    token varchar,
+    ip_address varchar,
+    user_agent varchar,
+    expires_at timestamptz,
+    created_at timestamptz,
+    updated_at timestamptz
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+    INSERT INTO sessions (id, user_id, token, ip_address, user_agent, expires_at, created_at, updated_at)
+    VALUES (p_id, p_user_id, p_token_hash, p_ip_address, p_user_agent, p_expires_at, p_now, p_now)
+    RETURNING id, user_id, token, ip_address, user_agent, expires_at, created_at, updated_at;
+$$;
+
+COMMENT ON FUNCTION app.create_session_for_user(uuid, int, text, varchar, varchar, timestamptz, timestamptz) IS
+    'Insert a session row with a caller-supplied id. Caller must have verified credentials/OTP/reset-token first.';
+
+-- Delete a session by exact hashed token (sign-out path). Idempotent.
+CREATE OR REPLACE FUNCTION app.delete_session_by_token(p_token_hash text)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+    DELETE FROM sessions WHERE token = p_token_hash;
+$$;
+
+COMMENT ON FUNCTION app.delete_session_by_token(text) IS
+    'Delete the session matching a hashed bearer token. Idempotent; used by sign-out.';
+
 REVOKE EXECUTE ON FUNCTION app.create_user_for_signup(uuid, text, text, text, text) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.mark_email_verified(int, timestamptz) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.set_password_reset_token(int, text, timestamptz) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.find_user_for_password_reset(text, text, timestamptz) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.complete_password_reset(int, text, timestamptz) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.create_session_for_user(uuid, int, text, varchar, varchar, timestamptz, timestamptz) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.delete_session_by_token(text) FROM PUBLIC;
 
--- Grants to poziomki_api are covered by the ALTER DEFAULT PRIVILEGES clause
--- applied in the earlier auth_security_definer migration; any new function in
--- the `app` schema is auto-granted EXECUTE. Nothing extra is needed here.
+-- Defensive grants. The earlier auth_security_definer migration already
+-- installed ALTER DEFAULT PRIVILEGES for functions in `app`, so a matching
+-- owner role will pick these up automatically. We repeat the explicit grant
+-- block here so this migration is self-contained on any environment where
+-- the prior default-privileges entry wasn't applied (e.g. the owner role
+-- was renamed, a pristine dev clone bootstrapped the API role later, etc.).
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.create_user_for_signup(uuid, text, text, text, text) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.mark_email_verified(int, timestamptz) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.set_password_reset_token(int, text, timestamptz) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_user_for_password_reset(text, text, timestamptz) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.complete_password_reset(int, text, timestamptz) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.create_session_for_user(uuid, int, text, varchar, varchar, timestamptz, timestamptz) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.delete_session_by_token(text) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/migrations/2026-04-18-020000_auth_writes_security_definer/up.sql
+++ b/backend/migrations/2026-04-18-020000_auth_writes_security_definer/up.sql
@@ -196,6 +196,7 @@ REVOKE EXECUTE ON FUNCTION app.delete_session_by_token(text) FROM PUBLIC;
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.create_user_for_signup(uuid, text, text, text, text) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.mark_email_verified(int, timestamptz) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.set_password_reset_token(int, text, timestamptz) TO poziomki_api';

--- a/backend/migrations/2026-04-18-020000_auth_writes_security_definer/up.sql
+++ b/backend/migrations/2026-04-18-020000_auth_writes_security_definer/up.sql
@@ -1,0 +1,142 @@
+-- SECURITY DEFINER helpers for pre-authentication writes to `users`.
+--
+-- Sign-up, email verification, and password reset all mutate the users table
+-- before a viewer context exists. Once Tier-A policies are enabled, anon
+-- connections cannot INSERT/UPDATE `users` directly; these helpers run as the
+-- owner (BYPASSRLS) and are tightly scoped so the API role can call them for
+-- exactly those flows and nothing else.
+
+-- Insert a new user row for the sign-up flow. Returns the inserted row.
+CREATE OR REPLACE FUNCTION app.create_user_for_signup(
+    p_pid uuid,
+    p_email text,
+    p_password text,
+    p_api_key text,
+    p_name text
+)
+RETURNS TABLE (
+    id int,
+    pid uuid,
+    email varchar,
+    password varchar,
+    name varchar,
+    email_verified_at timestamptz,
+    is_review_stub bool
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+    INSERT INTO users (pid, email, password, api_key, name)
+    VALUES (p_pid, p_email, p_password, p_api_key, p_name)
+    RETURNING id, pid, email, password, name, email_verified_at, is_review_stub;
+$$;
+
+COMMENT ON FUNCTION app.create_user_for_signup(uuid, text, text, text, text) IS
+    'Insert a user row for the sign-up flow. Runs as owner so it works before any viewer context exists.';
+
+-- Mark an email as verified (sets email_verified_at + bumps updated_at).
+CREATE OR REPLACE FUNCTION app.mark_email_verified(p_user_id int, p_now timestamptz)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+    UPDATE users
+    SET email_verified_at = p_now,
+        updated_at = p_now
+    WHERE id = p_user_id
+      AND email_verified_at IS NULL;
+$$;
+
+COMMENT ON FUNCTION app.mark_email_verified(int, timestamptz) IS
+    'Set email_verified_at on a user. Idempotent; no-ops if already verified.';
+
+-- Store a password-reset token for a user. Caller passes the SHA-256 hash.
+CREATE OR REPLACE FUNCTION app.set_password_reset_token(
+    p_user_id int,
+    p_token_hash text,
+    p_now timestamptz
+)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+    UPDATE users
+    SET reset_token = p_token_hash,
+        reset_sent_at = p_now,
+        updated_at = p_now
+    WHERE id = p_user_id;
+$$;
+
+COMMENT ON FUNCTION app.set_password_reset_token(int, text, timestamptz) IS
+    'Record a hashed reset token on a user. Caller must have already verified OTP.';
+
+-- Multi-filter lookup for the reset-password confirm step: matches on
+-- email + exact hashed token + not-expired cutoff.
+CREATE OR REPLACE FUNCTION app.find_user_for_password_reset(
+    p_email text,
+    p_token_hash text,
+    p_cutoff timestamptz
+)
+RETURNS TABLE (
+    id int,
+    pid uuid,
+    email varchar,
+    name varchar,
+    email_verified_at timestamptz,
+    is_review_stub bool
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT id, pid, email, name, email_verified_at, is_review_stub
+    FROM users
+    WHERE email = p_email
+      AND reset_token = p_token_hash
+      AND reset_sent_at > p_cutoff
+    LIMIT 1
+$$;
+
+COMMENT ON FUNCTION app.find_user_for_password_reset(text, text, timestamptz) IS
+    'Exact-match user lookup for the reset-password confirm step. Caller verifies TTL via p_cutoff.';
+
+-- Apply a completed password reset: rotate the password hash, clear the
+-- reset-token columns, and invalidate any existing sessions.
+CREATE OR REPLACE FUNCTION app.complete_password_reset(
+    p_user_id int,
+    p_new_password text,
+    p_now timestamptz
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    UPDATE users
+    SET password = p_new_password,
+        reset_token = NULL,
+        reset_sent_at = NULL,
+        updated_at = p_now
+    WHERE id = p_user_id;
+
+    DELETE FROM sessions WHERE user_id = p_user_id;
+END
+$$;
+
+COMMENT ON FUNCTION app.complete_password_reset(int, text, timestamptz) IS
+    'Rotate password hash, clear reset token, and invalidate all sessions for a user.';
+
+REVOKE EXECUTE ON FUNCTION app.create_user_for_signup(uuid, text, text, text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.mark_email_verified(int, timestamptz) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.set_password_reset_token(int, text, timestamptz) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.find_user_for_password_reset(text, text, timestamptz) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.complete_password_reset(int, text, timestamptz) FROM PUBLIC;
+
+-- Grants to poziomki_api are covered by the ALTER DEFAULT PRIVILEGES clause
+-- applied in the earlier auth_security_definer migration; any new function in
+-- the `app` schema is auto-granted EXECUTE. Nothing extra is needed here.

--- a/backend/src/api/auth/account.rs
+++ b/backend/src/api/auth/account.rs
@@ -8,7 +8,8 @@ use axum::response::Response;
 use axum::{extract::State, http::HeaderMap, response::IntoResponse, Json};
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::{AsyncConnection, RunQueryDsl};
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::RunQueryDsl;
 
 use crate::api::{auth_or_respond, error_response};
 
@@ -26,53 +27,72 @@ use crate::db::schema::{
     conversations, event_attendees, events, profile_tags, profiles, sessions, uploads,
     user_audit_log, user_settings, users,
 };
+use crate::db::{self, DbViewer};
 
 /// Record a GDPR-relevant action on an account (deletion, export, password
 /// change). Best-effort: logs a warning on failure but never blocks the
-/// originating operation.
-async fn write_audit(user_pid: uuid::Uuid, action: &'static str) {
-    let Ok(mut conn) = crate::db::conn().await else {
-        tracing::warn!(action, "audit log skipped: no DB conn");
-        return;
-    };
+/// originating operation. Runs under the caller's viewer context so the
+/// insert is attributable once RLS policies are enabled.
+async fn write_audit(viewer: DbViewer, user_pid: uuid::Uuid, action: &'static str) {
     let entry = NewUserAuditLog {
         id: uuid::Uuid::new_v4(),
         user_pid,
         action: action.to_string(),
         created_at: Utc::now(),
     };
-    if let Err(e) = diesel::insert_into(user_audit_log::table)
-        .values(&entry)
-        .execute(&mut conn)
-        .await
-    {
+    let result = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            diesel::insert_into(user_audit_log::table)
+                .values(&entry)
+                .execute(conn)
+                .await?;
+            Ok::<(), diesel::result::Error>(())
+        }
+        .scope_boxed()
+    })
+    .await;
+    if let Err(e) = result {
         tracing::warn!(action, error = %e, "audit log insert failed");
     }
 }
 
-async fn delete_user_data(user_id: i32) -> std::result::Result<(), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
+async fn delete_user_data(viewer: DbViewer) -> std::result::Result<(), crate::error::AppError> {
+    let user_id = viewer.user_id;
 
-    let profile_id: Option<uuid::Uuid> = profiles::table
-        .filter(profiles::user_id.eq(user_id))
-        .select(profiles::id)
-        .first(&mut conn)
-        .await
-        .optional()?;
+    // Collect upload filenames before the transaction so the outer-scope S3
+    // cleanup can delete them even though the rows get wiped.
+    let upload_filenames = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let profile_id: Option<uuid::Uuid> = profiles::table
+                .filter(profiles::user_id.eq(user_id))
+                .select(profiles::id)
+                .first(conn)
+                .await
+                .optional()?;
+            let files: Vec<String> = if let Some(pid) = profile_id {
+                uploads::table
+                    .filter(uploads::owner_id.eq(pid))
+                    .select(uploads::filename)
+                    .load(conn)
+                    .await?
+            } else {
+                vec![]
+            };
+            Ok::<Vec<String>, diesel::result::Error>(files)
+        }
+        .scope_boxed()
+    })
+    .await?;
 
-    // Collect upload filenames before the transaction for S3 cleanup afterwards
-    let upload_filenames: Vec<String> = if let Some(pid) = profile_id {
-        uploads::table
-            .filter(uploads::owner_id.eq(pid))
-            .select(uploads::filename)
-            .load(&mut conn)
-            .await?
-    } else {
-        vec![]
-    };
+    db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let profile_id: Option<uuid::Uuid> = profiles::table
+                .filter(profiles::user_id.eq(user_id))
+                .select(profiles::id)
+                .first(conn)
+                .await
+                .optional()?;
 
-    conn.transaction(|conn| {
-        Box::pin(async move {
             if let Some(pid) = profile_id {
                 // Collect upload IDs before removing the FK reference
                 let upload_ids: Vec<uuid::Uuid> = uploads::table
@@ -170,7 +190,8 @@ async fn delete_user_data(user_id: i32) -> std::result::Result<(), crate::error:
             }
 
             Ok::<(), diesel::result::Error>(())
-        })
+        }
+        .scope_boxed()
     })
     .await?;
 
@@ -195,10 +216,15 @@ pub(in crate::api) async fn delete_account(
         return Ok(unauthorized_error(&headers, "Invalid password"));
     }
 
+    let viewer = DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+
     // Record deletion request before wiping the user record so the audit
     // entry survives the cascade.
-    write_audit(user.pid, "account_delete").await;
-    delete_user_data(user.id).await?;
+    write_audit(viewer, user.pid, "account_delete").await;
+    delete_user_data(viewer).await?;
     invalidate_auth_cache_for_user_id(user.id).await;
 
     Ok(Json(SuccessResponse { success: true }).into_response())
@@ -230,11 +256,14 @@ pub(in crate::api) async fn change_password(
     }
 
     let new_hash = crate::security::hash_password(&payload.new_password)?;
-    let mut conn = crate::db::conn().await?;
+    let viewer = DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
 
-    conn.transaction(|conn| {
+    db::with_viewer_tx(viewer, |conn| {
         let new_hash = new_hash.clone();
-        Box::pin(async move {
+        async move {
             diesel::update(users::table.find(user.id))
                 .set((
                     users::password.eq(new_hash),
@@ -246,12 +275,13 @@ pub(in crate::api) async fn change_password(
                 .execute(conn)
                 .await?;
             Ok::<(), diesel::result::Error>(())
-        })
+        }
+        .scope_boxed()
     })
     .await?;
 
     invalidate_auth_cache_for_user_id(user.id).await;
-    write_audit(user.pid, "password_change").await;
+    write_audit(viewer, user.pid, "password_change").await;
 
     Ok(Json(DataResponse {
         data: SuccessResponse { success: true },
@@ -264,14 +294,23 @@ pub(in crate::api) async fn export_data(
     headers: HeaderMap,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
+    let viewer = DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
 
-    let mut conn = crate::db::conn().await?;
-
-    let profile = profiles::table
-        .filter(profiles::user_id.eq(user.id))
-        .first::<Profile>(&mut conn)
-        .await
-        .optional()?;
+    let profile = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            profiles::table
+                .filter(profiles::user_id.eq(user_id))
+                .first::<Profile>(conn)
+                .await
+                .optional()
+        }
+        .scope_boxed()
+    })
+    .await?;
 
     let profile_id = profile.as_ref().map(|p| p.id);
 
@@ -355,7 +394,7 @@ pub(in crate::api) async fn export_data(
         .map_err(|e| crate::error::AppError::message(format!("zip finish error: {e}")))?;
     let zip_bytes = cursor.into_inner();
 
-    write_audit(user.pid, "data_export").await;
+    write_audit(viewer, user.pid, "data_export").await;
 
     Ok((
         [

--- a/backend/src/api/auth/account.rs
+++ b/backend/src/api/auth/account.rs
@@ -299,25 +299,89 @@ pub(in crate::api) async fn export_data(
         is_review_stub: user.is_review_stub,
     };
     let user_id = user.id;
+    let user_pid_str = user.pid.to_string();
 
-    let profile = db::with_viewer_tx(viewer, |conn| {
+    // Run every export read inside one viewer-scoped transaction so future
+    // RLS policies scope every SELECT to this user's own rows.
+    let (
+        profile,
+        tags,
+        created_events,
+        attended_events,
+        event_interactions,
+        user_uploads,
+        rec_feedback,
+        user_sessions,
+        settings,
+        upload_filenames,
+    ) = db::with_viewer_tx(viewer, |conn| {
         async move {
-            profiles::table
+            let profile = profiles::table
                 .filter(profiles::user_id.eq(user_id))
                 .first::<Profile>(conn)
                 .await
-                .optional()
+                .optional()?;
+            let profile_id = profile.as_ref().map(|p| p.id);
+
+            let (tags, created, attended, interactions, uploads_list, rec) =
+                if let Some(pid) = profile_id {
+                    let tags = auth_export_queries::load_user_tags(conn, pid)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+                    let created = auth_export_queries::load_created_events(conn, pid)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+                    let attended = auth_export_queries::load_attended_events(conn, pid)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+                    let interactions = auth_export_queries::load_event_interactions(conn, pid)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+                    let uploads_list = auth_export_queries::load_user_uploads(conn, pid)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+                    let rec = auth_export_queries::load_recommendation_feedback(conn, pid)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+                    (tags, created, attended, interactions, uploads_list, rec)
+                } else {
+                    (vec![], vec![], vec![], vec![], vec![], vec![])
+                };
+
+            let us = auth_export_queries::load_user_sessions(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            let set = auth_export_queries::load_user_settings(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            let filenames = if let Some(pid) = profile_id {
+                auth_export_queries::load_upload_filenames(conn, pid)
+                    .await
+                    .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            } else {
+                vec![]
+            };
+            Ok::<_, diesel::result::Error>((
+                profile,
+                tags,
+                created,
+                attended,
+                interactions,
+                uploads_list,
+                rec,
+                us,
+                set,
+                filenames,
+            ))
         }
         .scope_boxed()
     })
     .await?;
 
-    let profile_id = profile.as_ref().map(|p| p.id);
-
     let profile_view: Option<serde_json::Value> = profile.map(|p| {
         serde_json::json!({
             "id": p.id.to_string(),
-            "userId": user.pid.to_string(),
+            "userId": user_pid_str,
             "name": p.name,
             "bio": p.bio,
             "profilePicture": p.profile_picture,
@@ -327,12 +391,6 @@ pub(in crate::api) async fn export_data(
             "updatedAt": p.updated_at.to_rfc3339(),
         })
     });
-
-    let (tags, created_events, attended_events, event_interactions, user_uploads, rec_feedback) =
-        load_profile_data(profile_id).await?;
-
-    let user_sessions = auth_export_queries::load_user_sessions(user.id).await?;
-    let settings = auth_export_queries::load_user_settings(user.id).await?;
 
     let export = serde_json::json!({
         "user": {
@@ -353,13 +411,6 @@ pub(in crate::api) async fn export_data(
         "settings": settings,
         "exportedAt": Utc::now().to_rfc3339(),
     });
-
-    // Collect image files from S3
-    let upload_filenames = if let Some(pid) = profile_id {
-        auth_export_queries::load_upload_filenames(pid).await?
-    } else {
-        vec![]
-    };
 
     let mut image_files: Vec<(String, Vec<u8>)> = Vec::new();
     for filename in &upload_filenames {
@@ -407,31 +458,4 @@ pub(in crate::api) async fn export_data(
         zip_bytes,
     )
         .into_response())
-}
-
-async fn load_profile_data(
-    profile_id: Option<uuid::Uuid>,
-) -> std::result::Result<
-    (
-        Vec<serde_json::Value>,
-        Vec<serde_json::Value>,
-        Vec<serde_json::Value>,
-        Vec<serde_json::Value>,
-        Vec<serde_json::Value>,
-        Vec<serde_json::Value>,
-    ),
-    crate::error::AppError,
-> {
-    let Some(pid) = profile_id else {
-        return Ok((vec![], vec![], vec![], vec![], vec![], vec![]));
-    };
-
-    let tags = auth_export_queries::load_user_tags(pid).await?;
-    let created = auth_export_queries::load_created_events(pid).await?;
-    let attended = auth_export_queries::load_attended_events(pid).await?;
-    let interactions = auth_export_queries::load_event_interactions(pid).await?;
-    let uploads = auth_export_queries::load_user_uploads(pid).await?;
-    let rec_feedback = auth_export_queries::load_recommendation_feedback(pid).await?;
-
-    Ok((tags, created, attended, interactions, uploads, rec_feedback))
 }

--- a/backend/src/api/auth/export_queries.rs
+++ b/backend/src/api/auth/export_queries.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::event_attendees::EventAttendee;
@@ -19,13 +19,12 @@ use crate::db::schema::{
 };
 
 pub(super) async fn load_user_tags(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
 ) -> std::result::Result<Vec<serde_json::Value>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let pt_rows = profile_tags::table
         .filter(profile_tags::profile_id.eq(profile_id))
-        .load::<ProfileTag>(&mut conn)
+        .load::<ProfileTag>(conn)
         .await?;
 
     let tag_ids: Vec<Uuid> = pt_rows.iter().map(|pt| pt.tag_id).collect();
@@ -35,7 +34,7 @@ pub(super) async fn load_user_tags(
 
     let tag_rows = tags::table
         .filter(tags::id.eq_any(&tag_ids))
-        .load::<Tag>(&mut conn)
+        .load::<Tag>(conn)
         .await?;
 
     Ok(tag_rows
@@ -54,18 +53,17 @@ pub(super) async fn load_user_tags(
 }
 
 pub(super) async fn load_created_events(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
 ) -> std::result::Result<Vec<serde_json::Value>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let event_rows = events::table
         .filter(events::creator_id.eq(profile_id))
-        .load::<Event>(&mut conn)
+        .load::<Event>(conn)
         .await?;
 
     let mut result = Vec::with_capacity(event_rows.len());
     for event in &event_rows {
-        let event_tag_rows = load_tags_for_event(&mut conn, event.id).await?;
+        let event_tag_rows = load_tags_for_event(conn, event.id).await?;
         result.push(serde_json::json!({
             "id": event.id.to_string(),
             "title": event.title,
@@ -82,7 +80,7 @@ pub(super) async fn load_created_events(
 }
 
 async fn load_tags_for_event(
-    conn: &mut diesel_async::AsyncPgConnection,
+    conn: &mut AsyncPgConnection,
     event_id: Uuid,
 ) -> std::result::Result<Vec<serde_json::Value>, crate::error::AppError> {
     let et_rows = event_tags::table
@@ -113,13 +111,12 @@ async fn load_tags_for_event(
 }
 
 pub(super) async fn load_attended_events(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
 ) -> std::result::Result<Vec<serde_json::Value>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let att_rows = event_attendees::table
         .filter(event_attendees::profile_id.eq(profile_id))
-        .load::<EventAttendee>(&mut conn)
+        .load::<EventAttendee>(conn)
         .await?;
 
     let event_ids: Vec<Uuid> = att_rows.iter().map(|a| a.event_id).collect();
@@ -129,7 +126,7 @@ pub(super) async fn load_attended_events(
 
     let event_rows = events::table
         .filter(events::id.eq_any(&event_ids))
-        .load::<Event>(&mut conn)
+        .load::<Event>(conn)
         .await?;
 
     Ok(att_rows
@@ -147,13 +144,12 @@ pub(super) async fn load_attended_events(
 }
 
 pub(super) async fn load_user_sessions(
+    conn: &mut AsyncPgConnection,
     user_id: i32,
 ) -> std::result::Result<Vec<serde_json::Value>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let session_rows = sessions::table
         .filter(sessions::user_id.eq(user_id))
-        .load::<Session>(&mut conn)
+        .load::<Session>(conn)
         .await?;
 
     Ok(session_rows
@@ -171,14 +167,13 @@ pub(super) async fn load_user_sessions(
 }
 
 pub(super) async fn load_user_uploads(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
 ) -> std::result::Result<Vec<serde_json::Value>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let upload_rows = uploads::table
         .filter(uploads::owner_id.eq(profile_id))
         .filter(uploads::deleted.eq(false))
-        .load::<Upload>(&mut conn)
+        .load::<Upload>(conn)
         .await?;
 
     Ok(upload_rows
@@ -196,13 +191,12 @@ pub(super) async fn load_user_uploads(
 }
 
 pub(super) async fn load_user_settings(
+    conn: &mut AsyncPgConnection,
     user_id: i32,
 ) -> std::result::Result<Option<serde_json::Value>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let settings = user_settings::table
         .filter(user_settings::user_id.eq(user_id))
-        .first::<UserSetting>(&mut conn)
+        .first::<UserSetting>(conn)
         .await
         .optional()?;
 
@@ -218,13 +212,12 @@ pub(super) async fn load_user_settings(
 }
 
 pub(super) async fn load_event_interactions(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
 ) -> std::result::Result<Vec<serde_json::Value>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let interaction_rows = event_interactions::table
         .filter(event_interactions::profile_id.eq(profile_id))
-        .load::<EventInteraction>(&mut conn)
+        .load::<EventInteraction>(conn)
         .await?;
 
     let event_ids: Vec<Uuid> = interaction_rows.iter().map(|row| row.event_id).collect();
@@ -233,7 +226,7 @@ pub(super) async fn load_event_interactions(
     } else {
         events::table
             .filter(events::id.eq_any(&event_ids))
-            .load::<Event>(&mut conn)
+            .load::<Event>(conn)
             .await?
     };
 
@@ -256,28 +249,26 @@ pub(super) async fn load_event_interactions(
 }
 
 pub(super) async fn load_upload_filenames(
+    conn: &mut AsyncPgConnection,
     profile_id: uuid::Uuid,
 ) -> std::result::Result<Vec<String>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let filenames = uploads::table
         .filter(uploads::owner_id.eq(profile_id))
         .filter(uploads::deleted.eq(false))
         .select(uploads::filename)
-        .load::<String>(&mut conn)
+        .load::<String>(conn)
         .await?;
 
     Ok(filenames)
 }
 
 pub(super) async fn load_recommendation_feedback(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
 ) -> std::result::Result<Vec<serde_json::Value>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let rows = recommendation_feedback::table
         .filter(recommendation_feedback::profile_id.eq(profile_id))
-        .load::<RecommendationFeedback>(&mut conn)
+        .load::<RecommendationFeedback>(conn)
         .await?;
 
     let event_ids: Vec<Uuid> = rows.iter().map(|r| r.event_id).collect();
@@ -286,7 +277,7 @@ pub(super) async fn load_recommendation_feedback(
     } else {
         events::table
             .filter(events::id.eq_any(&event_ids))
-            .load::<Event>(&mut conn)
+            .load::<Event>(conn)
             .await?
     };
 

--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -257,9 +257,7 @@ pub(super) async fn sign_out(
     if let Some(token) = extract_bearer_token(&headers) {
         let hashed = hash_session_token(&token);
         if let Ok(mut conn) = crate::db::conn().await {
-            let _ = diesel::delete(sessions::table.filter(sessions::token.eq(&hashed)))
-                .execute(&mut conn)
-                .await;
+            let _ = crate::db::delete_session_by_token(&mut conn, &hashed).await;
         }
         invalidate_auth_cache_for_token(&token).await;
     }
@@ -271,21 +269,32 @@ pub(super) async fn sessions(
     headers: HeaderMap,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
-
+    let viewer = crate::db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let caller_user_id = user.id;
     let now = Utc::now();
-    let mut conn = crate::db::conn().await?;
-    let user_sessions = sessions::table
-        .filter(sessions::user_id.eq(user.id))
-        .filter(sessions::expires_at.gt(now))
-        .load::<Session>(&mut conn)
-        .await?;
 
-    let user_pid = user.pid.to_string();
+    let user_sessions = crate::db::with_viewer_tx(viewer, |conn| {
+        use diesel_async::scoped_futures::ScopedFutureExt;
+        async move {
+            sessions::table
+                .filter(sessions::user_id.eq(caller_user_id))
+                .filter(sessions::expires_at.gt(now))
+                .load::<Session>(conn)
+                .await
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    let caller_pid = user.pid.to_string();
     let data = user_sessions
         .iter()
         .map(|s| SessionListItem {
             id: s.id.to_string(),
-            user_id: user_pid.clone(),
+            user_id: caller_pid.clone(),
             expires_at: s.expires_at.to_rfc3339(),
             created_at: s.created_at.to_rfc3339(),
             ip_address: s.ip_address.clone(),

--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -27,10 +27,10 @@ use diesel_async::RunQueryDsl;
 use super::{
     error_response,
     state::{
-        extract_bearer_token, hash_session_token, invalidate_auth_cache_for_token, is_valid_email,
-        normalize_email, otp_in_cooldown, upsert_otp, user_model_to_view, DataResponse,
-        ForgotPasswordBody, ForgotPasswordVerifyBody, ResendOtpBody, ResetPasswordBody,
-        SessionListItem, SignInBody, SignUpBody, SuccessResponse, VerifyOtpBody,
+        auth_user_row_to_view, extract_bearer_token, hash_session_token,
+        invalidate_auth_cache_for_token, is_valid_email, normalize_email, otp_in_cooldown,
+        upsert_otp, DataResponse, ForgotPasswordBody, ForgotPasswordVerifyBody, ResendOtpBody,
+        ResetPasswordBody, SessionListItem, SignInBody, SignUpBody, SuccessResponse, VerifyOtpBody,
     },
     ErrorSpec,
 };
@@ -68,7 +68,7 @@ pub(super) async fn sign_up(
     }
 
     let data = serde_json::json!({
-        "user": user_model_to_view(&user),
+        "user": auth_user_row_to_view(&user),
     });
     Ok((axum::http::StatusCode::OK, Json(DataResponse { data })).into_response())
 }

--- a/backend/src/api/auth/rate_limit.rs
+++ b/backend/src/api/auth/rate_limit.rs
@@ -2,9 +2,11 @@ use axum::http::HeaderMap;
 use axum::response::Response;
 use diesel::deserialize::QueryableByName;
 use diesel::sql_types::Integer;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::RunQueryDsl;
 
 use super::{error_response, ErrorSpec};
+use crate::db;
 
 const AUTH_RATE_LIMIT_WINDOW_SECS: i64 = 60;
 const AUTH_SIGN_UP_MAX_ATTEMPTS: u32 = 5;
@@ -78,31 +80,36 @@ async fn upsert_attempt(
     key: &str,
     window_secs: i64,
 ) -> std::result::Result<i64, Box<dyn std::error::Error + Send + Sync>> {
-    let mut conn = crate::db::conn().await?;
-
-    let row = diesel::sql_query(
-        r"
-        INSERT INTO auth_rate_limits (id, rate_key, window_start, attempts, updated_at)
-        VALUES (gen_random_uuid(), $1, NOW(), 1, NOW())
-        ON CONFLICT (rate_key) DO UPDATE
-        SET
-            window_start = CASE
-                WHEN auth_rate_limits.window_start <= NOW() - make_interval(secs => $2)
-                    THEN NOW()
-                ELSE auth_rate_limits.window_start
-            END,
-            attempts = CASE
-                WHEN auth_rate_limits.window_start <= NOW() - make_interval(secs => $2)
-                    THEN 1
-                ELSE auth_rate_limits.attempts + 1
-            END,
-            updated_at = NOW()
-        RETURNING attempts
-        ",
-    )
-    .bind::<diesel::sql_types::Text, _>(key)
-    .bind::<diesel::sql_types::BigInt, _>(window_secs)
-    .get_result::<AttemptRow>(&mut conn)
+    let key = key.to_owned();
+    let row = db::with_anon_tx(|conn| {
+        async move {
+            diesel::sql_query(
+                r"
+                INSERT INTO auth_rate_limits (id, rate_key, window_start, attempts, updated_at)
+                VALUES (gen_random_uuid(), $1, NOW(), 1, NOW())
+                ON CONFLICT (rate_key) DO UPDATE
+                SET
+                    window_start = CASE
+                        WHEN auth_rate_limits.window_start <= NOW() - make_interval(secs => $2)
+                            THEN NOW()
+                        ELSE auth_rate_limits.window_start
+                    END,
+                    attempts = CASE
+                        WHEN auth_rate_limits.window_start <= NOW() - make_interval(secs => $2)
+                            THEN 1
+                        ELSE auth_rate_limits.attempts + 1
+                    END,
+                    updated_at = NOW()
+                RETURNING attempts
+                ",
+            )
+            .bind::<diesel::sql_types::Text, _>(key)
+            .bind::<diesel::sql_types::BigInt, _>(window_secs)
+            .get_result::<AttemptRow>(conn)
+            .await
+        }
+        .scope_boxed()
+    })
     .await?;
 
     Ok(i64::from(row.attempts))

--- a/backend/src/api/auth/service.rs
+++ b/backend/src/api/auth/service.rs
@@ -5,22 +5,15 @@ pub(super) use auth_otp_email::send_otp_email;
 use axum::response::Response;
 use axum::{http::HeaderMap, response::IntoResponse, Json};
 use chrono::Utc;
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-
-use diesel_async::AsyncConnection;
 
 use super::super::{
     error_response,
     state::{
         auth_user_row_to_view, create_session_db, normalize_email, session_model_to_view,
-        upsert_otp, user_model_to_view, validate_signup_payload, verify_otp_db, DataResponse,
-        SignUpBody,
+        upsert_otp, validate_signup_payload, verify_otp_db, DataResponse, SignUpBody,
     },
     ErrorSpec,
 };
-use crate::db::models::users::{NewUser, User, UserChangeset};
-use crate::db::schema::{sessions, users};
 use crate::db::{self, AuthUserRow};
 use crate::jobs::enqueue_otp_email;
 
@@ -79,7 +72,7 @@ fn registration_failed_response(headers: &HeaderMap) -> Response {
 pub(super) async fn create_user_or_error(
     headers: &HeaderMap,
     payload: &SignUpBody,
-) -> std::result::Result<User, Response> {
+) -> std::result::Result<AuthUserRow, Response> {
     if let Err(spec) = validate_signup_payload(payload) {
         return Err(error_response(
             axum::http::StatusCode::BAD_REQUEST,
@@ -96,11 +89,8 @@ pub(super) async fn create_user_or_error(
         registration_failed_response(headers)
     })?;
 
-    let existing = users::table
-        .filter(users::email.eq(&email))
-        .first::<User>(&mut conn)
+    let existing = db::find_user_for_login(&mut conn, &email)
         .await
-        .optional()
         .map_err(|e| {
             tracing::error!("User lookup failed: {e}");
             registration_failed_response(headers)
@@ -130,17 +120,10 @@ pub(super) async fn create_user_or_error(
         registration_failed_response(headers)
     })?;
 
-    let new_user = NewUser {
-        pid: uuid::Uuid::new_v4(),
-        email,
-        password: password_hash,
-        api_key: format!("lo-{}", uuid::Uuid::new_v4()),
-        name,
-    };
+    let pid = uuid::Uuid::new_v4();
+    let api_key = format!("lo-{}", uuid::Uuid::new_v4());
 
-    diesel::insert_into(users::table)
-        .values(&new_user)
-        .get_result::<User>(&mut conn)
+    db::create_user_for_signup(&mut conn, pid, &email, &password_hash, &api_key, &name)
         .await
         .map_err(|e| {
             tracing::error!("User creation failed: {e}");
@@ -218,13 +201,7 @@ pub(super) async fn verify_otp_inner(
     if verified_user.email_verified_at.is_none() {
         let now = Utc::now();
         let mut conn = crate::db::conn().await?;
-        let _ = diesel::update(users::table.find(user.id))
-            .set(&UserChangeset {
-                email_verified_at: Some(Some(now)),
-                updated_at: Some(now),
-            })
-            .execute(&mut conn)
-            .await;
+        let _ = db::mark_email_verified(&mut conn, user.id, now).await;
         verified_user.email_verified_at = Some(now);
     }
 
@@ -279,14 +256,7 @@ pub(super) async fn forgot_password_verify_inner(
     let now = Utc::now();
 
     let mut conn = crate::db::conn().await?;
-    diesel::update(users::table.find(user.id))
-        .set((
-            users::reset_token.eq(&hashed),
-            users::reset_sent_at.eq(now),
-            users::updated_at.eq(now),
-        ))
-        .execute(&mut conn)
-        .await?;
+    db::set_password_reset_token(&mut conn, user.id, &hashed, now).await?;
 
     Ok(Json(DataResponse {
         data: serde_json::json!({ "resetToken": raw_token }),
@@ -316,13 +286,7 @@ pub(super) async fn reset_password_inner(
     let cutoff = Utc::now() - chrono::Duration::seconds(RESET_TOKEN_TTL_SECS);
 
     let mut conn = crate::db::conn().await?;
-    let user = users::table
-        .filter(users::email.eq(email))
-        .filter(users::reset_token.eq(&hashed_token))
-        .filter(users::reset_sent_at.gt(cutoff))
-        .first::<User>(&mut conn)
-        .await
-        .optional()?;
+    let user = db::find_user_for_password_reset(&mut conn, email, &hashed_token, cutoff).await?;
 
     let Some(user) = user else {
         return Ok(unauthorized_error(
@@ -332,33 +296,19 @@ pub(super) async fn reset_password_inner(
     };
 
     let new_hash = crate::security::hash_password(new_password)?;
-
-    conn.transaction(|conn| {
-        let new_hash = new_hash.clone();
-        Box::pin(async move {
-            diesel::update(users::table.find(user.id))
-                .set((
-                    users::password.eq(new_hash),
-                    users::reset_token.eq(None::<String>),
-                    users::reset_sent_at.eq(None::<chrono::DateTime<Utc>>),
-                    users::updated_at.eq(Utc::now()),
-                ))
-                .execute(conn)
-                .await?;
-            diesel::delete(sessions::table.filter(sessions::user_id.eq(user.id)))
-                .execute(conn)
-                .await?;
-            Ok::<(), diesel::result::Error>(())
-        })
-    })
-    .await?;
+    db::complete_password_reset(&mut conn, user.id, &new_hash, Utc::now()).await?;
 
     super::super::state::invalidate_auth_cache_for_user_id(user.id).await;
 
     let session = create_session_db(headers, user.id).await?;
     Ok(Json(DataResponse {
         data: serde_json::json!({
-            "user": user_model_to_view(&user),
+            "user": serde_json::json!({
+                "id": user.pid.to_string(),
+                "email": user.email,
+                "name": user.name,
+                "emailVerified": user.email_verified_at.is_some(),
+            }),
             "token": session.token,
             "session": session_model_to_view(&session.model),
         }),

--- a/backend/src/api/state/auth.rs
+++ b/backend/src/api/state/auth.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use super::super::{error_response, ErrorSpec};
 use super::{SessionView, UserView};
-use crate::db::models::sessions::{NewSession, Session, SessionUpdate};
+use crate::db::models::sessions::{Session, SessionUpdate};
 use crate::db::models::users::User;
 use crate::db::schema::{sessions, users};
 use crate::db::{self, DbViewer};
@@ -305,30 +305,48 @@ pub(in crate::api) async fn create_session_db(
     user_id: i32,
 ) -> std::result::Result<CreatedSession, crate::error::AppError> {
     let now = Utc::now();
+    let expires_at = now + Duration::seconds(SESSION_DURATION_SECS);
+    let ip_address = headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .map(ToOwned::to_owned);
+    let user_agent = headers
+        .get("user-agent")
+        .and_then(|v| v.to_str().ok())
+        .map(ToOwned::to_owned);
+
+    // The row id doubles as the first segment of the bearer token. Generate
+    // both client-side, then persist via the SECURITY DEFINER helper so the
+    // insert works before any viewer context is established (sign-in / OTP
+    // verify / password reset all land here pre-auth).
     let session_id = Uuid::new_v4();
     let secret = Uuid::new_v4().simple().to_string();
     let token = format!("{session_id}.{secret}");
-    let new = NewSession {
-        id: session_id,
-        user_id,
-        token: session_token_hash(&token),
-        ip_address: headers
-            .get("x-forwarded-for")
-            .and_then(|v| v.to_str().ok())
-            .map(ToOwned::to_owned),
-        user_agent: headers
-            .get("user-agent")
-            .and_then(|v| v.to_str().ok())
-            .map(ToOwned::to_owned),
-        expires_at: now + Duration::seconds(SESSION_DURATION_SECS),
-        created_at: now,
-        updated_at: now,
-    };
+    let token_hash = session_token_hash(&token);
+
     let mut conn = crate::db::conn().await?;
-    let model = diesel::insert_into(sessions::table)
-        .values(&new)
-        .get_result::<Session>(&mut conn)
-        .await?;
+    let row = crate::db::create_session_for_user(
+        &mut conn,
+        session_id,
+        user_id,
+        &token_hash,
+        ip_address.as_deref(),
+        user_agent.as_deref(),
+        now,
+        expires_at,
+    )
+    .await?;
+
+    let model = Session {
+        id: row.id,
+        user_id: row.user_id,
+        token: row.token,
+        ip_address: row.ip_address,
+        user_agent: row.user_agent,
+        expires_at: row.expires_at,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    };
     Ok(CreatedSession { model, token })
 }
 

--- a/backend/src/api/state/mod.rs
+++ b/backend/src/api/state/mod.rs
@@ -31,10 +31,12 @@ mod uploads_payloads;
 
 use chrono::{Duration, Utc};
 use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
 use super::ErrorSpec;
+use crate::db;
 use crate::db::models::otp_codes::{NewOtpCode, OtpCode};
 use crate::db::schema::otp_codes;
 pub(super) use auth::*;
@@ -65,14 +67,6 @@ pub(super) async fn upsert_otp(
 ) -> std::result::Result<(), crate::error::AppError> {
     let now = Utc::now();
     let expires_at = now + Duration::seconds(OTP_TTL_SECS);
-
-    let mut conn = crate::db::conn().await?;
-
-    // Delete any existing OTP for this email, then insert fresh
-    diesel::delete(otp_codes::table.filter(otp_codes::email.eq(email)))
-        .execute(&mut conn)
-        .await?;
-
     let new = NewOtpCode {
         id: Uuid::new_v4(),
         email: email.to_owned(),
@@ -82,31 +76,22 @@ pub(super) async fn upsert_otp(
         last_sent_at: now,
         created_at: now,
     };
-    diesel::insert_into(otp_codes::table)
-        .values(&new)
-        .execute(&mut conn)
-        .await?;
+    let email_for_delete = email.to_owned();
+    db::with_anon_tx(move |conn| {
+        async move {
+            diesel::delete(otp_codes::table.filter(otp_codes::email.eq(email_for_delete)))
+                .execute(conn)
+                .await?;
+            diesel::insert_into(otp_codes::table)
+                .values(&new)
+                .execute(conn)
+                .await?;
+            Ok::<(), diesel::result::Error>(())
+        }
+        .scope_boxed()
+    })
+    .await?;
     Ok(())
-}
-
-/// Load and validate an OTP entry: returns `None` if not found, expired, or max attempts exceeded.
-async fn load_valid_otp(email: &str) -> Option<(OtpCode, crate::db::DbConn)> {
-    let mut conn = crate::db::conn().await.ok()?;
-    let saved = otp_codes::table
-        .filter(otp_codes::email.eq(email))
-        .first::<OtpCode>(&mut conn)
-        .await
-        .optional()
-        .ok()
-        .flatten()?;
-    let now = Utc::now();
-    if saved.expires_at <= now || saved.attempts >= OTP_MAX_ATTEMPTS {
-        let _ = diesel::delete(otp_codes::table.find(saved.id))
-            .execute(&mut conn)
-            .await;
-        return None;
-    }
-    Some((saved, conn))
 }
 
 /// Verify an OTP code against the database. Returns true if valid.
@@ -118,58 +103,81 @@ async fn load_valid_otp(email: &str) -> Option<(OtpCode, crate::db::DbConn)> {
 pub(super) async fn verify_otp_db(email: &str, otp: &str) -> bool {
     use subtle::ConstantTimeEq;
 
-    let loaded = load_valid_otp(email).await;
+    let otp_bytes = otp.as_bytes().to_vec();
+    let email = email.to_owned();
 
-    // Always compare in constant time against something of the requested
-    // length — even when no OTP exists — so CPU-side timing is uniform.
-    let ct_match = if let Some((saved, _)) = loaded.as_ref() {
-        saved.code.len() == otp.len() && bool::from(saved.code.as_bytes().ct_eq(otp.as_bytes()))
-    } else {
-        let dummy = vec![0u8; otp.len()];
-        let _ = bool::from(dummy.as_slice().ct_eq(otp.as_bytes()));
-        false
-    };
+    let result: Result<bool, diesel::result::Error> = db::with_anon_tx(move |conn| {
+        async move {
+            let saved = otp_codes::table
+                .filter(otp_codes::email.eq(&email))
+                .first::<OtpCode>(conn)
+                .await
+                .optional()?;
+            let now = Utc::now();
+            let valid = saved.filter(|s| s.expires_at > now && s.attempts < OTP_MAX_ATTEMPTS);
 
-    let Some((saved, mut conn)) = loaded else {
-        // No valid OTP row. Issue a no-op write to match the DB round-trip
-        // of the "bad code" path, then fail.
-        if let Ok(mut conn) = crate::db::conn().await {
-            let _ = diesel::update(otp_codes::table.find(Uuid::nil()))
-                .set(otp_codes::attempts.eq(0))
-                .execute(&mut conn)
-                .await;
+            // Always perform the constant-time compare so CPU timing is uniform.
+            let ct_match = valid.as_ref().map_or_else(
+                || {
+                    let dummy = vec![0u8; otp_bytes.len()];
+                    let _ = bool::from(dummy.as_slice().ct_eq(&otp_bytes));
+                    false
+                },
+                |s| {
+                    s.code.len() == otp_bytes.len()
+                        && bool::from(s.code.as_bytes().ct_eq(&otp_bytes))
+                },
+            );
+
+            let Some(saved) = valid else {
+                // No valid OTP row. Issue a no-op write to match the DB
+                // round-trip of the "bad code" path, then fail.
+                diesel::update(otp_codes::table.find(Uuid::nil()))
+                    .set(otp_codes::attempts.eq(0))
+                    .execute(conn)
+                    .await?;
+                return Ok(false);
+            };
+
+            if !ct_match {
+                let new_attempts = saved.attempts.saturating_add(1);
+                diesel::update(otp_codes::table.find(saved.id))
+                    .set(otp_codes::attempts.eq(new_attempts))
+                    .execute(conn)
+                    .await?;
+                return Ok(false);
+            }
+
+            diesel::delete(otp_codes::table.find(saved.id))
+                .execute(conn)
+                .await?;
+            Ok(true)
         }
-        return false;
-    };
+        .scope_boxed()
+    })
+    .await;
 
-    if !ct_match {
-        let new_attempts = saved.attempts.saturating_add(1);
-        let _ = diesel::update(otp_codes::table.find(saved.id))
-            .set(otp_codes::attempts.eq(new_attempts))
-            .execute(&mut conn)
-            .await;
-        return false;
-    }
-
-    // Valid — delete the OTP row
-    let _ = diesel::delete(otp_codes::table.find(saved.id))
-        .execute(&mut conn)
-        .await;
-    true
+    result.unwrap_or(false)
 }
 
 /// Check if the OTP for this email is still within the resend cooldown.
 pub(super) async fn otp_in_cooldown(email: &str, cooldown_secs: i64) -> bool {
     let now = Utc::now();
-    let Ok(mut conn) = crate::db::conn().await else {
-        return false;
-    };
-    otp_codes::table
-        .filter(otp_codes::email.eq(email))
-        .first::<OtpCode>(&mut conn)
-        .await
-        .ok()
-        .is_some_and(|entry| entry.last_sent_at + Duration::seconds(cooldown_secs) > now)
+    let email = email.to_owned();
+    let entry = db::with_anon_tx(move |conn| {
+        async move {
+            otp_codes::table
+                .filter(otp_codes::email.eq(email))
+                .first::<OtpCode>(conn)
+                .await
+                .optional()
+        }
+        .scope_boxed()
+    })
+    .await
+    .ok()
+    .flatten();
+    entry.is_some_and(|e| e.last_sent_at + Duration::seconds(cooldown_secs) > now)
 }
 
 // --- Auth validation helpers ---

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -3,10 +3,11 @@ pub mod schema;
 pub mod viewer;
 
 pub use viewer::{
-    complete_password_reset, create_user_for_signup, find_user_for_login,
-    find_user_for_password_reset, mark_email_verified, resolve_session, set_anon_context,
-    set_password_reset_token, set_viewer_context, with_anon_tx, with_viewer_tx, AuthSessionRow,
-    AuthUserRow, DbViewer, PasswordResetUserRow,
+    complete_password_reset, create_session_for_user, create_user_for_signup,
+    delete_session_by_token, find_user_for_login, find_user_for_password_reset,
+    mark_email_verified, resolve_session, set_anon_context, set_password_reset_token,
+    set_viewer_context, with_anon_tx, with_viewer_tx, AuthSessionRow, AuthUserRow,
+    CreatedSessionRow, DbViewer, PasswordResetUserRow,
 };
 
 use deadpool::managed::Timeouts;

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -3,8 +3,10 @@ pub mod schema;
 pub mod viewer;
 
 pub use viewer::{
-    find_user_for_login, resolve_session, set_anon_context, set_viewer_context, with_anon_tx,
-    with_viewer_tx, AuthSessionRow, AuthUserRow, DbViewer,
+    complete_password_reset, create_user_for_signup, find_user_for_login,
+    find_user_for_password_reset, mark_email_verified, resolve_session, set_anon_context,
+    set_password_reset_token, set_viewer_context, with_anon_tx, with_viewer_tx, AuthSessionRow,
+    AuthUserRow, DbViewer, PasswordResetUserRow,
 };
 
 use deadpool::managed::Timeouts;

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -282,3 +282,59 @@ pub async fn complete_password_reset(
         .await?;
     Ok(())
 }
+
+#[derive(Debug, Clone, QueryableByName)]
+pub struct CreatedSessionRow {
+    #[diesel(sql_type = SqlUuid)]
+    pub id: uuid::Uuid,
+    #[diesel(sql_type = Integer)]
+    pub user_id: i32,
+    #[diesel(sql_type = VarChar)]
+    pub token: String,
+    #[diesel(sql_type = Nullable<VarChar>)]
+    pub ip_address: Option<String>,
+    #[diesel(sql_type = Nullable<VarChar>)]
+    pub user_agent: Option<String>,
+    #[diesel(sql_type = Timestamptz)]
+    pub expires_at: chrono::DateTime<chrono::Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Insert a session row for a user who has just authenticated.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_session_for_user(
+    conn: &mut AsyncPgConnection,
+    id: uuid::Uuid,
+    user_id: i32,
+    token_hash: &str,
+    ip_address: Option<&str>,
+    user_agent: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+    expires_at: chrono::DateTime<chrono::Utc>,
+) -> Result<CreatedSessionRow, diesel::result::Error> {
+    diesel::sql_query("SELECT * FROM app.create_session_for_user($1, $2, $3, $4, $5, $6, $7)")
+        .bind::<SqlUuid, _>(id)
+        .bind::<Integer, _>(user_id)
+        .bind::<Text, _>(token_hash)
+        .bind::<Nullable<VarChar>, _>(ip_address)
+        .bind::<Nullable<VarChar>, _>(user_agent)
+        .bind::<Timestamptz, _>(now)
+        .bind::<Timestamptz, _>(expires_at)
+        .get_result::<CreatedSessionRow>(conn)
+        .await
+}
+
+/// Delete a session matching the given hashed bearer token. Idempotent.
+pub async fn delete_session_by_token(
+    conn: &mut AsyncPgConnection,
+    token_hash: &str,
+) -> Result<(), diesel::result::Error> {
+    diesel::sql_query("SELECT app.delete_session_by_token($1)")
+        .bind::<Text, _>(token_hash)
+        .execute(conn)
+        .await?;
+    Ok(())
+}

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -172,3 +172,113 @@ pub async fn resolve_session(
         .await
         .optional()
 }
+
+// ---------------------------------------------------------------------------
+// SECURITY DEFINER writes for the pre-auth users flows.
+//
+// Sign-up, email verification, and password reset all mutate `users` before
+// any viewer context exists. The matching `app.*` functions are scoped to
+// exactly those flows so we don't need to grant the API role broad
+// INSERT/UPDATE on the underlying tables.
+// ---------------------------------------------------------------------------
+
+/// Insert a user row for the sign-up flow. Runs as owner so no viewer
+/// context is required. Returns the same shape as `find_user_for_login`.
+pub async fn create_user_for_signup(
+    conn: &mut AsyncPgConnection,
+    pid: uuid::Uuid,
+    email: &str,
+    password_hash: &str,
+    api_key: &str,
+    name: &str,
+) -> Result<AuthUserRow, diesel::result::Error> {
+    diesel::sql_query(
+        "SELECT id, pid, name, email, password, email_verified_at, is_review_stub \
+         FROM app.create_user_for_signup($1, $2, $3, $4, $5)",
+    )
+    .bind::<SqlUuid, _>(pid)
+    .bind::<Text, _>(email)
+    .bind::<Text, _>(password_hash)
+    .bind::<Text, _>(api_key)
+    .bind::<Text, _>(name)
+    .get_result::<AuthUserRow>(conn)
+    .await
+}
+
+/// Mark a user's email as verified. Idempotent.
+pub async fn mark_email_verified(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(), diesel::result::Error> {
+    diesel::sql_query("SELECT app.mark_email_verified($1, $2)")
+        .bind::<Integer, _>(user_id)
+        .bind::<Timestamptz, _>(now)
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+/// Record a hashed password-reset token on a user.
+pub async fn set_password_reset_token(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+    token_hash: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(), diesel::result::Error> {
+    diesel::sql_query("SELECT app.set_password_reset_token($1, $2, $3)")
+        .bind::<Integer, _>(user_id)
+        .bind::<Text, _>(token_hash)
+        .bind::<Timestamptz, _>(now)
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, QueryableByName)]
+pub struct PasswordResetUserRow {
+    #[diesel(sql_type = Integer)]
+    pub id: i32,
+    #[diesel(sql_type = SqlUuid)]
+    pub pid: uuid::Uuid,
+    #[diesel(sql_type = VarChar)]
+    pub email: String,
+    #[diesel(sql_type = VarChar)]
+    pub name: String,
+    #[diesel(sql_type = Nullable<Timestamptz>)]
+    pub email_verified_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[diesel(sql_type = Bool)]
+    pub is_review_stub: bool,
+}
+
+/// Look up a user by email + hashed reset token + TTL cutoff.
+pub async fn find_user_for_password_reset(
+    conn: &mut AsyncPgConnection,
+    email: &str,
+    token_hash: &str,
+    cutoff: chrono::DateTime<chrono::Utc>,
+) -> Result<Option<PasswordResetUserRow>, diesel::result::Error> {
+    diesel::sql_query("SELECT * FROM app.find_user_for_password_reset($1, $2, $3)")
+        .bind::<Text, _>(email)
+        .bind::<Text, _>(token_hash)
+        .bind::<Timestamptz, _>(cutoff)
+        .get_result::<PasswordResetUserRow>(conn)
+        .await
+        .optional()
+}
+
+/// Rotate password, clear reset token, and invalidate sessions for a user.
+pub async fn complete_password_reset(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+    new_password_hash: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(), diesel::result::Error> {
+    diesel::sql_query("SELECT app.complete_password_reset($1, $2, $3)")
+        .bind::<Integer, _>(user_id)
+        .bind::<Text, _>(new_password_hash)
+        .bind::<Timestamptz, _>(now)
+        .execute(conn)
+        .await?;
+    Ok(())
+}


### PR DESCRIPTION
**Finish migrating the `auth/` module to the viewer-aware path**

New SECURITY DEFINER helpers cover the pre-auth `users` and `sessions` writes (sign-up INSERT, email verification, reset-token storage, reset-password lookup + completion, session creation, sign-out deletion). `account.rs`, `rate_limit.rs`, and the OTP helpers now run inside viewer/anon transactions. `export_data` runs every read in one viewer-scoped transaction. With this PR, the entire `auth/` surface is viewer-context-ready; subsequent PRs can enable Tier-A policies without any further auth-layer changes.

- [x] CI green
- [x] sign-up, sign-in, OTP verify, forgot-password, reset-password, change-password, and delete-account exercised against the deployed build
- [x] `pg_stat_activity` shows pre-auth writes running as `poziomki_api` with the matching `app.*` helper in the trace