### PR TITLE
chore(backend): flatten a few 3-4 level nested conditionals

### DIFF
--- a/backend/src/api/auth/account.rs
+++ b/backend/src/api/auth/account.rs
@@ -69,16 +69,15 @@ async fn delete_user_data(viewer: DbViewer) -> std::result::Result<(), crate::er
                 .first(conn)
                 .await
                 .optional()?;
-            let files: Vec<String> = if let Some(pid) = profile_id {
-                uploads::table
-                    .filter(uploads::owner_id.eq(pid))
-                    .select(uploads::filename)
-                    .load(conn)
-                    .await?
-            } else {
-                vec![]
+            let Some(pid) = profile_id else {
+                return Ok::<Vec<String>, diesel::result::Error>(Vec::new());
             };
-            Ok::<Vec<String>, diesel::result::Error>(files)
+            let files: Vec<String> = uploads::table
+                .filter(uploads::owner_id.eq(pid))
+                .select(uploads::filename)
+                .load(conn)
+                .await?;
+            Ok(files)
         }
         .scope_boxed()
     })

--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -158,24 +158,44 @@ pub(super) async fn forgot_password(
         return Ok(*response);
     }
 
-    // Always return success to prevent email enumeration.
-    if let Ok(Some(user)) = find_user_by_email(&email).await {
-        if user.email_verified_at.is_some()
-            && !otp_in_cooldown(&email, OTP_RESEND_COOLDOWN_SECS).await
-        {
-            let code = generate_otp_code();
-            if upsert_otp(&email, &code).await.is_ok() {
-                if let Err(error) = enqueue_otp_email(&email, &code).await {
-                    tracing::error!(%error, email = %crate::api::redact_email(&email), "failed to enqueue OTP for forgot password");
-                }
-            }
-        }
-    }
+    // Always return success to prevent email enumeration. The dispatch below
+    // is best-effort — any failure along the chain falls through to the
+    // shared success response.
+    try_dispatch_forgot_password_otp(&email).await;
 
     Ok(Json(DataResponse {
         data: SuccessResponse { success: true },
     })
     .into_response())
+}
+
+/// Best-effort: look up the user by email, verify they're eligible for an
+/// OTP send, and enqueue the reset email. Each step is a guard; silently
+/// stops on the first miss so the caller can return a uniform success
+/// response regardless of outcome (prevents email enumeration).
+async fn try_dispatch_forgot_password_otp(email: &str) {
+    let Ok(Some(user)) = find_user_by_email(email).await else {
+        return;
+    };
+    if user.email_verified_at.is_none() {
+        return;
+    }
+    if otp_in_cooldown(email, OTP_RESEND_COOLDOWN_SECS).await {
+        return;
+    }
+
+    let code = generate_otp_code();
+    if upsert_otp(email, &code).await.is_err() {
+        return;
+    }
+
+    if let Err(error) = enqueue_otp_email(email, &code).await {
+        tracing::error!(
+            %error,
+            email = %crate::api::redact_email(email),
+            "failed to enqueue OTP for forgot password"
+        );
+    }
 }
 
 pub(super) async fn forgot_password_verify(

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -262,16 +262,12 @@ pub(in crate::api) async fn event_update(
         Err(response) => return Ok(*response),
     };
 
-    let validated_tag_ids = if payload.tag_ids.is_some() {
-        match payload.tag_ids.clone() {
-            Some(ids) => match parse_event_tag_ids(&headers, ids) {
-                Ok(parsed) => Some(parsed),
-                Err(response) => return Ok(*response),
-            },
-            None => None,
-        }
-    } else {
-        None
+    let validated_tag_ids = match payload.tag_ids.clone() {
+        Some(ids) => match parse_event_tag_ids(&headers, ids) {
+            Ok(parsed) => Some(parsed),
+            Err(response) => return Ok(*response),
+        },
+        None => None,
     };
 
     let mut conn = crate::db::conn().await?;


### PR DESCRIPTION
**Flatten a few genuinely nested conditionals**

Small cleanup after the RLS migration. Only touches actual business-logic nesting — not executor plumbing (with_viewer_tx / build_transaction closures).

- [x] forgot_password still returns a uniform success response regardless of outcome — `try_dispatch_forgot_password_otp` returns `()`; handler unconditionally emits `SuccessResponse { success: true }`
- [x] event_update still rejects invalid tagIds with 400 VALIDATION_ERROR — phase-3 contract test (`tagIds: ["11111111-…"]` → 400) passes on CI
- [x] delete_account still cleans up uploads for users both with and without profiles — flatten only touched the filename-collection helper; the deletion block is untouched, `delete_account_verifies_hashed_password` passes on CI