### PR TITLE
sec(rls): wrap xp endpoints in viewer-scoped transactions

### DIFF
--- a/backend/migrations/2026-04-18-070000_xp_award_helper/down.sql
+++ b/backend/migrations/2026-04-18-070000_xp_award_helper/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS app.award_profile_xp(uuid, int);

--- a/backend/migrations/2026-04-18-070000_xp_award_helper/up.sql
+++ b/backend/migrations/2026-04-18-070000_xp_award_helper/up.sql
@@ -9,33 +9,48 @@
 -- DEFINER function keeps the mutation narrow (single row, fixed columns)
 -- while letting it run as the owner.
 --
--- Streak logic: the targeted row's streak is either preserved (same
--- day), incremented (consecutive day), or reset to 1 (any other gap).
--- Matches the inline SQL it replaces in `backend/src/api/xp/service.rs`.
+-- Date handling: explicit `(now() AT TIME ZONE 'UTC')::date` instead of
+-- `CURRENT_DATE`, to match the pre-PR Rust behaviour
+-- (`Utc::now().date_naive()`). `CURRENT_DATE` would depend on the Postgres
+-- session timezone, so around UTC midnight streak preservation /
+-- increment / reset could diverge from what the app expects.
+--
+-- Amount bound: `p_amount` is restricted to `(0, 100]`. Current callers
+-- award 5 or 10; the bound keeps this helper from being repurposed to
+-- subtract XP or inflate it arbitrarily if a future bug or SQL-injection
+-- path reaches it. Out-of-range inputs raise and the UPDATE is skipped.
 CREATE OR REPLACE FUNCTION app.award_profile_xp(p_profile_id uuid, p_amount int)
 RETURNS void
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp
 AS $$
+DECLARE
+    today date := (now() AT TIME ZONE 'UTC')::date;
+BEGIN
+    IF p_amount IS NULL OR p_amount <= 0 OR p_amount > 100 THEN
+        RAISE EXCEPTION 'award_profile_xp: p_amount out of range (got %, expected 1..100)', p_amount;
+    END IF;
+
     UPDATE public.profiles
     SET xp = xp + p_amount,
         streak_current = CASE
-            WHEN streak_last_active = CURRENT_DATE THEN streak_current
-            WHEN streak_last_active = CURRENT_DATE - INTERVAL '1 day' THEN streak_current + 1
+            WHEN streak_last_active = today THEN streak_current
+            WHEN streak_last_active = today - INTERVAL '1 day' THEN streak_current + 1
             ELSE 1
         END,
         streak_longest = GREATEST(streak_longest, CASE
-            WHEN streak_last_active = CURRENT_DATE THEN streak_current
-            WHEN streak_last_active = CURRENT_DATE - INTERVAL '1 day' THEN streak_current + 1
+            WHEN streak_last_active = today THEN streak_current
+            WHEN streak_last_active = today - INTERVAL '1 day' THEN streak_current + 1
             ELSE 1
         END),
-        streak_last_active = CURRENT_DATE
-    WHERE id = p_profile_id
+        streak_last_active = today
+    WHERE id = p_profile_id;
+END
 $$;
 
 COMMENT ON FUNCTION app.award_profile_xp(uuid, int) IS
-    'Award XP + bump streak for a profile. Owner-level UPDATE so the scan_token handler and spawned award tasks can credit both parties without relying on viewer context.';
+    'Award XP + bump streak for a profile. Owner-level UPDATE so the scan_token handler and spawned award tasks can credit both parties without relying on viewer context. Amount bounded to 1..100; date evaluated in UTC.';
 
 REVOKE EXECUTE ON FUNCTION app.award_profile_xp(uuid, int) FROM PUBLIC;
 

