### PR TITLE
sec(rls): wrap profiles endpoints in viewer-scoped transactions

### DIFF
--- a/backend/migrations/2026-04-18-030000_profile_public_helpers/down.sql
+++ b/backend/migrations/2026-04-18-030000_profile_public_helpers/down.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS app.profile_program_visibility(int);
+DROP FUNCTION IF EXISTS app.user_pid_for_id(int);

--- a/backend/migrations/2026-04-18-030000_profile_public_helpers/up.sql
+++ b/backend/migrations/2026-04-18-030000_profile_public_helpers/up.sql
@@ -1,0 +1,59 @@
+-- Narrow public-projection helpers for cross-user profile reads.
+--
+-- A viewer rendering someone else's profile needs two non-sensitive facts
+-- from the owner: their external id (users.pid) and whether the owner allows
+-- their program to be shown (user_settings.privacy_show_program). Exposing
+-- the full users / user_settings rows to the API role would be necessary
+-- for the current handlers, but those tables carry sensitive columns
+-- (password hash, email, private settings) that the viewer must not see
+-- under a sane RLS policy.
+--
+-- The functions below run as owner and each returns a single value scoped
+-- to exactly the column the caller needs, so Tier-A policies on users and
+-- user_settings can be "own row only" without breaking public profile
+-- rendering.
+
+-- Return the external pid for a user_id, or NULL if the user doesn't exist.
+CREATE OR REPLACE FUNCTION app.user_pid_for_id(p_user_id int)
+RETURNS uuid
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT pid FROM users WHERE id = p_user_id
+$$;
+
+COMMENT ON FUNCTION app.user_pid_for_id(int) IS
+    'Return the public pid for a user. Narrow projection; safe to call across viewers.';
+
+-- Return the privacy_show_program flag for a user_id. Defaults to true when
+-- there is no user_settings row (matches the previous is_none_or fallback).
+CREATE OR REPLACE FUNCTION app.profile_program_visibility(p_user_id int)
+RETURNS bool
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT COALESCE(
+        (SELECT privacy_show_program FROM user_settings WHERE user_id = p_user_id),
+        true
+    )
+$$;
+
+COMMENT ON FUNCTION app.profile_program_visibility(int) IS
+    'Whether a user has opted to show their program on their public profile. Defaults to true when no row exists.';
+
+REVOKE EXECUTE ON FUNCTION app.user_pid_for_id(int) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.profile_program_visibility(int) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.user_pid_for_id(int) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.profile_program_visibility(int) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/api/profiles/blocks.rs
+++ b/backend/src/api/profiles/blocks.rs
@@ -3,7 +3,7 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::api::state::{DataResponse, SuccessResponse};
@@ -12,6 +12,7 @@ use crate::db::models::profile_blocks::ProfileBlock;
 use crate::db::schema::{profile_blocks, profiles};
 
 pub(in crate::api) async fn profile_block(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     my_profile_id: Uuid,
     target_id: Uuid,
@@ -28,13 +29,11 @@ pub(in crate::api) async fn profile_block(
         ));
     }
 
-    let mut conn = crate::db::conn().await?;
-
     // Verify target profile exists
     let target_exists = profiles::table
         .find(target_id)
         .select(profiles::id)
-        .first::<Uuid>(&mut conn)
+        .first::<Uuid>(conn)
         .await
         .optional()?;
     if target_exists.is_none() {
@@ -58,7 +57,7 @@ pub(in crate::api) async fn profile_block(
         })
         .on_conflict((profile_blocks::blocker_id, profile_blocks::blocked_id))
         .do_nothing()
