### PR TITLE
sec(rls): wrap uploads endpoints in viewer-scoped transactions

### DIFF
--- a/backend/src/api/uploads/auth_service.rs
+++ b/backend/src/api/uploads/auth_service.rs
@@ -1,13 +1,13 @@
 use crate::db::models::profiles::Profile;
 use crate::db::models::uploads::Upload;
 use axum::http::HeaderMap;
+use diesel_async::AsyncPgConnection;
 
 use super::uploads_http::{forbidden, not_found};
 use super::uploads_multipart::HandlerError;
 use super::uploads_read_repo::{
     find_active_upload_by_filename, find_owned_active_upload_by_filenames, load_profile_by_user_id,
 };
-use crate::api::state::require_auth_db;
 use crate::api::{error_response, ErrorSpec};
 
 #[allow(clippy::unnecessary_box_returns)]
@@ -23,14 +23,15 @@ pub(super) fn internal_upload_error(headers: &HeaderMap, message: &str) -> Handl
     ))
 }
 
-pub(super) async fn require_auth_profile(
+/// Load the caller's profile inside an existing viewer-scoped transaction.
+/// Returns a `HandlerError` matching the prior behaviour — 403 `ACCESS_DENIED`
+/// when the user has no profile yet.
+pub(super) async fn load_profile_for_user(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
+    user_id: i32,
 ) -> std::result::Result<Profile, HandlerError> {
-    let (_session, user) = require_auth_db(headers)
-        .await
-        .map_err(|e| e as HandlerError)?;
-
-    load_profile_by_user_id(user.id)
+    load_profile_by_user_id(conn, user_id)
         .await
         .map_err(|_| {
             Box::new(forbidden(headers, "ACCESS_DENIED", "Profile not found")) as HandlerError
@@ -39,11 +40,12 @@ pub(super) async fn require_auth_profile(
 }
 
 pub(super) async fn load_owned_upload(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     filename: &str,
     owner_profile_id: uuid::Uuid,
 ) -> std::result::Result<Upload, HandlerError> {
-    let upload = find_active_upload_by_filename(filename)
+    let upload = find_active_upload_by_filename(conn, filename)
         .await
         .map_err(|_| Box::new(not_found(headers)) as HandlerError)?
         .ok_or_else(|| Box::new(not_found(headers)) as HandlerError)?;
@@ -66,6 +68,7 @@ fn variant_stem(filename: &str) -> Option<&str> {
 }
 
 pub(super) async fn load_owned_original_for_variant(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     filename: &str,
     owner_profile_id: uuid::Uuid,
@@ -81,22 +84,24 @@ pub(super) async fn load_owned_original_for_variant(
         format!("{stem}.webp"),
     ];
 
-    find_owned_active_upload_by_filenames(owner_profile_id, &candidates)
+    find_owned_active_upload_by_filenames(conn, owner_profile_id, &candidates)
         .await
         .map_err(|_| Box::new(not_found(headers)) as HandlerError)
 }
 
 pub(super) async fn resolve_upload_mime_type(
+    conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     filename: &str,
     owner_profile_id: uuid::Uuid,
 ) -> std::result::Result<String, HandlerError> {
-    if let Ok(upload) = load_owned_upload(headers, filename, owner_profile_id).await {
+    if let Ok(upload) = load_owned_upload(conn, headers, filename, owner_profile_id).await {
         return Ok(upload.mime_type);
     }
-    let has_owned_original = load_owned_original_for_variant(headers, filename, owner_profile_id)
-        .await?
-        .is_some();
+    let has_owned_original =
+        load_owned_original_for_variant(conn, headers, filename, owner_profile_id)
+            .await?
+            .is_some();
     if !has_owned_original {
         return Err(Box::new(not_found(headers)));
     }

--- a/backend/src/api/uploads/auth_service.rs
+++ b/backend/src/api/uploads/auth_service.rs
@@ -24,19 +24,24 @@ pub(super) fn internal_upload_error(headers: &HeaderMap, message: &str) -> Handl
 }
 
 /// Load the caller's profile inside an existing viewer-scoped transaction.
-/// Returns a `HandlerError` matching the prior behaviour — 403 `ACCESS_DENIED`
-/// when the user has no profile yet.
+/// A missing profile row is a 403 `ACCESS_DENIED` ("Profile not found");
+/// a Diesel-level failure (connection drop, timeout, etc.) surfaces as a
+/// 500 `INTERNAL_ERROR` so real DB problems don't get masked as a client
+/// permission issue.
 pub(super) async fn load_profile_for_user(
     conn: &mut AsyncPgConnection,
     headers: &HeaderMap,
     user_id: i32,
 ) -> std::result::Result<Profile, HandlerError> {
-    load_profile_by_user_id(conn, user_id)
-        .await
-        .map_err(|_| {
-            Box::new(forbidden(headers, "ACCESS_DENIED", "Profile not found")) as HandlerError
-        })?
-        .ok_or_else(|| Box::new(forbidden(headers, "ACCESS_DENIED", "Profile not found")))
+    match load_profile_by_user_id(conn, user_id).await {
+        Ok(Some(profile)) => Ok(profile),
+        Ok(None) => Err(Box::new(forbidden(
+            headers,
+            "ACCESS_DENIED",
+            "Profile not found",
+        ))),
+        Err(_) => Err(internal_upload_error(headers, "Failed to load profile")),
+    }
 }
 
 pub(super) async fn load_owned_upload(

--- a/backend/src/api/uploads/http.rs
+++ b/backend/src/api/uploads/http.rs
@@ -84,12 +84,6 @@ pub(super) async fn storage_upload(
         .map_err(|err| Box::new(storage_error_to_response(headers, &err)))
 }
 
-pub(super) async fn storage_delete(headers: &HeaderMap, filename: &str) -> HandlerResult<()> {
-    uploads_storage::delete(filename)
-        .await
-        .map_err(|err| Box::new(storage_error_to_response(headers, &err)))
-}
-
 pub(super) async fn storage_read(headers: &HeaderMap, filename: &str) -> HandlerResult<Vec<u8>> {
     uploads_storage::read(filename)
         .await

--- a/backend/src/api/uploads/mod.rs
+++ b/backend/src/api/uploads/mod.rs
@@ -45,7 +45,7 @@ use crate::db::models::uploads::{NewUpload, UploadChangeset};
 use crate::jobs::enqueue_upload_variants_generation;
 use uploads_auth_service::{
     internal_upload_error, load_owned_original_for_variant, load_owned_upload,
-    require_auth_profile, resolve_upload_mime_type,
+    load_profile_for_user, resolve_upload_mime_type,
 };
 use uploads_http::{
     bad_request, not_found, storage_delete, storage_read, storage_signed_put_url, storage_upload,

--- a/backend/src/api/uploads/mod.rs
+++ b/backend/src/api/uploads/mod.rs
@@ -47,9 +47,7 @@ use uploads_auth_service::{
     internal_upload_error, load_owned_original_for_variant, load_owned_upload,
     load_profile_for_user, resolve_upload_mime_type,
 };
-use uploads_http::{
-    bad_request, not_found, storage_delete, storage_read, storage_signed_put_url, storage_upload,
-};
+use uploads_http::{bad_request, not_found, storage_read, storage_signed_put_url, storage_upload};
 use uploads_multipart::HandlerError;
 pub(super) use uploads_read_handler::{auth_check, file_get, file_status};
 use uploads_url_service::{encode_thumbhash, fallback_variant_urls, public_upload_url};

--- a/backend/src/api/uploads/read_handler.rs
+++ b/backend/src/api/uploads/read_handler.rs
@@ -1,11 +1,16 @@
 use super::{
     bad_request, encode_thumbhash, extract_filename_from_original_uri, fallback_variant_urls,
-    header, load_owned_original_for_variant, load_owned_upload, public_upload_url,
-    require_auth_profile, resolve_upload_mime_type, storage_read, uploads_resize,
-    validate_filename, AppContext, DataResponse, HandlerError, HeaderMap, HeaderValue, Json, Path,
-    Response, Result, State, UploadStatusResponse,
+    header, load_owned_original_for_variant, load_owned_upload, load_profile_for_user,
+    public_upload_url, resolve_upload_mime_type, storage_read, uploads_resize, validate_filename,
+    AppContext, DataResponse, HandlerError, HeaderMap, HeaderValue, Json, Path, Response, Result,
+    State, UploadStatusResponse,
 };
 use axum::response::IntoResponse;
+use diesel_async::scoped_futures::ScopedFutureExt;
+
+use crate::api::{error_response, ErrorSpec};
+use crate::db;
+use crate::db::models::uploads::Upload;
 
 pub(super) struct AuthCheckResponse {
     pub(super) ok: bool,
@@ -23,26 +28,79 @@ impl serde::Serialize for AuthCheckResponse {
     }
 }
 
+/// Translate the outcome of a viewer-scoped transaction that wraps
+/// `HandlerError`-returning work into the handler's `Result<T, HandlerError>`
+/// shape. `Ok(Ok(t))` means the tx committed and the business result is
+/// `t`; `Ok(Err(e))` means the work produced a response-level error
+/// (rolled back); `Err(db)` means Diesel itself failed.
+fn unwrap_viewer_tx<T>(
+    result: std::result::Result<std::result::Result<T, HandlerError>, diesel::result::Error>,
+    headers: &HeaderMap,
+) -> std::result::Result<T, HandlerError> {
+    match result {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(Box::new(error_response(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            headers,
+            ErrorSpec {
+                error: "Database error".to_string(),
+                code: "INTERNAL_ERROR",
+                details: None,
+            },
+        ))),
+    }
+}
+
 pub(in crate::api) async fn auth_check(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
     let response: std::result::Result<Response, HandlerError> = async {
-        let profile = require_auth_profile(&headers).await?;
+        let (_session, user) = crate::api::state::require_auth_db(&headers)
+            .await
+            .map_err(|e| e as HandlerError)?;
         let filename = extract_filename_from_original_uri(&headers)?;
-        match load_owned_upload(&headers, &filename, profile.id).await {
-            Ok(_upload) => {}
-            Err(owned_err) => {
-                let has_owned_original =
-                    load_owned_original_for_variant(&headers, &filename, profile.id)
-                        .await?
-                        .is_some();
-                if !has_owned_original {
-                    return Err(owned_err);
+        let viewer = db::DbViewer {
+            user_id: user.id,
+            is_review_stub: user.is_review_stub,
+        };
+
+        let headers_tx = headers.clone();
+        let filename_tx = filename.clone();
+        let tx_result = db::with_viewer_tx(viewer, move |conn| {
+            async move {
+                let profile = match load_profile_for_user(conn, &headers_tx, user.id).await {
+                    Ok(p) => p,
+                    Err(err) => return Ok(Err(err)),
+                };
+                match load_owned_upload(conn, &headers_tx, &filename_tx, profile.id).await {
+                    Ok(_) => Ok::<_, diesel::result::Error>(Ok(())),
+                    Err(owned_err) => {
+                        let has_owned_original = match load_owned_original_for_variant(
+                            conn,
+                            &headers_tx,
+                            &filename_tx,
+                            profile.id,
+                        )
+                        .await
+                        {
+                            Ok(v) => v.is_some(),
+                            Err(err) => return Ok(Err(err)),
+                        };
+                        if has_owned_original {
+                            Ok(Ok(()))
+                        } else {
+                            Ok(Err(owned_err))
+                        }
+                    }
                 }
             }
-        }
+            .scope_boxed()
+        })
+        .await;
 
+        unwrap_viewer_tx(tx_result, &headers)?;
         Ok(Json(AuthCheckResponse { ok: true }).into_response())
     }
     .await;
@@ -74,8 +132,32 @@ pub(in crate::api) async fn file_get(
             return Err(Box::new(bad_request(&headers, "INVALID_FILENAME", message)));
         }
 
-        let profile = require_auth_profile(&headers).await?;
-        let mime_type = resolve_upload_mime_type(&headers, &filename, profile.id).await?;
+        let (_session, user) = crate::api::state::require_auth_db(&headers)
+            .await
+            .map_err(|e| e as HandlerError)?;
+        let viewer = db::DbViewer {
+            user_id: user.id,
+            is_review_stub: user.is_review_stub,
+        };
+
+        let headers_tx = headers.clone();
+        let filename_tx = filename.clone();
+        let tx_result = db::with_viewer_tx(viewer, move |conn| {
+            async move {
+                let profile = match load_profile_for_user(conn, &headers_tx, user.id).await {
+                    Ok(p) => p,
+                    Err(err) => return Ok(Err(err)),
+                };
+                match resolve_upload_mime_type(conn, &headers_tx, &filename_tx, profile.id).await {
+                    Ok(mt) => Ok::<_, diesel::result::Error>(Ok(mt)),
+                    Err(err) => Ok(Err(err)),
+                }
+            }
+            .scope_boxed()
+        })
+        .await;
+
+        let mime_type = unwrap_viewer_tx(tx_result, &headers)?;
 
         if let Some(url) = crate::api::imgproxy_signing::signed_url(&filename, "full", "webp") {
             return Ok(Json(super::super::state::UploadUrlResponse { url }).into_response());
@@ -98,8 +180,32 @@ pub(in crate::api) async fn file_status(
             return Err(Box::new(bad_request(&headers, "INVALID_FILENAME", message)));
         }
 
-        let profile = require_auth_profile(&headers).await?;
-        let upload = load_owned_upload(&headers, &filename, profile.id).await?;
+        let (_session, user) = crate::api::state::require_auth_db(&headers)
+            .await
+            .map_err(|e| e as HandlerError)?;
+        let viewer = db::DbViewer {
+            user_id: user.id,
+            is_review_stub: user.is_review_stub,
+        };
+
+        let headers_tx = headers.clone();
+        let filename_tx = filename.clone();
+        let tx_result = db::with_viewer_tx(viewer, move |conn| {
+            async move {
+                let profile = match load_profile_for_user(conn, &headers_tx, user.id).await {
+                    Ok(p) => p,
+                    Err(err) => return Ok(Err(err)),
+                };
+                match load_owned_upload(conn, &headers_tx, &filename_tx, profile.id).await {
+                    Ok(upload) => Ok::<_, diesel::result::Error>(Ok(upload)),
+                    Err(err) => Ok(Err(err)),
+                }
+            }
+            .scope_boxed()
+        })
+        .await;
+
+        let upload: Upload = unwrap_viewer_tx(tx_result, &headers)?;
 
         let imgproxy = crate::api::imgproxy_signing::is_configured();
         let url = public_upload_url(&headers, &upload.filename).await;

--- a/backend/src/api/uploads/read_repo.rs
+++ b/backend/src/api/uploads/read_repo.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::profiles::Profile;
@@ -7,40 +7,40 @@ use crate::db::models::uploads::Upload;
 use crate::db::schema::{profiles, uploads};
 
 pub(in crate::api) async fn load_profile_by_user_id(
+    conn: &mut AsyncPgConnection,
     user_id: i32,
 ) -> std::result::Result<Option<Profile>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let profile = profiles::table
         .filter(profiles::user_id.eq(user_id))
-        .first::<Profile>(&mut conn)
+        .first::<Profile>(conn)
         .await
         .optional()?;
     Ok(profile)
 }
 
 pub(in crate::api) async fn find_active_upload_by_filename(
+    conn: &mut AsyncPgConnection,
     filename: &str,
 ) -> std::result::Result<Option<Upload>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let upload = uploads::table
         .filter(uploads::filename.eq(filename))
         .filter(uploads::deleted.eq(false))
-        .first::<Upload>(&mut conn)
+        .first::<Upload>(conn)
         .await
         .optional()?;
     Ok(upload)
 }
 
 pub(in crate::api) async fn find_owned_active_upload_by_filenames(
+    conn: &mut AsyncPgConnection,
     owner_profile_id: Uuid,
     filenames: &[String],
 ) -> std::result::Result<Option<Upload>, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     let upload = uploads::table
         .filter(uploads::owner_id.eq(Some(owner_profile_id)))
         .filter(uploads::deleted.eq(false))
         .filter(uploads::filename.eq_any(filenames))
-        .first::<Upload>(&mut conn)
+        .first::<Upload>(conn)
         .await
         .optional()?;
     Ok(upload)

--- a/backend/src/api/uploads/write_handler.rs
+++ b/backend/src/api/uploads/write_handler.rs
@@ -1,12 +1,11 @@
 use super::{
     bad_request, create_upload_filename, enqueue_upload_variants_generation, error_response,
     fallback_variant_urls, internal_upload_error, load_owned_upload, load_profile_for_user,
-    not_found, public_upload_url, storage_delete, storage_signed_put_url, storage_upload,
-    uploads_multipart, uploads_resize, uploads_storage, validate_filename,
-    validate_presign_payload, AppContext, DataResponse, DirectUploadCompleteBody,
-    DirectUploadPresignBody, DirectUploadPresignResponse, ErrorSpec, HandlerError, HeaderMap, Json,
-    Multipart, NewUpload, Path, Response, Result, State, SuccessResponse, UploadChangeset,
-    UploadResponse, Utc, Uuid,
+    not_found, public_upload_url, storage_signed_put_url, storage_upload, uploads_multipart,
+    uploads_resize, uploads_storage, validate_filename, validate_presign_payload, AppContext,
+    DataResponse, DirectUploadCompleteBody, DirectUploadPresignBody, DirectUploadPresignResponse,
+    ErrorSpec, HandlerError, HeaderMap, Json, Multipart, NewUpload, Path, Response, Result, State,
+    SuccessResponse, UploadChangeset, UploadResponse, Utc, Uuid,
 };
 use axum::response::IntoResponse;
 use diesel_async::scoped_futures::ScopedFutureExt;
@@ -337,59 +336,52 @@ pub(in crate::api) async fn file_delete(
 
         let (viewer, user_id) = auth_and_viewer(&headers).await?;
 
+        // Mark the upload row deleted in the same transaction that loads
+        // it, so ownership check and soft-delete are atomic. Storage
+        // cleanup happens *after* commit — swapping the old order prevents
+        // the "live row pointing at missing storage" race when the DB
+        // update fails after a successful S3 delete. If a later storage
+        // op fails, the row is already invisible to reads (deleted=true)
+        // and operators can clean up orphans later.
         let headers_tx = headers.clone();
         let filename_tx = filename.clone();
+        let changeset = UploadChangeset {
+            deleted: Some(true),
+            updated_at: Some(Utc::now()),
+            ..Default::default()
+        };
         let tx_result = db::with_viewer_tx(viewer, move |conn| {
             async move {
                 let profile = match load_profile_for_user(conn, &headers_tx, user_id).await {
                     Ok(p) => p,
                     Err(err) => return Ok(Err(err)),
                 };
-                match load_owned_upload(conn, &headers_tx, &filename_tx, profile.id).await {
-                    Ok(upload) => Ok::<_, diesel::result::Error>(Ok(upload)),
-                    Err(err) => Ok(Err(err)),
+                let upload = match load_owned_upload(conn, &headers_tx, &filename_tx, profile.id)
+                    .await
+                {
+                    Ok(u) => u,
+                    Err(err) => return Ok(Err(err)),
+                };
+                if let Err(error) = mark_upload_deleted(conn, upload.id, &changeset).await {
+                    tracing::warn!(filename = %filename_tx, %error, "failed to mark upload as deleted");
+                    return Err(diesel::result::Error::RollbackTransaction);
                 }
+                Ok::<_, diesel::result::Error>(Ok(()))
             }
             .scope_boxed()
         })
         .await;
-        let upload = unwrap_viewer_tx(tx_result, &headers)?;
+        unwrap_viewer_tx(tx_result, &headers)?;
 
-        storage_delete(&headers, &filename).await?;
-
-        // Best-effort delete variants regardless of DB flags to avoid stale files.
+        // Best-effort storage cleanup. Original + thumb + std variants are
+        // all dropped without failing the request — the row is already
+        // marked deleted, so a storage failure leaves an orphan object
+        // rather than an inconsistent API surface.
+        let _ = uploads_storage::delete(&filename).await;
         let thumb_name = uploads_resize::variant_filename(&filename, "thumb");
         let std_name = uploads_resize::variant_filename(&filename, "std");
         let _ = uploads_storage::delete(&thumb_name).await;
         let _ = uploads_storage::delete(&std_name).await;
-
-        let changeset = UploadChangeset {
-            deleted: Some(true),
-            updated_at: Some(Utc::now()),
-            ..Default::default()
-        };
-
-        let update_tx = db::with_viewer_tx(viewer, {
-            let changeset = changeset.clone();
-            let upload_id = upload.id;
-            move |conn| {
-                async move {
-                    mark_upload_deleted(conn, upload_id, &changeset)
-                        .await
-                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
-                    Ok::<(), diesel::result::Error>(())
-                }
-                .scope_boxed()
-            }
-        })
-        .await;
-        if let Err(error) = update_tx {
-            tracing::warn!(filename = %filename, %error, "failed to mark upload as deleted");
-            return Err(internal_upload_error(
-                &headers,
-                "Failed to update upload metadata",
-            ));
-        }
 
         Ok(Json(SuccessResponse { success: true }).into_response())
     }

--- a/backend/src/api/uploads/write_handler.rs
+++ b/backend/src/api/uploads/write_handler.rs
@@ -1,7 +1,7 @@
 use super::{
     bad_request, create_upload_filename, enqueue_upload_variants_generation, error_response,
-    fallback_variant_urls, internal_upload_error, load_owned_upload, not_found, public_upload_url,
-    require_auth_profile, storage_delete, storage_signed_put_url, storage_upload,
+    fallback_variant_urls, internal_upload_error, load_owned_upload, load_profile_for_user,
+    not_found, public_upload_url, storage_delete, storage_signed_put_url, storage_upload,
     uploads_multipart, uploads_resize, uploads_storage, validate_filename,
     validate_presign_payload, AppContext, DataResponse, DirectUploadCompleteBody,
     DirectUploadPresignBody, DirectUploadPresignResponse, ErrorSpec, HandlerError, HeaderMap, Json,
@@ -9,10 +9,48 @@ use super::{
     UploadResponse, Utc, Uuid,
 };
 use axum::response::IntoResponse;
+use diesel_async::scoped_futures::ScopedFutureExt;
 
 use super::uploads_write_repo::{insert_upload_metadata, mark_upload_deleted};
+use crate::db;
 
 const DIRECT_UPLOAD_PRESIGN_EXPIRY_SECS: u64 = 3600;
+
+/// Map a viewer-tx result carrying an inner `HandlerError` into the handler's
+/// `Result<T, HandlerError>` shape. Diesel-level failures become a generic
+/// 500 — matches the prior `?` behaviour which would have surfaced as
+/// `AppError::Any`.
+fn unwrap_viewer_tx<T>(
+    result: std::result::Result<std::result::Result<T, HandlerError>, diesel::result::Error>,
+    headers: &HeaderMap,
+) -> std::result::Result<T, HandlerError> {
+    match result {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(Box::new(error_response(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            headers,
+            ErrorSpec {
+                error: "Database error".to_string(),
+                code: "INTERNAL_ERROR",
+                details: None,
+            },
+        ))),
+    }
+}
+
+async fn auth_and_viewer(
+    headers: &HeaderMap,
+) -> std::result::Result<(db::DbViewer, i32), HandlerError> {
+    let (_session, user) = crate::api::state::require_auth_db(headers)
+        .await
+        .map_err(|e| e as HandlerError)?;
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    Ok((viewer, user.id))
+}
 
 pub(in crate::api) async fn file_upload(
     State(_ctx): State<AppContext>,
@@ -26,7 +64,23 @@ pub(in crate::api) async fn file_upload(
         )
         .await?;
 
-        let profile = require_auth_profile(&headers).await?;
+        let (viewer, user_id) = auth_and_viewer(&headers).await?;
+
+        // Resolve the caller's profile inside a short viewer tx before
+        // touching storage, so we don't S3-upload bytes for a user who
+        // has no profile yet.
+        let headers_for_profile = headers.clone();
+        let profile_tx = db::with_viewer_tx(viewer, move |conn| {
+            async move {
+                match load_profile_for_user(conn, &headers_for_profile, user_id).await {
+                    Ok(p) => Ok::<_, diesel::result::Error>(Ok(p)),
+                    Err(err) => Ok(Err(err)),
+                }
+            }
+            .scope_boxed()
+        })
+        .await;
+        let profile = unwrap_viewer_tx(profile_tx, &headers)?;
 
         let parsed = uploads_multipart::read_multipart(&headers, multipart).await?;
         let filename = create_upload_filename(&parsed.mime_type);
@@ -50,7 +104,22 @@ pub(in crate::api) async fn file_upload(
             updated_at: now,
         };
 
-        if let Err(error) = insert_upload_metadata(&new_upload).await {
+        // Insert metadata in its own viewer tx so Tier-C upload write policy
+        // (owner_id = viewer's profile) is enforced once it lands.
+        let insert_tx = db::with_viewer_tx(viewer, {
+            let new_upload = new_upload.clone();
+            move |conn| {
+                async move {
+                    insert_upload_metadata(conn, &new_upload)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+                    Ok::<(), diesel::result::Error>(())
+                }
+                .scope_boxed()
+            }
+        })
+        .await;
+        if let Err(error) = insert_tx {
             tracing::warn!(filename = %filename, %error, "failed to insert upload row");
             let _ = uploads_storage::delete(&filename).await;
             return Err(internal_upload_error(
@@ -103,7 +172,20 @@ pub(in crate::api) async fn file_upload_presign(
         .await?;
 
         let context = validate_presign_payload(&headers, &payload)?;
-        let profile = require_auth_profile(&headers).await?;
+        let (viewer, user_id) = auth_and_viewer(&headers).await?;
+
+        let headers_for_profile = headers.clone();
+        let profile_tx = db::with_viewer_tx(viewer, move |conn| {
+            async move {
+                match load_profile_for_user(conn, &headers_for_profile, user_id).await {
+                    Ok(p) => Ok::<_, diesel::result::Error>(Ok(p)),
+                    Err(err) => Ok(Err(err)),
+                }
+            }
+            .scope_boxed()
+        })
+        .await;
+        let profile = unwrap_viewer_tx(profile_tx, &headers)?;
 
         let filename = create_upload_filename(&payload.mime_type);
         let upload_url = storage_signed_put_url(&headers, &filename, &payload.mime_type).await?;
@@ -124,12 +206,23 @@ pub(in crate::api) async fn file_upload_presign(
             updated_at: now,
         };
 
-        insert_upload_metadata(&new_upload)
-            .await
-            .map_err(|error| {
-                tracing::warn!(%error, filename = %filename, "failed to insert direct-upload metadata row");
-                internal_upload_error(&headers, "Failed to save upload metadata")
-            })?;
+        let insert_tx = db::with_viewer_tx(viewer, {
+            let new_upload = new_upload.clone();
+            move |conn| {
+                async move {
+                    insert_upload_metadata(conn, &new_upload)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+                    Ok::<(), diesel::result::Error>(())
+                }
+                .scope_boxed()
+            }
+        })
+        .await;
+        insert_tx.map_err(|error| {
+            tracing::warn!(%error, filename = %filename, "failed to insert direct-upload metadata row");
+            internal_upload_error(&headers, "Failed to save upload metadata")
+        })?;
 
         Ok(Json(DataResponse {
             data: DirectUploadPresignResponse {
@@ -163,8 +256,25 @@ pub(in crate::api) async fn file_upload_complete(
             return Err(Box::new(bad_request(&headers, "INVALID_FILENAME", message)));
         }
 
-        let profile = require_auth_profile(&headers).await?;
-        let upload = load_owned_upload(&headers, &payload.filename, profile.id).await?;
+        let (viewer, user_id) = auth_and_viewer(&headers).await?;
+
+        let headers_tx = headers.clone();
+        let filename_tx = payload.filename.clone();
+        let tx_result = db::with_viewer_tx(viewer, move |conn| {
+            async move {
+                let profile = match load_profile_for_user(conn, &headers_tx, user_id).await {
+                    Ok(p) => p,
+                    Err(err) => return Ok(Err(err)),
+                };
+                match load_owned_upload(conn, &headers_tx, &filename_tx, profile.id).await {
+                    Ok(upload) => Ok::<_, diesel::result::Error>(Ok(upload)),
+                    Err(err) => Ok(Err(err)),
+                }
+            }
+            .scope_boxed()
+        })
+        .await;
+        let upload = unwrap_viewer_tx(tx_result, &headers)?;
 
         let exists = uploads_storage::exists(&payload.filename)
             .await
@@ -225,8 +335,25 @@ pub(in crate::api) async fn file_delete(
             return Err(Box::new(bad_request(&headers, "INVALID_FILENAME", message)));
         }
 
-        let profile = require_auth_profile(&headers).await?;
-        let upload = load_owned_upload(&headers, &filename, profile.id).await?;
+        let (viewer, user_id) = auth_and_viewer(&headers).await?;
+
+        let headers_tx = headers.clone();
+        let filename_tx = filename.clone();
+        let tx_result = db::with_viewer_tx(viewer, move |conn| {
+            async move {
+                let profile = match load_profile_for_user(conn, &headers_tx, user_id).await {
+                    Ok(p) => p,
+                    Err(err) => return Ok(Err(err)),
+                };
+                match load_owned_upload(conn, &headers_tx, &filename_tx, profile.id).await {
+                    Ok(upload) => Ok::<_, diesel::result::Error>(Ok(upload)),
+                    Err(err) => Ok(Err(err)),
+                }
+            }
+            .scope_boxed()
+        })
+        .await;
+        let upload = unwrap_viewer_tx(tx_result, &headers)?;
 
         storage_delete(&headers, &filename).await?;
 
@@ -242,7 +369,21 @@ pub(in crate::api) async fn file_delete(
             ..Default::default()
         };
 
-        if let Err(error) = mark_upload_deleted(upload.id, &changeset).await {
+        let update_tx = db::with_viewer_tx(viewer, {
+            let changeset = changeset.clone();
+            let upload_id = upload.id;
+            move |conn| {
+                async move {
+                    mark_upload_deleted(conn, upload_id, &changeset)
+                        .await
+                        .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+                    Ok::<(), diesel::result::Error>(())
+                }
+                .scope_boxed()
+            }
+        })
+        .await;
+        if let Err(error) = update_tx {
             tracing::warn!(filename = %filename, %error, "failed to mark upload as deleted");
             return Err(internal_upload_error(
                 &headers,

--- a/backend/src/api/uploads/write_repo.rs
+++ b/backend/src/api/uploads/write_repo.rs
@@ -1,29 +1,29 @@
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::uploads::{NewUpload, UploadChangeset};
 use crate::db::schema::uploads;
 
 pub(in crate::api) async fn insert_upload_metadata(
+    conn: &mut AsyncPgConnection,
     new_upload: &NewUpload,
 ) -> std::result::Result<(), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     diesel::insert_into(uploads::table)
         .values(new_upload)
-        .execute(&mut conn)
+        .execute(conn)
         .await?;
     Ok(())
 }
 
 pub(in crate::api) async fn mark_upload_deleted(
+    conn: &mut AsyncPgConnection,
     upload_id: Uuid,
     changeset: &UploadChangeset,
 ) -> std::result::Result<(), crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
     diesel::update(uploads::table.find(upload_id))
         .set(changeset)
-        .execute(&mut conn)
+        .execute(conn)
         .await?;
     Ok(())
 }

--- a/backend/src/db/models/uploads.rs
+++ b/backend/src/db/models/uploads.rs
@@ -20,7 +20,7 @@ pub struct Upload {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Insertable)]
+#[derive(Clone, Debug, Insertable)]
 #[diesel(table_name = uploads)]
 pub struct NewUpload {
     pub id: Uuid,
@@ -36,7 +36,7 @@ pub struct NewUpload {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, AsChangeset, Default)]
+#[derive(Clone, Debug, AsChangeset, Default)]
 #[diesel(table_name = uploads)]
 pub struct UploadChangeset {
     pub filename: Option<String>,


### PR DESCRIPTION
**PR #7 — uploads + thumbhash**

Wraps every uploads handler in \`db::with_viewer_tx\` so Tier-C upload policies can land without touching app code.

- [x] migration applies cleanly on prod — no new migration in this PR (verified \`git diff main...HEAD backend/migrations/\` returns empty); code-only refactor
- [x] auth_check still 200s for the owner of a variant; 403 for a different user — covered by \`uploads_auth_check_accepts_owned_variant_url\` (expects 200) and \`uploads_auth_check_rejects_other_users_variant_url\` (expects 403 for both original and variant). CI test job passed.
- [x] file_get still returns the signed imgproxy URL or raw bytes — resolve_upload_mime_type + imgproxy signing path unchanged inside the handler; covered indirectly by \`matching_and_uploads_endpoints_available\` (missing filename → 404) and by the auth-check tests which exercise the full file path.
- [x] file_status still returns variants + thumbhash for the owner — load_owned_upload + variant URL building unchanged post-tx; response shape identical (same \`UploadStatusResponse\` fields). Code inspection: \`backend/src/api/uploads/read_handler.rs:207-238\`.
- [x] file_upload (multipart): metadata row created, S3 object stays, variant job enqueued — \`upload_png\` helper is called from 6 other tests (e.g. \`events_flow_matches_phase_3_contract\` cover image, \`uploads_auth_check_accepts_owned_variant_url\`). CI test passed. Insert-failure path still covered by \`upload_returns_error_when_upload_row_insert_fails\`.
- [x] file_upload_presign: metadata row created, signed PUT URL returned — no explicit integration test, but the flow is auth → profile load → S3 signed URL → insert, each step identical to pre-PR behaviour (code inspection: \`write_handler.rs:163-234\`). Insert is now inside \`with_viewer_tx\` with the same \`NewUpload\` payload; response shape unchanged.
- [x] file_upload_complete: variant job enqueued, response returned — no explicit integration test; flow is load_owned_upload → S3 exists check → enqueue → response, unchanged modulo the tx boundary.
- [x] file_delete: mark deleted first, then best-effort storage cleanup — covered by \`delete_returns_error_when_upload_row_update_fails\` (expects 500 when UPDATE fails; with the new ordering the tx rolls back before any storage call). CI test passed.
- [x] variant_jobs worker path untouched — \`git diff main...HEAD -- backend/src/api/uploads/variant_jobs.rs\` is empty. Still runs as \`poziomki_worker\` (BYPASSRLS) against \`db::conn()\` directly.

**Follow-up commit:** \`file_delete\` ordering swapped to mark-deleted-first + best-effort storage cleanup (addresses the residual reviewer concern about a DB-update failure after successful S3 delete leaving orphan live rows).