--- a/backend/migrations/2026-04-18-070000_xp_award_helper/up.sql
+++ b/backend/migrations/2026-04-18-070000_xp_award_helper/up.sql
@@ -1,0 +1,49 @@
+-- SECURITY DEFINER helper for the XP / streak award path.
+--
+-- XP is awarded from several spawned background tasks (scan completion,
+-- event attend, event approve) and from the scan_token handler which
+-- credits *both* the scanner and the scanned profile. Under Tier-A
+-- `profiles` RLS (`USING (user_id = app.current_user_id())`), neither
+-- the spawned task's anon context nor the scanner's viewer context can
+-- UPDATE the other user's row. Moving the award to an `app.*` SECURITY
+-- DEFINER function keeps the mutation narrow (single row, fixed columns)
+-- while letting it run as the owner.
+--
+-- Streak logic: the targeted row's streak is either preserved (same
+-- day), incremented (consecutive day), or reset to 1 (any other gap).
+-- Matches the inline SQL it replaces in `backend/src/api/xp/service.rs`.
+CREATE OR REPLACE FUNCTION app.award_profile_xp(p_profile_id uuid, p_amount int)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+    UPDATE public.profiles
+    SET xp = xp + p_amount,
+        streak_current = CASE
+            WHEN streak_last_active = CURRENT_DATE THEN streak_current
+            WHEN streak_last_active = CURRENT_DATE - INTERVAL '1 day' THEN streak_current + 1
+            ELSE 1
+        END,
+        streak_longest = GREATEST(streak_longest, CASE
+            WHEN streak_last_active = CURRENT_DATE THEN streak_current
+            WHEN streak_last_active = CURRENT_DATE - INTERVAL '1 day' THEN streak_current + 1
+            ELSE 1
+        END),
+        streak_last_active = CURRENT_DATE
+    WHERE id = p_profile_id
+$$;
+
+COMMENT ON FUNCTION app.award_profile_xp(uuid, int) IS
+    'Award XP + bump streak for a profile. Owner-level UPDATE so the scan_token handler and spawned award tasks can credit both parties without relying on viewer context.';
+
+REVOKE EXECUTE ON FUNCTION app.award_profile_xp(uuid, int) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.award_profile_xp(uuid, int) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/api/xp/handler.rs
+++ b/backend/src/api/xp/handler.rs
@@ -4,15 +4,18 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use diesel_async::scoped_futures::ScopedFutureExt;
 use serde::{Deserialize, Serialize};
 
 use crate::api::state::DataResponse;
 use crate::api::{error_response, ErrorSpec};
 use crate::app::AppContext;
+use crate::db;
 
 use super::{service, token};
 
 type Result<T> = crate::error::AppResult<T>;
+type HandlerError = Box<Response>;
 
 pub fn routes() -> Router<AppContext> {
     Router::new()
@@ -51,6 +54,25 @@ struct ClaimTaskResponse {
     xp_gained: i32,
 }
 
+fn unwrap_viewer_tx<T>(
+    result: std::result::Result<std::result::Result<T, HandlerError>, diesel::result::Error>,
+    headers: &HeaderMap,
+) -> std::result::Result<T, HandlerError> {
+    match result {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(Box::new(error_response(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            headers,
+            ErrorSpec {
+                error: "Database error".to_string(),
+                code: "INTERNAL_ERROR",
+                details: None,
+            },
+        ))),
+    }
+}
+
 async fn claim_task(headers: HeaderMap, Json(body): Json<ClaimTaskBody>) -> Result<Response> {
     if let Err(response) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
         &headers,
@@ -61,32 +83,44 @@ async fn claim_task(headers: HeaderMap, Json(body): Json<ClaimTaskBody>) -> Resu
         return Ok(*response);
     }
 
-    let profile = match service::load_profile_for(&headers).await {
-        Ok(p) => p,
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
         Err(response) => return Ok(*response),
     };
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
 
-    let awarded = match service::try_record_task(profile.id, &body.task_id).await {
-        Ok(awarded) => awarded,
-        Err(e) => {
-            tracing::error!(error = %e, "failed to record task completion");
-            return Ok(error_response(
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                &headers,
-                ErrorSpec {
-                    error: "Failed to record task".to_string(),
-                    code: "INTERNAL_ERROR",
-                    details: None,
-                },
-            ));
+    // Load profile + record task completion atomically inside the viewer
+    // tx. `try_record_task` is idempotent per (profile_id, task_id, day),
+    // so the returned bool decides whether to award XP.
+    let headers_tx = headers.clone();
+    let task_id = body.task_id.clone();
+    let tx_result = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let profile = match service::load_profile_for_user(conn, &headers_tx, user.id).await {
+                Ok(p) => p,
+                Err(err) => return Ok(Err(err)),
+            };
+            match service::try_record_task(conn, profile.id, &task_id).await {
+                Ok(awarded) => Ok::<_, diesel::result::Error>(Ok((profile.id, awarded))),
+                Err(_) => Err(diesel::result::Error::RollbackTransaction),
+            }
         }
+        .scope_boxed()
+    })
+    .await;
+
+    let (profile_id, awarded) = match unwrap_viewer_tx(tx_result, &headers) {
+        Ok(v) => v,
+        Err(resp) => return Ok(*resp),
     };
 
     if awarded {
-        let profile_id = profile.id;
         tokio::spawn(async move {
             if let Err(e) = service::award_xp(profile_id, 5).await {
-                tracing::warn!(error = %e, profile_id = %profile_id, "failed to award task XP");
+                tracing::warn!(error = %e, %profile_id, "failed to award task XP");
             }
         });
     }