-        .execute(&mut conn)
+        .execute(conn)
         .await?;
 
     Ok(Json(DataResponse {
@@ -68,17 +67,16 @@ pub(in crate::api) async fn profile_block(
 }
 
 pub(in crate::api) async fn profile_unblock(
+    conn: &mut AsyncPgConnection,
     my_profile_id: Uuid,
     target_id: Uuid,
 ) -> crate::error::AppResult<Response> {
-    let mut conn = crate::db::conn().await?;
-
     diesel::delete(
         profile_blocks::table
             .filter(profile_blocks::blocker_id.eq(my_profile_id))
             .filter(profile_blocks::blocked_id.eq(target_id)),
     )
-    .execute(&mut conn)
+    .execute(conn)
     .await?;
 
     Ok(Json(DataResponse {

--- a/backend/src/api/profiles/bookmarks.rs
+++ b/backend/src/api/profiles/bookmarks.rs
@@ -3,7 +3,7 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::api::state::{DataResponse, SuccessResponse};
@@ -16,6 +16,7 @@ use super::profiles_view::profile_to_response;
 use crate::api::state::ProfileResponse;
 
 pub(in crate::api) async fn profile_bookmark(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     my_profile: &Profile,
     target_id: Uuid,
@@ -32,13 +33,11 @@ pub(in crate::api) async fn profile_bookmark(
         ));
     }
 
-    let mut conn = crate::db::conn().await?;
-
     // Verify target profile exists
     let target_exists = profiles::table
         .find(target_id)
         .select(profiles::id)
-        .first::<Uuid>(&mut conn)
+        .first::<Uuid>(conn)
         .await
         .optional()?;
     if target_exists.is_none() {
@@ -65,7 +64,7 @@ pub(in crate::api) async fn profile_bookmark(
             profile_bookmarks::target_profile_id,
         ))
         .do_nothing()
-        .execute(&mut conn)
+        .execute(conn)
         .await?;
 
     Ok(Json(DataResponse {
@@ -75,17 +74,16 @@ pub(in crate::api) async fn profile_bookmark(
 }
 
 pub(in crate::api) async fn profile_unbookmark(
+    conn: &mut AsyncPgConnection,
     my_profile_id: Uuid,
     target_id: Uuid,
 ) -> crate::error::AppResult<Response> {
-    let mut conn = crate::db::conn().await?;
-
     diesel::delete(
         profile_bookmarks::table
             .filter(profile_bookmarks::profile_id.eq(my_profile_id))
             .filter(profile_bookmarks::target_profile_id.eq(target_id)),
     )
-    .execute(&mut conn)
+    .execute(conn)
     .await?;
 
     Ok(Json(DataResponse {
@@ -95,11 +93,10 @@ pub(in crate::api) async fn profile_unbookmark(
 }
 
 pub(in crate::api) async fn profiles_bookmarked(
+    conn: &mut AsyncPgConnection,
     my_profile_id: Uuid,
     viewer_user_id: i32,
 ) -> crate::error::AppResult<Vec<ProfileResponse>> {
-    let mut conn = crate::db::conn().await?;
-
     let bookmarked_profiles: Vec<(ProfileBookmark, (Profile, Uuid))> = profile_bookmarks::table
         .inner_join(
             profiles::table
@@ -112,26 +109,26 @@ pub(in crate::api) async fn profiles_bookmarked(
             profile_bookmarks::all_columns,
             (profiles::all_columns, users::pid),
         ))
-        .load(&mut conn)
+        .load(conn)
         .await?;
 
     let mut responses = Vec::with_capacity(bookmarked_profiles.len());
     for (_bookmark, (profile, user_pid)) in bookmarked_profiles {
-        let response = profile_to_response(&profile, &user_pid, Some(viewer_user_id)).await;
+        let response = profile_to_response(conn, &profile, &user_pid, Some(viewer_user_id)).await;
         responses.push(response);
     }
     Ok(responses)
 }
 
 pub(in crate::api) async fn is_bookmarked(
+    conn: &mut AsyncPgConnection,
     my_profile_id: Uuid,
     target_profile_id: Uuid,
 ) -> crate::error::AppResult<bool> {
-    let mut conn = crate::db::conn().await?;
     let exists = profile_bookmarks::table
         .find((my_profile_id, target_profile_id))
         .select(profile_bookmarks::profile_id)
-        .first::<Uuid>(&mut conn)
+        .first::<Uuid>(conn)
         .await
         .optional()?;
     Ok(exists.is_some())

--- a/backend/src/api/profiles/bookmarks.rs
+++ b/backend/src/api/profiles/bookmarks.rs
@@ -8,9 +8,10 @@ use uuid::Uuid;
 
 use crate::api::state::{DataResponse, SuccessResponse};
 use crate::api::{error_response, ErrorSpec};
+use crate::db;
 use crate::db::models::profile_bookmarks::ProfileBookmark;
 use crate::db::models::profiles::Profile;
-use crate::db::schema::{profile_bookmarks, profiles, users};
+use crate::db::schema::{profile_bookmarks, profiles};
 
 use super::profiles_view::profile_to_response;
 use crate::api::state::ProfileResponse;
@@ -97,24 +98,22 @@ pub(in crate::api) async fn profiles_bookmarked(
     my_profile_id: Uuid,
     viewer_user_id: i32,
 ) -> crate::error::AppResult<Vec<ProfileResponse>> {
-    let bookmarked_profiles: Vec<(ProfileBookmark, (Profile, Uuid))> = profile_bookmarks::table
-        .inner_join(
-            profiles::table
-                .on(profile_bookmarks::target_profile_id.eq(profiles::id))
-                .inner_join(users::table),
-        )
+    let bookmarked_profiles: Vec<(ProfileBookmark, Profile)> = profile_bookmarks::table
+        .inner_join(profiles::table.on(profile_bookmarks::target_profile_id.eq(profiles::id)))
         .filter(profile_bookmarks::profile_id.eq(my_profile_id))
         .order(profile_bookmarks::created_at.desc())
-        .select((
-            profile_bookmarks::all_columns,
-            (profiles::all_columns, users::pid),
-        ))
+        .select((profile_bookmarks::all_columns, profiles::all_columns))
         .load(conn)
         .await?;
 
     let mut responses = Vec::with_capacity(bookmarked_profiles.len());
-    for (_bookmark, (profile, user_pid)) in bookmarked_profiles {
-        let response = profile_to_response(conn, &profile, &user_pid, Some(viewer_user_id)).await;
+    for (_bookmark, profile) in bookmarked_profiles {
+        // Narrow public-projection helper avoids reading the owner's full
+        // users row just to get their pid.
+        let owner_pid = db::user_pid_for_id(conn, profile.user_id)
+            .await?
+            .unwrap_or_else(Uuid::nil);
+        let response = profile_to_response(conn, &profile, &owner_pid, Some(viewer_user_id)).await;
         responses.push(response);
     }
     Ok(responses)

--- a/backend/src/api/profiles/mod.rs
+++ b/backend/src/api/profiles/mod.rs
@@ -20,6 +20,7 @@ type Result<T> = crate::error::AppResult<T>;
 use super::state::DataResponse;
 use crate::api::auth_or_respond;
 use crate::app::AppContext;
+use crate::db;
 use axum::response::Response;
 use axum::{
     extract::{Path, State},
@@ -27,6 +28,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
+use diesel_async::scoped_futures::ScopedFutureExt;
 use profiles_http::not_found_profile;
 pub(super) use profiles_http::validation_error;
 use profiles_repo::{load_profile_by_user_id, load_profile_with_owner_pid};
@@ -40,13 +42,31 @@ pub(super) async fn profile_me(
     headers: HeaderMap,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
-
-    let profile = load_profile_by_user_id(user.id).await?;
-
-    let data = match profile {
-        Some(ref p) => Some(full_profile_response(p, &user.pid, Some(user.id)).await?),
-        None => None,
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
+    let viewer_pid = user.pid;
+    let user_id = user.id;
+
+    let data = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let profile = profiles_repo::load_profile_by_user_id(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            let result = match profile {
+                Some(ref p) => Some(
+                    full_profile_response(conn, p, &viewer_pid, Some(user_id))
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?,
+                ),
+                None => None,
+            };
+            Ok::<_, diesel::result::Error>(result)
+        }
+        .scope_boxed()
+    })
+    .await?;
 
     Ok(Json(DataResponse { data }).into_response())
 }
@@ -57,15 +77,36 @@ pub(super) async fn profile_get(
     Path(id): Path<String>,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
 
     let profile_uuid = super::parse_uuid(&id, "profile")?;
 
-    let Some((profile, user_pid)) = load_profile_with_owner_pid(profile_uuid).await? else {
-        return Ok(not_found_profile(&headers, &id));
-    };
+    let result = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let loaded = load_profile_with_owner_pid(conn, profile_uuid)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            match loaded {
+                Some((profile, owner_pid)) => {
+                    let response =
+                        profile_to_response(conn, &profile, &owner_pid, Some(user_id)).await;
+                    Ok::<_, diesel::result::Error>(Some(response))
+                }
+                None => Ok(None),
+            }
+        }
+        .scope_boxed()
+    })
+    .await?;
 
-    let data = profile_to_response(&profile, &user_pid, Some(user.id)).await;
-    Ok(Json(DataResponse { data }).into_response())
+    result.map_or_else(
+        || Ok(not_found_profile(&headers, &id)),
+        |data| Ok(Json(DataResponse { data }).into_response()),
+    )
 }
 
 pub(super) async fn profile_get_full(
@@ -74,20 +115,47 @@ pub(super) async fn profile_get_full(
     Path(id): Path<String>,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
 
     let profile_uuid = super::parse_uuid(&id, "profile")?;
 
-    let Some((profile, user_pid)) = load_profile_with_owner_pid(profile_uuid).await? else {
-        return Ok(not_found_profile(&headers, &id));
-    };
+    let result = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some((profile, owner_pid)) = load_profile_with_owner_pid(conn, profile_uuid)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            else {
+                return Ok::<_, diesel::result::Error>(None);
+            };
 
-    let mut data = full_profile_response(&profile, &user_pid, Some(user.id)).await?;
+            let mut data = full_profile_response(conn, &profile, &owner_pid, Some(user_id))
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
 
-    if let Some(my_profile) = load_profile_by_user_id(user.id).await? {
-        data.is_bookmarked = profiles_bookmarks::is_bookmarked(my_profile.id, profile_uuid).await?;
-    }
+            if let Some(my_profile) = load_profile_by_user_id(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            {
+                data.is_bookmarked =
+                    profiles_bookmarks::is_bookmarked(conn, my_profile.id, profile_uuid)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            }
 
-    Ok(Json(DataResponse { data }).into_response())
+            Ok(Some(data))
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    result.map_or_else(
+        || Ok(not_found_profile(&headers, &id)),
+        |data| Ok(Json(DataResponse { data }).into_response()),
+    )
 }
 
 pub(super) async fn profile_bookmark_handler(
@@ -96,11 +164,37 @@ pub(super) async fn profile_bookmark_handler(
     Path(id): Path<String>,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
-    let target_uuid = super::parse_uuid(&id, "profile")?;
-    let Some(my_profile) = load_profile_by_user_id(user.id).await? else {
-        return Ok(not_found_profile(&headers, "me"));
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
-    profiles_bookmarks::profile_bookmark(&headers, &my_profile, target_uuid).await
+    let user_id = user.id;
+    let target_uuid = super::parse_uuid(&id, "profile")?;
+    let headers_clone = headers.clone();
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(my_profile) = profiles_repo::load_profile_by_user_id(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            else {
+                return Ok::<Option<Response>, diesel::result::Error>(None);
+            };
+            let response = profiles_bookmarks::profile_bookmark(
+                conn,
+                &headers_clone,
+                &my_profile,
+                target_uuid,
+            )
+            .await
+            .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok(Some(response))
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    Ok(outcome.unwrap_or_else(|| not_found_profile(&headers, "me")))
 }
 
 pub(super) async fn profile_unbookmark_handler(
@@ -109,11 +203,31 @@ pub(super) async fn profile_unbookmark_handler(
     Path(id): Path<String>,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
-    let target_uuid = super::parse_uuid(&id, "profile")?;
-    let Some(my_profile) = load_profile_by_user_id(user.id).await? else {
-        return Ok(not_found_profile(&headers, "me"));
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
-    profiles_bookmarks::profile_unbookmark(my_profile.id, target_uuid).await
+    let user_id = user.id;
+    let target_uuid = super::parse_uuid(&id, "profile")?;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(my_profile) = profiles_repo::load_profile_by_user_id(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            else {
+                return Ok::<Option<Response>, diesel::result::Error>(None);
+            };
+            let response = profiles_bookmarks::profile_unbookmark(conn, my_profile.id, target_uuid)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok(Some(response))
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    Ok(outcome.unwrap_or_else(|| not_found_profile(&headers, "me")))
 }
 
 pub(super) async fn profiles_bookmarked_handler(
@@ -121,11 +235,33 @@ pub(super) async fn profiles_bookmarked_handler(
     headers: HeaderMap,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
-    let Some(my_profile) = load_profile_by_user_id(user.id).await? else {
-        return Ok(not_found_profile(&headers, "me"));
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
-    let data = profiles_bookmarks::profiles_bookmarked(my_profile.id, user.id).await?;
-    Ok(Json(DataResponse { data }).into_response())
+    let user_id = user.id;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(my_profile) = profiles_repo::load_profile_by_user_id(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            else {
+                return Ok::<Option<Vec<_>>, diesel::result::Error>(None);
+            };
+            let data = profiles_bookmarks::profiles_bookmarked(conn, my_profile.id, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok(Some(data))
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    outcome.map_or_else(
+        || Ok(not_found_profile(&headers, "me")),
+        |data| Ok(Json(DataResponse { data }).into_response()),
+    )
 }
 
 pub(super) async fn profile_block_handler(
@@ -134,11 +270,33 @@ pub(super) async fn profile_block_handler(
     Path(id): Path<String>,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
-    let target_uuid = super::parse_uuid(&id, "profile")?;
-    let Some(my_profile) = load_profile_by_user_id(user.id).await? else {
-        return Ok(not_found_profile(&headers, "me"));
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
-    profiles_blocks::profile_block(&headers, my_profile.id, target_uuid).await
+    let user_id = user.id;
+    let target_uuid = super::parse_uuid(&id, "profile")?;
+    let headers_clone = headers.clone();
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(my_profile) = profiles_repo::load_profile_by_user_id(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            else {
+                return Ok::<Option<Response>, diesel::result::Error>(None);
+            };
+            let response =
+                profiles_blocks::profile_block(conn, &headers_clone, my_profile.id, target_uuid)
+                    .await
+                    .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok(Some(response))
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    Ok(outcome.unwrap_or_else(|| not_found_profile(&headers, "me")))
 }
 
 pub(super) async fn profile_unblock_handler(
@@ -147,9 +305,29 @@ pub(super) async fn profile_unblock_handler(
     Path(id): Path<String>,
 ) -> Result<Response> {
     let (_session, user) = auth_or_respond!(headers);
-    let target_uuid = super::parse_uuid(&id, "profile")?;
-    let Some(my_profile) = load_profile_by_user_id(user.id).await? else {
-        return Ok(not_found_profile(&headers, "me"));
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
-    profiles_blocks::profile_unblock(my_profile.id, target_uuid).await
+    let user_id = user.id;
+    let target_uuid = super::parse_uuid(&id, "profile")?;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(my_profile) = profiles_repo::load_profile_by_user_id(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            else {
+                return Ok::<Option<Response>, diesel::result::Error>(None);
+            };
+            let response = profiles_blocks::profile_unblock(conn, my_profile.id, target_uuid)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok(Some(response))
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    Ok(outcome.unwrap_or_else(|| not_found_profile(&headers, "me")))
 }

--- a/backend/src/api/profiles/repo.rs
+++ b/backend/src/api/profiles/repo.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::profiles::Profile;
@@ -7,24 +7,24 @@ use crate::db::models::users::User;
 use crate::db::schema::{profiles, users};
 
 pub(super) async fn load_profile_by_user_id(
+    conn: &mut AsyncPgConnection,
     user_id: i32,
 ) -> std::result::Result<Option<Profile>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     profiles::table
         .filter(profiles::user_id.eq(user_id))
-        .first::<Profile>(&mut conn)
+        .first::<Profile>(conn)
         .await
         .optional()
         .map_err(Into::into)
 }
 
 pub(super) async fn load_profile_with_owner_pid(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
 ) -> std::result::Result<Option<(Profile, Uuid)>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let profile = profiles::table
         .find(profile_id)
-        .first::<Profile>(&mut conn)
+        .first::<Profile>(conn)
         .await
         .optional()?;
 
@@ -34,7 +34,7 @@ pub(super) async fn load_profile_with_owner_pid(
 
     let owner = users::table
         .find(profile.user_id)
-        .first::<User>(&mut conn)
+        .first::<User>(conn)
         .await
         .optional()?;
     let user_pid = owner.map_or(Uuid::nil(), |u| u.pid);

--- a/backend/src/api/profiles/repo.rs
+++ b/backend/src/api/profiles/repo.rs
@@ -2,9 +2,9 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
+use crate::db;
 use crate::db::models::profiles::Profile;
-use crate::db::models::users::User;
-use crate::db::schema::{profiles, users};
+use crate::db::schema::profiles;
 
 pub(super) async fn load_profile_by_user_id(
     conn: &mut AsyncPgConnection,
@@ -32,12 +32,11 @@ pub(super) async fn load_profile_with_owner_pid(
         return Ok(None);
     };
 
-    let owner = users::table
-        .find(profile.user_id)
-        .first::<User>(conn)
-        .await
-        .optional()?;
-    let user_pid = owner.map_or(Uuid::nil(), |u| u.pid);
+    // Narrow public-projection helper: only returns the owner's pid, never
+    // the full users row (which carries password hash, email, etc.).
+    let owner_pid = db::user_pid_for_id(conn, profile.user_id)
+        .await?
+        .unwrap_or_else(Uuid::nil);
 
-    Ok(Some((profile, user_pid)))
+    Ok(Some((profile, owner_pid)))
 }

--- a/backend/src/api/profiles/tags_repo.rs
+++ b/backend/src/api/profiles/tags_repo.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::api::state::{TagResponse, TagScope};
@@ -15,16 +15,15 @@ fn scope_from_str(s: &str) -> TagScope {
 }
 
 pub(in crate::api) async fn load_profile_tags(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
 ) -> std::result::Result<Vec<TagResponse>, crate::error::AppError> {
     use crate::db::models::tags::Tag;
     use crate::db::schema::tags;
 
-    let mut conn = crate::db::conn().await?;
-
     let tag_links = profile_tags::table
         .filter(profile_tags::profile_id.eq(profile_id))
-        .load::<ProfileTag>(&mut conn)
+        .load::<ProfileTag>(conn)
         .await?;
 
     let tag_ids: Vec<Uuid> = tag_links.iter().map(|link| link.tag_id).collect();
@@ -34,7 +33,7 @@ pub(in crate::api) async fn load_profile_tags(
 
     let tag_models = tags::table
         .filter(tags::id.eq_any(&tag_ids))
-        .load::<Tag>(&mut conn)
+        .load::<Tag>(conn)
         .await?;
 
     Ok(tag_models
@@ -52,13 +51,12 @@ pub(in crate::api) async fn load_profile_tags(
 }
 
 pub(in crate::api) async fn sync_profile_tags(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
     tag_ids: &[Uuid],
 ) -> std::result::Result<(), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     diesel::delete(profile_tags::table.filter(profile_tags::profile_id.eq(profile_id)))
-        .execute(&mut conn)
+        .execute(conn)
         .await?;
 
     let new_tags: Vec<ProfileTag> = tag_ids
@@ -72,7 +70,7 @@ pub(in crate::api) async fn sync_profile_tags(
     if !new_tags.is_empty() {
         diesel::insert_into(profile_tags::table)
             .values(&new_tags)
-            .execute(&mut conn)
+            .execute(conn)
             .await?;
     }
 

--- a/backend/src/api/profiles/view.rs
+++ b/backend/src/api/profiles/view.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::api::{
@@ -27,6 +27,7 @@ async fn lookup_thumbhash(profile_picture: Option<&String>) -> Option<String> {
 }
 
 async fn resolve_program(
+    conn: &mut AsyncPgConnection,
     program: Option<String>,
     viewer_user_id: Option<i32>,
     profile_user_id: i32,
@@ -34,18 +35,13 @@ async fn resolve_program(
     if viewer_user_id == Some(profile_user_id) {
         return program;
     }
-    let show = {
-        let Ok(mut conn) = crate::db::conn().await else {
-            return None;
-        };
-        user_settings::table
-            .filter(user_settings::user_id.eq(profile_user_id))
-            .first::<UserSetting>(&mut conn)
-            .await
-            .optional()
-            .map(|opt| opt.is_none_or(|s| s.privacy_show_program))
-            .unwrap_or(false)
-    };
+    let show = user_settings::table
+        .filter(user_settings::user_id.eq(profile_user_id))
+        .first::<UserSetting>(conn)
+        .await
+        .optional()
+        .map(|opt| opt.is_none_or(|s| s.privacy_show_program))
+        .unwrap_or(false);
     if show {
         program
     } else {
@@ -54,6 +50,7 @@ async fn resolve_program(
 }
 
 pub(in crate::api) async fn profile_to_response(
+    conn: &mut AsyncPgConnection,
     profile: &Profile,
     user_pid: &Uuid,
     viewer_user_id: Option<i32>,
@@ -68,7 +65,13 @@ pub(in crate::api) async fn profile_to_response(
     let raw_images = decode_profile_images(profile);
     let images = resolve_image_urls(&raw_images).await;
 
-    let program = resolve_program(profile.program.clone(), viewer_user_id, profile.user_id).await;
+    let program = resolve_program(
+        conn,
+        profile.program.clone(),
+        viewer_user_id,
+        profile.user_id,
+    )
+    .await;
 
     let bio = match &profile.bio {
         Some(b) => Some(resolve_bio_image_urls(b).await),
@@ -95,11 +98,12 @@ pub(in crate::api) async fn profile_to_response(
 }
 
 pub(in crate::api) async fn full_profile_response(
+    conn: &mut AsyncPgConnection,
     profile: &Profile,
     user_pid: &Uuid,
     viewer_user_id: Option<i32>,
 ) -> std::result::Result<FullProfileResponse, crate::error::AppError> {
-    let profile_tags = load_profile_tags(profile.id).await?;
+    let profile_tags = load_profile_tags(conn, profile.id).await?;
 
     let profile_picture = match &profile.profile_picture {
         Some(pic) => Some(resolve_image_url(pic).await),
@@ -111,7 +115,13 @@ pub(in crate::api) async fn full_profile_response(
     let raw_images = decode_profile_images(profile);
     let images = resolve_image_urls(&raw_images).await;
 
-    let program = resolve_program(profile.program.clone(), viewer_user_id, profile.user_id).await;
+    let program = resolve_program(
+        conn,
+        profile.program.clone(),
+        viewer_user_id,
+        profile.user_id,
+    )
+    .await;
 
     let bio = match &profile.bio {
         Some(b) => Some(resolve_bio_image_urls(b).await),

--- a/backend/src/api/profiles/view.rs
+++ b/backend/src/api/profiles/view.rs
@@ -1,14 +1,12 @@
-use diesel::prelude::*;
-use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use diesel_async::AsyncPgConnection;
 use uuid::Uuid;
 
 use crate::api::{
     resolve_bio_image_urls, resolve_image_url, resolve_image_urls, resolve_thumbhashes,
     state::{FullProfileResponse, ProfileResponse},
 };
+use crate::db;
 use crate::db::models::profiles::Profile;
-use crate::db::models::user_settings::UserSetting;
-use crate::db::schema::user_settings;
 
 use super::profiles_tags_repo::load_profile_tags;
 
@@ -35,12 +33,11 @@ async fn resolve_program(
     if viewer_user_id == Some(profile_user_id) {
         return program;
     }
-    let show = user_settings::table
-        .filter(user_settings::user_id.eq(profile_user_id))
-        .first::<UserSetting>(conn)
+    // Narrow projection — only returns privacy_show_program, not the full
+    // user_settings row. Lets Tier-A policy on user_settings stay "own row
+    // only" without hiding public profile fields for every other viewer.
+    let show = db::profile_program_visibility(conn, profile_user_id)
         .await
-        .optional()
-        .map(|opt| opt.is_none_or(|s| s.privacy_show_program))
         .unwrap_or(false);
     if show {
         program

--- a/backend/src/api/profiles/write_handler.rs
+++ b/backend/src/api/profiles/write_handler.rs
@@ -10,7 +10,8 @@ use axum::{
 };
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use super::{full_profile_response, parse_tag_uuids, sync_profile_tags};
@@ -18,6 +19,7 @@ use crate::api::{
     extract_filename,
     state::{CreateProfileBody, DataResponse, SuccessResponse, UpdateProfileBody},
 };
+use crate::db;
 use crate::db::models::profiles::{NewProfile, Profile};
 use crate::db::schema::profiles;
 
@@ -56,19 +58,19 @@ fn build_create_model(
 }
 
 async fn insert_profile(
+    conn: &mut AsyncPgConnection,
     new_profile: &NewProfile,
     profile_id: Uuid,
     payload: &CreateProfileBody,
 ) -> Result<Profile> {
-    let mut conn = crate::db::conn().await?;
     let inserted = diesel::insert_into(profiles::table)
         .values(new_profile)
-        .get_result::<Profile>(&mut conn)
+        .get_result::<Profile>(conn)
         .await?;
 
     let tag_ids = parse_tag_uuids(payload.tags.clone().or_else(|| payload.tag_ids.clone()));
     if !tag_ids.is_empty() {
-        sync_profile_tags(profile_id, &tag_ids).await?;
+        sync_profile_tags(conn, profile_id, &tag_ids).await?;
     }
 
     Ok(inserted)
@@ -79,37 +81,72 @@ pub(in crate::api) async fn profile_create(
     headers: HeaderMap,
     Json(payload): Json<CreateProfileBody>,
 ) -> Result<Response> {
-    let user = match validate_create(&headers, &payload).await {
-        Ok(u) => u,
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(auth) => auth,
         Err(response) => return Ok(*response),
     };
-    let picture =
-        match resolve_picture_filename(&headers, None, payload.profile_picture.as_deref()).await {
-            Ok(p) => p,
-            Err(response) => return Ok(*response),
-        };
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
 
-    let (new_profile, profile_id) = build_create_model(&user, &payload, picture);
-    let inserted = insert_profile(&new_profile, profile_id, &payload).await?;
+    let user_clone = user.clone();
+    let payload_clone = payload.clone();
+    let headers_clone = headers.clone();
 
-    let data = full_profile_response(&inserted, &user.pid, Some(user.id)).await?;
-    Ok((axum::http::StatusCode::CREATED, Json(DataResponse { data })).into_response())
+    let result: Result<Response> = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            // validate_create re-verifies auth (cheap, uses cache) but we want
+            // the existence check to run inside this viewer transaction.
+            let user = match validate_create(conn, &headers_clone, &payload_clone).await {
+                Ok(u) => u,
+                Err(response) => return Ok::<Response, diesel::result::Error>(*response),
+            };
+            let picture = match resolve_picture_filename(
+                conn,
+                &headers_clone,
+                None,
+                payload_clone.profile_picture.as_deref(),
+            )
+            .await
+            {
+                Ok(p) => p,
+                Err(response) => return Ok(*response),
+            };
+
+            let (new_profile, profile_id) = build_create_model(&user, &payload_clone, picture);
+            let inserted = insert_profile(conn, &new_profile, profile_id, &payload_clone)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+            let data = full_profile_response(conn, &inserted, &user.pid, Some(user.id))
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok((axum::http::StatusCode::CREATED, Json(DataResponse { data })).into_response())
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(Into::into);
+
+    let _ = user_clone;
+    result
 }
 
 async fn apply_update(
+    conn: &mut AsyncPgConnection,
     profile: &Profile,
     payload: &UpdateProfileBody,
     changeset: crate::db::models::profiles::ProfileChangeset,
 ) -> Result<Profile> {
-    let mut conn = crate::db::conn().await?;
     let updated = diesel::update(profiles::table.find(profile.id))
         .set(&changeset)
-        .get_result::<Profile>(&mut conn)
+        .get_result::<Profile>(conn)
         .await?;
 
     if payload.tags.is_some() || payload.tag_ids.is_some() {
         let resolved = parse_tag_uuids(payload.tags.clone().or_else(|| payload.tag_ids.clone()));
-        sync_profile_tags(profile.id, &resolved).await?;
+        sync_profile_tags(conn, profile.id, &resolved).await?;
     }
 
     Ok(updated)
@@ -121,16 +158,46 @@ pub(in crate::api) async fn profile_update(
     Path(id): Path<String>,
     Json(payload): Json<UpdateProfileBody>,
 ) -> Result<Response> {
-    let (profile, user, picture) = match validate_and_prepare_update(&headers, &id, &payload).await
-    {
-        Ok(data) => data,
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(auth) => auth,
         Err(response) => return Ok(*response),
     };
-    let changeset = build_update_changeset(&payload, picture);
-    let updated = apply_update(&profile, &payload, changeset).await?;
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let headers_clone = headers.clone();
+    let payload_clone = payload.clone();
 
-    let data = full_profile_response(&updated, &user.pid, Some(user.id)).await?;
-    Ok(Json(DataResponse { data }).into_response())
+    db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let (profile, user, picture) = match validate_and_prepare_update(
+                conn,
+                &headers_clone,
+                &id,
+                &payload_clone,
+            )
+            .await
+            {
+                Ok(data) => data,
+                Err(response) => {
+                    return Ok::<Response, diesel::result::Error>(*response);
+                }
+            };
+            let changeset = build_update_changeset(&payload_clone, picture);
+            let updated = apply_update(conn, &profile, &payload_clone, changeset)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+            let data = full_profile_response(conn, &updated, &user.pid, Some(user.id))
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok(Json(DataResponse { data }).into_response())
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(Into::into)
 }
 
 pub(in crate::api) async fn profile_delete(
@@ -138,15 +205,31 @@ pub(in crate::api) async fn profile_delete(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let (profile, _user) = match load_and_verify_profile(&headers, &id).await {
-        Ok(p) => p,
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(auth) => auth,
         Err(response) => return Ok(*response),
     };
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let headers_clone = headers.clone();
 
-    let mut conn = crate::db::conn().await?;
-    diesel::delete(profiles::table.find(profile.id))
-        .execute(&mut conn)
-        .await?;
+    db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let (profile, _user) = match load_and_verify_profile(conn, &headers_clone, &id).await {
+                Ok(p) => p,
+                Err(response) => return Ok::<Response, diesel::result::Error>(*response),
+            };
 
-    Ok(Json(SuccessResponse { success: true }).into_response())
+            diesel::delete(profiles::table.find(profile.id))
+                .execute(conn)
+                .await?;
+
+            Ok(Json(SuccessResponse { success: true }).into_response())
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(Into::into)
 }

--- a/backend/src/api/profiles/write_service.rs
+++ b/backend/src/api/profiles/write_service.rs
@@ -1,7 +1,7 @@
 use axum::http::HeaderMap;
 use axum::response::Response;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::api::{
@@ -36,25 +36,13 @@ pub(super) fn validate_profile_fields(
 }
 
 async fn check_no_existing_profile(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     user_id: i32,
 ) -> std::result::Result<(), Box<Response>> {
-    let mut conn = crate::db::conn().await.map_err(|e| {
-        tracing::error!(error = %e, "database error checking existing profile");
-        Box::new(error_response(
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            headers,
-            ErrorSpec {
-                error: "Internal server error".to_string(),
-                code: "INTERNAL_ERROR",
-                details: None,
-            },
-        ))
-    })?;
-
     let existing = profiles::table
         .filter(profiles::user_id.eq(user_id))
-        .first::<Profile>(&mut conn)
+        .first::<Profile>(conn)
         .await
         .optional()
         .map_err(|e| {
@@ -84,12 +72,13 @@ async fn check_no_existing_profile(
 }
 
 pub(super) async fn validate_create(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     payload: &CreateProfileBody,
 ) -> std::result::Result<crate::db::models::users::User, Box<Response>> {
     let (_session, user) = require_auth_db(headers).await?;
     validate_profile_fields(headers, payload)?;
-    check_no_existing_profile(headers, user.id).await?;
+    check_no_existing_profile(conn, headers, user.id).await?;
     Ok(user)
 }
 
@@ -107,19 +96,16 @@ fn uploads_unavailable(headers: &HeaderMap) -> Box<Response> {
 }
 
 async fn verify_upload_ownership(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     profile_id: Uuid,
     filename: &str,
 ) -> std::result::Result<(), Box<Response>> {
-    let mut conn = crate::db::conn()
-        .await
-        .map_err(|_| uploads_unavailable(headers))?;
-
     let owned_upload = uploads::table
         .filter(uploads::owner_id.eq(Some(profile_id)))
         .filter(uploads::filename.eq(filename))
         .filter(uploads::deleted.eq(false))
-        .first::<Upload>(&mut conn)
+        .first::<Upload>(conn)
         .await
         .optional()
         .map_err(|_| uploads_unavailable(headers))?;
@@ -150,6 +136,7 @@ async fn verify_upload_exists(
 }
 
 async fn validate_profile_picture_reference(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     owner_profile_id: Option<Uuid>,
     raw_picture: &str,
@@ -158,7 +145,7 @@ async fn validate_profile_picture_reference(
     check_validation(headers, validate_filename(&filename))?;
 
     if let Some(profile_id) = owner_profile_id {
-        verify_upload_ownership(headers, profile_id, &filename).await?;
+        verify_upload_ownership(conn, headers, profile_id, &filename).await?;
     }
     verify_upload_exists(headers, &filename).await?;
 
@@ -166,12 +153,13 @@ async fn validate_profile_picture_reference(
 }
 
 pub(super) async fn resolve_picture_filename(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     owner_profile_id: Option<Uuid>,
     raw_picture: Option<&str>,
 ) -> std::result::Result<Option<String>, Box<Response>> {
     match raw_picture {
-        Some(raw) => validate_profile_picture_reference(headers, owner_profile_id, raw)
+        Some(raw) => validate_profile_picture_reference(conn, headers, owner_profile_id, raw)
             .await
             .map(Some),
         None => Ok(None),
@@ -180,6 +168,7 @@ pub(super) async fn resolve_picture_filename(
 
 #[allow(clippy::option_option)]
 pub(super) async fn validate_and_prepare_update(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     id: &str,
     payload: &UpdateProfileBody,
@@ -191,14 +180,15 @@ pub(super) async fn validate_and_prepare_update(
     ),
     Box<Response>,
 > {
-    let (profile, user) = load_and_verify_profile(headers, id).await?;
+    let (profile, user) = load_and_verify_profile(conn, headers, id).await?;
     validate_update_payload(headers, payload)?;
     let picture = match &payload.profile_picture {
         None => None,             // absent → don't change
         Some(None) => Some(None), // explicit null → clear
         Some(Some(raw)) => {
             let filename =
-                resolve_picture_filename(headers, Some(profile.id), Some(raw.as_str())).await?;
+                resolve_picture_filename(conn, headers, Some(profile.id), Some(raw.as_str()))
+                    .await?;
             Some(filename) // Some(Some(filename))
         }
     };
@@ -247,27 +237,16 @@ pub(super) fn build_update_changeset(
 }
 
 pub(super) async fn load_and_verify_profile(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     id: &str,
 ) -> std::result::Result<(Profile, crate::db::models::users::User), Box<Response>> {
     let (_session, user) = require_auth_db(headers).await?;
     let profile_uuid = crate::api::parse_uuid_response(id, "profile", headers)?;
 
-    let mut conn = crate::db::conn().await.map_err(|_| {
-        Box::new(error_response(
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            headers,
-            ErrorSpec {
-                error: "Internal server error".to_string(),
-                code: "INTERNAL_ERROR",
-                details: None,
-            },
-        ))
-    })?;
-
     let profile = profiles::table
         .find(profile_uuid)
-        .first::<Profile>(&mut conn)
+        .first::<Profile>(conn)
         .await
         .optional()
         .map_err(|_| Box::new(not_found_profile(headers, id)))?

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -5,9 +5,9 @@ pub mod viewer;
 pub use viewer::{
     complete_password_reset, create_session_for_user, create_user_for_signup,
     delete_session_by_token, find_user_for_login, find_user_for_password_reset,
-    mark_email_verified, resolve_session, set_anon_context, set_password_reset_token,
-    set_viewer_context, with_anon_tx, with_viewer_tx, AuthSessionRow, AuthUserRow,
-    CreatedSessionRow, DbViewer, PasswordResetUserRow,
+    mark_email_verified, profile_program_visibility, resolve_session, set_anon_context,
+    set_password_reset_token, set_viewer_context, user_pid_for_id, with_anon_tx, with_viewer_tx,
+    AuthSessionRow, AuthUserRow, CreatedSessionRow, DbViewer, PasswordResetUserRow,
 };
 
 use deadpool::managed::Timeouts;

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -338,3 +338,49 @@ pub async fn delete_session_by_token(
         .await?;
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Narrow public projections for cross-user profile reads.
+//
+// A viewer rendering someone else's profile needs to know just their public
+// pid and whether the owner has opted to display their program. The full
+// `users` / `user_settings` rows carry sensitive columns that the viewer
+// must not see under Tier-A policies, so these helpers return a single
+// scalar each.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, QueryableByName)]
+struct UuidRow {
+    #[diesel(sql_type = Nullable<SqlUuid>)]
+    value: Option<uuid::Uuid>,
+}
+
+/// Return the external pid for a user, if they exist.
+pub async fn user_pid_for_id(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+) -> Result<Option<uuid::Uuid>, diesel::result::Error> {
+    let row = diesel::sql_query("SELECT app.user_pid_for_id($1) AS value")
+        .bind::<Integer, _>(user_id)
+        .get_result::<UuidRow>(conn)
+        .await?;
+    Ok(row.value)
+}
+
+#[derive(Debug, Clone, QueryableByName)]
+struct BoolRow {
+    #[diesel(sql_type = Bool)]
+    value: bool,
+}
+
+/// Whether a user has opted to show their program on public profile views.
+pub async fn profile_program_visibility(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+) -> Result<bool, diesel::result::Error> {
+    let row = diesel::sql_query("SELECT app.profile_program_visibility($1) AS value")
+        .bind::<Integer, _>(user_id)
+        .get_result::<BoolRow>(conn)
+        .await?;
+    Ok(row.value)
+}


### PR DESCRIPTION
**Migrate the profiles module to the viewer-aware path**

Every `profiles/` handler now runs its DB work inside a single `with_viewer_tx(viewer)`. Repo, view, tags, blocks, and bookmarks helpers accept `&mut AsyncPgConnection` so the transaction boundary lives at the handler. Two narrow SECURITY DEFINER helpers (`app.user_pid_for_id`, `app.profile_program_visibility`) replace cross-user reads from `users` and `user_settings`, so those tables can ship Tier-A policies that are "own row only" without hiding public profile fields for other viewers.

- [x] CI green
- [x] GET /profiles/me + GET /profiles/{id} + GET /profiles/{id}/full exercised (same-user and cross-user)
- [x] POST /profiles (create), PATCH /profiles/{id}, DELETE /profiles/{id} exercised
- [x] bookmark / unbookmark / list-bookmarked + block / unblock exercised
- [x] cross-user profile render uses app.user_pid_for_id + app.profile_program_visibility (verified via the /profiles/{P2}/full flow with two separate users)