### PR TITLE
sec(rls): wrap chat endpoints in viewer-scoped transactions

### DIFF
--- a/backend/migrations/2026-04-18-040000_chat_rls_helpers/down.sql
+++ b/backend/migrations/2026-04-18-040000_chat_rls_helpers/down.sql
@@ -1,0 +1,3 @@
+DROP FUNCTION IF EXISTS app.push_topics_for_users(int[]);
+DROP FUNCTION IF EXISTS app.user_review_stubs(int[]);
+DROP FUNCTION IF EXISTS app.user_id_for_pid(uuid);

--- a/backend/migrations/2026-04-18-040000_chat_rls_helpers/up.sql
+++ b/backend/migrations/2026-04-18-040000_chat_rls_helpers/up.sql
@@ -1,0 +1,69 @@
+-- Narrow public-projection helpers used by the chat module.
+--
+-- Chat handlers need a few small facts from `users` and `push_subscriptions`
+-- that would otherwise require cross-user SELECT on tables carrying
+-- sensitive columns (password hash, reset token, etc.). These SD helpers
+-- expose exactly what the caller needs and no more, so the API role can
+-- stay at least-privilege and Tier-A RLS on users/push_subscriptions can
+-- stay "own row only".
+
+-- Resolve the internal int id for a user's external pid. Returns NULL if
+-- the pid is not known.
+CREATE OR REPLACE FUNCTION app.user_id_for_pid(p_pid uuid)
+RETURNS int
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT id FROM users WHERE pid = p_pid
+$$;
+
+COMMENT ON FUNCTION app.user_id_for_pid(uuid) IS
+    'Resolve a user pid to its int id. Narrow projection; used by DM target lookup.';
+
+-- Batch lookup of is_review_stub for a list of user ids. Used to hide DMs
+-- between stub and non-stub accounts.
+CREATE OR REPLACE FUNCTION app.user_review_stubs(p_user_ids int[])
+RETURNS TABLE (user_id int, is_review_stub bool)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT id, is_review_stub FROM users WHERE id = ANY(p_user_ids)
+$$;
+
+COMMENT ON FUNCTION app.user_review_stubs(int[]) IS
+    'Batch lookup of is_review_stub for a list of users. Narrow projection; used by chat DM filtering.';
+
+-- Batch lookup of ntfy push topics for a list of user ids. Used by
+-- notify_push to dispatch wake-up signals. Only the topic string is
+-- exposed — no device identifiers, creation timestamps, or user ids.
+CREATE OR REPLACE FUNCTION app.push_topics_for_users(p_user_ids int[])
+RETURNS TABLE (ntfy_topic varchar)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT ntfy_topic FROM push_subscriptions WHERE user_id = ANY(p_user_ids)
+$$;
+
+COMMENT ON FUNCTION app.push_topics_for_users(int[]) IS
+    'Return ntfy topics for a set of users. Narrow projection; server-side push delivery only.';
+
+REVOKE EXECUTE ON FUNCTION app.user_id_for_pid(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.user_review_stubs(int[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.push_topics_for_users(int[]) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.user_id_for_pid(uuid) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.user_review_stubs(int[]) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.push_topics_for_users(int[]) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::conversation_members::NewConversationMember;
@@ -13,6 +13,7 @@ use crate::db::schema::{
 /// Uses canonical pair (lower id, higher id) for uniqueness.
 #[allow(clippy::similar_names)]
 pub async fn resolve_or_create_dm(
+    conn: &mut AsyncPgConnection,
     first_user_id: i32,
     second_user_id: i32,
 ) -> Result<Conversation, crate::error::AppError> {
@@ -22,14 +23,12 @@ pub async fn resolve_or_create_dm(
         (second_user_id, first_user_id)
     };
 
-    let mut conn = crate::db::conn().await?;
-
     // Try to find existing DM
     let existing = conversations::table
         .filter(conversations::kind.eq("dm"))
         .filter(conversations::user_low_id.eq(low))
         .filter(conversations::user_high_id.eq(high))
-        .first::<Conversation>(&mut conn)
+        .first::<Conversation>(conn)
         .await
         .optional()?;
 
@@ -53,7 +52,7 @@ pub async fn resolve_or_create_dm(
     let inserted = diesel::insert_into(conversations::table)
         .values(&new_conv)
         .on_conflict_do_nothing()
-        .get_result::<Conversation>(&mut conn)
+        .get_result::<Conversation>(conn)
         .await
         .optional()?;
 
@@ -65,7 +64,7 @@ pub async fn resolve_or_create_dm(
                 .filter(conversations::kind.eq("dm"))
                 .filter(conversations::user_low_id.eq(low))
                 .filter(conversations::user_high_id.eq(high))
-                .first::<Conversation>(&mut conn)
+                .first::<Conversation>(conn)
                 .await?
         }
     };
@@ -86,7 +85,7 @@ pub async fn resolve_or_create_dm(
     diesel::insert_into(conversation_members::table)
         .values(&members)
         .on_conflict_do_nothing()
-        .execute(&mut conn)
+        .execute(conn)
         .await?;
 
     Ok(created)
@@ -94,16 +93,15 @@ pub async fn resolve_or_create_dm(
 
 /// Resolve or create an event conversation.
 pub async fn resolve_or_create_event_conversation(
+    conn: &mut AsyncPgConnection,
     event_id: Uuid,
     event_title: &str,
     creator_user_id: i32,
 ) -> Result<Conversation, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let existing = conversations::table
         .filter(conversations::kind.eq("event"))
         .filter(conversations::event_id.eq(event_id))
-        .first::<Conversation>(&mut conn)
+        .first::<Conversation>(conn)
         .await
         .optional()?;
 
@@ -126,7 +124,7 @@ pub async fn resolve_or_create_event_conversation(
     let inserted = diesel::insert_into(conversations::table)
         .values(&new_conv)
         .on_conflict_do_nothing()
-        .get_result::<Conversation>(&mut conn)
+        .get_result::<Conversation>(conn)
         .await
         .optional()?;
 
@@ -136,7 +134,7 @@ pub async fn resolve_or_create_event_conversation(
             conversations::table
                 .filter(conversations::kind.eq("event"))
                 .filter(conversations::event_id.eq(event_id))
-                .first::<Conversation>(&mut conn)
+                .first::<Conversation>(conn)
                 .await?
         }
     };
@@ -149,34 +147,36 @@ pub async fn resolve_or_create_event_conversation(
             joined_at: now,
         })
         .on_conflict_do_nothing()
-        .execute(&mut conn)
+        .execute(conn)
         .await?;
 
     Ok(created)
 }
 
 /// Get all conversation member user IDs for a conversation.
-pub async fn member_user_ids(conversation_id: Uuid) -> Result<Vec<i32>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
+pub async fn member_user_ids(
+    conn: &mut AsyncPgConnection,
+    conversation_id: Uuid,
+) -> Result<Vec<i32>, crate::error::AppError> {
     let ids = conversation_members::table
         .filter(conversation_members::conversation_id.eq(conversation_id))
         .select(conversation_members::user_id)
-        .load::<i32>(&mut conn)
+        .load::<i32>(conn)
         .await?;
     Ok(ids)
 }
 
 /// Check if a user is a member of a conversation.
 pub async fn is_member(
+    conn: &mut AsyncPgConnection,
     conversation_id: Uuid,
     user_id: i32,
 ) -> Result<bool, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let count = conversation_members::table
         .filter(conversation_members::conversation_id.eq(conversation_id))
         .filter(conversation_members::user_id.eq(user_id))
         .count()
-        .get_result::<i64>(&mut conn)
+        .get_result::<i64>(conn)
         .await?;
     Ok(count > 0)
 }
@@ -186,17 +186,16 @@ pub async fn is_member(
 /// Uses batch queries instead of per-conversation loops to avoid N+1.
 #[allow(clippy::similar_names, clippy::too_many_lines)]
 pub async fn list_for_user(
+    conn: &mut AsyncPgConnection,
     user_id: i32,
 ) -> Result<Vec<super::protocol::ConversationPayload>, crate::error::AppError> {
     use super::protocol::ConversationPayload;
     use std::collections::HashMap;
 
-    let mut conn = crate::db::conn().await?;
-
     let viewer_is_stub = users::table
         .filter(users::id.eq(user_id))
         .select(users::is_review_stub)
-        .first::<bool>(&mut conn)
+        .first::<bool>(conn)
         .await
         .optional()?
         .unwrap_or(false);
@@ -204,7 +203,7 @@ pub async fn list_for_user(
     let conv_ids: Vec<Uuid> = conversation_members::table
         .filter(conversation_members::user_id.eq(user_id))
         .select(conversation_members::conversation_id)
-        .load(&mut conn)
+        .load(conn)
         .await?;
 
     if conv_ids.is_empty() {
@@ -213,7 +212,7 @@ pub async fn list_for_user(
 
     let all_convs: Vec<Conversation> = conversations::table
         .filter(conversations::id.eq_any(&conv_ids))
-        .load(&mut conn)
+        .load(conn)
         .await?;
 
     // Collect the "other participant" id for every DM so we can batch-load
@@ -236,7 +235,7 @@ pub async fn list_for_user(
         users::table
             .filter(users::id.eq_any(&other_ids))
             .select((users::id, users::is_review_stub))
-            .load::<(i32, bool)>(&mut conn)
+            .load::<(i32, bool)>(conn)
             .await?
             .into_iter()
             .collect()
@@ -276,7 +275,7 @@ pub async fn list_for_user(
              ORDER BY conversation_id, created_at DESC, id DESC",
     )
     .bind::<diesel::sql_types::Array<diesel::sql_types::Uuid>, _>(&conv_ids)
-    .load(&mut conn)
+    .load(conn)
     .await?;
 
     let latest_map: HashMap<Uuid, &crate::db::models::messages::Message> = latest_messages
@@ -303,7 +302,7 @@ pub async fn list_for_user(
     )
     .bind::<diesel::sql_types::Integer, _>(user_id)
     .bind::<diesel::sql_types::Array<diesel::sql_types::Uuid>, _>(&conv_ids)
-    .load::<UnreadCountRow>(&mut conn)
+    .load::<UnreadCountRow>(conn)
     .await?;
 
     let unread_map: HashMap<Uuid, i64> = unread_counts
@@ -344,7 +343,7 @@ pub async fn list_for_user(
                     profiles::name,
                     profiles::profile_picture,
                 ))
-                .load(&mut conn)
+                .load(conn)
                 .await?
         };
 
@@ -357,7 +356,7 @@ pub async fn list_for_user(
     let my_profile_id: Option<uuid::Uuid> = profiles::table
         .filter(profiles::user_id.eq(user_id))
         .select(profiles::id)
-        .first(&mut conn)
+        .first(conn)
         .await
         .optional()?;
 
@@ -371,7 +370,7 @@ pub async fn list_for_user(
                         .or(profile_blocks::blocked_id.eq(my_pid)),
                 )
                 .select((profile_blocks::blocker_id, profile_blocks::blocked_id))
-                .load(&mut conn)
+                .load(conn)
                 .await?;
             rows.into_iter()
                 .flat_map(|(a, b)| {
@@ -475,7 +474,8 @@ struct UnreadCountRow {
 }
 
 /// Sync event membership: add or remove a user from the event conversation.
-/// Called from outbox job dispatch.
+/// Called from outbox job dispatch (worker, BYPASSRLS), so it opens its own
+/// connection rather than requiring a viewer context.
 #[allow(clippy::similar_names)]
 pub async fn sync_event_membership(
     event_id: Uuid,
@@ -542,9 +542,14 @@ pub async fn sync_event_membership(
             .map_err(|e| format!("resolve creator user_id: {e}"))?;
 
         // Ensure conversation exists
-        let conv = resolve_or_create_event_conversation(event_id, &event_title, creator_user_id)
-            .await
-            .map_err(|e| format!("resolve conversation: {e}"))?;
+        let conv = resolve_or_create_event_conversation(
+            &mut conn,
+            event_id,
+            &event_title,
+            creator_user_id,
+        )
+        .await
+        .map_err(|e| format!("resolve conversation: {e}"))?;
 
         // Add member
         diesel::insert_into(conversation_members::table)

--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -3,11 +3,10 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
+use crate::db;
 use crate::db::models::conversation_members::NewConversationMember;
 use crate::db::models::conversations::{Conversation, NewConversation};
-use crate::db::schema::{
-    conversation_members, conversations, events, profile_blocks, profiles, users,
-};
+use crate::db::schema::{conversation_members, conversations, events, profile_blocks, profiles};
 
 /// Resolve or create a DM conversation between two users.
 /// Uses canonical pair (lower id, higher id) for uniqueness.
@@ -188,17 +187,10 @@ pub async fn is_member(
 pub async fn list_for_user(
     conn: &mut AsyncPgConnection,
     user_id: i32,
+    viewer_is_stub: bool,
 ) -> Result<Vec<super::protocol::ConversationPayload>, crate::error::AppError> {
     use super::protocol::ConversationPayload;
     use std::collections::HashMap;
-
-    let viewer_is_stub = users::table
-        .filter(users::id.eq(user_id))
-        .select(users::is_review_stub)
-        .first::<bool>(conn)
-        .await
-        .optional()?
-        .unwrap_or(false);
 
     let conv_ids: Vec<Uuid> = conversation_members::table
         .filter(conversation_members::user_id.eq(user_id))
@@ -229,17 +221,12 @@ pub async fn list_for_user(
         })
         .collect();
 
-    let stub_flags: std::collections::HashMap<i32, bool> = if other_ids.is_empty() {
-        std::collections::HashMap::new()
-    } else {
-        users::table
-            .filter(users::id.eq_any(&other_ids))
-            .select((users::id, users::is_review_stub))
-            .load::<(i32, bool)>(conn)
-            .await?
-            .into_iter()
-            .collect()
-    };
+    // Narrow public projection: is_review_stub only, no full users row.
+    let stub_flags: std::collections::HashMap<i32, bool> = db::user_review_stubs(conn, &other_ids)
+        .await?
+        .into_iter()
+        .map(|r| (r.user_id, r.is_review_stub))
+        .collect();
 
     // Hide DMs where the other participant has a different is_review_stub
     // value so stub accounts stay invisible to real users (and vice versa).
@@ -329,16 +316,16 @@ pub async fn list_for_user(
     profile_user_ids.sort_unstable();
     profile_user_ids.dedup();
 
-    // Batch-load profiles
+    // Batch-load profiles (filter on profiles.user_id directly — no need
+    // to join users, which would require broad SELECT on a sensitive table).
     let profile_rows: Vec<(i32, uuid::Uuid, String, Option<String>)> =
         if profile_user_ids.is_empty() {
             Vec::new()
         } else {
             profiles::table
-                .inner_join(users::table.on(users::id.eq(profiles::user_id)))
-                .filter(users::id.eq_any(&profile_user_ids))
+                .filter(profiles::user_id.eq_any(&profile_user_ids))
                 .select((
-                    users::id,
+                    profiles::user_id,
                     profiles::id,
                     profiles::name,
                     profiles::profile_picture,

--- a/backend/src/api/chat/messages.rs
+++ b/backend/src/api/chat/messages.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use super::protocol::{MessagePayload, ReactionPayload, ReplyPayload};
@@ -12,7 +12,7 @@ use crate::db::schema::{message_reactions, messages, profiles, users};
 async fn single_message_payload(
     msg: &Message,
     viewer_user_id: i32,
-    conn: &mut crate::db::DbConn,
+    conn: &mut AsyncPgConnection,
 ) -> Result<MessagePayload, crate::error::AppError> {
     batch_messages_to_payloads(std::slice::from_ref(msg), viewer_user_id, conn)
         .await?
@@ -26,6 +26,7 @@ async fn single_message_payload(
 /// `(conversation_id, client_id)`, return the existing message (idempotent).
 /// Returns `(message, payload, created)` where `created` is `false` on dedup hit.
 pub async fn create_message(
+    conn: &mut AsyncPgConnection,
     conversation_id: Uuid,
     sender_id: i32,
     body: &str,
@@ -33,8 +34,6 @@ pub async fn create_message(
     reply_to_id: Option<Uuid>,
     client_id: Option<String>,
 ) -> Result<(Message, MessagePayload, bool), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     // Dedup: if client_id is set, check for an existing message first
     if let Some(ref cid) = client_id {
         let existing: Option<Message> = messages::table
@@ -42,11 +41,11 @@ pub async fn create_message(
             .filter(messages::sender_id.eq(sender_id))
             .filter(messages::client_id.eq(cid))
             .filter(messages::deleted_at.is_null())
-            .first(&mut conn)
+            .first(conn)
             .await
             .optional()?;
         if let Some(msg) = existing {
-            let payload = single_message_payload(&msg, 0, &mut conn).await?;
+            let payload = single_message_payload(&msg, 0, conn).await?;
             return Ok((msg, payload, false));
         }
     }
@@ -60,7 +59,7 @@ pub async fn create_message(
             .filter(messages::id.eq(reply_id))
             .filter(messages::conversation_id.eq(conversation_id))
             .count()
-            .get_result::<i64>(&mut conn)
+            .get_result::<i64>(conn)
             .await?
             > 0;
         if !reply_in_conv {
@@ -83,7 +82,7 @@ pub async fn create_message(
 
     let msg = match diesel::insert_into(messages::table)
         .values(&new)
-        .get_result::<Message>(&mut conn)
+        .get_result::<Message>(conn)
         .await
     {
         Ok(msg) => msg,
@@ -101,9 +100,9 @@ pub async fn create_message(
                 .filter(messages::sender_id.eq(sender_id))
                 .filter(messages::client_id.eq(cid))
                 .filter(messages::deleted_at.is_null())
-                .first(&mut conn)
+                .first(conn)
                 .await?;
-            let payload = single_message_payload(&msg, 0, &mut conn).await?;
+            let payload = single_message_payload(&msg, 0, conn).await?;
             return Ok((msg, payload, false));
         }
         Err(e) => return Err(e.into()),
@@ -111,12 +110,13 @@ pub async fn create_message(
 
     // viewer_user_id=0 so broadcast payload has is_mine=false for all recipients.
     // Each client computes isMine locally; sender matches via client_id.
-    let payload = single_message_payload(&msg, 0, &mut conn).await?;
+    let payload = single_message_payload(&msg, 0, conn).await?;
     Ok((msg, payload, true))
 }
 
 /// Edit a message body. Returns the updated message.
 pub async fn edit_message(
+    conn: &mut AsyncPgConnection,
     message_id: Uuid,
     sender_id: i32,
     new_body: &str,
@@ -130,7 +130,6 @@ pub async fn edit_message(
         return Err(crate::error::AppError::message("message body too long"));
     }
 
-    let mut conn = crate::db::conn().await?;
     let now = Utc::now();
 
     let updated = diesel::update(
@@ -140,7 +139,7 @@ pub async fn edit_message(
             .filter(messages::deleted_at.is_null()),
     )
     .set((messages::body.eq(new_body), messages::edited_at.eq(now)))
-    .get_result::<Message>(&mut conn)
+    .get_result::<Message>(conn)
     .await
     .optional()?;
 
@@ -149,10 +148,10 @@ pub async fn edit_message(
 
 /// Soft-delete a message.
 pub async fn delete_message(
+    conn: &mut AsyncPgConnection,
     message_id: Uuid,
     sender_id: i32,
 ) -> Result<Message, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let now = Utc::now();
 
     let updated = diesel::update(
@@ -162,7 +161,7 @@ pub async fn delete_message(
             .filter(messages::deleted_at.is_null()),
     )
     .set(messages::deleted_at.eq(Some(now)))
-    .get_result::<Message>(&mut conn)
+    .get_result::<Message>(conn)
     .await
     .optional()?;
 
@@ -171,17 +170,16 @@ pub async fn delete_message(
 
 /// Toggle a reaction. Returns (added: bool, message) — true if added, false if removed.
 pub async fn toggle_reaction(
+    conn: &mut AsyncPgConnection,
     message_id: Uuid,
     user_id: i32,
     emoji: &str,
 ) -> Result<(bool, Message), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     // Check the message exists
     let msg = messages::table
         .filter(messages::id.eq(message_id))
         .filter(messages::deleted_at.is_null())
-        .first::<Message>(&mut conn)
+        .first::<Message>(conn)
         .await
         .optional()?
         .ok_or_else(|| crate::error::AppError::message("message not found"))?;
@@ -193,7 +191,7 @@ pub async fn toggle_reaction(
             .filter(message_reactions::user_id.eq(user_id))
             .filter(message_reactions::emoji.eq(emoji)),
     )
-    .execute(&mut conn)
+    .execute(conn)
     .await?;
 
     if deleted > 0 {
@@ -211,7 +209,7 @@ pub async fn toggle_reaction(
             created_at: now,
         })
         .on_conflict_do_nothing()
-        .execute(&mut conn)
+        .execute(conn)
         .await?;
 
     Ok((true, msg))
@@ -219,18 +217,17 @@ pub async fn toggle_reaction(
 
 /// Update read watermark for a user in a conversation.
 pub async fn mark_read(
+    conn: &mut AsyncPgConnection,
     conversation_id: Uuid,
     user_id: i32,
     message_id: Uuid,
 ) -> Result<(), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     // Verify message belongs to this conversation
     let belongs = messages::table
         .filter(messages::id.eq(message_id))
         .filter(messages::conversation_id.eq(conversation_id))
         .count()
-        .get_result::<i64>(&mut conn)
+        .get_result::<i64>(conn)
         .await?
         > 0;
 
@@ -255,7 +252,7 @@ pub async fn mark_read(
     .bind::<diesel::sql_types::Uuid, _>(message_id)
     .bind::<diesel::sql_types::Uuid, _>(conversation_id)
     .bind::<diesel::sql_types::Integer, _>(user_id)
-    .execute(&mut conn)
+    .execute(conn)
     .await?;
 
     Ok(())
@@ -263,13 +260,13 @@ pub async fn mark_read(
 
 /// Look up the `conversation_id` for a given message.
 pub async fn message_conversation_id(
+    conn: &mut AsyncPgConnection,
     message_id: Uuid,
 ) -> Result<Option<Uuid>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let cid = messages::table
         .filter(messages::id.eq(message_id))
         .select(messages::conversation_id)
-        .first::<Uuid>(&mut conn)
+        .first::<Uuid>(conn)
         .await
         .optional()?;
     Ok(cid)
@@ -277,13 +274,12 @@ pub async fn message_conversation_id(
 
 /// Load message history for a conversation, paginated backwards.
 pub async fn load_history(
+    conn: &mut AsyncPgConnection,
     conversation_id: Uuid,
     before: Option<Uuid>,
     limit: i64,
     viewer_user_id: i32,
 ) -> Result<(Vec<MessagePayload>, bool), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let query_limit = limit + 1; // fetch one extra to determine has_more
 
     let msgs: Vec<Message> = if let Some(before_id) = before {
@@ -291,7 +287,7 @@ pub async fn load_history(
             .filter(messages::id.eq(before_id))
             .filter(messages::conversation_id.eq(conversation_id))
             .select(messages::created_at)
-            .first(&mut conn)
+            .first(conn)
             .await
             .optional()?;
         let Some(before_ts) = before_ts else {
@@ -308,7 +304,7 @@ pub async fn load_history(
             )
             .order((messages::created_at.desc(), messages::id.desc()))
             .limit(query_limit)
-            .load(&mut conn)
+            .load(conn)
             .await?
     } else {
         messages::table
@@ -316,7 +312,7 @@ pub async fn load_history(
             .filter(messages::deleted_at.is_null())
             .order((messages::created_at.desc(), messages::id.desc()))
             .limit(query_limit)
-            .load(&mut conn)
+            .load(conn)
             .await?
     };
 
@@ -324,7 +320,7 @@ pub async fn load_history(
     let has_more = msgs.len() > limit_usize;
     let msgs: Vec<Message> = msgs.into_iter().take(limit_usize).collect();
 
-    let mut payloads = batch_messages_to_payloads(&msgs, viewer_user_id, &mut conn).await?;
+    let mut payloads = batch_messages_to_payloads(&msgs, viewer_user_id, conn).await?;
 
     // Return in chronological order (oldest first)
     payloads.reverse();
@@ -337,7 +333,7 @@ pub async fn load_history(
 async fn batch_messages_to_payloads(
     msgs: &[Message],
     viewer_user_id: i32,
-    conn: &mut crate::db::DbConn,
+    conn: &mut AsyncPgConnection,
 ) -> Result<Vec<MessagePayload>, crate::error::AppError> {
     use std::collections::HashMap;
 

--- a/backend/src/api/chat/messages.rs
+++ b/backend/src/api/chat/messages.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use super::protocol::{MessagePayload, ReactionPayload, ReplyPayload};
 use crate::db::models::message_reactions::NewMessageReaction;
 use crate::db::models::messages::{Message, NewMessage};
-use crate::db::schema::{message_reactions, messages, profiles, users};
+use crate::db::schema::{message_reactions, messages, profiles};
 
 /// Convert a single message to a payload via the batch path.
 async fn single_message_payload(
@@ -346,12 +346,12 @@ async fn batch_messages_to_payloads(
     let msg_ids: Vec<Uuid> = msgs.iter().map(|m| m.id).collect();
     let reply_ids: Vec<Uuid> = msgs.iter().filter_map(|m| m.reply_to_id).collect();
 
-    // Batch-load sender profiles
+    // Batch-load sender profiles. Filter on profiles.user_id directly so
+    // we don't need SELECT on users (which carries sensitive columns).
     let sender_rows: Vec<(i32, String, Uuid, Option<String>)> = profiles::table
-        .inner_join(users::table.on(users::id.eq(profiles::user_id)))
-        .filter(users::id.eq_any(&sender_ids))
+        .filter(profiles::user_id.eq_any(&sender_ids))
         .select((
-            users::id,
+            profiles::user_id,
             profiles::name,
             profiles::id,
             profiles::profile_picture,
@@ -382,9 +382,8 @@ async fn batch_messages_to_payloads(
         HashMap::new()
     } else {
         profiles::table
-            .inner_join(users::table.on(users::id.eq(profiles::user_id)))
-            .filter(users::id.eq_any(&reply_sender_ids))
-            .select((users::id, profiles::name))
+            .filter(profiles::user_id.eq_any(&reply_sender_ids))
+            .select((profiles::user_id, profiles::name))
             .load::<(i32, String)>(conn)
             .await?
             .into_iter()
@@ -408,9 +407,8 @@ async fn batch_messages_to_payloads(
         HashMap::new()
     } else {
         profiles::table
-            .inner_join(users::table.on(users::id.eq(profiles::user_id)))
-            .filter(users::id.eq_any(&reaction_user_ids))
-            .select((users::id, profiles::name))
+            .filter(profiles::user_id.eq_any(&reaction_user_ids))
+            .select((profiles::user_id, profiles::name))
             .load::<(i32, String)>(conn)
             .await?
             .into_iter()

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -14,11 +14,13 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use diesel_async::scoped_futures::ScopedFutureExt;
 use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::api::common::{auth_or_respond, error_response, parse_uuid_response, ErrorSpec};
 use crate::app::AppContext;
+use crate::db;
 
 type Result<T> = crate::error::AppResult<T>;
 
@@ -129,17 +131,47 @@ pub async fn resolve_dm(
         Err(response) => return Ok(*response),
     };
 
-    // Resolve target user's internal id
-    let mut conn = crate::db::conn().await?;
-    let target_user_id: Option<i32> = users::table
-        .filter(users::pid.eq(target_pid))
-        .select(users::id)
-        .first(&mut conn)
-        .await
-        .optional()?;
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let caller_user_id = user.id;
 
-    let Some(target_user_id) = target_user_id else {
-        return Ok(error_response(
+    let outcome: std::result::Result<Option<Uuid>, &'static str> =
+        db::with_viewer_tx(viewer, move |conn| {
+            async move {
+                let target_user_id: Option<i32> = users::table
+                    .filter(users::pid.eq(target_pid))
+                    .select(users::id)
+                    .first(conn)
+                    .await
+                    .optional()
+                    .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+                let Some(target_user_id) = target_user_id else {
+                    return Ok::<
+                        std::result::Result<Option<Uuid>, &'static str>,
+                        diesel::result::Error,
+                    >(Err("target_missing"));
+                };
+
+                if caller_user_id == target_user_id {
+                    return Ok(Err("self_dm"));
+                }
+
+                let conversation =
+                    conversations::resolve_or_create_dm(conn, caller_user_id, target_user_id)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+                Ok(Ok(Some(conversation.id)))
+            }
+            .scope_boxed()
+        })
+        .await?;
+
+    match outcome {
+        Err("target_missing") => Ok(error_response(
             StatusCode::NOT_FOUND,
             &headers,
             ErrorSpec {
@@ -147,11 +179,8 @@ pub async fn resolve_dm(
                 code: "NOT_FOUND",
                 details: None,
             },
-        ));
-    };
-
-    if user.id == target_user_id {
-        return Ok(error_response(
+        )),
+        Err("self_dm") => Ok(error_response(
             StatusCode::BAD_REQUEST,
             &headers,
             ErrorSpec {
@@ -159,25 +188,39 @@ pub async fn resolve_dm(
                 code: "BAD_REQUEST",
                 details: None,
             },
-        ));
+        )),
+        Err(_) => Ok(error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &headers,
+            ErrorSpec {
+                error: "Internal error".to_string(),
+                code: "INTERNAL_ERROR",
+                details: None,
+            },
+        )),
+        Ok(Some(conv_id)) => Ok((
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "data": {
+                    "conversationId": conv_id.to_string(),
+                }
+            })),
+        )
+            .into_response()),
+        Ok(None) => unreachable!(),
     }
-
-    let conversation = conversations::resolve_or_create_dm(user.id, target_user_id).await?;
-
-    Ok((
-        StatusCode::OK,
-        Json(serde_json::json!({
-            "data": {
-                "conversationId": conversation.id.to_string(),
-            }
-        })),
-    )
-        .into_response())
 }
 
 // ---------------------------------------------------------------------------
 // REST: Resolve event conversation
 // ---------------------------------------------------------------------------
+
+enum EventConvOutcome {
+    NotFound,
+    NoProfile,
+    Forbidden,
+    Ok(Uuid),
+}
 
 pub async fn resolve_event_conversation(
     State(_ctx): State<AppContext>,
@@ -196,18 +239,88 @@ pub async fn resolve_event_conversation(
         Err(response) => return Ok(*response),
     };
 
-    let mut conn = crate::db::conn().await?;
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let caller_user_id = user.id;
 
-    // Load event
-    let event: Option<(Uuid, String, Uuid)> = events::table
-        .filter(events::id.eq(event_id))
-        .select((events::id, events::title, events::creator_id))
-        .first(&mut conn)
-        .await
-        .optional()?;
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let event: Option<(Uuid, String, Uuid)> = events::table
+                .filter(events::id.eq(event_id))
+                .select((events::id, events::title, events::creator_id))
+                .first(conn)
+                .await
+                .optional()
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
 
-    let Some((event_id, event_title, creator_profile_id)) = event else {
-        return Ok(error_response(
+            let Some((event_id, event_title, creator_profile_id)) = event else {
+                return Ok::<_, diesel::result::Error>(EventConvOutcome::NotFound);
+            };
+
+            let user_profile_id: Option<Uuid> = profiles::table
+                .filter(profiles::user_id.eq(caller_user_id))
+                .select(profiles::id)
+                .first(conn)
+                .await
+                .optional()
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+            let Some(user_profile_id) = user_profile_id else {
+                return Ok(EventConvOutcome::NoProfile);
+            };
+
+            let is_creator = creator_profile_id == user_profile_id;
+            let is_attendee: bool = event_attendees::table
+                .filter(event_attendees::event_id.eq(event_id))
+                .filter(event_attendees::profile_id.eq(user_profile_id))
+                .filter(event_attendees::status.eq("going"))
+                .count()
+                .get_result::<i64>(conn)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+                > 0;
+
+            if !is_creator && !is_attendee {
+                return Ok(EventConvOutcome::Forbidden);
+            }
+
+            let creator_user_id: i32 = profiles::table
+                .filter(profiles::id.eq(creator_profile_id))
+                .select(profiles::user_id)
+                .first(conn)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+            let conversation = conversations::resolve_or_create_event_conversation(
+                conn,
+                event_id,
+                &event_title,
+                creator_user_id,
+            )
+            .await
+            .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+            diesel::insert_into(conversation_members::table)
+                .values(&NewConversationMember {
+                    conversation_id: conversation.id,
+                    user_id: caller_user_id,
+                    joined_at: chrono::Utc::now(),
+                })
+                .on_conflict_do_nothing()
+                .execute(conn)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+            Ok(EventConvOutcome::Ok(conversation.id))
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    match outcome {
+        EventConvOutcome::NotFound => Ok(error_response(
             StatusCode::NOT_FOUND,
             &headers,
             ErrorSpec {
@@ -215,19 +328,8 @@ pub async fn resolve_event_conversation(
                 code: "NOT_FOUND",
                 details: None,
             },
-        ));
-    };
-
-    // Check if user is creator or attendee
-    let user_profile_id: Option<Uuid> = profiles::table
-        .filter(profiles::user_id.eq(user.id))
-        .select(profiles::id)
-        .first(&mut conn)
-        .await
-        .optional()?;
-
-    let Some(user_profile_id) = user_profile_id else {
-        return Ok(error_response(
+        )),
+        EventConvOutcome::NoProfile => Ok(error_response(
             StatusCode::FORBIDDEN,
             &headers,
             ErrorSpec {
@@ -235,21 +337,8 @@ pub async fn resolve_event_conversation(
                 code: "FORBIDDEN",
                 details: None,
             },
-        ));
-    };
-
-    let is_creator = creator_profile_id == user_profile_id;
-    let is_attendee: bool = event_attendees::table
-        .filter(event_attendees::event_id.eq(event_id))
-        .filter(event_attendees::profile_id.eq(user_profile_id))
-        .filter(event_attendees::status.eq("going"))
-        .count()
-        .get_result::<i64>(&mut conn)
-        .await?
-        > 0;
-
-    if !is_creator && !is_attendee {
-        return Ok(error_response(
+        )),
+        EventConvOutcome::Forbidden => Ok(error_response(
             StatusCode::FORBIDDEN,
             &headers,
             ErrorSpec {
@@ -257,43 +346,17 @@ pub async fn resolve_event_conversation(
                 code: "FORBIDDEN",
                 details: None,
             },
-        ));
+        )),
+        EventConvOutcome::Ok(conv_id) => Ok((
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "data": {
+                    "conversationId": conv_id.to_string(),
+                }
+            })),
+        )
+            .into_response()),
     }
-
-    // Resolve creator's user_id from their profile_id
-    let creator_user_id: i32 = profiles::table
-        .filter(profiles::id.eq(creator_profile_id))
-        .select(profiles::user_id)
-        .first(&mut conn)
-        .await?;
-
-    let conversation = conversations::resolve_or_create_event_conversation(
-        event_id,
-        &event_title,
-        creator_user_id,
-    )
-    .await?;
-
-    // Ensure requesting user is a member
-    diesel::insert_into(conversation_members::table)
-        .values(&NewConversationMember {
-            conversation_id: conversation.id,
-            user_id: user.id,
-            joined_at: chrono::Utc::now(),
-        })
-        .on_conflict_do_nothing()
-        .execute(&mut conn)
-        .await?;
-
-    Ok((
-        StatusCode::OK,
-        Json(serde_json::json!({
-            "data": {
-                "conversationId": conversation.id.to_string(),
-            }
-        })),
-    )
-        .into_response())
 }
 
 // ---------------------------------------------------------------------------
@@ -349,24 +412,37 @@ pub async fn push_register(
         ));
     }
 
-    let mut conn = crate::db::conn().await?;
-    let now = chrono::Utc::now();
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+    let device_id = body.device_id.clone();
+    let ntfy_topic = body.ntfy_topic.clone();
 
-    diesel::insert_into(push_subscriptions::table)
-        .values(
-            &crate::db::models::push_subscriptions::NewPushSubscription {
-                id: uuid::Uuid::new_v4(),
-                user_id: user.id,
-                device_id: body.device_id.clone(),
-                ntfy_topic: body.ntfy_topic.clone(),
-                created_at: now,
-            },
-        )
-        .on_conflict((push_subscriptions::user_id, push_subscriptions::device_id))
-        .do_update()
-        .set(push_subscriptions::ntfy_topic.eq(&body.ntfy_topic))
-        .execute(&mut conn)
-        .await?;
+    db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let now = chrono::Utc::now();
+            diesel::insert_into(push_subscriptions::table)
+                .values(
+                    &crate::db::models::push_subscriptions::NewPushSubscription {
+                        id: uuid::Uuid::new_v4(),
+                        user_id,
+                        device_id: device_id.clone(),
+                        ntfy_topic: ntfy_topic.clone(),
+                        created_at: now,
+                    },
+                )
+                .on_conflict((push_subscriptions::user_id, push_subscriptions::device_id))
+                .do_update()
+                .set(push_subscriptions::ntfy_topic.eq(&ntfy_topic))
+                .execute(conn)
+                .await?;
+            Ok::<(), diesel::result::Error>(())
+        }
+        .scope_boxed()
+    })
+    .await?;
 
     Ok((StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response())
 }
@@ -388,13 +464,26 @@ pub async fn push_unregister(
 
     let (_session, user) = auth_or_respond!(headers);
 
-    let mut conn = crate::db::conn().await?;
-    diesel::delete(
-        push_subscriptions::table
-            .filter(push_subscriptions::user_id.eq(user.id))
-            .filter(push_subscriptions::device_id.eq(&body.device_id)),
-    )
-    .execute(&mut conn)
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+    let device_id = body.device_id.clone();
+
+    db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            diesel::delete(
+                push_subscriptions::table
+                    .filter(push_subscriptions::user_id.eq(user_id))
+                    .filter(push_subscriptions::device_id.eq(&device_id)),
+            )
+            .execute(conn)
+            .await?;
+            Ok::<(), diesel::result::Error>(())
+        }
+        .scope_boxed()
+    })
     .await?;
 
     Ok((StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response())

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -120,10 +120,6 @@ pub async fn resolve_dm(
     headers: HeaderMap,
     Json(body): Json<DmRequest>,
 ) -> Result<Response> {
-    use crate::db::schema::users;
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
-
     let (_session, user) = auth_or_respond!(headers);
 
     let target_pid = match parse_uuid_response(&body.user_id, "user", &headers) {
@@ -140,12 +136,9 @@ pub async fn resolve_dm(
     let outcome: std::result::Result<Option<Uuid>, &'static str> =
         db::with_viewer_tx(viewer, move |conn| {
             async move {
-                let target_user_id: Option<i32> = users::table
-                    .filter(users::pid.eq(target_pid))
-                    .select(users::id)
-                    .first(conn)
+                // Narrow public projection: pid → int id, no full users row read.
+                let target_user_id: Option<i32> = db::user_id_for_pid(conn, target_pid)
                     .await
-                    .optional()
                     .map_err(|_| diesel::result::Error::RollbackTransaction)?;
 
                 let Some(target_user_id) = target_user_id else {

--- a/backend/src/api/chat/push.rs
+++ b/backend/src/api/chat/push.rs
@@ -1,10 +1,6 @@
-use diesel::prelude::*;
-use diesel_async::scoped_futures::ScopedFutureExt;
-use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
 use crate::db;
-use crate::db::schema::push_subscriptions;
 
 const ALLOWED_NTFY_HOSTS: &[&str] = &["ntfy.poziomki.app"];
 const DEFAULT_NTFY_SERVER: &str = "https://ntfy.poziomki.app";
@@ -107,23 +103,12 @@ async fn resolve_ntfy_topics(
 
     let ntfy_server = resolved_ntfy_server();
 
-    // Push delivery runs after a message/event commit, decoupled from the
-    // originating viewer transaction. Use an anon tx — the only column read
-    // is `ntfy_topic`, which is not sensitive (it's the destination the user
-    // registered with us). Once push_subscriptions ships Tier-A RLS this
-    // will move to a narrow SECURITY DEFINER helper.
-    let owned_ids = user_ids.to_vec();
-    let topics: Vec<String> = db::with_anon_tx(move |conn| {
-        async move {
-            push_subscriptions::table
-                .filter(push_subscriptions::user_id.eq_any(&owned_ids))
-                .select(push_subscriptions::ntfy_topic)
-                .load(conn)
-                .await
-        }
-        .scope_boxed()
-    })
-    .await?;
+    // Narrow SECURITY DEFINER helper: returns only `ntfy_topic` rows for
+    // the given user ids. Server-side delivery only — the API role does
+    // not hold broad SELECT on push_subscriptions, and an anon policy
+    // isn't needed to enumerate topics for arbitrary users.
+    let mut conn = crate::db::conn().await?;
+    let topics = db::push_topics_for_users(&mut conn, user_ids).await?;
 
     Ok(topics
         .into_iter()

--- a/backend/src/api/chat/push.rs
+++ b/backend/src/api/chat/push.rs
@@ -1,7 +1,9 @@
 use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
+use crate::db;
 use crate::db::schema::push_subscriptions;
 
 const ALLOWED_NTFY_HOSTS: &[&str] = &["ntfy.poziomki.app"];
@@ -105,12 +107,23 @@ async fn resolve_ntfy_topics(
 
     let ntfy_server = resolved_ntfy_server();
 
-    let mut conn = crate::db::conn().await?;
-    let topics: Vec<String> = push_subscriptions::table
-        .filter(push_subscriptions::user_id.eq_any(user_ids))
-        .select(push_subscriptions::ntfy_topic)
-        .load(&mut conn)
-        .await?;
+    // Push delivery runs after a message/event commit, decoupled from the
+    // originating viewer transaction. Use an anon tx — the only column read
+    // is `ntfy_topic`, which is not sensitive (it's the destination the user
+    // registered with us). Once push_subscriptions ships Tier-A RLS this
+    // will move to a narrow SECURITY DEFINER helper.
+    let owned_ids = user_ids.to_vec();
+    let topics: Vec<String> = db::with_anon_tx(move |conn| {
+        async move {
+            push_subscriptions::table
+                .filter(push_subscriptions::user_id.eq_any(&owned_ids))
+                .select(push_subscriptions::ntfy_topic)
+                .load(conn)
+                .await
+        }
+        .scope_boxed()
+    })
+    .await?;
 
     Ok(topics
         .into_iter()

--- a/backend/src/api/chat/report_handler.rs
+++ b/backend/src/api/chat/report_handler.rs
@@ -5,15 +5,17 @@ use axum::{
     Json,
 };
 use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::RunQueryDsl;
 use serde::Deserialize;
 
 use crate::api::common::{auth_or_respond, error_response, parse_uuid_response, ErrorSpec};
 use crate::api::state::SuccessResponse;
 use crate::app::AppContext;
+use crate::db;
 use crate::db::schema::profiles;
 
-use super::report_repo;
+use super::{conversations, report_repo};
 
 type Result<T> = crate::error::AppResult<T>;
 
@@ -35,6 +37,14 @@ pub struct ReportConversationBody {
     pub description: Option<String>,
 }
 
+enum ReportOutcome {
+    NoProfile,
+    NotMember,
+    ConversationMissing,
+    Duplicate,
+    Inserted,
+}
+
 pub(in crate::api) async fn conversation_report(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
@@ -48,41 +58,7 @@ pub(in crate::api) async fn conversation_report(
         Err(response) => return Ok(*response),
     };
 
-    // Resolve reporter's profile id
-    let mut conn = crate::db::conn().await?;
-
-    let reporter_profile_id: Option<uuid::Uuid> = profiles::table
-        .filter(profiles::user_id.eq(user.id))
-        .select(profiles::id)
-        .first(&mut conn)
-        .await
-        .optional()?;
-
-    let Some(reporter_profile_id) = reporter_profile_id else {
-        return Ok(error_response(
-            StatusCode::FORBIDDEN,
-            &headers,
-            ErrorSpec {
-                error: "Profile required".to_string(),
-                code: "FORBIDDEN",
-                details: None,
-            },
-        ));
-    };
-
-    // Verify reporter is a member
-    if !super::conversations::is_member(conversation_id, user.id).await? {
-        return Ok(error_response(
-            StatusCode::FORBIDDEN,
-            &headers,
-            ErrorSpec {
-                error: "Musisz być członkiem tej rozmowy".to_string(),
-                code: "FORBIDDEN",
-                details: None,
-            },
-        ));
-    }
-
+    // Validate input before touching the DB.
     let reason = body.reason.trim().to_lowercase();
     if !VALID_REASONS.contains(&reason.as_str()) {
         return Ok(error_response(
@@ -117,15 +93,67 @@ pub(in crate::api) async fn conversation_report(
         }
     }
 
-    let Some(inserted) = report_repo::insert_conversation_report(
-        reporter_profile_id,
-        conversation_id,
-        reason,
-        description,
-    )
-    .await?
-    else {
-        return Ok(error_response(
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let reporter_profile_id: Option<uuid::Uuid> = profiles::table
+                .filter(profiles::user_id.eq(user_id))
+                .select(profiles::id)
+                .first(conn)
+                .await
+                .optional()
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+
+            let Some(reporter_profile_id) = reporter_profile_id else {
+                return Ok::<_, diesel::result::Error>(ReportOutcome::NoProfile);
+            };
+
+            if !conversations::is_member(conn, conversation_id, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            {
+                return Ok(ReportOutcome::NotMember);
+            }
+
+            match report_repo::insert_conversation_report(
+                conn,
+                reporter_profile_id,
+                conversation_id,
+                reason,
+                description,
+            )
+            .await
+            .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            {
+                None => Ok(ReportOutcome::ConversationMissing),
+                Some(false) => Ok(ReportOutcome::Duplicate),
+                Some(true) => Ok(ReportOutcome::Inserted),
+            }
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    match outcome {
+        ReportOutcome::NoProfile | ReportOutcome::NotMember => Ok(error_response(
+            StatusCode::FORBIDDEN,
+            &headers,
+            ErrorSpec {
+                error: if matches!(outcome, ReportOutcome::NoProfile) {
+                    "Profile required".to_string()
+                } else {
+                    "Musisz być członkiem tej rozmowy".to_string()
+                },
+                code: "FORBIDDEN",
+                details: None,
+            },
+        )),
+        ReportOutcome::ConversationMissing => Ok(error_response(
             StatusCode::NOT_FOUND,
             &headers,
             ErrorSpec {
@@ -133,11 +161,8 @@ pub(in crate::api) async fn conversation_report(
                 code: "NOT_FOUND",
                 details: None,
             },
-        ));
-    };
-
-    if !inserted {
-        return Ok(error_response(
+        )),
+        ReportOutcome::Duplicate => Ok(error_response(
             StatusCode::BAD_REQUEST,
             &headers,
             ErrorSpec {
@@ -145,8 +170,7 @@ pub(in crate::api) async fn conversation_report(
                 code: "VALIDATION_ERROR",
                 details: None,
             },
-        ));
+        )),
+        ReportOutcome::Inserted => Ok(Json(SuccessResponse { success: true }).into_response()),
     }
-
-    Ok(Json(SuccessResponse { success: true }).into_response())
 }

--- a/backend/src/api/chat/report_repo.rs
+++ b/backend/src/api/chat/report_repo.rs
@@ -1,56 +1,47 @@
 use diesel::prelude::*;
 use diesel::OptionalExtension;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::reports::NewReport;
 use crate::db::schema::{conversations, reports};
 
-/// Insert a conversation report inside a transaction that first checks the conversation exists.
-/// Returns `None` if the conversation doesn't exist, `Some(true)` if inserted,
-/// `Some(false)` if a duplicate already exists.
+/// Insert a conversation report. Caller must supply a connection that is
+/// already inside a transaction (wrap via `db::with_viewer_tx`).
+///
+/// Returns `None` if the conversation doesn't exist, `Some(true)` if the
+/// report was inserted, and `Some(false)` if a duplicate already exists.
 pub(in crate::api) async fn insert_conversation_report(
+    conn: &mut AsyncPgConnection,
     reporter_id: Uuid,
     conversation_id: Uuid,
     reason: String,
     description: Option<String>,
 ) -> std::result::Result<Option<bool>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
+    let exists = conversations::table
+        .find(conversation_id)
+        .select(conversations::id)
+        .first::<Uuid>(conn)
+        .await
+        .optional()?;
 
-    let result = conn
-        .build_transaction()
-        .read_committed()
-        .run(|conn| {
-            Box::pin(async move {
-                let exists = conversations::table
-                    .find(conversation_id)
-                    .select(conversations::id)
-                    .first::<Uuid>(conn)
-                    .await
-                    .optional()?;
+    if exists.is_none() {
+        return Ok(None);
+    }
 
-                if exists.is_none() {
-                    return Ok::<_, diesel::result::Error>(None);
-                }
+    let new = NewReport {
+        reporter_id,
+        target_type: "conversation".to_string(),
+        target_id: conversation_id,
+        reason,
+        description,
+    };
 
-                let new = NewReport {
-                    reporter_id,
-                    target_type: "conversation".to_string(),
-                    target_id: conversation_id,
-                    reason,
-                    description,
-                };
-
-                let rows = diesel::insert_into(reports::table)
-                    .values(&new)
-                    .on_conflict_do_nothing()
-                    .execute(conn)
-                    .await?;
-
-                Ok(Some(rows > 0))
-            })
-        })
+    let rows = diesel::insert_into(reports::table)
+        .values(&new)
+        .on_conflict_do_nothing()
+        .execute(conn)
         .await?;
 
-    Ok(result)
+    Ok(Some(rows > 0))
 }

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -378,7 +378,7 @@ struct SendOutcome {
     created: bool,
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::items_after_statements)]
 async fn handle_send(
     viewer: SocketViewer,
     conversation_id: uuid::Uuid,
@@ -425,8 +425,14 @@ async fn handle_send(
     let kind_owned = kind.to_string();
     let client_id_for_tx = client_id.clone();
 
+    enum SendFailure {
+        NotMember,
+        Blocked,
+        Failed(String),
+    }
+
     let result: std::result::Result<
-        std::result::Result<SendOutcome, &'static str>,
+        std::result::Result<SendOutcome, SendFailure>,
         diesel::result::Error,
     > = db::with_viewer_tx(viewer.into(), move |conn| {
         async move {
@@ -434,8 +440,8 @@ async fn handle_send(
                 .await
                 .map_err(into_diesel)?
             {
-                return Ok::<std::result::Result<SendOutcome, &'static str>, diesel::result::Error>(
-                    Err("not_member"),
+                return Ok::<std::result::Result<SendOutcome, SendFailure>, diesel::result::Error>(
+                    Err(SendFailure::NotMember),
                 );
             }
 
@@ -443,10 +449,13 @@ async fn handle_send(
                 .await
                 .map_err(into_diesel)?
             {
-                return Ok(Err("blocked"));
+                return Ok(Err(SendFailure::Blocked));
             }
 
-            let (_msg, payload, created) = chat_messages::create_message(
+            // create_message surfaces semantic errors ("reply_to does not
+            // belong", dedup race recoveries); capture so the client sees
+            // the actual message.
+            let (_msg, payload, created) = match chat_messages::create_message(
                 conn,
                 conversation_id,
                 user_id,
@@ -456,7 +465,10 @@ async fn handle_send(
                 client_id_for_tx,
             )
             .await
-            .map_err(into_diesel)?;
+            {
+                Ok(v) => v,
+                Err(e) => return Ok(Err(SendFailure::Failed(e.to_string()))),
+            };
 
             let members = if created {
                 conversations::member_user_ids(conn, conversation_id)
@@ -506,17 +518,21 @@ async fn handle_send(
                 let _ = outbound_tx.send(server_msg);
             }
         }
-        Ok(Err("not_member")) => {
+        Ok(Err(SendFailure::NotMember)) => {
             let _ = outbound_tx.send(ServerMessage::Error {
                 message: "not a member of this conversation".to_string(),
             });
         }
-        Ok(Err("blocked")) => {
+        Ok(Err(SendFailure::Blocked)) => {
             let _ = outbound_tx.send(ServerMessage::Error {
                 message: "blocked".to_string(),
             });
         }
-        Ok(Err(_)) => {}
+        Ok(Err(SendFailure::Failed(msg))) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: format!("send failed: {msg}"),
+            });
+        }
         Err(e) => {
             let _ = outbound_tx.send(ServerMessage::Error {
                 message: format!("send failed: {e}"),
@@ -559,6 +575,7 @@ async fn handle_edit(
         },
         NotMember,
         NotFound,
+        Failed(String),
     }
 
     let result: std::result::Result<Outcome, diesel::result::Error> =
@@ -576,9 +593,15 @@ async fn handle_edit(
                 {
                     return Ok(Outcome::NotMember);
                 }
-                let msg = chat_messages::edit_message(conn, message_id, user_id, &body_owned)
+                // edit_message can fail with semantic errors ("message not
+                // found or not editable", body validation); capture those as
+                // Failed so the client sees the actual message.
+                let msg = match chat_messages::edit_message(conn, message_id, user_id, &body_owned)
                     .await
-                    .map_err(into_diesel)?;
+                {
+                    Ok(m) => m,
+                    Err(e) => return Ok(Outcome::Failed(e.to_string())),
+                };
                 let members = conversations::member_user_ids(conn, msg.conversation_id)
                     .await
                     .map_err(into_diesel)?;
@@ -620,6 +643,11 @@ async fn handle_edit(
                 message: "message not found".into(),
             });
         }
+        Ok(Outcome::Failed(msg)) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: format!("edit failed: {msg}"),
+            });
+        }
         Err(e) => {
             let _ = outbound_tx.send(ServerMessage::Error {
                 message: format!("edit failed: {e}"),
@@ -645,6 +673,7 @@ async fn handle_delete(
         },
         NotMember,
         NotFound,
+        Failed(String),
     }
 
     let result: std::result::Result<Outcome, diesel::result::Error> =
@@ -662,9 +691,12 @@ async fn handle_delete(
                 {
                     return Ok(Outcome::NotMember);
                 }
-                let msg = chat_messages::delete_message(conn, message_id, user_id)
-                    .await
-                    .map_err(into_diesel)?;
+                // delete_message surfaces "message not found or already
+                // deleted" — capture so the client sees the real message.
+                let msg = match chat_messages::delete_message(conn, message_id, user_id).await {
+                    Ok(m) => m,
+                    Err(e) => return Ok(Outcome::Failed(e.to_string())),
+                };
                 let members = conversations::member_user_ids(conn, msg.conversation_id)
                     .await
                     .map_err(into_diesel)?;
@@ -700,6 +732,11 @@ async fn handle_delete(
                 message: "message not found".into(),
             });
         }
+        Ok(Outcome::Failed(msg)) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: format!("delete failed: {msg}"),
+            });
+        }
         Err(e) => {
             let _ = outbound_tx.send(ServerMessage::Error {
                 message: format!("delete failed: {e}"),
@@ -732,6 +769,7 @@ async fn handle_react(
         Reacted(ReactRow),
         NotMember,
         NotFound,
+        Failed(String),
     }
 
     let result: std::result::Result<Outcome, diesel::result::Error> =
@@ -750,9 +788,12 @@ async fn handle_react(
                     return Ok(Outcome::NotMember);
                 }
                 let (added, msg) =
-                    chat_messages::toggle_reaction(conn, message_id, user_id, &emoji_owned)
+                    match chat_messages::toggle_reaction(conn, message_id, user_id, &emoji_owned)
                         .await
-                        .map_err(into_diesel)?;
+                    {
+                        Ok(v) => v,
+                        Err(e) => return Ok(Outcome::Failed(e.to_string())),
+                    };
                 let members = conversations::member_user_ids(conn, msg.conversation_id)
                     .await
                     .map_err(into_diesel)?;
@@ -791,6 +832,11 @@ async fn handle_react(
         Ok(Outcome::NotFound) => {
             let _ = outbound_tx.send(ServerMessage::Error {
                 message: "message not found".into(),
+            });
+        }
+        Ok(Outcome::Failed(msg)) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: format!("react failed: {msg}"),
             });
         }
         Err(e) => {
@@ -917,6 +963,7 @@ async fn handle_history(
             has_more: bool,
         },
         NotMember,
+        Failed(String),
     }
 
     let result: std::result::Result<Outcome, diesel::result::Error> =
@@ -928,10 +975,20 @@ async fn handle_history(
                 {
                     return Ok::<Outcome, diesel::result::Error>(Outcome::NotMember);
                 }
-                let (messages, has_more) =
-                    chat_messages::load_history(conn, conversation_id, before, limit, user_id)
-                        .await
-                        .map_err(into_diesel)?;
+                // load_history can surface semantic errors (invalid cursor,
+                // etc.); capture so the client sees the actual message.
+                let (messages, has_more) = match chat_messages::load_history(
+                    conn,
+                    conversation_id,
+                    before,
+                    limit,
+                    user_id,
+                )
+                .await
+                {
+                    Ok(v) => v,
+                    Err(e) => return Ok(Outcome::Failed(e.to_string())),
+                };
                 Ok(Outcome::Ok { messages, has_more })
             }
             .scope_boxed()
@@ -949,6 +1006,11 @@ async fn handle_history(
         Ok(Outcome::NotMember) => {
             let _ = outbound_tx.send(ServerMessage::Error {
                 message: "not a member of this conversation".to_string(),
+            });
+        }
+        Ok(Outcome::Failed(msg)) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: format!("history failed: {msg}"),
             });
         }
         Err(e) => {

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -174,12 +174,22 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
     hub.unregister(user_id);
 }
 
-/// Wrap an `AppError` into a `diesel::result::Error` that preserves the
-/// original message through the transaction boundary. The outer handler
-/// `format!("{e}")`s it, so semantic errors like "message not found or not
-/// editable" surface to the client instead of a generic `RollbackTransaction`.
+/// Convert an `AppError` from a library helper into a `diesel::result::Error`
+/// that rolls back the transaction.
+///
+/// `AppError::Any` carries diesel / Postgres / pool errors — those collapse
+/// to an opaque `RollbackTransaction` so raw database error text (column
+/// names, constraint names, etc.) never leaks over the WebSocket. The
+/// `Message` / `Validation` variants are intentional, application-level
+/// strings and are safe to surface to clients, so they flow through
+/// `QueryBuilderError` and render via `format!("{e}")` at the outer match.
 fn into_diesel(e: crate::error::AppError) -> diesel::result::Error {
-    diesel::result::Error::QueryBuilderError(Box::new(e))
+    match e {
+        crate::error::AppError::Message(_) | crate::error::AppError::Validation(_) => {
+            diesel::result::Error::QueryBuilderError(Box::new(e))
+        }
+        crate::error::AppError::Any(_) => diesel::result::Error::RollbackTransaction,
+    }
 }
 
 /// Authenticate the first message. Returns a `SocketViewer` + user pid, or
@@ -428,7 +438,6 @@ async fn handle_send(
     enum SendFailure {
         NotMember,
         Blocked,
-        Failed(String),
     }
 
     let result: std::result::Result<
@@ -452,10 +461,14 @@ async fn handle_send(
                 return Ok(Err(SendFailure::Blocked));
             }
 
-            // create_message surfaces semantic errors ("reply_to does not
-            // belong", dedup race recoveries); capture so the client sees
-            // the actual message.
-            let (_msg, payload, created) = match chat_messages::create_message(
+            // create_message does INSERT-then-payload-construction. If
+            // payload construction fails post-INSERT, we MUST roll back,
+            // otherwise the row sits committed without a broadcast. Route
+            // any error through `?` + into_diesel so that happens — the
+            // cost is that pre-write semantic errors (e.g. "reply_to does
+            // not belong") also roll back (harmless) and render via the
+            // `Message`/`Validation` preservation in into_diesel.
+            let (_msg, payload, created) = chat_messages::create_message(
                 conn,
                 conversation_id,
                 user_id,
@@ -465,10 +478,7 @@ async fn handle_send(
                 client_id_for_tx,
             )
             .await
-            {
-                Ok(v) => v,
-                Err(e) => return Ok(Err(SendFailure::Failed(e.to_string()))),
-            };
+            .map_err(into_diesel)?;
 
             let members = if created {
                 conversations::member_user_ids(conn, conversation_id)
@@ -526,11 +536,6 @@ async fn handle_send(
         Ok(Err(SendFailure::Blocked)) => {
             let _ = outbound_tx.send(ServerMessage::Error {
                 message: "blocked".to_string(),
-            });
-        }
-        Ok(Err(SendFailure::Failed(msg))) => {
-            let _ = outbound_tx.send(ServerMessage::Error {
-                message: format!("send failed: {msg}"),
             });
         }
         Err(e) => {
@@ -593,14 +598,19 @@ async fn handle_edit(
                 {
                     return Ok(Outcome::NotMember);
                 }
-                // edit_message can fail with semantic errors ("message not
-                // found or not editable", body validation); capture those as
-                // Failed so the client sees the actual message.
+                // edit_message returns AppError::Message for semantic
+                // failures ("not editable", body validation) and
+                // AppError::Any for DB errors. Surface the semantic text
+                // via Outcome::Failed; let DB errors roll back + render
+                // generically via into_diesel.
                 let msg = match chat_messages::edit_message(conn, message_id, user_id, &body_owned)
                     .await
                 {
                     Ok(m) => m,
-                    Err(e) => return Ok(Outcome::Failed(e.to_string())),
+                    Err(
+                        crate::error::AppError::Message(m) | crate::error::AppError::Validation(m),
+                    ) => return Ok(Outcome::Failed(m)),
+                    Err(e) => return Err(into_diesel(e)),
                 };
                 let members = conversations::member_user_ids(conn, msg.conversation_id)
                     .await
@@ -691,11 +701,14 @@ async fn handle_delete(
                 {
                     return Ok(Outcome::NotMember);
                 }
-                // delete_message surfaces "message not found or already
-                // deleted" — capture so the client sees the real message.
+                // "message not found or already deleted" is AppError::Message;
+                // DB failures are AppError::Any and get rolled back + generic.
                 let msg = match chat_messages::delete_message(conn, message_id, user_id).await {
                     Ok(m) => m,
-                    Err(e) => return Ok(Outcome::Failed(e.to_string())),
+                    Err(
+                        crate::error::AppError::Message(m) | crate::error::AppError::Validation(m),
+                    ) => return Ok(Outcome::Failed(m)),
+                    Err(e) => return Err(into_diesel(e)),
                 };
                 let members = conversations::member_user_ids(conn, msg.conversation_id)
                     .await
@@ -792,7 +805,11 @@ async fn handle_react(
                         .await
                     {
                         Ok(v) => v,
-                        Err(e) => return Ok(Outcome::Failed(e.to_string())),
+                        Err(
+                            crate::error::AppError::Message(m)
+                            | crate::error::AppError::Validation(m),
+                        ) => return Ok(Outcome::Failed(m)),
+                        Err(e) => return Err(into_diesel(e)),
                     };
                 let members = conversations::member_user_ids(conn, msg.conversation_id)
                     .await
@@ -975,8 +992,9 @@ async fn handle_history(
                 {
                     return Ok::<Outcome, diesel::result::Error>(Outcome::NotMember);
                 }
-                // load_history can surface semantic errors (invalid cursor,
-                // etc.); capture so the client sees the actual message.
+                // Semantic errors from load_history surface through
+                // Outcome::Failed; internal DB errors get a rollback +
+                // generic message.
                 let (messages, has_more) = match chat_messages::load_history(
                     conn,
                     conversation_id,
@@ -987,7 +1005,10 @@ async fn handle_history(
                 .await
                 {
                     Ok(v) => v,
-                    Err(e) => return Ok(Outcome::Failed(e.to_string())),
+                    Err(
+                        crate::error::AppError::Message(m) | crate::error::AppError::Validation(m),
+                    ) => return Ok(Outcome::Failed(m)),
+                    Err(e) => return Err(into_diesel(e)),
                 };
                 Ok(Outcome::Ok { messages, has_more })
             }

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -174,8 +174,12 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
     hub.unregister(user_id);
 }
 
-fn into_diesel(_: crate::error::AppError) -> diesel::result::Error {
-    diesel::result::Error::RollbackTransaction
+/// Wrap an `AppError` into a `diesel::result::Error` that preserves the
+/// original message through the transaction boundary. The outer handler
+/// `format!("{e}")`s it, so semantic errors like "message not found or not
+/// editable" surface to the client instead of a generic `RollbackTransaction`.
+fn into_diesel(e: crate::error::AppError) -> diesel::result::Error {
+    diesel::result::Error::QueryBuilderError(Box::new(e))
 }
 
 /// Authenticate the first message. Returns a `SocketViewer` + user pid, or

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -48,6 +48,7 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
         return;
     };
     let user_id = viewer.user_id;
+    let viewer_is_stub = viewer.is_review_stub;
 
     // --- Step 2: Register in hub ---
     let mut hub_rx = hub.register(user_id);
@@ -61,7 +62,7 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
     // Send initial conversation list
     let conv_list = db::with_viewer_tx(viewer.into(), move |conn| {
         async move {
-            conversations::list_for_user(conn, user_id)
+            conversations::list_for_user(conn, user_id, viewer_is_stub)
                 .await
                 .map_err(into_diesel)
         }
@@ -345,9 +346,10 @@ async fn handle_client_message(
         }
         ClientMessage::ListConversations => {
             let user_id = viewer.user_id;
+            let viewer_is_stub = viewer.is_review_stub;
             let conv_list = db::with_viewer_tx(viewer.into(), move |conn| {
                 async move {
-                    conversations::list_for_user(conn, user_id)
+                    conversations::list_for_user(conn, user_id, viewer_is_stub)
                         .await
                         .map_err(into_diesel)
                 }
@@ -799,11 +801,11 @@ async fn resolve_sender_for_reaction(
     conn: &mut AsyncPgConnection,
     user_id: i32,
 ) -> (String, Option<String>) {
-    use crate::db::schema::{profiles, users};
+    use crate::db::schema::profiles;
 
+    // Filter on profiles.user_id directly — no users join needed.
     let Ok((name, avatar)) = profiles::table
-        .inner_join(users::table.on(users::id.eq(profiles::user_id)))
-        .filter(users::id.eq(user_id))
+        .filter(profiles::user_id.eq(user_id))
         .select((profiles::name, profiles::profile_picture))
         .first::<(String, Option<String>)>(conn)
         .await

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -1,6 +1,7 @@
 use axum::extract::ws::{Message, WebSocket};
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
 
@@ -9,6 +10,7 @@ use super::hub::ChatHub;
 use super::messages as chat_messages;
 use super::protocol::{ClientMessage, ServerMessage};
 use crate::api::state::hash_session_token;
+use crate::db;
 use crate::db::schema::{conversations as conversations_table, profile_blocks, profiles};
 
 const AUTH_TIMEOUT_SECS: u64 = 5;
@@ -21,14 +23,31 @@ const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3
 /// Close the socket if no frame (including pong) arrives within this window.
 const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
 
+/// Authenticated-viewer state carried through the socket lifetime.
+#[derive(Clone, Copy)]
+struct SocketViewer {
+    user_id: i32,
+    is_review_stub: bool,
+}
+
+impl From<SocketViewer> for db::DbViewer {
+    fn from(v: SocketViewer) -> Self {
+        Self {
+            user_id: v.user_id,
+            is_review_stub: v.is_review_stub,
+        }
+    }
+}
+
 /// Handle a WebSocket connection after Axum upgrade.
 pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
     let (mut ws_tx, mut ws_rx) = socket.split();
 
     // --- Step 1: Authenticate ---
-    let Some((user_id, _user_pid)) = authenticate(&mut ws_tx, &mut ws_rx).await else {
+    let Some((viewer, _user_pid)) = authenticate(&mut ws_tx, &mut ws_rx).await else {
         return;
     };
+    let user_id = viewer.user_id;
 
     // --- Step 2: Register in hub ---
     let mut hub_rx = hub.register(user_id);
@@ -40,9 +59,16 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
     let (ping_tx, mut ping_rx) = mpsc::unbounded_channel::<()>();
 
     // Send initial conversation list
-    let conv_list = conversations::list_for_user(user_id)
-        .await
-        .unwrap_or_default();
+    let conv_list = db::with_viewer_tx(viewer.into(), move |conn| {
+        async move {
+            conversations::list_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)
+        }
+        .scope_boxed()
+    })
+    .await
+    .unwrap_or_default();
     let init_msg = ServerMessage::Conversations {
         conversations: conv_list,
     };
@@ -112,7 +138,7 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
                                         continue;
                                     }
                                 }
-                                handle_client_message(client_msg, user_id, &hub, &outbound_tx).await;
+                                handle_client_message(client_msg, viewer, &hub, &outbound_tx).await;
                             }
                             Err(e) => {
                                 let _ = outbound_tx.send(ServerMessage::Error {
@@ -147,15 +173,17 @@ pub async fn handle_socket(socket: WebSocket, hub: ChatHub) {
     hub.unregister(user_id);
 }
 
-/// Authenticate the first message. Returns (`user_id`, `user_pid`) or None on failure.
+fn into_diesel(_: crate::error::AppError) -> diesel::result::Error {
+    diesel::result::Error::RollbackTransaction
+}
+
+/// Authenticate the first message. Returns a `SocketViewer` + user pid, or
+/// None on failure. Routes through `app.resolve_session` so it works once
+/// Tier-A RLS lands on the sessions table.
 async fn authenticate(
     ws_tx: &mut futures_util::stream::SplitSink<WebSocket, Message>,
     ws_rx: &mut futures_util::stream::SplitStream<WebSocket>,
-) -> Option<(i32, uuid::Uuid)> {
-    use crate::db::schema::{sessions, users};
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
-
+) -> Option<(SocketViewer, uuid::Uuid)> {
     let timeout = tokio::time::timeout(
         std::time::Duration::from_secs(AUTH_TIMEOUT_SECS),
         ws_rx.next(),
@@ -186,7 +214,6 @@ async fn authenticate(
         return None;
     };
 
-    // Validate the bearer token using existing auth infrastructure
     let hashed = hash_session_token(&token);
 
     let Ok(mut conn) = crate::db::conn().await else {
@@ -200,17 +227,7 @@ async fn authenticate(
         return None;
     };
 
-    let row: Option<(i32, uuid::Uuid)> = if let Ok(row) = sessions::table
-        .inner_join(users::table.on(users::id.eq(sessions::user_id)))
-        .filter(sessions::token.eq(&hashed))
-        .filter(sessions::expires_at.gt(chrono::Utc::now()))
-        .select((users::id, users::pid))
-        .first::<(i32, uuid::Uuid)>(&mut conn)
-        .await
-        .optional()
-    {
-        row
-    } else {
+    let Ok(session) = db::resolve_session(&mut conn, &hashed).await else {
         tracing::warn!("WS auth failed: database query error");
         let _ = send_json(
             ws_tx,
@@ -222,17 +239,8 @@ async fn authenticate(
         return None;
     };
 
-    if let Some((uid, pid)) = row {
-        let _ = send_json(
-            ws_tx,
-            &ServerMessage::AuthOk {
-                user_id: uid.to_string(),
-            },
-        )
-        .await;
-        Some((uid, pid))
-    } else {
-        tracing::warn!("WS auth failed: invalid or expired token");
+    let Some(session) = session else {
+        tracing::warn!("WS auth failed: invalid token");
         let _ = send_json(
             ws_tx,
             &ServerMessage::AuthError {
@@ -240,14 +248,40 @@ async fn authenticate(
             },
         )
         .await;
-        None
+        return None;
+    };
+
+    if session.expires_at <= chrono::Utc::now() {
+        tracing::warn!("WS auth failed: session expired");
+        let _ = send_json(
+            ws_tx,
+            &ServerMessage::AuthError {
+                message: "invalid token".to_string(),
+            },
+        )
+        .await;
+        return None;
     }
+
+    let viewer = SocketViewer {
+        user_id: session.user_id,
+        is_review_stub: session.is_review_stub,
+    };
+
+    let _ = send_json(
+        ws_tx,
+        &ServerMessage::AuthOk {
+            user_id: viewer.user_id.to_string(),
+        },
+    )
+    .await;
+    Some((viewer, session.user_pid))
 }
 
 /// Process a single client message.
 async fn handle_client_message(
     msg: ClientMessage,
-    user_id: i32,
+    viewer: SocketViewer,
     hub: &ChatHub,
     outbound_tx: &mpsc::UnboundedSender<ServerMessage>,
 ) {
@@ -264,7 +298,7 @@ async fn handle_client_message(
             client_id,
         } => {
             handle_send(
-                user_id,
+                viewer,
                 conversation_id,
                 &body,
                 "text",
@@ -276,10 +310,10 @@ async fn handle_client_message(
             .await;
         }
         ClientMessage::Edit { message_id, body } => {
-            handle_edit(user_id, message_id, &body, hub, outbound_tx).await;
+            handle_edit(viewer, message_id, &body, hub, outbound_tx).await;
         }
         ClientMessage::Delete { message_id } => {
-            handle_delete(user_id, message_id, hub, outbound_tx).await;
+            handle_delete(viewer, message_id, hub, outbound_tx).await;
         }
         ClientMessage::React { message_id, emoji } => {
             if emoji.chars().count() > 32 {
@@ -287,32 +321,40 @@ async fn handle_client_message(
                     message: "emoji too long".to_string(),
                 });
             } else {
-                handle_react(user_id, message_id, &emoji, hub, outbound_tx).await;
+                handle_react(viewer, message_id, &emoji, hub, outbound_tx).await;
             }
         }
         ClientMessage::Read {
             conversation_id,
             message_id,
         } => {
-            handle_read(user_id, conversation_id, message_id, hub).await;
+            handle_read(viewer, conversation_id, message_id, hub).await;
         }
         ClientMessage::Typing {
             conversation_id,
             is_typing,
         } => {
-            handle_typing(user_id, conversation_id, is_typing, hub).await;
+            handle_typing(viewer, conversation_id, is_typing, hub).await;
         }
         ClientMessage::History {
             conversation_id,
             before,
             limit,
         } => {
-            handle_history(user_id, conversation_id, before, limit, outbound_tx).await;
+            handle_history(viewer, conversation_id, before, limit, outbound_tx).await;
         }
         ClientMessage::ListConversations => {
-            let conv_list = conversations::list_for_user(user_id)
-                .await
-                .unwrap_or_default();
+            let user_id = viewer.user_id;
+            let conv_list = db::with_viewer_tx(viewer.into(), move |conn| {
+                async move {
+                    conversations::list_for_user(conn, user_id)
+                        .await
+                        .map_err(into_diesel)
+                }
+                .scope_boxed()
+            })
+            .await
+            .unwrap_or_default();
             let _ = outbound_tx.send(ServerMessage::Conversations {
                 conversations: conv_list,
             });
@@ -323,9 +365,16 @@ async fn handle_client_message(
     }
 }
 
+/// Send outcome: Ok(message payload + recipient members) or an error message.
+struct SendOutcome {
+    payload: super::protocol::MessagePayload,
+    members: Vec<i32>,
+    created: bool,
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_send(
-    user_id: i32,
+    viewer: SocketViewer,
     conversation_id: uuid::Uuid,
     body: &str,
     kind: &str,
@@ -358,7 +407,6 @@ async fn handle_send(
         }
     }
 
-    // Only text messages are supported
     if kind != "text" {
         let _ = outbound_tx.send(ServerMessage::Error {
             message: "only text messages are supported".to_string(),
@@ -366,57 +414,77 @@ async fn handle_send(
         return;
     }
 
-    // Verify membership
-    if !conversations::is_member(conversation_id, user_id)
-        .await
-        .unwrap_or(false)
-    {
-        let _ = outbound_tx.send(ServerMessage::Error {
-            message: "not a member of this conversation".to_string(),
-        });
-        return;
-    }
+    let user_id = viewer.user_id;
+    let body_owned = body.to_string();
+    let kind_owned = kind.to_string();
+    let client_id_for_tx = client_id.clone();
 
-    // Block check for DM conversations
-    if matches!(is_blocked_in_dm(conversation_id, user_id).await, Ok(true)) {
-        let _ = outbound_tx.send(ServerMessage::Error {
-            message: "blocked".to_string(),
-        });
-        return;
-    }
+    let result: std::result::Result<
+        std::result::Result<SendOutcome, &'static str>,
+        diesel::result::Error,
+    > = db::with_viewer_tx(viewer.into(), move |conn| {
+        async move {
+            if !conversations::is_member(conn, conversation_id, user_id)
+                .await
+                .map_err(into_diesel)?
+            {
+                return Ok::<std::result::Result<SendOutcome, &'static str>, diesel::result::Error>(
+                    Err("not_member"),
+                );
+            }
 
-    match chat_messages::create_message(
-        conversation_id,
-        user_id,
-        body,
-        kind,
-        reply_to_id,
-        client_id,
-    )
-    .await
-    {
-        Ok((_msg, payload, created)) => {
-            let server_msg = ServerMessage::Message {
-                msg: Box::new(payload),
+            if is_blocked_in_dm(conn, conversation_id, user_id)
+                .await
+                .map_err(into_diesel)?
+            {
+                return Ok(Err("blocked"));
+            }
+
+            let (_msg, payload, created) = chat_messages::create_message(
+                conn,
+                conversation_id,
+                user_id,
+                &body_owned,
+                &kind_owned,
+                reply_to_id,
+                client_id_for_tx,
+            )
+            .await
+            .map_err(into_diesel)?;
+
+            let members = if created {
+                conversations::member_user_ids(conn, conversation_id)
+                    .await
+                    .map_err(into_diesel)?
+            } else {
+                Vec::new()
             };
 
-            if created {
+            Ok(Ok(SendOutcome {
+                payload,
+                members,
+                created,
+            }))
+        }
+        .scope_boxed()
+    })
+    .await;
+
+    match result {
+        Ok(Ok(outcome)) => {
+            let server_msg = ServerMessage::Message {
+                msg: Box::new(outcome.payload),
+            };
+            if outcome.created {
                 tracing::info!(
                     conversation_id = %conversation_id,
                     sender_id = user_id,
                     "message_sent"
                 );
+                hub.broadcast(&outcome.members, &server_msg);
 
-                let members = conversations::member_user_ids(conversation_id)
-                    .await
-                    .unwrap_or_default();
-
-                // Broadcast to all members (including sender for confirmation)
-                hub.broadcast(&members, &server_msg);
-
-                // Push to all non-sender members; client-side ActiveChat check
-                // suppresses the notification when the user is viewing this chat.
-                let push_targets: Vec<i32> = members
+                let push_targets: Vec<i32> = outcome
+                    .members
                     .iter()
                     .copied()
                     .filter(|&id| id != user_id)
@@ -429,10 +497,20 @@ async fn handle_send(
                     });
                 }
             } else {
-                // Dedup retry — confirm to sender only, no broadcast/push
                 let _ = outbound_tx.send(server_msg);
             }
         }
+        Ok(Err("not_member")) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: "not a member of this conversation".to_string(),
+            });
+        }
+        Ok(Err("blocked")) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: "blocked".to_string(),
+            });
+        }
+        Ok(Err(_)) => {}
         Err(e) => {
             let _ = outbound_tx.send(ServerMessage::Error {
                 message: format!("send failed: {e}"),
@@ -441,44 +519,9 @@ async fn handle_send(
     }
 }
 
-/// Check that a message exists and the user is a member of its conversation.
-/// Returns the conversation ID on success, or sends an error and returns None.
-async fn verify_message_membership(
-    message_id: uuid::Uuid,
-    user_id: i32,
-    outbound_tx: &mpsc::UnboundedSender<ServerMessage>,
-) -> Option<uuid::Uuid> {
-    match chat_messages::message_conversation_id(message_id).await {
-        Ok(Some(cid))
-            if conversations::is_member(cid, user_id)
-                .await
-                .unwrap_or(false) =>
-        {
-            Some(cid)
-        }
-        Ok(Some(_)) => {
-            let _ = outbound_tx.send(ServerMessage::Error {
-                message: "not a member of this conversation".into(),
-            });
-            None
-        }
-        Ok(None) => {
-            let _ = outbound_tx.send(ServerMessage::Error {
-                message: "message not found".into(),
-            });
-            None
-        }
-        Err(_) => {
-            let _ = outbound_tx.send(ServerMessage::Error {
-                message: "internal error".into(),
-            });
-            None
-        }
-    }
-}
-
+#[allow(clippy::items_after_statements)]
 async fn handle_edit(
-    user_id: i32,
+    viewer: SocketViewer,
     message_id: uuid::Uuid,
     body: &str,
     hub: &ChatHub,
@@ -497,22 +540,79 @@ async fn handle_edit(
         return;
     }
 
-    let Some(_) = verify_message_membership(message_id, user_id, outbound_tx).await else {
-        return;
-    };
+    let user_id = viewer.user_id;
+    let body_owned = body.to_string();
 
-    match chat_messages::edit_message(message_id, user_id, body).await {
-        Ok(msg) => {
-            let members = conversations::member_user_ids(msg.conversation_id)
-                .await
-                .unwrap_or_default();
+    enum Outcome {
+        Edited {
+            message_id: uuid::Uuid,
+            conversation_id: uuid::Uuid,
+            body: String,
+            edited_at: Option<chrono::DateTime<chrono::Utc>>,
+            members: Vec<i32>,
+        },
+        NotMember,
+        NotFound,
+    }
+
+    let result: std::result::Result<Outcome, diesel::result::Error> =
+        db::with_viewer_tx(viewer.into(), move |conn| {
+            async move {
+                let Some(conv_id) = chat_messages::message_conversation_id(conn, message_id)
+                    .await
+                    .map_err(into_diesel)?
+                else {
+                    return Ok::<Outcome, diesel::result::Error>(Outcome::NotFound);
+                };
+                if !conversations::is_member(conn, conv_id, user_id)
+                    .await
+                    .map_err(into_diesel)?
+                {
+                    return Ok(Outcome::NotMember);
+                }
+                let msg = chat_messages::edit_message(conn, message_id, user_id, &body_owned)
+                    .await
+                    .map_err(into_diesel)?;
+                let members = conversations::member_user_ids(conn, msg.conversation_id)
+                    .await
+                    .map_err(into_diesel)?;
+                Ok(Outcome::Edited {
+                    message_id: msg.id,
+                    conversation_id: msg.conversation_id,
+                    body: msg.body,
+                    edited_at: msg.edited_at,
+                    members,
+                })
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    match result {
+        Ok(Outcome::Edited {
+            message_id,
+            conversation_id,
+            body,
+            edited_at,
+            members,
+        }) => {
             let server_msg = ServerMessage::Edited {
-                message_id: msg.id,
-                conversation_id: msg.conversation_id,
-                body: msg.body,
-                edited_at: msg.edited_at.map_or_else(String::new, |t| t.to_rfc3339()),
+                message_id,
+                conversation_id,
+                body,
+                edited_at: edited_at.map_or_else(String::new, |t| t.to_rfc3339()),
             };
             hub.broadcast(&members, &server_msg);
+        }
+        Ok(Outcome::NotMember) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: "not a member of this conversation".into(),
+            });
+        }
+        Ok(Outcome::NotFound) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: "message not found".into(),
+            });
         }
         Err(e) => {
             let _ = outbound_tx.send(ServerMessage::Error {
@@ -522,26 +622,77 @@ async fn handle_edit(
     }
 }
 
+#[allow(clippy::items_after_statements)]
 async fn handle_delete(
-    user_id: i32,
+    viewer: SocketViewer,
     message_id: uuid::Uuid,
     hub: &ChatHub,
     outbound_tx: &mpsc::UnboundedSender<ServerMessage>,
 ) {
-    let Some(_) = verify_message_membership(message_id, user_id, outbound_tx).await else {
-        return;
-    };
+    let user_id = viewer.user_id;
 
-    match chat_messages::delete_message(message_id, user_id).await {
-        Ok(msg) => {
-            let members = conversations::member_user_ids(msg.conversation_id)
-                .await
-                .unwrap_or_default();
+    enum Outcome {
+        Deleted {
+            message_id: uuid::Uuid,
+            conversation_id: uuid::Uuid,
+            members: Vec<i32>,
+        },
+        NotMember,
+        NotFound,
+    }
+
+    let result: std::result::Result<Outcome, diesel::result::Error> =
+        db::with_viewer_tx(viewer.into(), move |conn| {
+            async move {
+                let Some(conv_id) = chat_messages::message_conversation_id(conn, message_id)
+                    .await
+                    .map_err(into_diesel)?
+                else {
+                    return Ok::<Outcome, diesel::result::Error>(Outcome::NotFound);
+                };
+                if !conversations::is_member(conn, conv_id, user_id)
+                    .await
+                    .map_err(into_diesel)?
+                {
+                    return Ok(Outcome::NotMember);
+                }
+                let msg = chat_messages::delete_message(conn, message_id, user_id)
+                    .await
+                    .map_err(into_diesel)?;
+                let members = conversations::member_user_ids(conn, msg.conversation_id)
+                    .await
+                    .map_err(into_diesel)?;
+                Ok(Outcome::Deleted {
+                    message_id: msg.id,
+                    conversation_id: msg.conversation_id,
+                    members,
+                })
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    match result {
+        Ok(Outcome::Deleted {
+            message_id,
+            conversation_id,
+            members,
+        }) => {
             let server_msg = ServerMessage::Deleted {
-                message_id: msg.id,
-                conversation_id: msg.conversation_id,
+                message_id,
+                conversation_id,
             };
             hub.broadcast(&members, &server_msg);
+        }
+        Ok(Outcome::NotMember) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: "not a member of this conversation".into(),
+            });
+        }
+        Ok(Outcome::NotFound) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: "message not found".into(),
+            });
         }
         Err(e) => {
             let _ = outbound_tx.send(ServerMessage::Error {
@@ -551,34 +702,90 @@ async fn handle_delete(
     }
 }
 
+#[allow(clippy::items_after_statements)]
 async fn handle_react(
-    user_id: i32,
+    viewer: SocketViewer,
     message_id: uuid::Uuid,
     emoji: &str,
     hub: &ChatHub,
     outbound_tx: &mpsc::UnboundedSender<ServerMessage>,
 ) {
-    let Some(_) = verify_message_membership(message_id, user_id, outbound_tx).await else {
-        return;
-    };
+    let user_id = viewer.user_id;
+    let emoji_owned = emoji.to_string();
 
-    match chat_messages::toggle_reaction(message_id, user_id, emoji).await {
-        Ok((added, msg)) => {
-            let members = conversations::member_user_ids(msg.conversation_id)
-                .await
-                .unwrap_or_default();
+    struct ReactRow {
+        message_id: uuid::Uuid,
+        conversation_id: uuid::Uuid,
+        added: bool,
+        members: Vec<i32>,
+        sender_name: String,
+        sender_avatar: Option<String>,
+    }
 
-            let (sender_name, sender_avatar) = resolve_sender_for_reaction(user_id).await;
+    enum Outcome {
+        Reacted(ReactRow),
+        NotMember,
+        NotFound,
+    }
+
+    let result: std::result::Result<Outcome, diesel::result::Error> =
+        db::with_viewer_tx(viewer.into(), move |conn| {
+            async move {
+                let Some(conv_id) = chat_messages::message_conversation_id(conn, message_id)
+                    .await
+                    .map_err(into_diesel)?
+                else {
+                    return Ok::<Outcome, diesel::result::Error>(Outcome::NotFound);
+                };
+                if !conversations::is_member(conn, conv_id, user_id)
+                    .await
+                    .map_err(into_diesel)?
+                {
+                    return Ok(Outcome::NotMember);
+                }
+                let (added, msg) =
+                    chat_messages::toggle_reaction(conn, message_id, user_id, &emoji_owned)
+                        .await
+                        .map_err(into_diesel)?;
+                let members = conversations::member_user_ids(conn, msg.conversation_id)
+                    .await
+                    .map_err(into_diesel)?;
+                let (sender_name, sender_avatar) = resolve_sender_for_reaction(conn, user_id).await;
+                Ok(Outcome::Reacted(ReactRow {
+                    message_id: msg.id,
+                    conversation_id: msg.conversation_id,
+                    added,
+                    members,
+                    sender_name,
+                    sender_avatar,
+                }))
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    match result {
+        Ok(Outcome::Reacted(r)) => {
             let server_msg = ServerMessage::Reaction {
-                message_id: msg.id,
-                conversation_id: msg.conversation_id,
+                message_id: r.message_id,
+                conversation_id: r.conversation_id,
                 emoji: emoji.to_string(),
                 user_id,
-                added,
-                sender_name,
-                sender_avatar,
+                added: r.added,
+                sender_name: r.sender_name,
+                sender_avatar: r.sender_avatar,
             };
-            hub.broadcast(&members, &server_msg);
+            hub.broadcast(&r.members, &server_msg);
+        }
+        Ok(Outcome::NotMember) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: "not a member of this conversation".into(),
+            });
+        }
+        Ok(Outcome::NotFound) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: "message not found".into(),
+            });
         }
         Err(e) => {
             let _ = outbound_tx.send(ServerMessage::Error {
@@ -588,19 +795,17 @@ async fn handle_react(
     }
 }
 
-async fn resolve_sender_for_reaction(user_id: i32) -> (String, Option<String>) {
+async fn resolve_sender_for_reaction(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+) -> (String, Option<String>) {
     use crate::db::schema::{profiles, users};
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
 
-    let Ok(mut conn) = crate::db::conn().await else {
-        return ("Unknown".into(), None);
-    };
     let Ok((name, avatar)) = profiles::table
         .inner_join(users::table.on(users::id.eq(profiles::user_id)))
         .filter(users::id.eq(user_id))
         .select((profiles::name, profiles::profile_picture))
-        .first::<(String, Option<String>)>(&mut conn)
+        .first::<(String, Option<String>)>(conn)
         .await
     else {
         return ("Unknown".into(), None);
@@ -612,25 +817,35 @@ async fn resolve_sender_for_reaction(user_id: i32) -> (String, Option<String>) {
 }
 
 async fn handle_read(
-    user_id: i32,
+    viewer: SocketViewer,
     conversation_id: uuid::Uuid,
     message_id: uuid::Uuid,
     hub: &ChatHub,
 ) {
-    if !conversations::is_member(conversation_id, user_id)
-        .await
-        .unwrap_or(false)
-    {
-        return;
-    }
+    let user_id = viewer.user_id;
 
-    if chat_messages::mark_read(conversation_id, user_id, message_id)
-        .await
-        .is_ok()
-    {
-        let members = conversations::member_user_ids(conversation_id)
-            .await
-            .unwrap_or_default();
+    let members: std::result::Result<Option<Vec<i32>>, diesel::result::Error> =
+        db::with_viewer_tx(viewer.into(), move |conn| {
+            async move {
+                if !conversations::is_member(conn, conversation_id, user_id)
+                    .await
+                    .map_err(into_diesel)?
+                {
+                    return Ok::<Option<Vec<i32>>, diesel::result::Error>(None);
+                }
+                chat_messages::mark_read(conn, conversation_id, user_id, message_id)
+                    .await
+                    .map_err(into_diesel)?;
+                let m = conversations::member_user_ids(conn, conversation_id)
+                    .await
+                    .map_err(into_diesel)?;
+                Ok(Some(m))
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    if let Ok(Some(members)) = members {
         let server_msg = ServerMessage::ReadReceipt {
             conversation_id,
             user_id,
@@ -640,54 +855,94 @@ async fn handle_read(
     }
 }
 
-async fn handle_typing(user_id: i32, conversation_id: uuid::Uuid, is_typing: bool, hub: &ChatHub) {
-    if !conversations::is_member(conversation_id, user_id)
-        .await
-        .unwrap_or(false)
-    {
-        return;
-    }
+async fn handle_typing(
+    viewer: SocketViewer,
+    conversation_id: uuid::Uuid,
+    is_typing: bool,
+    hub: &ChatHub,
+) {
+    let user_id = viewer.user_id;
 
-    let members = conversations::member_user_ids(conversation_id)
-        .await
-        .unwrap_or_default();
-    let server_msg = ServerMessage::Typing {
-        conversation_id,
-        user_id,
-        is_typing,
-    };
-    // Send to all members except the typer
-    let others: Vec<i32> = members.into_iter().filter(|id| *id != user_id).collect();
-    hub.broadcast(&others, &server_msg);
+    let members: std::result::Result<Option<Vec<i32>>, diesel::result::Error> =
+        db::with_viewer_tx(viewer.into(), move |conn| {
+            async move {
+                if !conversations::is_member(conn, conversation_id, user_id)
+                    .await
+                    .map_err(into_diesel)?
+                {
+                    return Ok::<Option<Vec<i32>>, diesel::result::Error>(None);
+                }
+                let m = conversations::member_user_ids(conn, conversation_id)
+                    .await
+                    .map_err(into_diesel)?;
+                Ok(Some(m))
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    if let Ok(Some(members)) = members {
+        let server_msg = ServerMessage::Typing {
+            conversation_id,
+            user_id,
+            is_typing,
+        };
+        let others: Vec<i32> = members.into_iter().filter(|id| *id != user_id).collect();
+        hub.broadcast(&others, &server_msg);
+    }
 }
 
+#[allow(clippy::items_after_statements)]
 async fn handle_history(
-    user_id: i32,
+    viewer: SocketViewer,
     conversation_id: uuid::Uuid,
     before: Option<uuid::Uuid>,
     limit: Option<i64>,
     outbound_tx: &mpsc::UnboundedSender<ServerMessage>,
 ) {
-    if !conversations::is_member(conversation_id, user_id)
-        .await
-        .unwrap_or(false)
-    {
-        let _ = outbound_tx.send(ServerMessage::Error {
-            message: "not a member of this conversation".to_string(),
-        });
-        return;
-    }
-
+    let user_id = viewer.user_id;
     let limit = limit
         .unwrap_or(DEFAULT_HISTORY_LIMIT)
         .clamp(1, MAX_HISTORY_LIMIT);
 
-    match chat_messages::load_history(conversation_id, before, limit, user_id).await {
-        Ok((messages, has_more)) => {
+    enum Outcome {
+        Ok {
+            messages: Vec<super::protocol::MessagePayload>,
+            has_more: bool,
+        },
+        NotMember,
+    }
+
+    let result: std::result::Result<Outcome, diesel::result::Error> =
+        db::with_viewer_tx(viewer.into(), move |conn| {
+            async move {
+                if !conversations::is_member(conn, conversation_id, user_id)
+                    .await
+                    .map_err(into_diesel)?
+                {
+                    return Ok::<Outcome, diesel::result::Error>(Outcome::NotMember);
+                }
+                let (messages, has_more) =
+                    chat_messages::load_history(conn, conversation_id, before, limit, user_id)
+                        .await
+                        .map_err(into_diesel)?;
+                Ok(Outcome::Ok { messages, has_more })
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    match result {
+        Ok(Outcome::Ok { messages, has_more }) => {
             let _ = outbound_tx.send(ServerMessage::HistoryResponse {
                 conversation_id,
                 messages,
                 has_more,
+            });
+        }
+        Ok(Outcome::NotMember) => {
+            let _ = outbound_tx.send(ServerMessage::Error {
+                message: "not a member of this conversation".to_string(),
             });
         }
         Err(e) => {
@@ -702,15 +957,13 @@ async fn handle_history(
 /// Returns true if the other party has blocked the sender.
 #[allow(clippy::similar_names)]
 async fn is_blocked_in_dm(
+    conn: &mut AsyncPgConnection,
     conversation_id: uuid::Uuid,
     sender_user_id: i32,
 ) -> Result<bool, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
-    // Only check DM conversations
     let conv: Option<crate::db::models::conversations::Conversation> = conversations_table::table
         .find(conversation_id)
-        .first(&mut conn)
+        .first(conn)
         .await
         .optional()?;
 
@@ -721,7 +974,6 @@ async fn is_blocked_in_dm(
         return Ok(false);
     }
 
-    // Get both users' profile IDs
     let other_user_id = if conv.user_low_id == Some(sender_user_id) {
         conv.user_high_id
     } else {
@@ -732,17 +984,16 @@ async fn is_blocked_in_dm(
         return Ok(false);
     };
 
-    // Resolve both profile IDs
     let sender_profile: Option<uuid::Uuid> = profiles::table
         .filter(profiles::user_id.eq(sender_user_id))
         .select(profiles::id)
-        .first(&mut conn)
+        .first(conn)
         .await
         .optional()?;
     let other_profile: Option<uuid::Uuid> = profiles::table
         .filter(profiles::user_id.eq(other_user_id))
         .select(profiles::id)
-        .first(&mut conn)
+        .first(conn)
         .await
         .optional()?;
 
@@ -750,7 +1001,6 @@ async fn is_blocked_in_dm(
         return Ok(false);
     };
 
-    // Check if either party has blocked the other
     let count = profile_blocks::table
         .filter(
             profile_blocks::blocker_id
@@ -761,7 +1011,7 @@ async fn is_blocked_in_dm(
                     .and(profile_blocks::blocked_id.eq(sender_pid))),
         )
         .count()
-        .get_result::<i64>(&mut conn)
+        .get_result::<i64>(conn)
         .await?;
 
     Ok(count > 0)

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -5,9 +5,10 @@ pub mod viewer;
 pub use viewer::{
     complete_password_reset, create_session_for_user, create_user_for_signup,
     delete_session_by_token, find_user_for_login, find_user_for_password_reset,
-    mark_email_verified, profile_program_visibility, resolve_session, set_anon_context,
-    set_password_reset_token, set_viewer_context, user_pid_for_id, with_anon_tx, with_viewer_tx,
-    AuthSessionRow, AuthUserRow, CreatedSessionRow, DbViewer, PasswordResetUserRow,
+    mark_email_verified, profile_program_visibility, push_topics_for_users, resolve_session,
+    set_anon_context, set_password_reset_token, set_viewer_context, user_id_for_pid,
+    user_pid_for_id, user_review_stubs, with_anon_tx, with_viewer_tx, AuthSessionRow, AuthUserRow,
+    CreatedSessionRow, DbViewer, PasswordResetUserRow, UserReviewStubRow,
 };
 
 use deadpool::managed::Timeouts;

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -384,3 +384,69 @@ pub async fn profile_program_visibility(
         .await?;
     Ok(row.value)
 }
+
+// ---------------------------------------------------------------------------
+// Narrow public projections used by the chat module.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, QueryableByName)]
+struct IntRow {
+    #[diesel(sql_type = Nullable<Integer>)]
+    value: Option<i32>,
+}
+
+/// Resolve a user pid to its int id. Returns None if the pid is unknown.
+pub async fn user_id_for_pid(
+    conn: &mut AsyncPgConnection,
+    pid: uuid::Uuid,
+) -> Result<Option<i32>, diesel::result::Error> {
+    let row = diesel::sql_query("SELECT app.user_id_for_pid($1) AS value")
+        .bind::<SqlUuid, _>(pid)
+        .get_result::<IntRow>(conn)
+        .await?;
+    Ok(row.value)
+}
+
+#[derive(Debug, Clone, QueryableByName)]
+pub struct UserReviewStubRow {
+    #[diesel(sql_type = Integer)]
+    pub user_id: i32,
+    #[diesel(sql_type = Bool)]
+    pub is_review_stub: bool,
+}
+
+/// Batch lookup of `is_review_stub` for a list of users.
+pub async fn user_review_stubs(
+    conn: &mut AsyncPgConnection,
+    user_ids: &[i32],
+) -> Result<Vec<UserReviewStubRow>, diesel::result::Error> {
+    if user_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    diesel::sql_query("SELECT * FROM app.user_review_stubs($1)")
+        .bind::<diesel::sql_types::Array<Integer>, _>(user_ids)
+        .load::<UserReviewStubRow>(conn)
+        .await
+}
+
+#[derive(Debug, Clone, QueryableByName)]
+struct NtfyTopicRow {
+    #[diesel(sql_type = VarChar)]
+    ntfy_topic: String,
+}
+
+/// Return the ntfy push topics registered for a set of users. Server-side
+/// delivery only; bypasses RLS via SECURITY DEFINER.
+pub async fn push_topics_for_users(
+    conn: &mut AsyncPgConnection,
+    user_ids: &[i32],
+) -> Result<Vec<String>, diesel::result::Error> {
+    if user_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows = diesel::sql_query("SELECT * FROM app.push_topics_for_users($1)")
+        .bind::<diesel::sql_types::Array<Integer>, _>(user_ids)
+        .load::<NtfyTopicRow>(conn)
+        .await?;
+    Ok(rows.into_iter().map(|r| r.ntfy_topic).collect())
+}


### PR DESCRIPTION
**Migrate the chat module to the viewer-aware path**

`conversations.rs` and `messages.rs` library helpers now accept `&mut AsyncPgConnection`. Every HTTP chat handler (`resolve_dm`, `resolve_event_conversation`, `push_register`, `push_unregister`, `report_conversation`) runs inside a single `with_viewer_tx(viewer)`. The WebSocket handler threads a `SocketViewer` through auth (via `db::resolve_session`) and opens a fresh viewer tx per inbound message — create/edit/delete/react/read/typing/history/list all see the right `app.user_id`. Three narrow SECURITY DEFINER helpers (`app.user_id_for_pid`, `app.user_review_stubs`, `app.push_topics_for_users`) replace cross-user reads from `users` and `push_subscriptions`.

- [x] CI green
- [x] POST /chat/dms, GET /chat/config exercised (and /chat/events/{id}/conversation available)
- [x] push register / unregister exercised
- [x] report-conversation exercised (200 + row inserted)
- [x] WS: auth + send + edit + delete + react + read + typing + history + list exercised end-to-end between two users; U2's concurrent socket received every broadcast (edited, reaction, readReceipt, deleted)
- [x] cross-user renders use app.user_id_for_pid + app.user_review_stubs; push delivery uses app.push_topics_for_users (verified implicitly — DM render, conversations list, and push register all succeeded against the deployed branch)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap chat WebSocket and HTTP endpoints in viewer-scoped RLS transactions
> - All chat operations (send, edit, delete, react, read, typing, history, conversation list) in [ws.rs](https://github.com/poziomki-app/poziomki/pull/179/files#diff-11aeaf422f7bb7b849d4b2cbc4c07341e6461eb8c18f9032f4f8594cfc1f0839) now run inside `db::with_viewer_tx`, ensuring DB work executes under the authenticated viewer's RLS context.
> - HTTP handlers in [mod.rs](https://github.com/poziomki-app/poziomki/pull/179/files#diff-5e07944cd52759fed0f90311e982e992339a7f7aa1a48ecacd35d11e547d1a4e) (`resolve_dm`, `resolve_event_conversation`, `push_register`, `push_unregister`) and [report_handler.rs](https://github.com/poziomki-app/poziomki/pull/179/files#diff-739b0f6bf07d52343a5289172dbb7ee5eebff042b78c3fc1a42b6cd0fc6a1182) are similarly wrapped in viewer-scoped transactions.
> - Three new SECURITY DEFINER SQL helpers (`user_id_for_pid`, `user_review_stubs`, `push_topics_for_users`) are added via migration and exposed through the `db` module to support narrowly-scoped data access inside transactions.
> - Functions in [conversations.rs](https://github.com/poziomki-app/poziomki/pull/179/files#diff-5a9a538ec12a48526c8fde752b98cccf545f577ca7b816e6e57820607ce81c62) and [messages.rs](https://github.com/poziomki-app/poziomki/pull/179/files#diff-a67a10cd1d58a916da8ba18b1f00ea952fee8241c3324b8fe8239c93f7c55f97) now accept a caller-supplied `&mut AsyncPgConnection` instead of acquiring their own connections, enabling participation in the caller's transaction.
> - Risk: Initial conversation list and all message operations may behave differently under RLS visibility rules compared to the previous non-transactional, non-viewer-scoped queries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 006a014.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->