@@ -109,9 +143,30 @@ pub(in crate::api) async fn get_token(headers: HeaderMap) -> Result<Response> {
         return Ok(*response);
     }
 
-    let profile = match service::load_profile_for(&headers).await {
-        Ok(p) => p,
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
         Err(response) => return Ok(*response),
+    };
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+
+    let headers_tx = headers.clone();
+    let tx_result = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            match service::load_profile_for_user(conn, &headers_tx, user.id).await {
+                Ok(p) => Ok::<_, diesel::result::Error>(Ok(p)),
+                Err(err) => Ok(Err(err)),
+            }
+        }
+        .scope_boxed()
+    })
+    .await;
+
+    let profile = match unwrap_viewer_tx(tx_result, &headers) {
+        Ok(p) => p,
+        Err(resp) => return Ok(*resp),
     };
 
     match token::generate(profile.id) {
@@ -150,11 +205,6 @@ pub(in crate::api) async fn scan_token(
         return Ok(*response);
     }
 
-    let scanner = match service::load_profile_for(&headers).await {
-        Ok(p) => p,
-        Err(response) => return Ok(*response),
-    };
-
     let Ok(scanned_id) = token::verify(&body.token) else {
         return Ok(error_response(
             axum::http::StatusCode::BAD_REQUEST,
@@ -167,39 +217,54 @@ pub(in crate::api) async fn scan_token(
         ));
     };
 
-    if scanned_id == scanner.id {
-        return Ok(error_response(
-            axum::http::StatusCode::BAD_REQUEST,
-            &headers,
-            ErrorSpec {
-                error: "Cannot scan your own QR code".to_string(),
-                code: "VALIDATION_ERROR",
-                details: None,
-            },
-        ));
-    }
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
 
-    let awarded = match service::try_record_scan(scanner.id, scanned_id).await {
-        Ok(awarded) => awarded,
-        Err(e) => {
-            tracing::error!(error = %e, "failed to record XP scan");
-            return Ok(error_response(
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                &headers,
-                ErrorSpec {
-                    error: "Failed to record scan".to_string(),
-                    code: "INTERNAL_ERROR",
-                    details: None,
-                },
-            ));
+    // Load scanner profile + insert scan record atomically. The scan row
+    // is owned by the scanner (scanner_id = viewer's profile), so
+    // Tier-A policy on xp_scans can enforce write-on-own-row.
+    let headers_tx = headers.clone();
+    let tx_result = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let scanner = match service::load_profile_for_user(conn, &headers_tx, user.id).await {
+                Ok(p) => p,
+                Err(err) => return Ok(Err(err)),
+            };
+            if scanner.id == scanned_id {
+                return Ok(Err(Box::new(error_response(
+                    axum::http::StatusCode::BAD_REQUEST,
+                    &headers_tx,
+                    ErrorSpec {
+                        error: "Cannot scan your own QR code".to_string(),
+                        code: "VALIDATION_ERROR",
+                        details: None,
+                    },
+                ))));
+            }
+            match service::try_record_scan(conn, scanner.id, scanned_id).await {
+                Ok(awarded) => Ok::<_, diesel::result::Error>(Ok((scanner.id, awarded))),
+                Err(_) => Err(diesel::result::Error::RollbackTransaction),
+            }
         }
+        .scope_boxed()
+    })
+    .await;
+
+    let (my_profile_id, awarded) = match unwrap_viewer_tx(tx_result, &headers) {
+        Ok(v) => v,
+        Err(resp) => return Ok(*resp),
     };
 
     if awarded {
-        let my_id = scanner.id;
         tokio::spawn(async move {
-            if let Err(e) = service::award_xp(my_id, 5).await {
-                tracing::warn!(error = %e, profile_id = %my_id, "failed to award XP to scanner");
+            if let Err(e) = service::award_xp(my_profile_id, 5).await {
+                tracing::warn!(error = %e, profile_id = %my_profile_id, "failed to award XP to scanner");
             }
             if let Err(e) = service::award_xp(scanned_id, 5).await {
                 tracing::warn!(error = %e, profile_id = %scanned_id, "failed to award XP to scanned");

--- a/backend/src/api/xp/handler.rs
+++ b/backend/src/api/xp/handler.rs
@@ -205,6 +205,19 @@ pub(in crate::api) async fn scan_token(
         return Ok(*response);
     }
 
+    // Authenticate first so an unauthenticated caller can't use a 400
+    // "Invalid or expired token" response as an oracle for token validity.
+    // The pre-PR flow ran load_profile_for (which called require_auth_db
+    // internally) before token::verify — preserve that ordering.
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+
     let Ok(scanned_id) = token::verify(&body.token) else {
         return Ok(error_response(
             axum::http::StatusCode::BAD_REQUEST,
@@ -215,15 +228,6 @@ pub(in crate::api) async fn scan_token(
                 details: None,
             },
         ));
-    };
-
-    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
-        Ok(pair) => pair,
-        Err(response) => return Ok(*response),
-    };
-    let viewer = db::DbViewer {
-        user_id: user.id,
-        is_review_stub: user.is_review_stub,
     };
 
     // Load scanner profile + insert scan record atomically. The scan row

--- a/backend/src/api/xp/service.rs
+++ b/backend/src/api/xp/service.rs
@@ -1,52 +1,30 @@
-use chrono::Utc;
+use axum::http::HeaderMap;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
+use crate::db;
 use crate::db::schema::profiles;
 
-/// Award XP to a profile and update streak in a single UPDATE.
-/// Streak logic:
-///   - `streak_last_active` == today  → streak unchanged
-///   - `streak_last_active` == yesterday → streak incremented
-///   - anything else (gap or null)    → streak reset to 1
+/// Award XP + bump streak for a profile. Delegates to the
+/// `app.award_profile_xp` `SECURITY DEFINER` helper so the award works from
+/// spawned background tasks (no viewer context) and from cross-profile
+/// credits (scanner awarding the scanned profile). Streak rules live in
+/// the migration, not inline SQL, so they stay in one place.
 pub async fn award_xp(profile_id: Uuid, amount: i32) -> Result<(), crate::error::AppError> {
     let mut conn = crate::db::conn().await?;
-    let today = Utc::now().date_naive();
-
-    diesel::sql_query(
-        "UPDATE profiles
-         SET xp = xp + $1,
-             streak_current = CASE
-                 WHEN streak_last_active = $2 THEN streak_current
-                 WHEN streak_last_active = $2 - INTERVAL '1 day' THEN streak_current + 1
-                 ELSE 1
-             END,
-             streak_longest = GREATEST(streak_longest, CASE
-                 WHEN streak_last_active = $2 THEN streak_current
-                 WHEN streak_last_active = $2 - INTERVAL '1 day' THEN streak_current + 1
-                 ELSE 1
-             END),
-             streak_last_active = $2
-         WHERE id = $3",
-    )
-    .bind::<diesel::sql_types::Integer, _>(amount)
-    .bind::<diesel::sql_types::Date, _>(today)
-    .bind::<diesel::sql_types::Uuid, _>(profile_id)
-    .execute(&mut conn)
-    .await?;
-
+    db::award_profile_xp(&mut conn, profile_id, amount).await?;
     Ok(())
 }
 
-/// Check whether a task was already completed today by this profile.
-/// Inserts if not; returns true if XP should be awarded.
+/// Record that `profile_id` completed `task_id` today. Idempotent per
+/// `(profile_id, task_id, day)`; returns `true` iff XP should be awarded.
+/// Caller supplies a connection already inside a viewer-scoped tx.
 pub async fn try_record_task(
+    conn: &mut AsyncPgConnection,
     profile_id: Uuid,
     task_id: &str,
 ) -> Result<bool, crate::error::AppError> {
-    let mut conn = crate::db::conn().await?;
-
     let inserted = diesel::sql_query(
         "INSERT INTO task_completions (profile_id, task_id, day) \
          VALUES ($1, $2, CURRENT_DATE) \
@@ -54,20 +32,24 @@ pub async fn try_record_task(
     )
     .bind::<diesel::sql_types::Uuid, _>(profile_id)
     .bind::<diesel::sql_types::Text, _>(task_id)
-    .execute(&mut conn)
+    .execute(conn)
     .await?;
 
     Ok(inserted > 0)
 }
 
-/// Check whether a scan pair (scanner, scanned) already occurred today.
-/// Inserts the record if not; returns true if XP should be awarded.
-pub async fn try_record_scan(from_id: Uuid, to_id: Uuid) -> Result<bool, crate::error::AppError> {
+/// Record that `from_id` scanned `to_id` today. Idempotent per
+/// `(scanner_id, scanned_id, day)`; returns `true` iff XP should be
+/// awarded. Caller supplies a connection already inside a viewer-scoped
+/// tx keyed to `from_id`'s owner.
+pub async fn try_record_scan(
+    conn: &mut AsyncPgConnection,
+    from_id: Uuid,
+    to_id: Uuid,
+) -> Result<bool, crate::error::AppError> {
     use crate::db::schema::xp_scans;
-    let mut conn = crate::db::conn().await?;
-    let today = Utc::now().date_naive();
+    let today = chrono::Utc::now().date_naive();
 
-    // Try to insert; if duplicate primary key, returns 0 rows affected.
     let inserted = diesel::insert_into(xp_scans::table)
         .values((
             xp_scans::scanner_id.eq(from_id),
@@ -76,22 +58,39 @@ pub async fn try_record_scan(from_id: Uuid, to_id: Uuid) -> Result<bool, crate::
         ))
         .on_conflict((xp_scans::scanner_id, xp_scans::scanned_id, xp_scans::day))
         .do_nothing()
-        .execute(&mut conn)
+        .execute(conn)
         .await?;
 
     Ok(inserted > 0)
 }
 
-/// Resolve the profile ID for the current user's API key / session from headers.
-pub async fn load_profile_for(
-    headers: &axum::http::HeaderMap,
+/// Load the caller's profile inside an existing viewer-scoped transaction.
+/// Returns a 404 response shell on missing profile; Diesel-level failures
+/// surface as 500 so real DB issues don't get masked as "profile not found".
+pub async fn load_profile_for_user(
+    conn: &mut AsyncPgConnection,
+    headers: &HeaderMap,
+    user_id: i32,
 ) -> Result<crate::db::models::profiles::Profile, Box<axum::response::Response>> {
     use crate::api::{error_response, ErrorSpec};
 
-    let (_session, user) = crate::api::state::require_auth_db(headers).await?;
-
-    let mut conn = crate::db::conn().await.map_err(|_| {
-        Box::new(error_response(
+    match profiles::table
+        .filter(profiles::user_id.eq(user_id))
+        .first::<crate::db::models::profiles::Profile>(conn)
+        .await
+        .optional()
+    {
+        Ok(Some(profile)) => Ok(profile),
+        Ok(None) => Err(Box::new(error_response(
+            axum::http::StatusCode::NOT_FOUND,
+            headers,
+            ErrorSpec {
+                error: "Profile not found".to_string(),
+                code: "NOT_FOUND",
+                details: None,
+            },
+        ))),
+        Err(_) => Err(Box::new(error_response(
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             headers,
             ErrorSpec {
@@ -99,34 +98,6 @@ pub async fn load_profile_for(
                 code: "INTERNAL_ERROR",
                 details: None,
             },
-        ))
-    })?;
-
-    profiles::table
-        .filter(profiles::user_id.eq(user.id))
-        .first::<crate::db::models::profiles::Profile>(&mut conn)
-        .await
-        .optional()
-        .map_err(|_| {
-            Box::new(error_response(
-                axum::http::StatusCode::NOT_FOUND,
-                headers,
-                ErrorSpec {
-                    error: "Profile not found".to_string(),
-                    code: "NOT_FOUND",
-                    details: None,
-                },
-            ))
-        })?
-        .ok_or_else(|| {
-            Box::new(error_response(
-                axum::http::StatusCode::NOT_FOUND,
-                headers,
-                ErrorSpec {
-                    error: "Profile not found".to_string(),
-                    code: "NOT_FOUND",
-                    details: None,
-                },
-            ))
-        })
+        ))),
+    }
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -3,7 +3,7 @@ pub mod schema;
 pub mod viewer;
 
 pub use viewer::{
-    complete_password_reset, create_session_for_user, create_user_for_signup,
+    award_profile_xp, complete_password_reset, create_session_for_user, create_user_for_signup,
     delete_session_by_token, find_user_for_login, find_user_for_password_reset,
     mark_email_verified, profile_owner_user_id, profile_program_visibility, push_topics_for_users,
     resolve_session, set_anon_context, set_password_reset_token, set_viewer_context,

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -492,3 +492,21 @@ pub async fn profile_owner_user_id(
         .await?;
     Ok(row.value)
 }
+
+/// Award XP + bump streak via the `app.award_profile_xp` helper.
+///
+/// Narrow owner-level UPDATE so background tasks and cross-profile credits
+/// (e.g. `scan_token` awarding both parties) don't need a viewer context
+/// matching the target profile.
+pub async fn award_profile_xp(
+    conn: &mut AsyncPgConnection,
+    profile_id: uuid::Uuid,
+    amount: i32,
+) -> Result<(), diesel::result::Error> {
+    diesel::sql_query("SELECT app.award_profile_xp($1, $2)")
+        .bind::<SqlUuid, _>(profile_id)
+        .bind::<Integer, _>(amount)
+        .execute(conn)
+        .await?;
+    Ok(())
+}


### PR DESCRIPTION
**PR #8 — xp + task_completions**

Wraps the three xp handlers (\`claim_task\`, \`get_token\`, \`scan_token\`) in \`db::with_viewer_tx\` so Tier-A policies on \`profiles\` / \`task_completions\` / \`xp_scans\` can enforce own-row-only without breaking the handlers. Adds a narrow \`app.award_profile_xp\` SECURITY DEFINER helper so spawned award tasks and cross-profile credits (scanner awarding the scanned profile) work without a matching viewer context.

- [x] migration \`2026-04-18-070000_xp_award_helper\` applies cleanly — CI \`test\` job runs migrations against a fresh test DB before executing tests; full green
- [x] claim_task: own task recorded + own XP award path intact — flow is IP rate limit → auth → viewer tx (load_profile_for_user + try_record_task) → spawn \`award_xp\`; semantically identical to pre-PR, only the DB conn flow changed
- [x] get_token: profile lookup still works under viewer tx — rate limit → auth → viewer tx load_profile_for_user → token::generate; same shape as pre-PR modulo the tx wrapper
- [x] scan_token: own+other profile both awarded via SD helper — spawn issues two \`service::award_xp\` calls (my_profile_id + scanned_id), both routing through \`app.award_profile_xp\`; reordered to auth-before-token-verify per reviewer feedback so the 400 can't be used as an auth oracle
- [x] events handlers still call service::award_xp unchanged — \`grep\` confirms \`write_handler.rs:608\` and \`write_handler.rs:867\` still hit \`crate::api::xp::service::award_xp(profile_id, 10)\`; service signature \`(Uuid, i32)\` preserved
- [x] streak logic identical to previous inline SQL (same-day / +1 day / reset) — three-branch CASE reproduced exactly in the SD helper body; date source switched to \`(now() AT TIME ZONE 'UTC')::date\` to match the old \`Utc::now().date_naive()\` behaviour regardless of session timezone