### PR TITLE
sec(rls): wrap events endpoints in viewer-scoped transactions

### DIFF
--- a/backend/migrations/2026-04-18-050000_event_rls_helpers/down.sql
+++ b/backend/migrations/2026-04-18-050000_event_rls_helpers/down.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS app.profile_owner_user_id(uuid);
+DROP FUNCTION IF EXISTS app.user_pids_for_ids(int[]);

--- a/backend/migrations/2026-04-18-050000_event_rls_helpers/up.sql
+++ b/backend/migrations/2026-04-18-050000_event_rls_helpers/up.sql
@@ -1,0 +1,53 @@
+-- Narrow public-projection helpers used by the events module.
+--
+-- Attendee listing and the event-approval push notification need a few
+-- small facts from `users` and `profiles` that would otherwise require
+-- cross-user SELECT on rows containing sensitive columns. These SD
+-- helpers expose exactly what the caller needs and no more, so the API
+-- role can stay at least-privilege when Tier-A RLS lands.
+
+-- Batch lookup of (id, pid) pairs for a list of user ids. Used by the
+-- attendee listing endpoint to resolve user pids without granting the
+-- API role a broad SELECT on users.
+CREATE OR REPLACE FUNCTION app.user_pids_for_ids(p_user_ids int[])
+RETURNS TABLE (user_id int, pid uuid)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT id, pid FROM users WHERE id = ANY(p_user_ids)
+$$;
+
+COMMENT ON FUNCTION app.user_pids_for_ids(int[]) IS
+    'Batch lookup of (user_id, pid) for a list of users. Narrow projection; used by event attendee listing.';
+
+-- Resolve the owner user_id for a profile. Used by the event-approval
+-- push notification path where the handler has a profile_id and needs
+-- the owning user to dispatch a push. Narrow projection: no profile
+-- fields leak, only the owning user_id.
+CREATE OR REPLACE FUNCTION app.profile_owner_user_id(p_profile_id uuid)
+RETURNS int
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+    SELECT user_id FROM profiles WHERE id = p_profile_id
+$$;
+
+COMMENT ON FUNCTION app.profile_owner_user_id(uuid) IS
+    'Resolve the owner user_id of a profile. Narrow projection; used by event approval push notifications.';
+
+REVOKE EXECUTE ON FUNCTION app.user_pids_for_ids(int[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.profile_owner_user_id(uuid) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.user_pids_for_ids(int[]) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.profile_owner_user_id(uuid) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/migrations/2026-04-18-050000_event_rls_helpers/up.sql
+++ b/backend/migrations/2026-04-18-050000_event_rls_helpers/up.sql
@@ -5,6 +5,11 @@
 -- cross-user SELECT on rows containing sensitive columns. These SD
 -- helpers expose exactly what the caller needs and no more, so the API
 -- role can stay at least-privilege when Tier-A RLS lands.
+--
+-- All `app.*` SECURITY DEFINER functions use `SET search_path = pg_catalog,
+-- pg_temp` and schema-qualified table names to defeat pg_temp search-path
+-- hijacks. The `sd_helpers_harden_search_path` migration applies the same
+-- header to the prior 010000..040000 helpers in one place.
 
 -- Batch lookup of (id, pid) pairs for a list of user ids. Used by the
 -- attendee listing endpoint to resolve user pids without granting the
@@ -13,10 +18,10 @@ CREATE OR REPLACE FUNCTION app.user_pids_for_ids(p_user_ids int[])
 RETURNS TABLE (user_id int, pid uuid)
 LANGUAGE sql
 SECURITY DEFINER
-SET search_path = public, pg_temp
+SET search_path = pg_catalog, pg_temp
 STABLE
 AS $$
-    SELECT id, pid FROM users WHERE id = ANY(p_user_ids)
+    SELECT id, pid FROM public.users WHERE id = ANY(p_user_ids)
 $$;
 
 COMMENT ON FUNCTION app.user_pids_for_ids(int[]) IS
@@ -30,10 +35,10 @@ CREATE OR REPLACE FUNCTION app.profile_owner_user_id(p_profile_id uuid)
 RETURNS int
 LANGUAGE sql
 SECURITY DEFINER
-SET search_path = public, pg_temp
+SET search_path = pg_catalog, pg_temp
 STABLE
 AS $$
-    SELECT user_id FROM profiles WHERE id = p_profile_id
+    SELECT user_id FROM public.profiles WHERE id = p_profile_id
 $$;
 
 COMMENT ON FUNCTION app.profile_owner_user_id(uuid) IS

--- a/backend/migrations/2026-04-18-060000_sd_helpers_harden_search_path/down.sql
+++ b/backend/migrations/2026-04-18-060000_sd_helpers_harden_search_path/down.sql
@@ -1,0 +1,4 @@
+-- No-op rollback: re-running the prior migrations' CREATE OR REPLACE
+-- statements would restore the pre-hardening search_path. That is a
+-- regression we would never want — leave the functions hardened.
+SELECT 1;

--- a/backend/migrations/2026-04-18-060000_sd_helpers_harden_search_path/up.sql
+++ b/backend/migrations/2026-04-18-060000_sd_helpers_harden_search_path/up.sql
@@ -1,0 +1,307 @@
+-- Harden every SECURITY DEFINER helper in `app` against pg_temp search-path
+-- hijacks (CVE-2018-1058 style).
+--
+-- Before this migration the helpers were defined with
+-- `SET search_path = public, pg_temp`. Postgres always searches the temp
+-- schema before an unqualified schema list unless `pg_catalog` is explicitly
+-- named first, so any caller with TEMPORARY privilege could install a
+-- `pg_temp.users` / `pg_temp.profiles` / `pg_temp.sessions` view and the
+-- SD functions would read from it. For `user_pids_for_ids` and
+-- `profile_owner_user_id` that means attacker-controlled `(user_id, pid)`
+-- pairs or a fabricated owner `user_id` — enough to impersonate users in
+-- attendee listings and misdirect push notifications.
+--
+-- CREATE OR REPLACE the functions with:
+--   * `SET search_path = pg_catalog, pg_temp` — Postgres will not implicitly
+--     search pg_temp first when pg_catalog is listed, and we only want
+--     pg_temp around for session-temp tables, never name resolution.
+--   * Fully schema-qualified table references (`public.users`,
+--     `public.profiles`, `public.sessions`, `public.user_settings`,
+--     `public.push_subscriptions`) so no lookup is affected by search_path
+--     at all.
+--
+-- All EXECUTE grants are inherited through CREATE OR REPLACE; we re-run
+-- the idempotent grant block at the end for defence.
+
+-- ---------------------------------------------------------------------------
+-- auth_security_definer (010000)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION app.find_user_for_login(p_email text)
+RETURNS TABLE (
+    id int,
+    pid uuid,
+    name varchar,
+    email varchar,
+    password varchar,
+    email_verified_at timestamptz,
+    is_review_stub bool
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT u.id, u.pid, u.name, u.email, u.password, u.email_verified_at, u.is_review_stub
+    FROM public.users u
+    WHERE u.email = p_email
+    LIMIT 1
+$$;
+
+CREATE OR REPLACE FUNCTION app.resolve_session(p_token_hash text)
+RETURNS TABLE (
+    session_id uuid,
+    user_id int,
+    user_pid uuid,
+    token varchar,
+    ip_address varchar,
+    user_agent varchar,
+    expires_at timestamptz,
+    created_at timestamptz,
+    updated_at timestamptz,
+    is_review_stub bool
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT s.id, s.user_id, u.pid, s.token, s.ip_address, s.user_agent,
+           s.expires_at, s.created_at, s.updated_at, u.is_review_stub
+    FROM public.sessions s
+    JOIN public.users u ON u.id = s.user_id
+    WHERE s.token = p_token_hash
+    LIMIT 1
+$$;
+
+-- ---------------------------------------------------------------------------
+-- auth_writes_security_definer (020000)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION app.create_user_for_signup(
+    p_pid uuid,
+    p_email text,
+    p_password text,
+    p_api_key text,
+    p_name text
+)
+RETURNS TABLE (
+    id int,
+    pid uuid,
+    email varchar,
+    password varchar,
+    name varchar,
+    email_verified_at timestamptz,
+    is_review_stub bool
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+    INSERT INTO public.users (pid, email, password, api_key, name)
+    VALUES (p_pid, p_email, p_password, p_api_key, p_name)
+    RETURNING id, pid, email, password, name, email_verified_at, is_review_stub;
+$$;
+
+CREATE OR REPLACE FUNCTION app.mark_email_verified(p_user_id int, p_now timestamptz)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+    UPDATE public.users
+    SET email_verified_at = p_now,
+        updated_at = p_now
+    WHERE id = p_user_id
+      AND email_verified_at IS NULL;
+$$;
+
+CREATE OR REPLACE FUNCTION app.set_password_reset_token(
+    p_user_id int,
+    p_token_hash text,
+    p_now timestamptz
+)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+    UPDATE public.users
+    SET reset_token = p_token_hash,
+        reset_sent_at = p_now,
+        updated_at = p_now
+    WHERE id = p_user_id;
+$$;
+
+CREATE OR REPLACE FUNCTION app.find_user_for_password_reset(
+    p_email text,
+    p_token_hash text,
+    p_cutoff timestamptz
+)
+RETURNS TABLE (
+    id int,
+    pid uuid,
+    email varchar,
+    name varchar,
+    email_verified_at timestamptz,
+    is_review_stub bool
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT id, pid, email, name, email_verified_at, is_review_stub
+    FROM public.users
+    WHERE email = p_email
+      AND reset_token = p_token_hash
+      AND reset_sent_at > p_cutoff
+    LIMIT 1
+$$;
+
+CREATE OR REPLACE FUNCTION app.complete_password_reset(
+    p_user_id int,
+    p_new_password text,
+    p_now timestamptz
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    UPDATE public.users
+    SET password = p_new_password,
+        reset_token = NULL,
+        reset_sent_at = NULL,
+        updated_at = p_now
+    WHERE id = p_user_id;
+
+    DELETE FROM public.sessions WHERE user_id = p_user_id;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION app.create_session_for_user(
+    p_id uuid,
+    p_user_id int,
+    p_token_hash text,
+    p_ip_address varchar,
+    p_user_agent varchar,
+    p_now timestamptz,
+    p_expires_at timestamptz
+)
+RETURNS TABLE (
+    id uuid,
+    user_id int,
+    token varchar,
+    ip_address varchar,
+    user_agent varchar,
+    expires_at timestamptz,
+    created_at timestamptz,
+    updated_at timestamptz
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+    INSERT INTO public.sessions (id, user_id, token, ip_address, user_agent, expires_at, created_at, updated_at)
+    VALUES (p_id, p_user_id, p_token_hash, p_ip_address, p_user_agent, p_expires_at, p_now, p_now)
+    RETURNING id, user_id, token, ip_address, user_agent, expires_at, created_at, updated_at;
+$$;
+
+CREATE OR REPLACE FUNCTION app.delete_session_by_token(p_token_hash text)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+    DELETE FROM public.sessions WHERE token = p_token_hash;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- profile_public_helpers (030000)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION app.user_pid_for_id(p_user_id int)
+RETURNS uuid
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT pid FROM public.users WHERE id = p_user_id
+$$;
+
+CREATE OR REPLACE FUNCTION app.profile_program_visibility(p_user_id int)
+RETURNS bool
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT COALESCE(
+        (SELECT privacy_show_program FROM public.user_settings WHERE user_id = p_user_id),
+        true
+    )
+$$;
+
+-- ---------------------------------------------------------------------------
+-- chat_rls_helpers (040000)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION app.user_id_for_pid(p_pid uuid)
+RETURNS int
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT id FROM public.users WHERE pid = p_pid
+$$;
+
+CREATE OR REPLACE FUNCTION app.user_review_stubs(p_user_ids int[])
+RETURNS TABLE (user_id int, is_review_stub bool)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT id, is_review_stub FROM public.users WHERE id = ANY(p_user_ids)
+$$;
+
+CREATE OR REPLACE FUNCTION app.push_topics_for_users(p_user_ids int[])
+RETURNS TABLE (ntfy_topic varchar)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT ntfy_topic FROM public.push_subscriptions WHERE user_id = ANY(p_user_ids)
+$$;
+
+-- ---------------------------------------------------------------------------
+-- event_rls_helpers (050000) — re-define with the hardened header too, even
+-- though the same migration in the same PR is already correct. Running
+-- `CREATE OR REPLACE` twice is a no-op and keeps every SD helper in one
+-- authoritative place.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION app.user_pids_for_ids(p_user_ids int[])
+RETURNS TABLE (user_id int, pid uuid)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT id, pid FROM public.users WHERE id = ANY(p_user_ids)
+$$;
+
+CREATE OR REPLACE FUNCTION app.profile_owner_user_id(p_profile_id uuid)
+RETURNS int
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT user_id FROM public.profiles WHERE id = p_profile_id
+$$;

--- a/backend/src/api/events/interactions_repo.rs
+++ b/backend/src/api/events/interactions_repo.rs
@@ -9,15 +9,6 @@ use crate::db::schema::event_interactions;
 pub(in crate::api) const EVENT_INTERACTION_SAVED: &str = "saved";
 pub(super) const EVENT_INTERACTION_JOINED: &str = "joined";
 
-pub(super) async fn upsert_event_interaction(
-    profile_id: Uuid,
-    event_id: Uuid,
-    kind: &str,
-) -> std::result::Result<(), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-    upsert_event_interaction_with_conn(&mut conn, profile_id, event_id, kind).await
-}
-
 pub(super) async fn upsert_event_interaction_with_conn(
     conn: &mut AsyncPgConnection,
     profile_id: Uuid,
@@ -45,15 +36,6 @@ pub(super) async fn upsert_event_interaction_with_conn(
         .await?;
 
     Ok(())
-}
-
-pub(super) async fn delete_event_interaction(
-    profile_id: Uuid,
-    event_id: Uuid,
-    kind: &str,
-) -> std::result::Result<(), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-    delete_event_interaction_with_conn(&mut conn, profile_id, event_id, kind).await
 }
 
 pub(super) async fn delete_event_interaction_with_conn(

--- a/backend/src/api/events/mod.rs
+++ b/backend/src/api/events/mod.rs
@@ -22,6 +22,7 @@ mod report_repo;
 type Result<T> = crate::error::AppResult<T>;
 
 use crate::app::AppContext;
+use crate::db;
 use axum::response::Response;
 use axum::{
     extract::{Path, Query, State},
@@ -30,14 +31,17 @@ use axum::{
     Json,
 };
 use chrono::Utc;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use uuid::Uuid;
 
 use super::state::{DataResponse, EventsQuery};
-use events_service::{not_found_event, require_auth_profile};
-use events_view::attendee_info;
+use events_service::{not_found_event, profile_not_found};
 
 pub(super) use events_interactions_repo::EVENT_INTERACTION_SAVED;
-pub(super) use events_view::{build_event_response, build_event_responses_with_conn};
+pub(super) use events_view::{
+    build_event_response_raw, build_event_responses_raw,
+    resolve_event_images as resolve_event_images_for_responses,
+};
 pub(super) use events_write_handler::{
     event_approve_attendee, event_attend, event_create, event_delete, event_leave,
     event_reject_attendee, event_save, event_unsave, event_update,
@@ -53,59 +57,111 @@ fn with_private_short_cache(mut response: Response) -> Response {
     response
 }
 
+enum ListOutcome {
+    NoProfile,
+    Listed(Vec<crate::api::state::EventResponse>),
+}
+
+async fn list_events_with_viewer<F>(
+    headers: &HeaderMap,
+    load: F,
+) -> std::result::Result<Response, crate::error::AppError>
+where
+    F: for<'c> FnOnce(
+            &'c mut diesel_async::AsyncPgConnection,
+            uuid::Uuid,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = std::result::Result<
+                            Vec<crate::db::models::events::Event>,
+                            crate::error::AppError,
+                        >,
+                    > + Send
+                    + 'c,
+            >,
+        > + Send,
+{
+    let (_session, user) = match crate::api::state::require_auth_db(headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+
+    let outcome = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let Some(profile) = events_service::load_profile_for_user(conn, user.id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<ListOutcome, diesel::result::Error>(ListOutcome::NoProfile);
+            };
+            let events = load(conn, profile.id).await.map_err(into_diesel)?;
+            let responses = events_view::build_event_responses_raw(conn, &events, &profile.id)
+                .await
+                .map_err(into_diesel)?;
+            Ok(ListOutcome::Listed(responses))
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        ListOutcome::NoProfile => Ok(profile_not_found(headers)),
+        ListOutcome::Listed(mut responses) => {
+            events_view::resolve_event_images(&mut responses).await;
+            Ok(with_private_short_cache(
+                Json(DataResponse { data: responses }).into_response(),
+            ))
+        }
+    }
+}
+
+fn into_diesel(e: crate::error::AppError) -> diesel::result::Error {
+    diesel::result::Error::QueryBuilderError(Box::new(e))
+}
+
 pub(super) async fn events_list(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
     Query(query): Query<EventsQuery>,
 ) -> Result<Response> {
-    let (profile, _user_pid) = match require_auth_profile(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
-
     let limit = i64::from(query.limit.unwrap_or(20).clamp(1, 100));
     let now = Utc::now();
-
-    let all_events = events_repo::list_upcoming_events(now, limit).await?;
-
-    let data = events_view::build_event_responses(&all_events, &profile.id).await?;
-    Ok(with_private_short_cache(
-        Json(DataResponse { data }).into_response(),
-    ))
+    list_events_with_viewer(&headers, move |conn, _profile_id| {
+        Box::pin(async move { events_repo::list_upcoming_events(conn, now, limit).await })
+    })
+    .await
 }
 
 pub(super) async fn events_mine(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    let (profile, _user_pid) = match require_auth_profile(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
-
-    let my_events = events_repo::list_events_by_creator(profile.id).await?;
-
-    let data = events_view::build_event_responses(&my_events, &profile.id).await?;
-    Ok(with_private_short_cache(
-        Json(DataResponse { data }).into_response(),
-    ))
+    list_events_with_viewer(&headers, |conn, profile_id| {
+        Box::pin(async move { events_repo::list_events_by_creator(conn, profile_id).await })
+    })
+    .await
 }
 
 pub(super) async fn events_saved(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    let (profile, _user_pid) = match require_auth_profile(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
+    list_events_with_viewer(&headers, |conn, profile_id| {
+        Box::pin(async move { events_repo::list_saved_events(conn, profile_id).await })
+    })
+    .await
+}
 
-    let saved_events = events_repo::list_saved_events(profile.id).await?;
-
-    let data = events_view::build_event_responses(&saved_events, &profile.id).await?;
-    Ok(with_private_short_cache(
-        Json(DataResponse { data }).into_response(),
-    ))
+enum EventGetOutcome {
+    NoProfile,
+    NotFound,
+    Loaded(Box<crate::api::state::EventResponse>),
 }
 
 pub(super) async fn event_get(
@@ -113,22 +169,67 @@ pub(super) async fn event_get(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let (profile, _user_pid) = match require_auth_profile(&headers).await {
-        Ok(auth) => auth,
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
         Err(response) => return Ok(*response),
     };
 
     let event_uuid = Uuid::parse_str(&id)
         .map_err(|_| crate::error::AppError::Message("Invalid event ID".to_string()))?;
 
-    let Some(event) = events_repo::find_event(event_uuid).await? else {
-        return Ok(not_found_event(&headers, &id));
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
 
-    let data = build_event_response(&event, &profile.id).await?;
-    Ok(with_private_short_cache(
-        Json(DataResponse { data }).into_response(),
-    ))
+    let outcome = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let Some(profile) = events_service::load_profile_for_user(conn, user.id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<EventGetOutcome, diesel::result::Error>(EventGetOutcome::NoProfile);
+            };
+
+            let Some(event) = events_repo::find_event(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(EventGetOutcome::NotFound);
+            };
+
+            let response = build_event_response_raw(conn, &event, &profile.id)
+                .await
+                .map_err(into_diesel)?;
+            Ok(EventGetOutcome::Loaded(Box::new(response)))
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        EventGetOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        EventGetOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        EventGetOutcome::Loaded(response) => {
+            let mut slice = [*response];
+            events_view::resolve_event_images(&mut slice).await;
+            let Some(response) = slice.into_iter().next() else {
+                return Err(crate::error::AppError::Message(
+                    "empty response".to_string(),
+                ));
+            };
+            Ok(with_private_short_cache(
+                Json(DataResponse { data: response }).into_response(),
+            ))
+        }
+    }
+}
+
+enum AttendeesOutcome {
+    NoProfile,
+    NotFound,
+    Listed(Vec<crate::api::state::AttendeeFullInfo>),
 }
 
 pub(super) async fn event_attendees(
@@ -136,18 +237,47 @@ pub(super) async fn event_attendees(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let (_profile, _user_pid) = match require_auth_profile(&headers).await {
-        Ok(auth) => auth,
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
         Err(response) => return Ok(*response),
     };
 
     let event_uuid = Uuid::parse_str(&id)
         .map_err(|_| crate::error::AppError::Message("Invalid event ID".to_string()))?;
 
-    let Some(event) = events_repo::find_event(event_uuid).await? else {
-        return Ok(not_found_event(&headers, &id));
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
 
-    let data = attendee_info(event_uuid, event.creator_id).await?;
-    Ok(Json(DataResponse { data }).into_response())
+    let outcome = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            if events_service::load_profile_for_user(conn, user.id)
+                .await
+                .map_err(into_diesel)?
+                .is_none()
+            {
+                return Ok::<AttendeesOutcome, diesel::result::Error>(AttendeesOutcome::NoProfile);
+            }
+            let Some(event) = events_repo::find_event(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(AttendeesOutcome::NotFound);
+            };
+            let list = events_view::attendee_info(conn, event_uuid, event.creator_id)
+                .await
+                .map_err(into_diesel)?;
+            Ok(AttendeesOutcome::Listed(list))
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        AttendeesOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        AttendeesOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        AttendeesOutcome::Listed(list) => Ok(Json(DataResponse { data: list }).into_response()),
+    }
 }

--- a/backend/src/api/events/repo.rs
+++ b/backend/src/api/events/repo.rs
@@ -1,41 +1,41 @@
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::events::Event;
 use crate::db::schema::{event_interactions, events};
 
 pub(in crate::api) async fn list_upcoming_events(
+    conn: &mut AsyncPgConnection,
     now: DateTime<Utc>,
     limit: i64,
 ) -> std::result::Result<Vec<Event>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let models = events::table
         .filter(events::starts_at.ge(now))
         .order(events::starts_at.asc())
         .limit(limit)
-        .load::<Event>(&mut conn)
+        .load::<Event>(conn)
         .await?;
     Ok(models)
 }
 
 pub(in crate::api) async fn list_events_by_creator(
+    conn: &mut AsyncPgConnection,
     creator_id: Uuid,
 ) -> std::result::Result<Vec<Event>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let models = events::table
         .filter(events::creator_id.eq(creator_id))
         .order(events::starts_at.desc())
-        .load::<Event>(&mut conn)
+        .load::<Event>(conn)
         .await?;
     Ok(models)
 }
 
 pub(in crate::api) async fn list_saved_events(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
 ) -> std::result::Result<Vec<Event>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let models = events::table
         .inner_join(
             event_interactions::table.on(event_interactions::event_id
@@ -45,18 +45,18 @@ pub(in crate::api) async fn list_saved_events(
         )
         .order(event_interactions::created_at.desc())
         .select(events::all_columns)
-        .load::<Event>(&mut conn)
+        .load::<Event>(conn)
         .await?;
     Ok(models)
 }
 
 pub(in crate::api) async fn find_event(
+    conn: &mut AsyncPgConnection,
     event_id: Uuid,
 ) -> std::result::Result<Option<Event>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let model = events::table
         .find(event_id)
-        .first::<Event>(&mut conn)
+        .first::<Event>(conn)
         .await
         .optional()?;
     Ok(model)

--- a/backend/src/api/events/report_handler.rs
+++ b/backend/src/api/events/report_handler.rs
@@ -7,12 +7,15 @@ use axum::{
     response::IntoResponse,
     Json,
 };
+use diesel_async::scoped_futures::ScopedFutureExt;
 
 use crate::api::state::{ReportEventBody, SuccessResponse};
 use crate::app::AppContext;
+use crate::db;
 
 use super::events_service::{
-    forbidden, load_event, not_found_event, require_auth_profile, validation_error,
+    forbidden, load_event_by_id, load_profile_for_user, not_found_event, profile_not_found,
+    validation_error,
 };
 use super::report_repo;
 
@@ -27,28 +30,37 @@ const VALID_REASONS: &[&str] = &[
     "other",
 ];
 
+enum ReportOutcome {
+    NoProfile,
+    NotFound,
+    OwnEvent,
+    Duplicate,
+    Inserted,
+}
+
+fn into_diesel(e: crate::error::AppError) -> diesel::result::Error {
+    match e {
+        crate::error::AppError::Message(_) | crate::error::AppError::Validation(_) => {
+            diesel::result::Error::QueryBuilderError(Box::new(e))
+        }
+        crate::error::AppError::Any(_) => diesel::result::Error::RollbackTransaction,
+    }
+}
+
 pub(in crate::api) async fn event_report(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<ReportEventBody>,
 ) -> Result<Response> {
-    let (profile, _user_pid) = match require_auth_profile(&headers).await {
-        Ok(auth) => auth,
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
         Err(response) => return Ok(*response),
     };
-
-    let (event, event_id) = match load_event(&headers, &id).await {
-        Ok(ev) => ev,
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
         Err(response) => return Ok(*response),
     };
-
-    if event.creator_id == profile.id {
-        return Ok(forbidden(
-            &headers,
-            "Nie możesz zgłosić własnego wydarzenia",
-        ));
-    }
 
     let reason = body.reason.trim().to_lowercase();
     if !VALID_REASONS.contains(&reason.as_str()) {
@@ -71,18 +83,60 @@ pub(in crate::api) async fn event_report(
         }
     }
 
-    let Some(inserted) =
-        report_repo::insert_event_report(profile.id, event_id, reason, description).await?
-    else {
-        return Ok(not_found_event(&headers, &id));
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
+    let user_id = user.id;
 
-    if !inserted {
-        return Ok(validation_error(
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<ReportOutcome, diesel::result::Error>(ReportOutcome::NoProfile);
+            };
+            let Some(event) = load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(ReportOutcome::NotFound);
+            };
+            if event.creator_id == profile.id {
+                return Ok(ReportOutcome::OwnEvent);
+            }
+            match report_repo::insert_event_report(
+                conn,
+                profile.id,
+                event_uuid,
+                reason,
+                description,
+            )
+            .await
+            .map_err(into_diesel)?
+            {
+                None => Ok(ReportOutcome::NotFound),
+                Some(false) => Ok(ReportOutcome::Duplicate),
+                Some(true) => Ok(ReportOutcome::Inserted),
+            }
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        ReportOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        ReportOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        ReportOutcome::OwnEvent => Ok(forbidden(
+            &headers,
+            "Nie możesz zgłosić własnego wydarzenia",
+        )),
+        ReportOutcome::Duplicate => Ok(validation_error(
             &headers,
             "To wydarzenie zostało już przez Ciebie zgłoszone",
-        ));
+        )),
+        ReportOutcome::Inserted => Ok(Json(SuccessResponse { success: true }).into_response()),
     }
-
-    Ok(Json(SuccessResponse { success: true }).into_response())
 }

--- a/backend/src/api/events/report_repo.rs
+++ b/backend/src/api/events/report_repo.rs
@@ -1,57 +1,47 @@
 use diesel::prelude::*;
 use diesel::OptionalExtension;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::reports::NewReport;
 use crate::db::schema::{events, reports};
 
-/// Insert an event report inside a transaction that first checks the event exists.
-/// Returns `None` if the event doesn't exist, `Some(true)` if inserted,
-/// `Some(false)` if a duplicate already exists.
+/// Insert an event report. Caller must supply a connection already inside
+/// a viewer-scoped transaction.
+///
+/// Returns `None` when the event doesn't exist, `Some(true)` when the
+/// report was inserted, and `Some(false)` when a duplicate already exists.
 pub(in crate::api) async fn insert_event_report(
+    conn: &mut AsyncPgConnection,
     reporter_id: Uuid,
     event_id: Uuid,
     reason: String,
     description: Option<String>,
 ) -> std::result::Result<Option<bool>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
+    let exists = events::table
+        .find(event_id)
+        .select(events::id)
+        .first::<Uuid>(conn)
+        .await
+        .optional()?;
 
-    let result = conn
-        .build_transaction()
-        .read_committed()
-        .run(|conn| {
-            Box::pin(async move {
-                // Check event exists inside the transaction
-                let exists = events::table
-                    .find(event_id)
-                    .select(events::id)
-                    .first::<Uuid>(conn)
-                    .await
-                    .optional()?;
+    if exists.is_none() {
+        return Ok(None);
+    }
 
-                if exists.is_none() {
-                    return Ok::<_, diesel::result::Error>(None);
-                }
+    let new = NewReport {
+        reporter_id,
+        target_type: "event".to_string(),
+        target_id: event_id,
+        reason,
+        description,
+    };
 
-                let new = NewReport {
-                    reporter_id,
-                    target_type: "event".to_string(),
-                    target_id: event_id,
-                    reason,
-                    description,
-                };
-
-                let rows = diesel::insert_into(reports::table)
-                    .values(&new)
-                    .on_conflict_do_nothing()
-                    .execute(conn)
-                    .await?;
-
-                Ok(Some(rows > 0))
-            })
-        })
+    let rows = diesel::insert_into(reports::table)
+        .values(&new)
+        .on_conflict_do_nothing()
+        .execute(conn)
         .await?;
 
-    Ok(result)
+    Ok(Some(rows > 0))
 }

--- a/backend/src/api/events/service.rs
+++ b/backend/src/api/events/service.rs
@@ -1,7 +1,7 @@
 use axum::http::HeaderMap;
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::api::{error_response, state::CreateEventBody, ErrorSpec};
@@ -42,6 +42,18 @@ pub(in crate::api) fn not_found_event(
     )
 }
 
+pub(in crate::api) fn profile_not_found(headers: &HeaderMap) -> axum::response::Response {
+    error_response(
+        axum::http::StatusCode::NOT_FOUND,
+        headers,
+        ErrorSpec {
+            error: "Profile not found. Create a profile first.".to_string(),
+            code: "NOT_FOUND",
+            details: None,
+        },
+    )
+}
+
 pub(in crate::api) fn forbidden(headers: &HeaderMap, message: &str) -> axum::response::Response {
     error_response(
         axum::http::StatusCode::FORBIDDEN,
@@ -54,72 +66,32 @@ pub(in crate::api) fn forbidden(headers: &HeaderMap, message: &str) -> axum::res
     )
 }
 
-pub(in crate::api) async fn require_auth_profile(
-    headers: &HeaderMap,
-) -> std::result::Result<(Profile, Uuid), HandlerError> {
-    let (_session, user) = crate::api::state::require_auth_db(headers).await?;
-
-    let mut conn = crate::db::conn().await.map_err(|_| {
-        Box::new(error_response(
-            axum::http::StatusCode::NOT_FOUND,
-            headers,
-            ErrorSpec {
-                error: "Profile not found. Create a profile first.".to_string(),
-                code: "NOT_FOUND",
-                details: None,
-            },
-        ))
-    })?;
-
+/// Load the caller's profile inside an existing viewer-scoped transaction.
+/// Returns `None` when the caller has no profile; callers translate that into
+/// a 404 response.
+pub(in crate::api) async fn load_profile_for_user(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+) -> std::result::Result<Option<Profile>, crate::error::AppError> {
     let profile = profiles::table
-        .filter(profiles::user_id.eq(user.id))
-        .first::<Profile>(&mut conn)
+        .filter(profiles::user_id.eq(user_id))
+        .first::<Profile>(conn)
         .await
-        .optional()
-        .map_err(|_| {
-            Box::new(error_response(
-                axum::http::StatusCode::NOT_FOUND,
-                headers,
-                ErrorSpec {
-                    error: "Profile not found. Create a profile first.".to_string(),
-                    code: "NOT_FOUND",
-                    details: None,
-                },
-            ))
-        })?
-        .ok_or_else(|| {
-            Box::new(error_response(
-                axum::http::StatusCode::NOT_FOUND,
-                headers,
-                ErrorSpec {
-                    error: "Profile not found. Create a profile first.".to_string(),
-                    code: "NOT_FOUND",
-                    details: None,
-                },
-            ))
-        })?;
-    Ok((profile, user.pid))
+        .optional()?;
+    Ok(profile)
 }
 
-pub(in crate::api) async fn load_event(
-    headers: &HeaderMap,
-    id: &str,
-) -> std::result::Result<(Event, Uuid), HandlerError> {
-    let event_uuid = crate::api::parse_uuid_response(id, "event", headers)?;
-
-    let mut conn = crate::db::conn()
-        .await
-        .map_err(|_| Box::new(not_found_event(headers, id)))?;
-
+/// Load an event by id inside an existing viewer-scoped transaction.
+pub(in crate::api) async fn load_event_by_id(
+    conn: &mut AsyncPgConnection,
+    event_id: Uuid,
+) -> std::result::Result<Option<Event>, crate::error::AppError> {
     let event = events::table
-        .find(event_uuid)
-        .first::<Event>(&mut conn)
+        .find(event_id)
+        .first::<Event>(conn)
         .await
-        .optional()
-        .map_err(|_| Box::new(not_found_event(headers, id)))?
-        .ok_or_else(|| Box::new(not_found_event(headers, id)))?;
-
-    Ok((event, event_uuid))
+        .optional()?;
+    Ok(event)
 }
 
 pub(in crate::api) fn parse_timestamp(

--- a/backend/src/api/events/tags_repo.rs
+++ b/backend/src/api/events/tags_repo.rs
@@ -8,13 +8,6 @@ use crate::db::models::event_tags::EventTag;
 use crate::db::models::tags::{NewTag, Tag};
 use crate::db::schema::{event_attendees, event_tags, tags};
 
-pub(in crate::api) async fn find_or_create_event_tag(name: String) -> Option<Uuid> {
-    let mut conn = crate::db::conn().await.ok()?;
-    find_or_create_event_tag_with_conn(&mut conn, name)
-        .await
-        .ok()
-}
-
 pub(in crate::api) async fn find_or_create_event_tag_with_conn(
     conn: &mut AsyncPgConnection,
     name: String,

--- a/backend/src/api/events/tags_service.rs
+++ b/backend/src/api/events/tags_service.rs
@@ -1,48 +1,34 @@
 use axum::http::HeaderMap;
-use axum::response::IntoResponse;
 use diesel_async::AsyncPgConnection;
 use uuid::Uuid;
 
 use super::events_service::{validation_error, HandlerError};
 use super::events_tags_repo::{
-    find_or_create_event_tag, find_or_create_event_tag_with_conn, load_existing_event_tag_ids,
-    sync_event_tags_with_conn,
+    find_or_create_event_tag_with_conn, load_existing_event_tag_ids, sync_event_tags_with_conn,
 };
 
 const MAX_EVENT_TAGS: usize = 15;
 
-pub(in crate::api) async fn resolve_event_tag_ids(
+/// Parse and deduplicate a list of tag id strings. Returns a handler error
+/// response on invalid input. Caller must then validate the parsed ids
+/// exist via `validate_event_tag_ids_with_conn` inside a viewer tx.
+pub(in crate::api) fn parse_event_tag_ids(
     headers: &HeaderMap,
-    tag_names: Option<Vec<String>>,
-    tag_ids: Option<Vec<String>>,
+    ids: Vec<String>,
 ) -> std::result::Result<Vec<Uuid>, HandlerError> {
-    if let Some(ids) = tag_ids {
-        if ids.len() > MAX_EVENT_TAGS {
-            return Err(Box::new(validation_error(headers, "Too many tags")));
-        }
-        return validate_event_tag_ids(headers, ids).await;
-    }
-
-    let names = tag_names.unwrap_or_default();
-    if names.len() > MAX_EVENT_TAGS {
+    if ids.len() > MAX_EVENT_TAGS {
         return Err(Box::new(validation_error(headers, "Too many tags")));
     }
 
-    let mut resolved = Vec::new();
-    for raw in names {
-        let trimmed = raw.trim().to_string();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if let Some(id) = find_or_create_event_tag(trimmed).await {
-            resolved.push(id);
-        } else {
-            return Err(Box::new(validation_error(headers, "Invalid tag name")));
-        }
+    let mut parsed = Vec::new();
+    for raw in ids {
+        let uuid = Uuid::parse_str(&raw)
+            .map_err(|_| Box::new(validation_error(headers, "All tagIds must be valid UUIDs")))?;
+        parsed.push(uuid);
     }
-    resolved.sort_unstable();
-    resolved.dedup();
-    Ok(resolved)
+    parsed.sort_unstable();
+    parsed.dedup();
+    Ok(parsed)
 }
 
 pub(in crate::api) async fn resolve_event_tag_ids_with_conn(
@@ -96,45 +82,4 @@ pub(in crate::api) async fn maybe_sync_tags_with_conn(
         sync_event_tags_with_conn(conn, event_id, &resolved).await?;
     }
     Ok(())
-}
-
-async fn validate_event_tag_ids(
-    headers: &HeaderMap,
-    ids: Vec<String>,
-) -> std::result::Result<Vec<Uuid>, HandlerError> {
-    if ids.len() > MAX_EVENT_TAGS {
-        return Err(Box::new(validation_error(headers, "Too many tags")));
-    }
-
-    let mut parsed = Vec::new();
-    for raw in ids {
-        let uuid = Uuid::parse_str(&raw)
-            .map_err(|_| Box::new(validation_error(headers, "All tagIds must be valid UUIDs")))?;
-        parsed.push(uuid);
-    }
-
-    parsed.sort_unstable();
-    parsed.dedup();
-
-    if parsed.is_empty() {
-        return Ok(parsed);
-    }
-
-    let mut conn = crate::db::conn()
-        .await
-        .map_err(|e| Box::new(crate::error::AppError::from(e).into_response()))?;
-    let matched: std::collections::HashSet<Uuid> = load_existing_event_tag_ids(&mut conn, &parsed)
-        .await
-        .map_err(|e| Box::new(e.into_response()))?
-        .into_iter()
-        .collect();
-
-    if matched.len() != parsed.len() {
-        return Err(Box::new(validation_error(
-            headers,
-            "All tagIds must reference existing interest tags",
-        )));
-    }
-
-    Ok(parsed)
 }

--- a/backend/src/api/events/view.rs
+++ b/backend/src/api/events/view.rs
@@ -6,14 +6,15 @@ mod events_view_images;
 mod events_view_repo;
 
 use axum::response::IntoResponse;
+use diesel_async::AsyncPgConnection;
 use uuid::Uuid;
 
 use crate::api::state::{AttendeeStatus, DataResponse, EventResponse, ProfilePreview};
 use crate::db::models::events::Event;
-use events_view_images::resolve_event_images;
 use events_view_repo::load_event_batch_context;
 
 pub(in crate::api) use events_view_attendees::attendee_info;
+pub(in crate::api) use events_view_images::resolve_event_images;
 
 const PREVIEW_LIMIT: usize = 5;
 
@@ -101,34 +102,30 @@ fn build_from_context(
     }
 }
 
-pub(in crate::api) async fn build_event_responses(
+/// Build raw event responses inside an existing viewer-scoped transaction.
+/// Image URLs are not resolved — callers must apply `resolve_event_images`
+/// after the transaction closes (avoids holding a DB connection while we
+/// call into imgproxy).
+pub(in crate::api) async fn build_event_responses_raw(
+    conn: &mut AsyncPgConnection,
     event_models: &[Event],
     profile_id: &Uuid,
 ) -> std::result::Result<Vec<EventResponse>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-    build_event_responses_with_conn(event_models, profile_id, &mut conn).await
-}
-
-pub(in crate::api) async fn build_event_responses_with_conn(
-    event_models: &[Event],
-    profile_id: &Uuid,
-    conn: &mut crate::db::DbConn,
-) -> std::result::Result<Vec<EventResponse>, crate::error::AppError> {
-    let batch_ctx = load_event_batch_context(event_models, *profile_id, conn).await?;
-    let mut responses: Vec<EventResponse> = event_models
+    let batch_ctx = load_event_batch_context(conn, event_models, *profile_id).await?;
+    Ok(event_models
         .iter()
         .map(|event| build_from_context(event, profile_id, &batch_ctx))
-        .collect();
-    resolve_event_images(&mut responses).await;
-    Ok(responses)
+        .collect())
 }
 
-pub(in crate::api) async fn build_event_response(
+pub(in crate::api) async fn build_event_response_raw(
+    conn: &mut AsyncPgConnection,
     event: &Event,
     profile_id: &Uuid,
 ) -> std::result::Result<EventResponse, crate::error::AppError> {
-    let responses = build_event_responses(std::slice::from_ref(event), profile_id).await?;
-    responses.into_iter().next().ok_or_else(|| {
+    let mut responses =
+        build_event_responses_raw(conn, std::slice::from_ref(event), profile_id).await?;
+    responses.pop().ok_or_else(|| {
         crate::error::AppError::Message("Failed to build event response".to_string())
     })
 }

--- a/backend/src/api/events/view_attendees.rs
+++ b/backend/src/api/events/view_attendees.rs
@@ -1,39 +1,42 @@
 use std::collections::HashMap;
 
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::AsyncPgConnection;
 use uuid::Uuid;
 
 use super::events_view_images::resolve_image_map;
 use super::events_view_repo::{load_attendee_rows, AttendeeRow};
 use crate::api::state::AttendeeFullInfo;
-use crate::db::models::users::User;
-use crate::db::schema::users;
+use crate::db;
 
-async fn load_users_for_profiles(
+/// Resolve `profile.user_id -> user.pid` for a set of attendee profiles via
+/// the narrow `app.user_pids_for_ids` SECURITY DEFINER helper. The API role
+/// does not hold broad SELECT on `users`; this helper returns only the
+/// `(id, pid)` tuples needed to render attendee identifiers.
+async fn load_user_pids(
+    conn: &mut AsyncPgConnection,
     rows: &[AttendeeRow],
-    conn: &mut crate::db::DbConn,
-) -> std::result::Result<Vec<User>, crate::error::AppError> {
+) -> std::result::Result<HashMap<i32, Uuid>, crate::error::AppError> {
     let user_ids: Vec<i32> = rows.iter().map(|r| r.profile.user_id).collect();
     if user_ids.is_empty() {
-        return Ok(vec![]);
+        return Ok(HashMap::new());
     }
-    Ok(users::table
-        .filter(users::id.eq_any(&user_ids))
-        .load::<User>(conn)
-        .await?)
+    let pairs = db::user_pids_for_ids(conn, &user_ids).await?;
+    Ok(pairs
+        .into_iter()
+        .map(|row| (row.user_id, row.pid))
+        .collect())
 }
 
 fn build_attendee_info(
     row: &AttendeeRow,
-    user_models: &[User],
+    user_pids: &HashMap<i32, Uuid>,
     url_map: &HashMap<String, String>,
     creator_id: Uuid,
 ) -> AttendeeFullInfo {
-    let user_pid = user_models
-        .iter()
-        .find(|u| u.id == row.profile.user_id)
-        .map_or(uuid::Uuid::nil(), |u| u.pid);
+    let user_pid = user_pids
+        .get(&row.profile.user_id)
+        .copied()
+        .unwrap_or_else(Uuid::nil);
     let profile_picture = row
         .profile
         .profile_picture
@@ -50,13 +53,15 @@ fn build_attendee_info(
     }
 }
 
+/// Collect attendee rows + the viewer-facing pid/name/picture tuples required
+/// to render them. Must run inside an existing viewer-scoped transaction.
 pub(in crate::api) async fn attendee_info(
+    conn: &mut AsyncPgConnection,
     event_id: Uuid,
     creator_id: Uuid,
 ) -> std::result::Result<Vec<AttendeeFullInfo>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-    let rows = load_attendee_rows(event_id, &mut conn).await?;
-    let user_models = load_users_for_profiles(&rows, &mut conn).await?;
+    let rows = load_attendee_rows(conn, event_id).await?;
+    let user_pids = load_user_pids(conn, &rows).await?;
 
     let filenames = rows
         .iter()
@@ -66,7 +71,7 @@ pub(in crate::api) async fn attendee_info(
 
     let mut list: Vec<AttendeeFullInfo> = rows
         .iter()
-        .map(|row| build_attendee_info(row, &user_models, &url_map, creator_id))
+        .map(|row| build_attendee_info(row, &user_pids, &url_map, creator_id))
         .collect();
     list.sort_by(|a, b| {
         b.is_creator

--- a/backend/src/api/events/view_images.rs
+++ b/backend/src/api/events/view_images.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::api::state::EventResponse;
 
 /// Resolve a set of raw image filenames to signed URLs in parallel, returning a lookup map.
-pub(super) async fn resolve_image_map(raw_values: HashSet<String>) -> HashMap<String, String> {
+pub async fn resolve_image_map(raw_values: HashSet<String>) -> HashMap<String, String> {
     let resolve = crate::api::resolve_image_url;
     let futs: Vec<_> = raw_values
         .into_iter()
@@ -43,7 +43,7 @@ fn replace_resolved_image(value: &mut Option<String>, url_map: &HashMap<String, 
 }
 
 /// Resolve all image URLs (cover, creator, attendee previews) in event responses.
-pub(super) async fn resolve_event_images(responses: &mut [EventResponse]) {
+pub async fn resolve_event_images(responses: &mut [EventResponse]) {
     let filenames = collect_image_filenames(responses);
     if filenames.is_empty() {
         return;

--- a/backend/src/api/events/view_repo.rs
+++ b/backend/src/api/events/view_repo.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use super::status_from_str;
@@ -36,8 +36,8 @@ fn scope_from_str(s: &str) -> TagScope {
 }
 
 async fn load_profiles_by_ids(
+    conn: &mut AsyncPgConnection,
     ids: &[Uuid],
-    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<HashMap<Uuid, Profile>, crate::error::AppError> {
     if ids.is_empty() {
         return Ok(HashMap::new());
@@ -51,8 +51,8 @@ async fn load_profiles_by_ids(
 }
 
 pub(super) async fn load_attendee_rows(
+    conn: &mut AsyncPgConnection,
     event_id: Uuid,
-    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<Vec<AttendeeRow>, crate::error::AppError> {
     let links = event_attendees::table
         .filter(event_attendees::event_id.eq(event_id))
@@ -65,7 +65,7 @@ pub(super) async fn load_attendee_rows(
     }
 
     let profiles_map =
-        load_profiles_by_ids(&profile_ids.into_iter().collect::<Vec<_>>(), conn).await?;
+        load_profiles_by_ids(conn, &profile_ids.into_iter().collect::<Vec<_>>()).await?;
 
     let mut rows: Vec<AttendeeRow> = links
         .iter()
@@ -85,12 +85,12 @@ pub(super) async fn load_attendee_rows(
 }
 
 async fn load_creator_previews(
+    conn: &mut AsyncPgConnection,
     events_list: &[Event],
-    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<HashMap<Uuid, ProfilePreview>, crate::error::AppError> {
     let creator_ids: HashSet<Uuid> = events_list.iter().map(|event| event.creator_id).collect();
     let creator_models =
-        load_profiles_by_ids(&creator_ids.into_iter().collect::<Vec<_>>(), conn).await?;
+        load_profiles_by_ids(conn, &creator_ids.into_iter().collect::<Vec<_>>()).await?;
 
     Ok(creator_models
         .into_values()
@@ -108,8 +108,8 @@ async fn load_creator_previews(
 }
 
 async fn load_event_attendee_map(
+    conn: &mut AsyncPgConnection,
     event_ids: &[Uuid],
-    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<HashMap<Uuid, Vec<AttendeeRow>>, crate::error::AppError> {
     let attendee_links = event_attendees::table
         .filter(event_attendees::event_id.eq_any(event_ids))
@@ -121,7 +121,7 @@ async fn load_event_attendee_map(
         .map(|attendee| attendee.profile_id)
         .collect();
     let attendee_profiles =
-        load_profiles_by_ids(&attendee_profile_ids.into_iter().collect::<Vec<_>>(), conn).await?;
+        load_profiles_by_ids(conn, &attendee_profile_ids.into_iter().collect::<Vec<_>>()).await?;
 
     let mut attendees: HashMap<Uuid, Vec<AttendeeRow>> = HashMap::new();
     for link in &attendee_links {
@@ -144,8 +144,8 @@ async fn load_event_attendee_map(
 }
 
 async fn load_event_tag_map(
+    conn: &mut AsyncPgConnection,
     event_ids: &[Uuid],
-    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<HashMap<Uuid, Vec<EventTagResponse>>, crate::error::AppError> {
     let tag_links = event_tags::table
         .filter(event_tags::event_id.eq_any(event_ids))
@@ -184,9 +184,9 @@ async fn load_event_tag_map(
 }
 
 async fn load_saved_event_ids(
+    conn: &mut AsyncPgConnection,
     event_ids: &[Uuid],
     profile_id: Uuid,
-    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<HashSet<Uuid>, crate::error::AppError> {
     if event_ids.is_empty() {
         return Ok(HashSet::new());
@@ -203,9 +203,9 @@ async fn load_saved_event_ids(
 }
 
 pub(super) async fn load_event_batch_context(
+    conn: &mut AsyncPgConnection,
     event_models: &[Event],
     profile_id: Uuid,
-    conn: &mut crate::db::DbConn,
 ) -> std::result::Result<EventBatchContext, crate::error::AppError> {
     if event_models.is_empty() {
         return Ok(EventBatchContext {
@@ -217,10 +217,10 @@ pub(super) async fn load_event_batch_context(
     }
 
     let event_ids: Vec<Uuid> = event_models.iter().map(|event| event.id).collect();
-    let creators = load_creator_previews(event_models, conn).await?;
-    let attendees = load_event_attendee_map(&event_ids, conn).await?;
-    let tags = load_event_tag_map(&event_ids, conn).await?;
-    let saved_event_ids = load_saved_event_ids(&event_ids, profile_id, conn).await?;
+    let creators = load_creator_previews(conn, event_models).await?;
+    let attendees = load_event_attendee_map(conn, &event_ids).await?;
+    let tags = load_event_tag_map(conn, &event_ids).await?;
+    let saved_event_ids = load_saved_event_ids(conn, &event_ids, profile_id).await?;
 
     Ok(EventBatchContext {
         creators,

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -9,58 +9,93 @@ use axum::{
     Json,
 };
 use chrono::Utc;
-use diesel::QueryDsl;
-use diesel_async::{AsyncConnection, RunQueryDsl};
+use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
 use crate::api::state::{
-    AttendEventBody, AttendeeStatus, CreateEventBody, DataResponse, SuccessResponse,
+    AttendEventBody, AttendeeStatus, CreateEventBody, DataResponse, EventResponse, SuccessResponse,
     UpdateEventBody,
 };
-use crate::db::models::events::{Event, NewEvent};
-use crate::db::models::profiles::Profile;
+use crate::db;
+use crate::db::models::events::{Event, EventChangeset, NewEvent};
 use crate::jobs::enqueue_chat_membership_sync;
 
 use super::events_interactions_repo::{
-    delete_event_interaction, delete_event_interaction_with_conn, upsert_event_interaction,
-    upsert_event_interaction_with_conn, EVENT_INTERACTION_JOINED, EVENT_INTERACTION_SAVED,
+    delete_event_interaction_with_conn, upsert_event_interaction_with_conn,
+    EVENT_INTERACTION_JOINED, EVENT_INTERACTION_SAVED,
 };
 use super::events_service::{
-    forbidden, load_event, parse_create_dates, require_auth_profile, validate_max_attendees,
-    validation_error,
+    forbidden, load_event_by_id, load_profile_for_user, not_found_event, parse_create_dates,
+    profile_not_found, validate_max_attendees, validation_error,
 };
 use super::events_tags_repo::{sync_event_tags_with_conn, upsert_attendee_with_conn};
 use super::events_tags_service::{
-    maybe_sync_tags_with_conn, resolve_event_tag_ids, resolve_event_tag_ids_with_conn,
+    maybe_sync_tags_with_conn, parse_event_tag_ids, resolve_event_tag_ids_with_conn,
 };
-use super::events_view::{build_event_response, created_event_response};
-use super::events_write_repo;
-use super::events_write_service::event_update_inner;
+use super::events_view::{build_event_response_raw, created_event_response, resolve_event_images};
+use super::events_write_repo::{self, is_serialization_failure};
+use super::events_write_service::prepare_update_changeset;
+
+/// Wrap an `AppError` into a diesel-level error so it can propagate through
+/// transaction boundaries. `Message` / `Validation` preserve their text for
+/// the caller to surface; everything else rolls back generically.
+fn into_diesel(e: crate::error::AppError) -> diesel::result::Error {
+    match e {
+        crate::error::AppError::Message(_) | crate::error::AppError::Validation(_) => {
+            diesel::result::Error::QueryBuilderError(Box::new(e))
+        }
+        crate::error::AppError::Any(_) => diesel::result::Error::RollbackTransaction,
+    }
+}
+
+async fn auth_and_viewer(
+    headers: &HeaderMap,
+) -> std::result::Result<(db::DbViewer, crate::db::models::users::User), Box<Response>> {
+    let (_session, user) = crate::api::state::require_auth_db(headers).await?;
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    Ok((viewer, user))
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
 
 struct ValidatedCreate {
-    profile: Profile,
     title: String,
     starts_at: chrono::DateTime<Utc>,
     ends_at: Option<chrono::DateTime<Utc>>,
+    validated_tag_ids: Option<Vec<Uuid>>,
 }
 
-async fn event_create_validate(
+fn validate_create(
     headers: &HeaderMap,
     payload: &CreateEventBody,
 ) -> std::result::Result<ValidatedCreate, Box<Response>> {
-    let (profile, _user_pid) = require_auth_profile(headers).await?;
     let (title, starts_at, ends_at) = parse_create_dates(headers, payload)?;
     validate_max_attendees(payload.max_attendees)
         .map_err(|msg| Box::new(validation_error(headers, msg)))?;
+    let validated_tag_ids = match payload.tag_ids.clone() {
+        Some(ids) => Some(parse_event_tag_ids(headers, ids)?),
+        None => None,
+    };
     Ok(ValidatedCreate {
-        profile,
         title,
         starts_at,
         ends_at,
+        validated_tag_ids,
     })
 }
 
-fn build_create_event(validated: &ValidatedCreate, payload: &CreateEventBody) -> (NewEvent, Uuid) {
+fn build_new_event(
+    profile_id: Uuid,
+    validated: &ValidatedCreate,
+    payload: &CreateEventBody,
+) -> (NewEvent, Uuid) {
     let now = Utc::now();
     let event_id = Uuid::new_v4();
     let model = NewEvent {
@@ -72,7 +107,7 @@ fn build_create_event(validated: &ValidatedCreate, payload: &CreateEventBody) ->
         location: payload.location.clone(),
         starts_at: validated.starts_at,
         ends_at: validated.ends_at,
-        creator_id: validated.profile.id,
+        creator_id: profile_id,
         conversation_id: None,
         latitude: payload.latitude,
         longitude: payload.longitude,
@@ -84,72 +119,119 @@ fn build_create_event(validated: &ValidatedCreate, payload: &CreateEventBody) ->
     (model, event_id)
 }
 
+enum CreateOutcome {
+    NoProfile,
+    Created { event: Box<Event>, profile_id: Uuid },
+}
+
 pub(in crate::api) async fn event_create(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
     Json(payload): Json<CreateEventBody>,
 ) -> Result<Response> {
-    let validated = match event_create_validate(&headers, &payload).await {
-        Ok(data) => data,
+    let (viewer, _user) = match auth_and_viewer(&headers).await {
+        Ok(pair) => pair,
         Err(response) => return Ok(*response),
     };
 
-    let (new_event, event_id) = build_create_event(&validated, &payload);
-    let tag_names = payload.tags.clone();
-    let validated_tag_ids = match payload.tag_ids.clone() {
-        Some(ids) => match resolve_event_tag_ids(&headers, None, Some(ids)).await {
-            Ok(ids) => Some(ids),
-            Err(response) => return Ok(*response),
-        },
-        None => None,
+    let validated = match validate_create(&headers, &payload) {
+        Ok(v) => v,
+        Err(response) => return Ok(*response),
     };
+    let tag_names = payload.tags.clone();
+    let user_id = viewer.user_id;
 
-    let mut conn = crate::db::conn().await?;
-    let inserted = conn
-        .transaction(|conn| {
-            let new_event = NewEvent {
-                id: new_event.id,
-                title: new_event.title.clone(),
-                description: new_event.description.clone(),
-                cover_image: new_event.cover_image.clone(),
-                category: new_event.category.clone(),
-                location: new_event.location.clone(),
-                starts_at: new_event.starts_at,
-                ends_at: new_event.ends_at,
-                creator_id: new_event.creator_id,
-                conversation_id: new_event.conversation_id.clone(),
-                latitude: new_event.latitude,
-                longitude: new_event.longitude,
-                max_attendees: new_event.max_attendees,
-                created_at: new_event.created_at,
-                updated_at: new_event.updated_at,
-                requires_approval: new_event.requires_approval,
+    let outcome = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<CreateOutcome, diesel::result::Error>(CreateOutcome::NoProfile);
             };
-            let tag_names = tag_names.clone();
-            let validated_tag_ids = validated_tag_ids.clone();
-            let profile_id = validated.profile.id;
-            Box::pin(async move {
-                let inserted = events_write_repo::insert_event_with_conn(conn, &new_event).await?;
-                let tag_ids =
-                    resolve_event_tag_ids_with_conn(conn, tag_names, validated_tag_ids).await?;
-                if !tag_ids.is_empty() {
-                    sync_event_tags_with_conn(conn, event_id, &tag_ids).await?;
-                }
-                upsert_attendee_with_conn(conn, event_id, profile_id, ATTENDEE_GOING).await?;
-                upsert_event_interaction_with_conn(
-                    conn,
-                    profile_id,
-                    event_id,
-                    EVENT_INTERACTION_JOINED,
-                )
-                .await?;
-                Ok::<Event, crate::error::AppError>(inserted)
-            })
-        })
-        .await?;
 
-    let data = build_event_response(&inserted, &validated.profile.id).await?;
-    Ok(created_event_response(data))
+            let (new_event, event_id) = build_new_event(profile.id, &validated, &payload);
+            let inserted = events_write_repo::insert_event_with_conn(conn, &new_event)
+                .await
+                .map_err(into_diesel)?;
+            let tag_ids =
+                resolve_event_tag_ids_with_conn(conn, tag_names, validated.validated_tag_ids)
+                    .await
+                    .map_err(into_diesel)?;
+            if !tag_ids.is_empty() {
+                sync_event_tags_with_conn(conn, event_id, &tag_ids)
+                    .await
+                    .map_err(into_diesel)?;
+            }
+            upsert_attendee_with_conn(conn, event_id, profile.id, ATTENDEE_GOING)
+                .await
+                .map_err(into_diesel)?;
+            upsert_event_interaction_with_conn(
+                conn,
+                profile.id,
+                event_id,
+                EVENT_INTERACTION_JOINED,
+            )
+            .await
+            .map_err(into_diesel)?;
+
+            Ok(CreateOutcome::Created {
+                event: Box::new(inserted),
+                profile_id: profile.id,
+            })
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        CreateOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        CreateOutcome::Created { event, profile_id } => {
+            let mut response = build_response_after_tx(viewer, &event, profile_id).await?;
+            resolve_single(&mut response).await;
+            Ok(created_event_response(response))
+        }
+    }
+}
+
+async fn build_response_after_tx(
+    viewer: db::DbViewer,
+    event: &Event,
+    profile_id: Uuid,
+) -> std::result::Result<EventResponse, crate::error::AppError> {
+    let event = event.clone();
+    db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            build_event_response_raw(conn, &event, &profile_id)
+                .await
+                .map_err(into_diesel)
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)
+}
+
+async fn resolve_single(response: &mut EventResponse) {
+    let slice = std::slice::from_mut(response);
+    resolve_event_images(slice).await;
+}
+
+// ---------------------------------------------------------------------------
+// Update (serializable with retry)
+// ---------------------------------------------------------------------------
+
+enum UpdateOutcome {
+    NoProfile,
+    NotFound,
+    Forbidden,
+    Invalid(Box<Response>),
+    Updated {
+        event: Box<Event>,
+        profile_id: Uuid,
+        auto_approved: Vec<Uuid>,
+    },
 }
 
 pub(in crate::api) async fn event_update(
@@ -158,114 +240,157 @@ pub(in crate::api) async fn event_update(
     Path(id): Path<String>,
     Json(payload): Json<UpdateEventBody>,
 ) -> Result<Response> {
-    let (changeset, event_uuid, profile, _current_event) =
-        match event_update_inner(&headers, &id, &payload).await {
-            Ok(data) => data,
-            Err(response) => return Ok(*response),
-        };
+    let (viewer, _user) = match auth_and_viewer(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
 
-    let tag_names = payload.tags.clone();
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+
     let validated_tag_ids = if payload.tag_ids.is_some() {
-        match resolve_event_tag_ids(&headers, None, payload.tag_ids.clone()).await {
-            Ok(ids) => Some(ids),
-            Err(response) => return Ok(*response),
+        match payload.tag_ids.clone() {
+            Some(ids) => match parse_event_tag_ids(&headers, ids) {
+                Ok(parsed) => Some(parsed),
+                Err(response) => return Ok(*response),
+            },
+            None => None,
         }
     } else {
         None
     };
 
-    let sets_approval_false = changeset.requires_approval == Some(false);
-
     let mut conn = crate::db::conn().await?;
+    let user_id = viewer.user_id;
     let mut attempts = 0;
-    let (updated, auto_approved) = loop {
+    let outcome = loop {
         attempts += 1;
+        let headers = &headers;
+        let payload = &payload;
+        let tag_names = payload.tags.clone();
+        let validated_tag_ids_clone = validated_tag_ids.clone();
         let result = conn
             .build_transaction()
             .serializable()
             .run(|conn| {
-                let changeset = crate::db::models::events::EventChangeset {
-                    title: changeset.title.clone(),
-                    description: changeset.description.clone(),
-                    cover_image: changeset.cover_image.clone(),
-                    category: changeset.category.clone(),
-                    location: changeset.location.clone(),
-                    starts_at: changeset.starts_at,
-                    ends_at: changeset.ends_at,
-                    conversation_id: changeset.conversation_id.clone(),
-                    latitude: changeset.latitude,
-                    longitude: changeset.longitude,
-                    max_attendees: changeset.max_attendees,
-                    updated_at: changeset.updated_at,
-                    requires_approval: changeset.requires_approval,
-                };
-                let tag_names = tag_names.clone();
-                let validated_tag_ids = validated_tag_ids.clone();
                 Box::pin(async move {
-                    // Read requires_approval inside the txn so retries see fresh state
+                    db::set_viewer_context(conn, viewer).await?;
+
+                    let Some(profile) = load_profile_for_user(conn, user_id)
+                        .await
+                        .map_err(into_diesel)?
+                    else {
+                        return Ok::<UpdateOutcome, diesel::result::Error>(
+                            UpdateOutcome::NoProfile,
+                        );
+                    };
+
+                    let Some(event) = load_event_by_id(conn, event_uuid)
+                        .await
+                        .map_err(into_diesel)?
+                    else {
+                        return Ok(UpdateOutcome::NotFound);
+                    };
+
+                    if event.creator_id != profile.id {
+                        return Ok(UpdateOutcome::Forbidden);
+                    }
+
+                    let changeset: EventChangeset =
+                        match prepare_update_changeset(headers, &event, profile.id, payload) {
+                            Ok(c) => c,
+                            Err(response) => return Ok(UpdateOutcome::Invalid(response)),
+                        };
+
+                    let sets_approval_false = changeset.requires_approval == Some(false);
                     let was_requiring = sets_approval_false
                         && crate::db::schema::events::table
                             .find(event_uuid)
                             .select(crate::db::schema::events::requires_approval)
                             .first::<bool>(conn)
                             .await?;
+
                     let updated =
                         events_write_repo::update_event_with_conn(conn, event_uuid, &changeset)
-                            .await?;
+                            .await
+                            .map_err(into_diesel)?;
+
                     let auto_approved = if was_requiring {
                         events_write_repo::auto_approve_pending_with_conn(
                             conn,
                             event_uuid,
                             updated.max_attendees,
                         )
-                        .await?
+                        .await
+                        .map_err(into_diesel)?
                     } else {
                         vec![]
                     };
-                    maybe_sync_tags_with_conn(conn, event_uuid, tag_names, validated_tag_ids)
-                        .await?;
-                    Ok::<(Event, Vec<Uuid>), crate::error::AppError>((updated, auto_approved))
+
+                    maybe_sync_tags_with_conn(conn, event_uuid, tag_names, validated_tag_ids_clone)
+                        .await
+                        .map_err(into_diesel)?;
+
+                    Ok(UpdateOutcome::Updated {
+                        event: Box::new(updated),
+                        profile_id: profile.id,
+                        auto_approved,
+                    })
                 })
             })
             .await;
         match result {
             Ok(val) => break val,
             Err(ref e)
-                if attempts < events_write_repo::MAX_ATTEMPTS
-                    && events_write_repo::is_serialization_failure_app(e) =>
+                if attempts < events_write_repo::MAX_ATTEMPTS && is_serialization_failure(e) =>
             {
                 tokio::time::sleep(std::time::Duration::from_millis(10u64 << attempts)).await;
             }
-            Err(e) => return Err(e),
+            Err(e) => return Err(crate::error::AppError::from(e)),
         }
     };
 
-    for pid in &auto_approved {
-        if let Err(error) = enqueue_chat_membership_sync(&updated.id, pid, false).await {
-            tracing::warn!(
-                %error,
-                event_id = %updated.id,
-                profile_id = %pid,
-                "failed to enqueue chat membership sync for auto-approved attendee"
-            );
+    match outcome {
+        UpdateOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        UpdateOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        UpdateOutcome::Forbidden => Ok(forbidden(
+            &headers,
+            "Only the creator can update this event",
+        )),
+        UpdateOutcome::Invalid(response) => Ok(*response),
+        UpdateOutcome::Updated {
+            event,
+            profile_id,
+            auto_approved,
+        } => {
+            for pid in &auto_approved {
+                if let Err(error) = enqueue_chat_membership_sync(&event.id, pid, false).await {
+                    tracing::warn!(
+                        %error,
+                        event_id = %event.id,
+                        profile_id = %pid,
+                        "failed to enqueue chat membership sync for auto-approved attendee"
+                    );
+                }
+            }
+            let mut response = build_response_after_tx(viewer, &event, profile_id).await?;
+            resolve_single(&mut response).await;
+            Ok(Json(DataResponse { data: response }).into_response())
         }
     }
-
-    let data = build_event_response(&updated, &profile.id).await?;
-    Ok(Json(DataResponse { data }).into_response())
 }
 
-async fn load_owned_event(
-    headers: &HeaderMap,
-    id: &str,
-    message: &str,
-) -> std::result::Result<(Event, Uuid), Box<Response>> {
-    let (profile, _user_pid) = require_auth_profile(headers).await?;
-    let (event, event_uuid) = load_event(headers, id).await?;
-    if event.creator_id != profile.id {
-        return Err(Box::new(forbidden(headers, message)));
-    }
-    Ok((event, event_uuid))
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+enum SimpleOutcome {
+    NoProfile,
+    NotFound,
+    Forbidden,
+    Ok,
 }
 
 pub(in crate::api) async fn event_delete(
@@ -273,28 +398,60 @@ pub(in crate::api) async fn event_delete(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let (_event, event_uuid) =
-        match load_owned_event(&headers, &id, "Only the creator can delete this event").await {
-            Ok(data) => data,
-            Err(response) => return Ok(*response),
-        };
+    let (viewer, _user) = match auth_and_viewer(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+    let user_id = viewer.user_id;
 
-    events_write_repo::delete_event(event_uuid).await?;
-
-    Ok(Json(DataResponse {
-        data: SuccessResponse { success: true },
+    let outcome = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<SimpleOutcome, diesel::result::Error>(SimpleOutcome::NoProfile);
+            };
+            let Some(event) = load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(SimpleOutcome::NotFound);
+            };
+            if event.creator_id != profile.id {
+                return Ok(SimpleOutcome::Forbidden);
+            }
+            events_write_repo::delete_event_with_conn(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?;
+            Ok(SimpleOutcome::Ok)
+        }
+        .scope_boxed()
     })
-    .into_response())
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        SimpleOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        SimpleOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        SimpleOutcome::Forbidden => Ok(forbidden(
+            &headers,
+            "Only the creator can delete this event",
+        )),
+        SimpleOutcome::Ok => Ok(Json(DataResponse {
+            data: SuccessResponse { success: true },
+        })
+        .into_response()),
+    }
 }
 
-async fn load_event_with_profile(
-    headers: &HeaderMap,
-    id: &str,
-) -> std::result::Result<(Event, Uuid, Profile), Box<Response>> {
-    let (profile, _user_pid) = require_auth_profile(headers).await?;
-    let (event, event_uuid) = load_event(headers, id).await?;
-    Ok((event, event_uuid, profile))
-}
+// ---------------------------------------------------------------------------
+// Attend (serializable)
+// ---------------------------------------------------------------------------
 
 const ATTENDEE_GOING: &str = "going";
 const ATTENDEE_INTERESTED: &str = "interested";
@@ -305,11 +462,21 @@ fn resolve_attend_status(payload: Option<Json<AttendEventBody>>) -> &'static str
         .and_then(|Json(body)| body.status)
         .unwrap_or(AttendeeStatus::Going)
     {
-        // Clients cannot self-assign pending; the approval gate below handles downgrade
         AttendeeStatus::Going | AttendeeStatus::Pending => ATTENDEE_GOING,
         AttendeeStatus::Interested => ATTENDEE_INTERESTED,
         AttendeeStatus::Invited => ATTENDEE_INVITED,
     }
+}
+
+enum AttendOutcome {
+    NoProfile,
+    NotFound,
+    Full,
+    Accepted {
+        event: Box<Event>,
+        profile_id: Uuid,
+        written_status: String,
+    },
 }
 
 pub(in crate::api) async fn event_attend(
@@ -318,57 +485,129 @@ pub(in crate::api) async fn event_attend(
     Path(id): Path<String>,
     payload: Option<Json<AttendEventBody>>,
 ) -> Result<Response> {
-    let (event, event_uuid, profile) = match load_event_with_profile(&headers, &id).await {
-        Ok(data) => data,
+    let (viewer, _user) = match auth_and_viewer(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
         Err(response) => return Ok(*response),
     };
 
     let status_str = resolve_attend_status(payload);
+    let user_id = viewer.user_id;
 
-    // Approval gate only applies to "going" — "interested" is a soft signal that
-    // intentionally bypasses approval so users can bookmark events without creator action.
-    let requires_approval =
-        event.requires_approval && status_str == ATTENDEE_GOING && event.creator_id != profile.id;
+    let mut conn = crate::db::conn().await?;
+    let mut attempts = 0;
+    let outcome = loop {
+        attempts += 1;
+        let result: std::result::Result<AttendOutcome, diesel::result::Error> = conn
+            .build_transaction()
+            .serializable()
+            .run(|conn| {
+                Box::pin(async move {
+                    db::set_viewer_context(conn, viewer).await?;
 
-    let outcome = events_write_repo::check_capacity_and_upsert(
-        event_uuid,
-        profile.id,
-        status_str,
-        event.max_attendees,
-        None,
-        requires_approval,
-    )
-    .await?;
-    let written_status = match outcome {
-        events_write_repo::UpsertOutcome::Full => {
-            return Ok(validation_error(&headers, "Event is full"));
-        }
-        events_write_repo::UpsertOutcome::Accepted(s) => s,
-        events_write_repo::UpsertOutcome::StatusMismatch => {
-            debug_assert!(false, "StatusMismatch returned with require_status = None");
-            return Ok(validation_error(&headers, "Unexpected status mismatch"));
+                    let Some(profile) = load_profile_for_user(conn, user_id)
+                        .await
+                        .map_err(into_diesel)?
+                    else {
+                        return Ok(AttendOutcome::NoProfile);
+                    };
+                    let Some(event) = load_event_by_id(conn, event_uuid)
+                        .await
+                        .map_err(into_diesel)?
+                    else {
+                        return Ok(AttendOutcome::NotFound);
+                    };
+
+                    let requires_approval = event.requires_approval
+                        && status_str == ATTENDEE_GOING
+                        && event.creator_id != profile.id;
+
+                    let outcome = events_write_repo::check_capacity_and_upsert_with_conn(
+                        conn,
+                        event_uuid,
+                        profile.id,
+                        status_str,
+                        event.max_attendees,
+                        None,
+                        requires_approval,
+                    )
+                    .await?;
+
+                    match outcome {
+                        events_write_repo::UpsertOutcome::Full => Ok(AttendOutcome::Full),
+                        events_write_repo::UpsertOutcome::StatusMismatch => {
+                            debug_assert!(
+                                false,
+                                "StatusMismatch returned with require_status = None"
+                            );
+                            Ok(AttendOutcome::Full)
+                        }
+                        events_write_repo::UpsertOutcome::Accepted(s) => {
+                            Ok(AttendOutcome::Accepted {
+                                event: Box::new(event),
+                                profile_id: profile.id,
+                                written_status: s,
+                            })
+                        }
+                    }
+                })
+            })
+            .await;
+        match result {
+            Ok(val) => break val,
+            Err(ref e)
+                if attempts < events_write_repo::MAX_ATTEMPTS && is_serialization_failure(e) =>
+            {
+                tokio::time::sleep(std::time::Duration::from_millis(10u64 << attempts)).await;
+            }
+            Err(e) => return Err(crate::error::AppError::from(e)),
         }
     };
 
-    if written_status == ATTENDEE_GOING {
-        if let Err(error) = enqueue_chat_membership_sync(&event.id, &profile.id, false).await {
-            tracing::warn!(
-                %error,
-                event_id = %event.id,
-                profile_id = %profile.id,
-                "failed to enqueue chat membership sync after attend"
-            );
-        }
-        let profile_id = profile.id;
-        tokio::spawn(async move {
-            if let Err(e) = crate::api::xp::service::award_xp(profile_id, 10).await {
-                tracing::warn!(error = %e, %profile_id, "failed to award XP for event attendance");
+    match outcome {
+        AttendOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        AttendOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        AttendOutcome::Full => Ok(validation_error(&headers, "Event is full")),
+        AttendOutcome::Accepted {
+            event,
+            profile_id,
+            written_status,
+        } => {
+            if written_status == ATTENDEE_GOING {
+                if let Err(error) =
+                    enqueue_chat_membership_sync(&event.id, &profile_id, false).await
+                {
+                    tracing::warn!(
+                        %error,
+                        event_id = %event.id,
+                        profile_id = %profile_id,
+                        "failed to enqueue chat membership sync after attend"
+                    );
+                }
+                tokio::spawn(async move {
+                    if let Err(e) = crate::api::xp::service::award_xp(profile_id, 10).await {
+                        tracing::warn!(error = %e, %profile_id, "failed to award XP for event attendance");
+                    }
+                });
             }
-        });
+            let mut response = build_response_after_tx(viewer, &event, profile_id).await?;
+            resolve_single(&mut response).await;
+            Ok(Json(DataResponse { data: response }).into_response())
+        }
     }
+}
 
-    let data = build_event_response(&event, &profile.id).await?;
-    Ok(Json(DataResponse { data }).into_response())
+// ---------------------------------------------------------------------------
+// Save / Unsave (simple)
+// ---------------------------------------------------------------------------
+
+enum LoadedOutcome {
+    NoProfile,
+    NotFound,
+    Loaded { event: Box<Event>, profile_id: Uuid },
 }
 
 pub(in crate::api) async fn event_save(
@@ -376,181 +615,49 @@ pub(in crate::api) async fn event_save(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let (event, event_uuid, profile) = match load_event_with_profile(&headers, &id).await {
-        Ok(data) => data,
+    let (viewer, _user) = match auth_and_viewer(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
         Err(response) => return Ok(*response),
     };
 
-    upsert_event_interaction(profile.id, event_uuid, EVENT_INTERACTION_SAVED).await?;
-
-    let data = build_event_response(&event, &profile.id).await?;
-    Ok(Json(DataResponse { data }).into_response())
-}
-
-pub(in crate::api) async fn event_approve_attendee(
-    State(_ctx): State<AppContext>,
-    headers: HeaderMap,
-    Path((id, profile_id_str)): Path<(String, String)>,
-) -> Result<Response> {
-    let (profile, _user_pid) = match require_auth_profile(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
-
-    let (event, event_uuid) = match load_event(&headers, &id).await {
-        Ok(data) => data,
-        Err(response) => return Ok(*response),
-    };
-
-    if event.creator_id != profile.id {
-        return Ok(forbidden(
-            &headers,
-            "Only the creator can approve attendees",
-        ));
-    }
-
-    let target_profile_id = Uuid::parse_str(&profile_id_str)
-        .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
-
-    let outcome = events_write_repo::check_capacity_and_upsert(
-        event_uuid,
-        target_profile_id,
-        "going",
-        event.max_attendees,
-        Some("pending"),
-        false,
-    )
-    .await?;
-    match outcome {
-        events_write_repo::UpsertOutcome::Full => {
-            return Ok(validation_error(&headers, "Event is full"));
-        }
-        events_write_repo::UpsertOutcome::StatusMismatch => {
-            return Ok(super::events_service::validation_error(
-                &headers,
-                "Attendee is not pending approval",
-            ));
-        }
-        events_write_repo::UpsertOutcome::Accepted(_) => {}
-    }
-
-    if let Err(error) = enqueue_chat_membership_sync(&event.id, &target_profile_id, false).await {
-        tracing::warn!(
-            %error,
-            event_id = %event.id,
-            profile_id = %target_profile_id,
-            "failed to enqueue chat membership sync after approve"
-        );
-    }
-
-    // Award XP to the approved attendee
-    tokio::spawn(async move {
-        if let Err(e) = crate::api::xp::service::award_xp(target_profile_id, 10).await {
-            tracing::warn!(error = %e, profile_id = %target_profile_id, "failed to award XP for event approval");
-        }
-        notify_event_approval(target_profile_id, &event.title, true).await;
-    });
-
-    Ok(Json(DataResponse {
-        data: SuccessResponse { success: true },
-    })
-    .into_response())
-}
-
-pub(in crate::api) async fn event_reject_attendee(
-    State(_ctx): State<AppContext>,
-    headers: HeaderMap,
-    Path((id, profile_id_str)): Path<(String, String)>,
-) -> Result<Response> {
-    let (profile, _user_pid) = match require_auth_profile(&headers).await {
-        Ok(auth) => auth,
-        Err(response) => return Ok(*response),
-    };
-
-    let (event, event_uuid) = match load_event(&headers, &id).await {
-        Ok(data) => data,
-        Err(response) => return Ok(*response),
-    };
-
-    if event.creator_id != profile.id {
-        return Ok(forbidden(&headers, "Only the creator can reject attendees"));
-    }
-
-    let target_profile_id = Uuid::parse_str(&profile_id_str)
-        .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
-
-    let deleted = events_write_repo::delete_pending_attendee(event_uuid, target_profile_id).await?;
-    if !deleted {
-        return Ok(super::events_service::validation_error(
-            &headers,
-            "Attendee is not pending approval",
-        ));
-    }
-
-    // Notify the rejected user via ntfy
-    tokio::spawn(async move {
-        notify_event_approval(target_profile_id, &event.title, false).await;
-    });
-
-    Ok(Json(DataResponse {
-        data: SuccessResponse { success: true },
-    })
-    .into_response())
-}
-
-async fn load_event_for_leave(
-    headers: &HeaderMap,
-    id: &str,
-) -> std::result::Result<(Event, Uuid, Profile), Box<Response>> {
-    let (profile, _user_pid) = require_auth_profile(headers).await?;
-    let (event, event_uuid) = load_event(headers, id).await?;
-    if event.creator_id == profile.id {
-        return Err(Box::new(forbidden(
-            headers,
-            "Event creator cannot leave the event",
-        )));
-    }
-    Ok((event, event_uuid, profile))
-}
-
-pub(in crate::api) async fn event_leave(
-    State(_ctx): State<AppContext>,
-    headers: HeaderMap,
-    Path(id): Path<String>,
-) -> Result<Response> {
-    let (event, event_uuid, profile) = match load_event_for_leave(&headers, &id).await {
-        Ok(data) => data,
-        Err(response) => return Ok(*response),
-    };
-
-    let mut conn = crate::db::conn().await?;
-    conn.transaction(|conn| {
-        Box::pin(async move {
-            events_write_repo::delete_event_attendee_with_conn(conn, event_uuid, profile.id)
-                .await?;
-            delete_event_interaction_with_conn(
+    let user_id = viewer.user_id;
+    let outcome = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<LoadedOutcome, diesel::result::Error>(LoadedOutcome::NoProfile);
+            };
+            let Some(event) = load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(LoadedOutcome::NotFound);
+            };
+            upsert_event_interaction_with_conn(
                 conn,
                 profile.id,
                 event_uuid,
-                EVENT_INTERACTION_JOINED,
+                EVENT_INTERACTION_SAVED,
             )
-            .await?;
-            Ok::<(), crate::error::AppError>(())
-        })
+            .await
+            .map_err(into_diesel)?;
+            Ok(LoadedOutcome::Loaded {
+                event: Box::new(event),
+                profile_id: profile.id,
+            })
+        }
+        .scope_boxed()
     })
-    .await?;
+    .await
+    .map_err(crate::error::AppError::from)?;
 
-    if let Err(error) = enqueue_chat_membership_sync(&event.id, &profile.id, true).await {
-        tracing::warn!(
-            %error,
-            event_id = %event.id,
-            profile_id = %profile.id,
-            "failed to enqueue chat membership sync after leave"
-        );
-    }
-
-    let data = build_event_response(&event, &profile.id).await?;
-    Ok(Json(DataResponse { data }).into_response())
+    finalize_loaded_event(&headers, &id, viewer, outcome).await
 }
 
 pub(in crate::api) async fn event_unsave(
@@ -558,35 +665,377 @@ pub(in crate::api) async fn event_unsave(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let (event, event_uuid, profile) = match load_event_with_profile(&headers, &id).await {
-        Ok(data) => data,
+    let (viewer, _user) = match auth_and_viewer(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
         Err(response) => return Ok(*response),
     };
 
-    delete_event_interaction(profile.id, event_uuid, EVENT_INTERACTION_SAVED).await?;
+    let user_id = viewer.user_id;
+    let outcome = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<LoadedOutcome, diesel::result::Error>(LoadedOutcome::NoProfile);
+            };
+            let Some(event) = load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(LoadedOutcome::NotFound);
+            };
+            delete_event_interaction_with_conn(
+                conn,
+                profile.id,
+                event_uuid,
+                EVENT_INTERACTION_SAVED,
+            )
+            .await
+            .map_err(into_diesel)?;
+            Ok(LoadedOutcome::Loaded {
+                event: Box::new(event),
+                profile_id: profile.id,
+            })
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
 
-    let data = build_event_response(&event, &profile.id).await?;
-    Ok(Json(DataResponse { data }).into_response())
+    finalize_loaded_event(&headers, &id, viewer, outcome).await
 }
 
-async fn notify_event_approval(target_profile_id: Uuid, event_title: &str, approved: bool) {
-    use diesel::ExpressionMethods;
-    use diesel::QueryDsl;
-    use diesel_async::RunQueryDsl;
-
-    let user_id: i32 = {
-        let Ok(mut conn) = crate::db::conn().await else {
-            return;
-        };
-        match crate::db::schema::profiles::table
-            .filter(crate::db::schema::profiles::id.eq(target_profile_id))
-            .select(crate::db::schema::profiles::user_id)
-            .first::<i32>(&mut conn)
-            .await
-        {
-            Ok(uid) => uid,
-            Err(_) => return,
+async fn finalize_loaded_event(
+    headers: &HeaderMap,
+    id: &str,
+    viewer: db::DbViewer,
+    outcome: LoadedOutcome,
+) -> Result<Response> {
+    match outcome {
+        LoadedOutcome::NoProfile => Ok(profile_not_found(headers)),
+        LoadedOutcome::NotFound => Ok(not_found_event(headers, id)),
+        LoadedOutcome::Loaded { event, profile_id } => {
+            let mut response = build_response_after_tx(viewer, &event, profile_id).await?;
+            resolve_single(&mut response).await;
+            Ok(Json(DataResponse { data: response }).into_response())
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Approve / Reject attendee
+// ---------------------------------------------------------------------------
+
+enum ApproveOutcome {
+    NoProfile,
+    NotFound,
+    Forbidden,
+    Full,
+    StatusMismatch,
+    Accepted { event_id: Uuid, title: String },
+}
+
+pub(in crate::api) async fn event_approve_attendee(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path((id, profile_id_str)): Path<(String, String)>,
+) -> Result<Response> {
+    let (viewer, _user) = match auth_and_viewer(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+    let target_profile_id = Uuid::parse_str(&profile_id_str)
+        .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
+    let user_id = viewer.user_id;
+
+    let mut conn = crate::db::conn().await?;
+    let mut attempts = 0;
+    let outcome = loop {
+        attempts += 1;
+        let result: std::result::Result<ApproveOutcome, diesel::result::Error> = conn
+            .build_transaction()
+            .serializable()
+            .run(|conn| {
+                Box::pin(async move {
+                    db::set_viewer_context(conn, viewer).await?;
+
+                    let Some(profile) = load_profile_for_user(conn, user_id)
+                        .await
+                        .map_err(into_diesel)?
+                    else {
+                        return Ok(ApproveOutcome::NoProfile);
+                    };
+                    let Some(event) = load_event_by_id(conn, event_uuid)
+                        .await
+                        .map_err(into_diesel)?
+                    else {
+                        return Ok(ApproveOutcome::NotFound);
+                    };
+                    if event.creator_id != profile.id {
+                        return Ok(ApproveOutcome::Forbidden);
+                    }
+
+                    let outcome = events_write_repo::check_capacity_and_upsert_with_conn(
+                        conn,
+                        event_uuid,
+                        target_profile_id,
+                        "going",
+                        event.max_attendees,
+                        Some("pending"),
+                        false,
+                    )
+                    .await?;
+                    match outcome {
+                        events_write_repo::UpsertOutcome::Full => Ok(ApproveOutcome::Full),
+                        events_write_repo::UpsertOutcome::StatusMismatch => {
+                            Ok(ApproveOutcome::StatusMismatch)
+                        }
+                        events_write_repo::UpsertOutcome::Accepted(_) => {
+                            Ok(ApproveOutcome::Accepted {
+                                event_id: event.id,
+                                title: event.title,
+                            })
+                        }
+                    }
+                })
+            })
+            .await;
+        match result {
+            Ok(val) => break val,
+            Err(ref e)
+                if attempts < events_write_repo::MAX_ATTEMPTS && is_serialization_failure(e) =>
+            {
+                tokio::time::sleep(std::time::Duration::from_millis(10u64 << attempts)).await;
+            }
+            Err(e) => return Err(crate::error::AppError::from(e)),
+        }
+    };
+
+    match outcome {
+        ApproveOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        ApproveOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        ApproveOutcome::Forbidden => Ok(forbidden(
+            &headers,
+            "Only the creator can approve attendees",
+        )),
+        ApproveOutcome::Full => Ok(validation_error(&headers, "Event is full")),
+        ApproveOutcome::StatusMismatch => Ok(validation_error(
+            &headers,
+            "Attendee is not pending approval",
+        )),
+        ApproveOutcome::Accepted { event_id, title } => {
+            if let Err(error) =
+                enqueue_chat_membership_sync(&event_id, &target_profile_id, false).await
+            {
+                tracing::warn!(
+                    %error,
+                    %event_id,
+                    profile_id = %target_profile_id,
+                    "failed to enqueue chat membership sync after approve"
+                );
+            }
+            tokio::spawn(async move {
+                if let Err(e) = crate::api::xp::service::award_xp(target_profile_id, 10).await {
+                    tracing::warn!(error = %e, profile_id = %target_profile_id, "failed to award XP for event approval");
+                }
+                notify_event_approval(target_profile_id, &title, true).await;
+            });
+            Ok(Json(DataResponse {
+                data: SuccessResponse { success: true },
+            })
+            .into_response())
+        }
+    }
+}
+
+enum RejectOutcome {
+    NoProfile,
+    NotFound,
+    Forbidden,
+    NotPending,
+    Rejected { title: String },
+}
+
+pub(in crate::api) async fn event_reject_attendee(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path((id, profile_id_str)): Path<(String, String)>,
+) -> Result<Response> {
+    let (viewer, _user) = match auth_and_viewer(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+    let target_profile_id = Uuid::parse_str(&profile_id_str)
+        .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
+    let user_id = viewer.user_id;
+
+    let outcome = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<RejectOutcome, diesel::result::Error>(RejectOutcome::NoProfile);
+            };
+            let Some(event) = load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(RejectOutcome::NotFound);
+            };
+            if event.creator_id != profile.id {
+                return Ok(RejectOutcome::Forbidden);
+            }
+            let deleted = events_write_repo::delete_pending_attendee_with_conn(
+                conn,
+                event_uuid,
+                target_profile_id,
+            )
+            .await
+            .map_err(into_diesel)?;
+            if !deleted {
+                return Ok(RejectOutcome::NotPending);
+            }
+            Ok(RejectOutcome::Rejected { title: event.title })
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        RejectOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        RejectOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        RejectOutcome::Forbidden => {
+            Ok(forbidden(&headers, "Only the creator can reject attendees"))
+        }
+        RejectOutcome::NotPending => Ok(validation_error(
+            &headers,
+            "Attendee is not pending approval",
+        )),
+        RejectOutcome::Rejected { title } => {
+            tokio::spawn(async move {
+                notify_event_approval(target_profile_id, &title, false).await;
+            });
+            Ok(Json(DataResponse {
+                data: SuccessResponse { success: true },
+            })
+            .into_response())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Leave
+// ---------------------------------------------------------------------------
+
+enum LeaveOutcome {
+    NoProfile,
+    NotFound,
+    CreatorCannotLeave,
+    Left { event: Box<Event>, profile_id: Uuid },
+}
+
+pub(in crate::api) async fn event_leave(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Response> {
+    let (viewer, _user) = match auth_and_viewer(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+    let user_id = viewer.user_id;
+
+    let outcome = db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<LeaveOutcome, diesel::result::Error>(LeaveOutcome::NoProfile);
+            };
+            let Some(event) = load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(LeaveOutcome::NotFound);
+            };
+            if event.creator_id == profile.id {
+                return Ok(LeaveOutcome::CreatorCannotLeave);
+            }
+            events_write_repo::delete_event_attendee_with_conn(conn, event_uuid, profile.id)
+                .await
+                .map_err(into_diesel)?;
+            delete_event_interaction_with_conn(
+                conn,
+                profile.id,
+                event_uuid,
+                EVENT_INTERACTION_JOINED,
+            )
+            .await
+            .map_err(into_diesel)?;
+            Ok(LeaveOutcome::Left {
+                event: Box::new(event),
+                profile_id: profile.id,
+            })
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        LeaveOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        LeaveOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        LeaveOutcome::CreatorCannotLeave => {
+            Ok(forbidden(&headers, "Event creator cannot leave the event"))
+        }
+        LeaveOutcome::Left { event, profile_id } => {
+            if let Err(error) = enqueue_chat_membership_sync(&event.id, &profile_id, true).await {
+                tracing::warn!(
+                    %error,
+                    event_id = %event.id,
+                    profile_id = %profile_id,
+                    "failed to enqueue chat membership sync after leave"
+                );
+            }
+            let mut response = build_response_after_tx(viewer, &event, profile_id).await?;
+            resolve_single(&mut response).await;
+            Ok(Json(DataResponse { data: response }).into_response())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Push notification for approval/rejection (spawned background task)
+// ---------------------------------------------------------------------------
+
+async fn notify_event_approval(target_profile_id: Uuid, event_title: &str, approved: bool) {
+    let Ok(mut conn) = crate::db::conn().await else {
+        return;
+    };
+    // Resolve the owner user_id via a narrow SECURITY DEFINER helper so the
+    // API role doesn't need broad SELECT on profiles.
+    let Ok(Some(user_id)) = db::profile_owner_user_id(&mut conn, target_profile_id).await else {
+        return;
     };
 
     let body = if approved {

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -183,7 +183,19 @@ pub(in crate::api) async fn event_create(
         .scope_boxed()
     })
     .await
-    .map_err(crate::error::AppError::from)?;
+    .map_err(crate::error::AppError::from);
+
+    let outcome = match outcome {
+        Ok(o) => o,
+        // Validation failures surfaced from inside the tx (e.g. tagIds that
+        // reference missing tags) match the REST contract for this endpoint:
+        // 400 BAD_REQUEST with code VALIDATION_ERROR, not 422. The default
+        // `AppError::Validation` -> 422 mapping is wrong here.
+        Err(crate::error::AppError::Validation(msg)) => {
+            return Ok(validation_error(&headers, &msg));
+        }
+        Err(e) => return Err(e),
+    };
 
     match outcome {
         CreateOutcome::NoProfile => Ok(profile_not_found(&headers)),
@@ -348,7 +360,16 @@ pub(in crate::api) async fn event_update(
             {
                 tokio::time::sleep(std::time::Duration::from_millis(10u64 << attempts)).await;
             }
-            Err(e) => return Err(crate::error::AppError::from(e)),
+            Err(e) => {
+                // Validation failures (e.g. tagIds) match the existing REST
+                // contract: 400 BAD_REQUEST, not the default 422 mapping for
+                // AppError::Validation.
+                let app_err = crate::error::AppError::from(e);
+                if let crate::error::AppError::Validation(msg) = app_err {
+                    return Ok(validation_error(headers, &msg));
+                }
+                return Err(app_err);
+            }
         }
     };
 
@@ -753,8 +774,11 @@ pub(in crate::api) async fn event_approve_attendee(
         Ok(uuid) => uuid,
         Err(response) => return Ok(*response),
     };
-    let target_profile_id = Uuid::parse_str(&profile_id_str)
-        .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
+    let target_profile_id =
+        match crate::api::parse_uuid_response(&profile_id_str, "profile", &headers) {
+            Ok(uuid) => uuid,
+            Err(response) => return Ok(*response),
+        };
     let user_id = viewer.user_id;
 
     let mut conn = crate::db::conn().await?;
@@ -878,8 +902,11 @@ pub(in crate::api) async fn event_reject_attendee(
         Ok(uuid) => uuid,
         Err(response) => return Ok(*response),
     };
-    let target_profile_id = Uuid::parse_str(&profile_id_str)
-        .map_err(|_| crate::error::AppError::Message("Invalid profile ID".to_string()))?;
+    let target_profile_id =
+        match crate::api::parse_uuid_response(&profile_id_str, "profile", &headers) {
+            Ok(uuid) => uuid,
+            Err(response) => return Ok(*response),
+        };
     let user_id = viewer.user_id;
 
     let outcome = db::with_viewer_tx(viewer, |conn| {

--- a/backend/src/api/events/write_repo.rs
+++ b/backend/src/api/events/write_repo.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use diesel::prelude::*;
-use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::event_attendees::EventAttendee;
@@ -10,7 +10,7 @@ use crate::db::schema::{conversations, event_attendees, event_interactions, even
 
 pub(in crate::api) const MAX_ATTEMPTS: usize = 3;
 
-const fn is_serialization_failure(err: &diesel::result::Error) -> bool {
+pub(in crate::api) const fn is_serialization_failure(err: &diesel::result::Error) -> bool {
     matches!(
         err,
         diesel::result::Error::DatabaseError(
@@ -18,15 +18,6 @@ const fn is_serialization_failure(err: &diesel::result::Error) -> bool {
             _
         )
     )
-}
-
-pub(in crate::api) fn is_serialization_failure_app(err: &crate::error::AppError) -> bool {
-    match err {
-        crate::error::AppError::Any(boxed) => boxed
-            .downcast_ref::<diesel::result::Error>()
-            .is_some_and(is_serialization_failure),
-        _ => false,
-    }
 }
 
 pub(in crate::api) enum UpsertOutcome {
@@ -38,120 +29,79 @@ pub(in crate::api) enum UpsertOutcome {
     StatusMismatch,
 }
 
-/// Atomically check capacity, upsert the attendee, and track the interaction
-/// inside a serializable transaction so that two concurrent requests cannot
-/// exceed `max_attendees` and the interaction stays consistent.
-///
-/// When `require_status` is `Some`, the attendee's current status is verified
-/// inside the transaction before proceeding, preventing TOCTOU races.
-///
-/// When `requires_approval` is true and the requested status is "going",
-/// the approval gate is evaluated inside the transaction: if the attendee
-/// is not already "going", the written status is downgraded to "pending".
-/// The actual written status is returned in `UpsertOutcome::Accepted`.
-pub(in crate::api) async fn check_capacity_and_upsert(
+/// Body of the capacity/approval check. Caller is responsible for running
+/// this inside a serializable transaction with the viewer context set.
+pub(in crate::api) async fn check_capacity_and_upsert_with_conn(
+    conn: &mut AsyncPgConnection,
     event_id: Uuid,
     profile_id: Uuid,
     status: &str,
     max_attendees: Option<i32>,
     require_status: Option<&str>,
     requires_approval: bool,
-) -> std::result::Result<UpsertOutcome, crate::error::AppError> {
-    let status = status.to_string();
-    let require_status = require_status.map(String::from);
-    let mut conn = crate::db::conn().await?;
+) -> std::result::Result<UpsertOutcome, diesel::result::Error> {
+    // Read current status inside the txn so retries see fresh state
+    let current_status = event_attendees::table
+        .filter(event_attendees::event_id.eq(event_id))
+        .filter(event_attendees::profile_id.eq(profile_id))
+        .select(event_attendees::status)
+        .first::<String>(conn)
+        .await
+        .optional()?;
 
-    let mut attempts = 0;
-    loop {
-        attempts += 1;
-        let result = conn
-            .build_transaction()
-            .serializable()
-            .run(|conn| {
-                let status = status.clone();
-                let require_status = require_status.clone();
-                Box::pin(async move {
-                    // Read current status inside the txn so retries see fresh state
-                    let current_status = event_attendees::table
-                        .filter(event_attendees::event_id.eq(event_id))
-                        .filter(event_attendees::profile_id.eq(profile_id))
-                        .select(event_attendees::status)
-                        .first::<String>(conn)
-                        .await
-                        .optional()?;
-
-                    // Precondition: verify attendee has required status
-                    if let Some(required) = &require_status {
-                        if current_status.as_deref() != Some(required.as_str()) {
-                            return Ok::<UpsertOutcome, diesel::result::Error>(
-                                UpsertOutcome::StatusMismatch,
-                            );
-                        }
-                    }
-
-                    let already_going = current_status.as_deref() == Some("going");
-
-                    // Approval gate: downgrade "going" → "pending" unless already going
-                    let effective_status =
-                        if requires_approval && status == "going" && !already_going {
-                            "pending".to_string()
-                        } else {
-                            status
-                        };
-
-                    // Capacity gate: only enforce when switching to "going"
-                    if effective_status == "going" && !already_going {
-                        if let Some(max) = max_attendees {
-                            let current_going = event_attendees::table
-                                .filter(event_attendees::event_id.eq(event_id))
-                                .filter(event_attendees::status.eq("going"))
-                                .count()
-                                .get_result::<i64>(conn)
-                                .await?;
-                            if current_going >= i64::from(max) {
-                                return Ok(UpsertOutcome::Full);
-                            }
-                        }
-                    }
-
-                    // Upsert attendee: delete-then-insert
-                    diesel::delete(
-                        event_attendees::table
-                            .filter(event_attendees::event_id.eq(event_id))
-                            .filter(event_attendees::profile_id.eq(profile_id)),
-                    )
-                    .execute(conn)
-                    .await?;
-
-                    let attendee = EventAttendee {
-                        event_id,
-                        profile_id,
-                        status: effective_status.clone(),
-                    };
-                    diesel::insert_into(event_attendees::table)
-                        .values(&attendee)
-                        .execute(conn)
-                        .await?;
-
-                    // Track "joined" interaction atomically with the attendee change
-                    if effective_status == "going" {
-                        upsert_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
-                    } else {
-                        delete_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
-                    }
-
-                    Ok(UpsertOutcome::Accepted(effective_status))
-                })
-            })
-            .await;
-        match result {
-            Ok(val) => return Ok(val),
-            Err(ref e) if attempts < MAX_ATTEMPTS && is_serialization_failure(e) => {
-                tokio::time::sleep(std::time::Duration::from_millis(10u64 << attempts)).await;
-            }
-            Err(e) => return Err(e.into()),
+    if let Some(required) = require_status {
+        if current_status.as_deref() != Some(required) {
+            return Ok(UpsertOutcome::StatusMismatch);
         }
     }
+
+    let already_going = current_status.as_deref() == Some("going");
+
+    let effective_status = if requires_approval && status == "going" && !already_going {
+        "pending".to_string()
+    } else {
+        status.to_string()
+    };
+
+    if effective_status == "going" && !already_going {
+        if let Some(max) = max_attendees {
+            let current_going = event_attendees::table
+                .filter(event_attendees::event_id.eq(event_id))
+                .filter(event_attendees::status.eq("going"))
+                .count()
+                .get_result::<i64>(conn)
+                .await?;
+            if current_going >= i64::from(max) {
+                return Ok(UpsertOutcome::Full);
+            }
+        }
+    }
+
+    diesel::delete(
+        event_attendees::table
+            .filter(event_attendees::event_id.eq(event_id))
+            .filter(event_attendees::profile_id.eq(profile_id)),
+    )
+    .execute(conn)
+    .await?;
+
+    let attendee = EventAttendee {
+        event_id,
+        profile_id,
+        status: effective_status.clone(),
+    };
+    diesel::insert_into(event_attendees::table)
+        .values(&attendee)
+        .execute(conn)
+        .await?;
+
+    if effective_status == "going" {
+        upsert_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
+    } else {
+        delete_interaction_with_conn(conn, profile_id, event_id, "joined").await?;
+    }
+
+    Ok(UpsertOutcome::Accepted(effective_status))
 }
 
 pub(in crate::api) async fn insert_event_with_conn(
@@ -177,46 +127,42 @@ pub(in crate::api) async fn update_event_with_conn(
     Ok(updated)
 }
 
-pub(in crate::api) async fn delete_event(
+/// Delete an event plus its reports and chat conversation. Caller must
+/// supply a connection already inside a transaction.
+pub(in crate::api) async fn delete_event_with_conn(
+    conn: &mut AsyncPgConnection,
     event_id: Uuid,
 ) -> std::result::Result<(), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-    conn.transaction(|conn| {
-        Box::pin(async move {
-            diesel::delete(
-                reports::table
-                    .filter(reports::target_type.eq("event"))
-                    .filter(reports::target_id.eq(event_id)),
-            )
-            .execute(conn)
-            .await?;
-            diesel::delete(conversations::table.filter(conversations::event_id.eq(event_id)))
-                .execute(conn)
-                .await?;
-            diesel::delete(events::table.find(event_id))
-                .execute(conn)
-                .await?;
-            Ok::<(), diesel::result::Error>(())
-        })
-    })
+    diesel::delete(
+        reports::table
+            .filter(reports::target_type.eq("event"))
+            .filter(reports::target_id.eq(event_id)),
+    )
+    .execute(conn)
     .await?;
+    diesel::delete(conversations::table.filter(conversations::event_id.eq(event_id)))
+        .execute(conn)
+        .await?;
+    diesel::delete(events::table.find(event_id))
+        .execute(conn)
+        .await?;
     Ok(())
 }
 
 /// Atomically delete an attendee only if their status is "pending".
 /// Returns `true` when the row was deleted, `false` when no pending row existed.
-pub(in crate::api) async fn delete_pending_attendee(
+pub(in crate::api) async fn delete_pending_attendee_with_conn(
+    conn: &mut AsyncPgConnection,
     event_id: Uuid,
     profile_id: Uuid,
 ) -> std::result::Result<bool, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let deleted = diesel::delete(
         event_attendees::table
             .filter(event_attendees::event_id.eq(event_id))
             .filter(event_attendees::profile_id.eq(profile_id))
             .filter(event_attendees::status.eq("pending")),
     )
-    .execute(&mut conn)
+    .execute(conn)
     .await?;
     Ok(deleted > 0)
 }

--- a/backend/src/api/events/write_service.rs
+++ b/backend/src/api/events/write_service.rs
@@ -4,11 +4,10 @@ use uuid::Uuid;
 
 use crate::api::state::UpdateEventBody;
 use crate::db::models::events::{Event, EventChangeset};
-use crate::db::models::profiles::Profile;
 
 use super::events_service::{
-    self, forbidden, load_event, require_auth_profile, validate_event_category,
-    validate_event_description, validate_event_location, validate_max_attendees,
+    self, forbidden, validate_event_category, validate_event_description, validate_event_location,
+    validate_max_attendees,
 };
 
 type EventDates = (chrono::DateTime<Utc>, Option<chrono::DateTime<Utc>>);
@@ -120,30 +119,21 @@ fn build_update_changeset(payload: &UpdateEventBody, dates: EventDates) -> Event
     changeset
 }
 
-fn validate_creator(
+/// Build an `EventChangeset` for an update, after validating creator ownership
+/// and input fields. Pure validation — no DB access.
+pub(in crate::api) fn prepare_update_changeset(
     headers: &HeaderMap,
     event: &Event,
     profile_id: Uuid,
-) -> std::result::Result<(), Box<axum::response::Response>> {
+    payload: &UpdateEventBody,
+) -> std::result::Result<EventChangeset, Box<axum::response::Response>> {
     if event.creator_id != profile_id {
         return Err(Box::new(forbidden(
             headers,
             "Only the creator can update this event",
         )));
     }
-    Ok(())
-}
-
-pub(in crate::api) async fn event_update_inner(
-    headers: &HeaderMap,
-    id: &str,
-    payload: &UpdateEventBody,
-) -> std::result::Result<(EventChangeset, Uuid, Profile, Event), Box<axum::response::Response>> {
-    let (profile, _user_pid) = require_auth_profile(headers).await?;
-    let (event, event_uuid) = load_event(headers, id).await?;
-    validate_creator(headers, &event, profile.id)?;
     validate_event_basic_fields(headers, payload)?;
-    let dates = parse_event_dates(headers, &event, payload)?;
-    let changeset = build_update_changeset(payload, dates);
-    Ok((changeset, event_uuid, profile, event))
+    let dates = parse_event_dates(headers, event, payload)?;
+    Ok(build_update_changeset(payload, dates))
 }

--- a/backend/src/api/matching/assembler.rs
+++ b/backend/src/api/matching/assembler.rs
@@ -12,6 +12,16 @@ use crate::db::models::user_settings::UserSetting;
 use crate::db::models::users::User;
 use crate::db::schema::user_settings;
 
+/// DB-only context for the top-N scored profiles. Collected inside the viewer
+/// transaction so RLS applies; external image / thumbhash resolution happens
+/// in `finalize_recommendations` after the tx closes.
+pub(super) struct RecommendationData {
+    pub(super) scored: Vec<(f64, Profile)>,
+    pub(super) user_models: Vec<User>,
+    pub(super) profile_tags: HashMap<Uuid, Vec<MatchingTagResponse>>,
+    pub(super) privacy_map: HashMap<i32, bool>,
+}
+
 struct RecommendationContext<'a> {
     user_models: &'a [User],
     pic_map: &'a HashMap<String, String>,
@@ -84,19 +94,41 @@ pub(super) async fn batch_load_show_program(
         .collect())
 }
 
-pub(super) async fn build_recommendations_response(
+/// Load the DB-backed fields needed to render a recommendations payload.
+/// Must run inside a viewer-scoped transaction. `finalize_recommendations`
+/// converts the result into the HTTP response shape.
+pub(super) async fn load_recommendation_data(
     top: &[(f64, &Profile)],
     repo: &MatchingRepository,
     conn: &mut diesel_async::AsyncPgConnection,
     privacy_map: &HashMap<i32, bool>,
-) -> std::result::Result<Vec<ProfileRecommendation>, crate::error::AppError> {
+) -> std::result::Result<RecommendationData, crate::error::AppError> {
     let user_ids: Vec<i32> = top.iter().map(|(_, p)| p.user_id).collect();
     let user_models = repo.load_users_by_ids(&user_ids, conn).await?;
 
     let top_ids: Vec<Uuid> = top.iter().map(|(_, p)| p.id).collect();
-    let top_tags = repo.batch_load_profile_tags(&top_ids, conn).await?;
+    let profile_tags = repo.batch_load_profile_tags(&top_ids, conn).await?;
 
-    let pic_filenames: Vec<String> = top
+    let scored: Vec<(f64, Profile)> = top
+        .iter()
+        .map(|(score, profile)| (*score, (*profile).clone()))
+        .collect();
+
+    Ok(RecommendationData {
+        scored,
+        user_models,
+        profile_tags,
+        privacy_map: privacy_map.clone(),
+    })
+}
+
+/// Resolve signed image URLs / thumbhashes and build the final response. Runs
+/// outside the DB transaction so imgproxy latency doesn't hold a connection.
+pub(super) async fn finalize_recommendations(
+    data: RecommendationData,
+) -> Vec<ProfileRecommendation> {
+    let pic_filenames: Vec<String> = data
+        .scored
         .iter()
         .filter_map(|(_, p)| p.profile_picture.clone())
         .collect();
@@ -108,16 +140,20 @@ pub(super) async fn build_recommendations_response(
     let pic_map: HashMap<String, String> = pic_filenames.into_iter().zip(resolved_pics).collect();
 
     let ctx = RecommendationContext {
-        user_models: &user_models,
+        user_models: &data.user_models,
         pic_map: &pic_map,
         thumbhash_map: &thumbhash_map,
-        privacy_map,
+        privacy_map: &data.privacy_map,
     };
-    Ok(top
+    data.scored
         .iter()
         .map(|(score, profile)| {
-            let profile_tags = top_tags.get(&profile.id).cloned().unwrap_or_default();
+            let profile_tags = data
+                .profile_tags
+                .get(&profile.id)
+                .cloned()
+                .unwrap_or_default();
             build_profile_recommendation(*score, profile, &ctx, profile_tags)
         })
-        .collect())
+        .collect()
 }

--- a/backend/src/api/matching/assembler.rs
+++ b/backend/src/api/matching/assembler.rs
@@ -69,7 +69,7 @@ fn build_profile_recommendation(
 
 pub(super) async fn batch_load_show_program(
     user_ids: &[i32],
-    conn: &mut crate::db::DbConn,
+    conn: &mut diesel_async::AsyncPgConnection,
 ) -> crate::error::AppResult<HashMap<i32, bool>> {
     if user_ids.is_empty() {
         return Ok(HashMap::new());
@@ -87,7 +87,7 @@ pub(super) async fn batch_load_show_program(
 pub(super) async fn build_recommendations_response(
     top: &[(f64, &Profile)],
     repo: &MatchingRepository,
-    conn: &mut crate::db::DbConn,
+    conn: &mut diesel_async::AsyncPgConnection,
     privacy_map: &HashMap<i32, bool>,
 ) -> std::result::Result<Vec<ProfileRecommendation>, crate::error::AppError> {
     let user_ids: Vec<i32> = top.iter().map(|(_, p)| p.user_id).collect();

--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -30,7 +30,9 @@ use crate::db;
 use crate::db::models::events::Event;
 use crate::db::models::profiles::Profile;
 use crate::db::schema::{events, profiles, recommendation_feedback};
-use matching_assembler::{batch_load_show_program, build_recommendations_response};
+use matching_assembler::{
+    batch_load_show_program, finalize_recommendations, load_recommendation_data,
+};
 use matching_repo::MatchingRepository;
 use matching_scoring::{
     build_affinity_map, rank_and_take, rank_events_and_take, score_event, score_profile,
@@ -118,7 +120,7 @@ pub(super) async fn profiles_recommendations(
 
             let top = rank_and_take(&mut scored, limit);
 
-            build_recommendations_response(&top, &repo, conn, &privacy_map)
+            load_recommendation_data(&top, &repo, conn, &privacy_map)
                 .await
                 .map_err(matching_into_diesel)
         }
@@ -126,6 +128,10 @@ pub(super) async fn profiles_recommendations(
     })
     .await
     .map_err(crate::error::AppError::from)?;
+
+    // imgproxy / thumbhash resolution runs after the tx closes so external
+    // storage latency can't hold a DB connection open.
+    let data = finalize_recommendations(data).await;
 
     let mut response = Json(DataResponse { data }).into_response();
     response

--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -20,11 +20,13 @@ use axum::{
 };
 use chrono::Utc;
 use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
 use super::state::{DataResponse, EventFeedbackRequest, MatchingQuery, SuccessResponse};
 use crate::api::{error_response, ErrorSpec};
+use crate::db;
 use crate::db::models::events::Event;
 use crate::db::models::profiles::Profile;
 use crate::db::schema::{events, profiles, recommendation_feedback};
@@ -65,54 +67,80 @@ pub(super) async fn profiles_recommendations(
 
     let limit = query.limit.unwrap_or(10).clamp(1, 50) as usize;
 
-    let mut conn = crate::db::conn().await?;
-    let user_ctx = repo.load_profile_context(user.id, &mut conn).await?;
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
 
-    // Fetch candidate profiles (more than limit so we can score and rank)
-    let candidates = repo
-        .load_candidate_profiles(user.id, 200, &mut conn)
-        .await?;
+    let data = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let user_ctx = repo
+                .load_profile_context(user.id, conn)
+                .await
+                .map_err(matching_into_diesel)?;
 
-    // Batch-load all candidate tag IDs in one query
-    let candidate_ids: Vec<Uuid> = candidates.iter().map(|c| c.id).collect();
-    let all_candidate_tags = repo
-        .batch_load_profile_tag_ids(&candidate_ids, &mut conn)
-        .await?;
+            let candidates = repo
+                .load_candidate_profiles(user.id, 200, conn)
+                .await
+                .map_err(matching_into_diesel)?;
 
-    let my_program = user_ctx.profile.as_ref().and_then(|p| p.program.clone());
+            let candidate_ids: Vec<Uuid> = candidates.iter().map(|c| c.id).collect();
+            let all_candidate_tags = repo
+                .batch_load_profile_tag_ids(&candidate_ids, conn)
+                .await
+                .map_err(matching_into_diesel)?;
 
-    let candidate_user_ids: Vec<i32> = candidates.iter().map(|c| c.user_id).collect();
-    let privacy_map = batch_load_show_program(&candidate_user_ids, &mut conn).await?;
+            let my_program = user_ctx.profile.as_ref().and_then(|p| p.program.clone());
 
-    // Score each candidate
-    let mut scored: Vec<(f64, &Profile)> = candidates
-        .iter()
-        .map(|candidate| {
-            let candidate_tags = all_candidate_tags
-                .get(&candidate.id)
-                .cloned()
-                .unwrap_or_default();
-            let show_program = privacy_map.get(&candidate.user_id).copied().unwrap_or(true);
-            let score = score_profile(
-                &user_ctx.profile_tag_ids,
-                &candidate_tags,
-                my_program.as_deref(),
-                candidate,
-                show_program,
-            );
-            (score, candidate)
-        })
-        .collect();
+            let candidate_user_ids: Vec<i32> = candidates.iter().map(|c| c.user_id).collect();
+            let privacy_map = batch_load_show_program(&candidate_user_ids, conn)
+                .await
+                .map_err(matching_into_diesel)?;
 
-    let top = rank_and_take(&mut scored, limit);
+            let mut scored: Vec<(f64, &Profile)> = candidates
+                .iter()
+                .map(|candidate| {
+                    let candidate_tags = all_candidate_tags
+                        .get(&candidate.id)
+                        .cloned()
+                        .unwrap_or_default();
+                    let show_program = privacy_map.get(&candidate.user_id).copied().unwrap_or(true);
+                    let score = score_profile(
+                        &user_ctx.profile_tag_ids,
+                        &candidate_tags,
+                        my_program.as_deref(),
+                        candidate,
+                        show_program,
+                    );
+                    (score, candidate)
+                })
+                .collect();
 
-    let data = build_recommendations_response(&top, &repo, &mut conn, &privacy_map).await?;
+            let top = rank_and_take(&mut scored, limit);
+
+            build_recommendations_response(&top, &repo, conn, &privacy_map)
+                .await
+                .map_err(matching_into_diesel)
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
 
     let mut response = Json(DataResponse { data }).into_response();
     response
         .headers_mut()
         .insert(axum::http::header::CACHE_CONTROL, PRIVATE_CACHE_SHORT);
     Ok(response)
+}
+
+fn matching_into_diesel(e: crate::error::AppError) -> diesel::result::Error {
+    match e {
+        crate::error::AppError::Message(_) | crate::error::AppError::Validation(_) => {
+            diesel::result::Error::QueryBuilderError(Box::new(e))
+        }
+        crate::error::AppError::Any(_) => diesel::result::Error::RollbackTransaction,
+    }
 }
 
 pub(super) async fn events_recommendations(
@@ -127,112 +155,134 @@ pub(super) async fn events_recommendations(
     let candidate_limit =
         i64::try_from(std::cmp::max(limit.saturating_mul(20), 500)).unwrap_or(i64::MAX);
 
-    let mut conn = crate::db::conn().await?;
-    let user_ctx = repo.load_user_context(user.id, &mut conn).await?;
-    let my_profile_id = user_ctx.profile.as_ref().map_or(Uuid::nil(), |p| p.id);
-
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
     let now = Utc::now();
 
-    // Fetch future events, exclude saved/joined (but keep "less" — they get a penalty instead)
-    let future_events = repo
-        .load_future_events(now, candidate_limit, &mut conn)
-        .await?
-        .into_iter()
-        .filter(|event| {
-            !should_exclude_seen_event(
-                event.id,
-                &user_ctx.saved_event_ids,
-                &user_ctx.joined_event_ids,
-            )
-        })
-        .collect::<Vec<_>>();
+    // DB reads + ranking happen inside the viewer tx so Tier-A/B/C policies
+    // on events/event_attendees/event_interactions apply. Image URL signing
+    // is external I/O and must not hold the DB connection, so it's done
+    // after the tx closes.
+    let (mut base, score_by_event) = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let user_ctx = repo
+                .load_user_context(user.id, conn)
+                .await
+                .map_err(matching_into_diesel)?;
+            let my_profile_id = user_ctx.profile.as_ref().map_or(Uuid::nil(), |p| p.id);
 
-    // Batch-load all event tag IDs in one query
-    let event_ids: Vec<Uuid> = future_events.iter().map(|e| e.id).collect();
-    let all_event_tags = repo.batch_load_event_tag_ids(&event_ids, &mut conn).await?;
-    let tag_parent_map = repo.load_tag_parent_map(&mut conn).await?;
-
-    let profile_affinity = build_affinity_map(
-        user_ctx
-            .profile_tag_ids
-            .iter()
-            .copied()
-            .map(|tag_id| (tag_id, 1.0)),
-        &tag_parent_map,
-    );
-
-    let saved_event_ids: Vec<Uuid> = user_ctx.saved_event_ids.iter().copied().collect();
-    let joined_event_ids: Vec<Uuid> = user_ctx.joined_event_ids.iter().copied().collect();
-    let more_event_ids: Vec<Uuid> = user_ctx.more_event_ids.iter().copied().collect();
-    let mut all_history_ids = saved_event_ids.clone();
-    all_history_ids.extend(&joined_event_ids);
-    all_history_ids.extend(&more_event_ids);
-    all_history_ids.sort_unstable();
-    all_history_ids.dedup();
-    let all_history_tags = repo
-        .batch_load_event_tag_ids(&all_history_ids, &mut conn)
-        .await?;
-    // Deduplicate: joined=1.0, more=0.7, saved=0.5 — keep max weight
-    let mut event_weights: HashMap<Uuid, f64> = HashMap::new();
-    for &id in &joined_event_ids {
-        event_weights.insert(id, 1.0);
-    }
-    for &id in &more_event_ids {
-        event_weights.entry(id).or_insert(0.7);
-    }
-    for &id in &saved_event_ids {
-        event_weights.entry(id).or_insert(0.5);
-    }
-    let history_affinity = build_affinity_map(
-        event_weights.iter().flat_map(|(id, &weight)| {
-            all_history_tags
-                .get(id)
+            let future_events = repo
+                .load_future_events(now, candidate_limit, conn)
+                .await
+                .map_err(matching_into_diesel)?
                 .into_iter()
-                .flat_map(move |tags| tags.iter().copied().map(move |tag_id| (tag_id, weight)))
-        }),
-        &tag_parent_map,
-    );
+                .filter(|event| {
+                    !should_exclude_seen_event(
+                        event.id,
+                        &user_ctx.saved_event_ids,
+                        &user_ctx.joined_event_ids,
+                    )
+                })
+                .collect::<Vec<_>>();
 
-    // Resolve user geo query: lat, lng, max radius in km (default 20 km)
-    let user_geo = query.lat.zip(query.lng).map(|(lat, lng)| {
-        (
-            lat,
-            lng,
-            f64::from(query.radius_m.unwrap_or(20_000)) / 1000.0,
-        )
-    });
+            let event_ids: Vec<Uuid> = future_events.iter().map(|e| e.id).collect();
+            let all_event_tags = repo
+                .batch_load_event_tag_ids(&event_ids, conn)
+                .await
+                .map_err(matching_into_diesel)?;
+            let tag_parent_map = repo
+                .load_tag_parent_map(conn)
+                .await
+                .map_err(matching_into_diesel)?;
 
-    let mut scored: Vec<(f64, &Event)> = future_events
-        .iter()
-        .map(|event| {
-            let event_tag_ids = all_event_tags.get(&event.id).cloned().unwrap_or_default();
-            let mut s = score_event(
-                &profile_affinity,
-                &history_affinity,
-                &user_ctx.interest_categories,
-                &event_tag_ids,
-                event,
-                user_geo,
+            let profile_affinity = build_affinity_map(
+                user_ctx
+                    .profile_tag_ids
+                    .iter()
+                    .copied()
+                    .map(|tag_id| (tag_id, 1.0)),
                 &tag_parent_map,
             );
-            // Soft penalty for "less" feedback — demote but don't hide
-            if user_ctx.less_event_ids.contains(&event.id) {
-                s *= 0.3;
+
+            let saved_event_ids: Vec<Uuid> = user_ctx.saved_event_ids.iter().copied().collect();
+            let joined_event_ids: Vec<Uuid> = user_ctx.joined_event_ids.iter().copied().collect();
+            let more_event_ids: Vec<Uuid> = user_ctx.more_event_ids.iter().copied().collect();
+            let mut all_history_ids = saved_event_ids.clone();
+            all_history_ids.extend(&joined_event_ids);
+            all_history_ids.extend(&more_event_ids);
+            all_history_ids.sort_unstable();
+            all_history_ids.dedup();
+            let all_history_tags = repo
+                .batch_load_event_tag_ids(&all_history_ids, conn)
+                .await
+                .map_err(matching_into_diesel)?;
+            let mut event_weights: HashMap<Uuid, f64> = HashMap::new();
+            for &id in &joined_event_ids {
+                event_weights.insert(id, 1.0);
             }
-            (s, event)
-        })
-        .collect();
+            for &id in &more_event_ids {
+                event_weights.entry(id).or_insert(0.7);
+            }
+            for &id in &saved_event_ids {
+                event_weights.entry(id).or_insert(0.5);
+            }
+            let history_affinity = build_affinity_map(
+                event_weights.iter().flat_map(|(id, &weight)| {
+                    all_history_tags.get(id).into_iter().flat_map(move |tags| {
+                        tags.iter().copied().map(move |tag_id| (tag_id, weight))
+                    })
+                }),
+                &tag_parent_map,
+            );
 
-    let top = rank_events_and_take(&mut scored, limit);
+            let user_geo = query.lat.zip(query.lng).map(|(lat, lng)| {
+                (
+                    lat,
+                    lng,
+                    f64::from(query.radius_m.unwrap_or(20_000)) / 1000.0,
+                )
+            });
 
-    let top_models: Vec<Event> = top.iter().map(|(_, event)| (*event).clone()).collect();
-    let mut base =
-        super::events::build_event_responses_raw(&mut conn, &top_models, &my_profile_id).await?;
+            let mut scored: Vec<(f64, &Event)> = future_events
+                .iter()
+                .map(|event| {
+                    let event_tag_ids = all_event_tags.get(&event.id).cloned().unwrap_or_default();
+                    let mut s = score_event(
+                        &profile_affinity,
+                        &history_affinity,
+                        &user_ctx.interest_categories,
+                        &event_tag_ids,
+                        event,
+                        user_geo,
+                        &tag_parent_map,
+                    );
+                    if user_ctx.less_event_ids.contains(&event.id) {
+                        s *= 0.3;
+                    }
+                    (s, event)
+                })
+                .collect();
+
+            let top = rank_events_and_take(&mut scored, limit);
+            let top_models: Vec<Event> = top.iter().map(|(_, event)| (*event).clone()).collect();
+            let base = super::events::build_event_responses_raw(conn, &top_models, &my_profile_id)
+                .await
+                .map_err(matching_into_diesel)?;
+            let score_by_event: HashMap<Uuid, f64> = top
+                .iter()
+                .map(|(score, event)| (event.id, *score))
+                .collect();
+
+            Ok::<_, diesel::result::Error>((base, score_by_event))
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
     super::events::resolve_event_images_for_responses(&mut base).await;
-    let score_by_event: HashMap<Uuid, f64> = top
-        .iter()
-        .map(|(score, event)| (event.id, *score))
-        .collect();
     let data = base
         .into_iter()
         .map(|mut event| {
@@ -251,6 +301,12 @@ pub(super) async fn events_recommendations(
     Ok(response)
 }
 
+enum FeedbackOutcome {
+    NoProfile,
+    NotFound,
+    Saved,
+}
+
 pub(super) async fn event_feedback(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
@@ -265,17 +321,64 @@ pub(super) async fn event_feedback(
 
     let event_uuid = crate::api::parse_uuid(&event_id, "event")?;
 
-    let mut conn = crate::db::conn().await?;
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let feedback = body.feedback.clone();
+    let user_id = user.id;
 
-    // Issue 1: Return proper 404 when user has no profile
-    let Some(profile_id) = profiles::table
-        .filter(profiles::user_id.eq(user.id))
-        .select(profiles::id)
-        .first::<Uuid>(&mut conn)
-        .await
-        .optional()?
-    else {
-        return Ok(error_response(
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let profile_id: Option<Uuid> = profiles::table
+                .filter(profiles::user_id.eq(user_id))
+                .select(profiles::id)
+                .first::<Uuid>(conn)
+                .await
+                .optional()?;
+            let Some(profile_id) = profile_id else {
+                return Ok::<FeedbackOutcome, diesel::result::Error>(FeedbackOutcome::NoProfile);
+            };
+
+            let event_exists = events::table
+                .find(event_uuid)
+                .select(events::id)
+                .first::<Uuid>(conn)
+                .await
+                .optional()?;
+            if event_exists.is_none() {
+                return Ok(FeedbackOutcome::NotFound);
+            }
+
+            let now = Utc::now();
+            diesel::insert_into(recommendation_feedback::table)
+                .values((
+                    recommendation_feedback::profile_id.eq(profile_id),
+                    recommendation_feedback::event_id.eq(event_uuid),
+                    recommendation_feedback::feedback.eq(&feedback),
+                    recommendation_feedback::created_at.eq(now),
+                ))
+                .on_conflict((
+                    recommendation_feedback::profile_id,
+                    recommendation_feedback::event_id,
+                ))
+                .do_update()
+                .set((
+                    recommendation_feedback::feedback.eq(&feedback),
+                    recommendation_feedback::created_at.eq(now),
+                ))
+                .execute(conn)
+                .await?;
+
+            Ok(FeedbackOutcome::Saved)
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        FeedbackOutcome::NoProfile => Ok(error_response(
             StatusCode::NOT_FOUND,
             &headers,
             ErrorSpec {
@@ -283,18 +386,8 @@ pub(super) async fn event_feedback(
                 code: "NOT_FOUND",
                 details: None,
             },
-        ));
-    };
-
-    // Issue 3: Validate event exists before insert to avoid FK violation → 500
-    let event_exists = events::table
-        .find(event_uuid)
-        .select(events::id)
-        .first::<Uuid>(&mut conn)
-        .await
-        .optional()?;
-    if event_exists.is_none() {
-        return Ok(error_response(
+        )),
+        FeedbackOutcome::NotFound => Ok(error_response(
             StatusCode::NOT_FOUND,
             &headers,
             ErrorSpec {
@@ -302,34 +395,12 @@ pub(super) async fn event_feedback(
                 code: "NOT_FOUND",
                 details: None,
             },
-        ));
+        )),
+        FeedbackOutcome::Saved => Ok(Json(DataResponse {
+            data: SuccessResponse { success: true },
+        })
+        .into_response()),
     }
-
-    let now = Utc::now();
-    diesel::insert_into(recommendation_feedback::table)
-        .values((
-            recommendation_feedback::profile_id.eq(profile_id),
-            recommendation_feedback::event_id.eq(event_uuid),
-            recommendation_feedback::feedback.eq(&body.feedback),
-            recommendation_feedback::created_at.eq(now),
-        ))
-        .on_conflict((
-            recommendation_feedback::profile_id,
-            recommendation_feedback::event_id,
-        ))
-        .do_update()
-        .set((
-            recommendation_feedback::feedback.eq(&body.feedback),
-            recommendation_feedback::created_at.eq(now),
-        ))
-        .execute(&mut conn)
-        .await?;
-
-    // Issue 2: Return DataResponse<SuccessResponse> instead of 204 No Content
-    Ok(Json(DataResponse {
-        data: SuccessResponse { success: true },
-    })
-    .into_response())
 }
 
 #[cfg(test)]

--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -226,9 +226,9 @@ pub(super) async fn events_recommendations(
     let top = rank_events_and_take(&mut scored, limit);
 
     let top_models: Vec<Event> = top.iter().map(|(_, event)| (*event).clone()).collect();
-    let base =
-        super::events::build_event_responses_with_conn(&top_models, &my_profile_id, &mut conn)
-            .await?;
+    let mut base =
+        super::events::build_event_responses_raw(&mut conn, &top_models, &my_profile_id).await?;
+    super::events::resolve_event_images_for_responses(&mut base).await;
     let score_by_event: HashMap<Uuid, f64> = top
         .iter()
         .map(|(score, event)| (event.id, *score))

--- a/backend/src/api/matching/repo.rs
+++ b/backend/src/api/matching/repo.rs
@@ -40,7 +40,7 @@ impl MatchingRepository {
     async fn load_profile_tag_ids(
         &self,
         profile_id: Uuid,
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<HashSet<Uuid>, crate::error::AppError> {
         let tag_links = profile_tags::table
             .filter(profile_tags::profile_id.eq(profile_id))
@@ -52,7 +52,7 @@ impl MatchingRepository {
     async fn load_profile_interest_categories(
         &self,
         profile_id: Uuid,
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<HashSet<String>, crate::error::AppError> {
         let rows = profile_tags::table
             .inner_join(tags::table.on(tags::id.eq(profile_tags::tag_id)))
@@ -70,7 +70,7 @@ impl MatchingRepository {
         &self,
         profile_id: Uuid,
         kind: &str,
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<HashSet<Uuid>, crate::error::AppError> {
         let interactions = event_interactions::table
             .filter(event_interactions::profile_id.eq(profile_id))
@@ -83,7 +83,7 @@ impl MatchingRepository {
     async fn load_feedback_event_ids(
         &self,
         profile_id: Uuid,
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<(HashSet<Uuid>, HashSet<Uuid>), crate::error::AppError> {
         let rows = recommendation_feedback::table
             .filter(recommendation_feedback::profile_id.eq(profile_id))
@@ -109,7 +109,7 @@ impl MatchingRepository {
     pub(super) async fn load_profile_context(
         &self,
         user_id: i32,
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<MatchingProfileContext, crate::error::AppError> {
         let profile = profiles::table
             .filter(profiles::user_id.eq(user_id))
@@ -129,7 +129,7 @@ impl MatchingRepository {
     pub(super) async fn load_user_context(
         &self,
         user_id: i32,
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<MatchingUserContext, crate::error::AppError> {
         let profile = profiles::table
             .filter(profiles::user_id.eq(user_id))
@@ -182,7 +182,7 @@ impl MatchingRepository {
         &self,
         user_id: i32,
         limit: i64,
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<Vec<Profile>, crate::error::AppError> {
         let viewer_is_stub = users::table
             .filter(users::id.eq(user_id))
@@ -214,7 +214,7 @@ impl MatchingRepository {
         &self,
         now: DateTime<Utc>,
         limit: i64,
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<Vec<Event>, crate::error::AppError> {
         events::table
             .filter(events::starts_at.ge(now))
@@ -228,7 +228,7 @@ impl MatchingRepository {
     pub(super) async fn batch_load_profile_tags(
         &self,
         profile_ids: &[Uuid],
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<HashMap<Uuid, Vec<MatchingTagResponse>>, crate::error::AppError> {
         if profile_ids.is_empty() {
             return Ok(HashMap::new());
@@ -271,7 +271,7 @@ impl MatchingRepository {
     pub(super) async fn batch_load_profile_tag_ids(
         &self,
         profile_ids: &[Uuid],
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<HashMap<Uuid, HashSet<Uuid>>, crate::error::AppError> {
         if profile_ids.is_empty() {
             return Ok(HashMap::new());
@@ -295,7 +295,7 @@ impl MatchingRepository {
     pub(super) async fn batch_load_event_tag_ids(
         &self,
         event_ids: &[Uuid],
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<HashMap<Uuid, HashSet<Uuid>>, crate::error::AppError> {
         if event_ids.is_empty() {
             return Ok(HashMap::new());
@@ -316,7 +316,7 @@ impl MatchingRepository {
     pub(super) async fn load_users_by_ids(
         &self,
         user_ids: &[i32],
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<Vec<User>, crate::error::AppError> {
         if user_ids.is_empty() {
             return Ok(vec![]);
@@ -331,7 +331,7 @@ impl MatchingRepository {
 
     pub(super) async fn load_tag_parent_map(
         &self,
-        conn: &mut crate::db::DbConn,
+        conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<HashMap<Uuid, Option<Uuid>>, crate::error::AppError> {
         Ok(tags::table
             .select((tags::id, tags::parent_id))

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -5,10 +5,11 @@ pub mod viewer;
 pub use viewer::{
     complete_password_reset, create_session_for_user, create_user_for_signup,
     delete_session_by_token, find_user_for_login, find_user_for_password_reset,
-    mark_email_verified, profile_program_visibility, push_topics_for_users, resolve_session,
-    set_anon_context, set_password_reset_token, set_viewer_context, user_id_for_pid,
-    user_pid_for_id, user_review_stubs, with_anon_tx, with_viewer_tx, AuthSessionRow, AuthUserRow,
-    CreatedSessionRow, DbViewer, PasswordResetUserRow, UserReviewStubRow,
+    mark_email_verified, profile_owner_user_id, profile_program_visibility, push_topics_for_users,
+    resolve_session, set_anon_context, set_password_reset_token, set_viewer_context,
+    user_id_for_pid, user_pid_for_id, user_pids_for_ids, user_review_stubs, with_anon_tx,
+    with_viewer_tx, AuthSessionRow, AuthUserRow, CreatedSessionRow, DbViewer, PasswordResetUserRow,
+    UserPidRow, UserReviewStubRow,
 };
 
 use deadpool::managed::Timeouts;

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -450,3 +450,45 @@ pub async fn push_topics_for_users(
         .await?;
     Ok(rows.into_iter().map(|r| r.ntfy_topic).collect())
 }
+
+// ---------------------------------------------------------------------------
+// Narrow public projections used by the events module.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, QueryableByName)]
+pub struct UserPidRow {
+    #[diesel(sql_type = Integer)]
+    pub user_id: i32,
+    #[diesel(sql_type = SqlUuid)]
+    pub pid: uuid::Uuid,
+}
+
+/// Batch lookup of `(user_id, pid)` pairs for a list of users. Used by the
+/// attendee listing endpoint so the API role doesn't need broad SELECT on
+/// `users`.
+pub async fn user_pids_for_ids(
+    conn: &mut AsyncPgConnection,
+    user_ids: &[i32],
+) -> Result<Vec<UserPidRow>, diesel::result::Error> {
+    if user_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    diesel::sql_query("SELECT * FROM app.user_pids_for_ids($1)")
+        .bind::<diesel::sql_types::Array<Integer>, _>(user_ids)
+        .load::<UserPidRow>(conn)
+        .await
+}
+
+/// Resolve the owner `user_id` of a profile. Returns `None` if the profile
+/// does not exist. Narrow projection used by push-dispatch paths that have
+/// a profile id and need the owning user.
+pub async fn profile_owner_user_id(
+    conn: &mut AsyncPgConnection,
+    profile_id: uuid::Uuid,
+) -> Result<Option<i32>, diesel::result::Error> {
+    let row = diesel::sql_query("SELECT app.profile_owner_user_id($1) AS value")
+        .bind::<SqlUuid, _>(profile_id)
+        .get_result::<IntRow>(conn)
+        .await?;
+    Ok(row.value)
+}

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -51,6 +51,21 @@ impl From<&str> for AppError {
 
 impl From<diesel::result::Error> for AppError {
     fn from(value: diesel::result::Error) -> Self {
+        // `with_viewer_tx` closures stash application-level errors inside
+        // `QueryBuilderError(Box<AppError>)` so user-facing `Message` /
+        // `Validation` variants survive the transaction boundary. Unwrap
+        // that shape back into the original `AppError`; anything else
+        // bubbles up as an opaque `Any`.
+        if let diesel::result::Error::QueryBuilderError(ref boxed) = value {
+            if boxed.downcast_ref::<Self>().is_some() {
+                if let diesel::result::Error::QueryBuilderError(owned) = value {
+                    if let Ok(app) = owned.downcast::<Self>() {
+                        return *app;
+                    }
+                    unreachable!("downcast_ref succeeded but downcast failed");
+                }
+            }
+        }
         Self::Any(value.into())
     }
 }

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -1145,3 +1145,315 @@ async fn sign_in_rate_limit_not_bypassed_by_spoofed_forwarded_for_headers() {
     })
     .await;
 }
+
+// ---------------------------------------------------------------------------
+// Phase-6 events coverage: endpoints the phase-3 contract test doesn't hit.
+// These exercise the viewer-scoped transaction wrappers on the endpoints that
+// were otherwise only reachable via phased scenarios.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn event_attendees_listing_returns_user_pids() {
+    request(|request, _ctx| async move {
+        let (owner_key, owner_value) =
+            create_user_with_profile(&request, "attlist-owner@example.com", "Owner").await;
+        let (attendee_key, attendee_value) =
+            create_user_with_profile(&request, "attlist-att@example.com", "Attendee").await;
+
+        let create = request
+            .post("/api/v1/events")
+            .add_header(owner_key.clone(), owner_value.clone())
+            .json(&serde_json::json!({
+                "title": "Attendee listing",
+                "startsAt": "2030-06-01T12:00:00Z",
+            }))
+            .await;
+        assert_eq!(create.status_code(), 201);
+        let event_id = create.json::<serde_json::Value>()["data"]["id"]
+            .as_str()
+            .expect("event id")
+            .to_string();
+
+        let attend = request
+            .post(&format!("/api/v1/events/{event_id}/attend"))
+            .add_header(attendee_key.clone(), attendee_value.clone())
+            .json(&serde_json::json!({ "status": "going" }))
+            .await;
+        assert_eq!(attend.status_code(), 200);
+
+        let attendees = request
+            .get(&format!("/api/v1/events/{event_id}/attendees"))
+            .add_header(owner_key.clone(), owner_value.clone())
+            .await;
+        assert_eq!(attendees.status_code(), 200);
+        let payload: serde_json::Value = attendees.json();
+        let rows = payload["data"].as_array().expect("attendees array");
+        assert_eq!(rows.len(), 2);
+        // The narrow `app.user_pids_for_ids` helper returns real pids — not
+        // the nil UUID fallback. Both attendees should expose non-nil userIds
+        // so the mobile client can open DMs or link to profiles.
+        for row in rows {
+            let uid = row["userId"].as_str().unwrap_or_default();
+            assert_ne!(uid, "00000000-0000-0000-0000-000000000000");
+            assert!(uuid::Uuid::parse_str(uid).is_ok(), "userId must be a uuid");
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn event_delete_removes_event_and_is_creator_only() {
+    request(|request, _ctx| async move {
+        let (owner_key, owner_value) =
+            create_user_with_profile(&request, "del-owner@example.com", "Owner").await;
+        let (other_key, other_value) =
+            create_user_with_profile(&request, "del-other@example.com", "Other").await;
+
+        let create = request
+            .post("/api/v1/events")
+            .add_header(owner_key.clone(), owner_value.clone())
+            .json(&serde_json::json!({
+                "title": "To delete",
+                "startsAt": "2030-06-02T12:00:00Z",
+            }))
+            .await;
+        let event_id = create.json::<serde_json::Value>()["data"]["id"]
+            .as_str()
+            .expect("event id")
+            .to_string();
+
+        // Non-creator gets 403
+        let forbidden = request
+            .delete(&format!("/api/v1/events/{event_id}"))
+            .add_header(other_key.clone(), other_value.clone())
+            .await;
+        assert_eq!(forbidden.status_code(), 403);
+
+        // Creator deletes successfully
+        let deleted = request
+            .delete(&format!("/api/v1/events/{event_id}"))
+            .add_header(owner_key.clone(), owner_value.clone())
+            .await;
+        assert_eq!(deleted.status_code(), 200);
+
+        // GET returns 404
+        let after = request
+            .get(&format!("/api/v1/events/{event_id}"))
+            .add_header(owner_key.clone(), owner_value.clone())
+            .await;
+        assert_eq!(after.status_code(), 404);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn event_leave_removes_attendee_and_blocks_creator() {
+    request(|request, _ctx| async move {
+        let (owner_key, owner_value) =
+            create_user_with_profile(&request, "leave-owner@example.com", "Owner").await;
+        let (att_key, att_value) =
+            create_user_with_profile(&request, "leave-att@example.com", "Att").await;
+
+        let event_id = request
+            .post("/api/v1/events")
+            .add_header(owner_key.clone(), owner_value.clone())
+            .json(&serde_json::json!({
+                "title": "Leave flow",
+                "startsAt": "2030-06-03T12:00:00Z",
+            }))
+            .await
+            .json::<serde_json::Value>()["data"]["id"]
+            .as_str()
+            .expect("event id")
+            .to_string();
+
+        // Creator cannot leave their own event
+        let creator_leave = request
+            .delete(&format!("/api/v1/events/{event_id}/attend"))
+            .add_header(owner_key.clone(), owner_value.clone())
+            .await;
+        assert_eq!(creator_leave.status_code(), 403);
+
+        // Attendee joins then leaves
+        let attend = request
+            .post(&format!("/api/v1/events/{event_id}/attend"))
+            .add_header(att_key.clone(), att_value.clone())
+            .json(&serde_json::json!({ "status": "going" }))
+            .await;
+        assert_eq!(attend.status_code(), 200);
+
+        let leave = request
+            .delete(&format!("/api/v1/events/{event_id}/attend"))
+            .add_header(att_key.clone(), att_value.clone())
+            .await;
+        assert_eq!(leave.status_code(), 200);
+        let payload: serde_json::Value = leave.json();
+        assert_eq!(payload["data"]["isAttending"], false);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn event_approve_and_reject_flow() {
+    request(|request, _ctx| async move {
+        let (owner_key, owner_value) =
+            create_user_with_profile(&request, "approve-owner@example.com", "Owner").await;
+        let (ok_key, ok_value) =
+            create_user_with_profile(&request, "approve-ok@example.com", "Ok").await;
+        let (rej_key, rej_value) =
+            create_user_with_profile(&request, "approve-rej@example.com", "Rej").await;
+
+        let event = request
+            .post("/api/v1/events")
+            .add_header(owner_key.clone(), owner_value.clone())
+            .json(&serde_json::json!({
+                "title": "Approvals",
+                "startsAt": "2030-06-04T12:00:00Z",
+                "requiresApproval": true,
+            }))
+            .await;
+        let event_id = event.json::<serde_json::Value>()["data"]["id"]
+            .as_str()
+            .expect("event id")
+            .to_string();
+
+        // Both attendees request to go — approval gate downgrades to pending.
+        for (k, v) in [
+            (ok_key.clone(), ok_value.clone()),
+            (rej_key.clone(), rej_value.clone()),
+        ] {
+            let r = request
+                .post(&format!("/api/v1/events/{event_id}/attend"))
+                .add_header(k, v)
+                .json(&serde_json::json!({ "status": "going" }))
+                .await;
+            assert_eq!(r.status_code(), 200);
+            let p: serde_json::Value = r.json();
+            assert_eq!(p["data"]["isPending"], true);
+            assert_eq!(p["data"]["isAttending"], false);
+        }
+
+        // Rejecting a non-creator is 403.
+        let ok_profile_id = request
+            .get("/api/v1/profiles/me")
+            .add_header(ok_key.clone(), ok_value.clone())
+            .await
+            .json::<serde_json::Value>()["data"]["id"]
+            .as_str()
+            .expect("profile id")
+            .to_string();
+        let rej_profile_id = request
+            .get("/api/v1/profiles/me")
+            .add_header(rej_key.clone(), rej_value.clone())
+            .await
+            .json::<serde_json::Value>()["data"]["id"]
+            .as_str()
+            .expect("profile id")
+            .to_string();
+
+        let non_creator_approve = request
+            .post(&format!(
+                "/api/v1/events/{event_id}/attendees/{ok_profile_id}/approve"
+            ))
+            .add_header(ok_key.clone(), ok_value.clone())
+            .await;
+        assert_eq!(non_creator_approve.status_code(), 403);
+
+        // Creator approves one and rejects the other.
+        let approve = request
+            .post(&format!(
+                "/api/v1/events/{event_id}/attendees/{ok_profile_id}/approve"
+            ))
+            .add_header(owner_key.clone(), owner_value.clone())
+            .await;
+        assert_eq!(approve.status_code(), 200);
+
+        let reject = request
+            .post(&format!(
+                "/api/v1/events/{event_id}/attendees/{rej_profile_id}/reject"
+            ))
+            .add_header(owner_key.clone(), owner_value.clone())
+            .await;
+        assert_eq!(reject.status_code(), 200);
+
+        // Bad profile id → 400 BAD_REQUEST, not 500.
+        let bad = request
+            .post(&format!(
+                "/api/v1/events/{event_id}/attendees/not-a-uuid/approve"
+            ))
+            .add_header(owner_key.clone(), owner_value.clone())
+            .await;
+        assert_eq!(bad.status_code(), 400);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn event_report_flow() {
+    request(|request, _ctx| async move {
+        let (owner_key, owner_value) =
+            create_user_with_profile(&request, "report-owner@example.com", "Owner").await;
+        let (reporter_key, reporter_value) =
+            create_user_with_profile(&request, "report-reporter@example.com", "Reporter").await;
+
+        let event_id = request
+            .post("/api/v1/events")
+            .add_header(owner_key.clone(), owner_value.clone())
+            .json(&serde_json::json!({
+                "title": "Report target",
+                "startsAt": "2030-06-05T12:00:00Z",
+            }))
+            .await
+            .json::<serde_json::Value>()["data"]["id"]
+            .as_str()
+            .expect("event id")
+            .to_string();
+
+        // Owner reporting own event → 403
+        let self_report = request
+            .post(&format!("/api/v1/events/{event_id}/report"))
+            .add_header(owner_key.clone(), owner_value.clone())
+            .json(&serde_json::json!({ "reason": "spam" }))
+            .await;
+        assert_eq!(self_report.status_code(), 403);
+
+        // Invalid reason → 400
+        let bad_reason = request
+            .post(&format!("/api/v1/events/{event_id}/report"))
+            .add_header(reporter_key.clone(), reporter_value.clone())
+            .json(&serde_json::json!({ "reason": "not-a-reason" }))
+            .await;
+        assert_eq!(bad_reason.status_code(), 400);
+
+        // First report → 200 success
+        let ok = request
+            .post(&format!("/api/v1/events/{event_id}/report"))
+            .add_header(reporter_key.clone(), reporter_value.clone())
+            .json(&serde_json::json!({ "reason": "spam" }))
+            .await;
+        assert_eq!(ok.status_code(), 200);
+
+        // Duplicate → 400 VALIDATION_ERROR
+        let dup = request
+            .post(&format!("/api/v1/events/{event_id}/report"))
+            .add_header(reporter_key.clone(), reporter_value.clone())
+            .json(&serde_json::json!({ "reason": "spam" }))
+            .await;
+        assert_eq!(dup.status_code(), 400);
+
+        // Missing event → 404
+        let missing_id = uuid::Uuid::new_v4();
+        let missing = request
+            .post(&format!("/api/v1/events/{missing_id}/report"))
+            .add_header(reporter_key.clone(), reporter_value.clone())
+            .json(&serde_json::json!({ "reason": "spam" }))
+            .await;
+        assert_eq!(missing.status_code(), 404);
+    })
+    .await;
+}


### PR DESCRIPTION
**PR #6 — events + event_attendees**

Next step in the progressive RLS migration (plan: `implement-rls-properly`). Wraps every event handler in `db::with_viewer_tx` so Tier-A policies can land later without touching app code. No policies yet.

- [ ] migration applies cleanly on prod (verified at deploy)
- [x] events_list / events_mine / events_saved render correctly — `events_flow_matches_phase_3_contract`
- [x] event_get / event_attendees render correctly — `event_attendees_listing_returns_user_pids`, phase-3 test
- [x] event_create / event_update / event_delete — phase-3 test + `event_delete_removes_event_and_is_creator_only`
- [x] event_attend (capacity + approval race) — phase-3 test (`Event is full` + full update path)
- [x] event_approve_attendee / event_reject_attendee — `event_approve_and_reject_flow`
- [x] event_save / event_unsave / event_leave — phase-3 test + `event_leave_removes_attendee_and_blocks_creator`
- [x] event_report — `event_report_flow` (self-report 403, invalid reason 400, duplicate 400, missing 404)
- [x] attendee listing uses `app.user_pids_for_ids` — `backend/src/api/events/view_attendees.rs:23`; observed in `event_attendees_listing_returns_user_pids` (real uuid pid, not nil fallback)
- [x] approval push notification uses `app.profile_owner_user_id` — `backend/src/api/events/write_handler.rs:1064`