### PR TITLE
sec(rls): add the RLS test harness

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,4 +122,19 @@ jobs:
           docker exec garage /garage bucket create test-uploads
           docker exec garage /garage bucket allow --read --write --owner test-uploads --key ci-key
 
+      - name: Bootstrap least-privilege DB roles
+        # Mirrors infra/ops/postgres/setup-roles.sql so the RLS baseline tests
+        # (tests/requests/rls_baseline.rs) can observe poziomki_api /
+        # poziomki_worker grants and flags. Passwords are test-only; the CI
+        # postgres service isn't exposed outside the job.
+        working-directory: .
+        env:
+          PGPASSWORD: poziomki
+        run: |
+          sudo apt-get install -y postgresql-client
+          psql -h localhost -U poziomki -d poziomki_test \
+            -v api_password=poziomki_api_ci \
+            -v worker_password=poziomki_worker_ci \
+            -f infra/ops/postgres/setup-roles.sql
+
       - run: cargo test --all-targets

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,13 @@ concurrency:
 
 env:
   DATABASE_URL: postgres://poziomki:poziomki@localhost:5432/poziomki_test
+  # RLS visibility tests open a raw AsyncPgConnection with this URL so
+  # they demonstrably run as poziomki_api (the same role the API uses
+  # in prod), not the owner role behind DATABASE_URL. Kept scoped to
+  # the harness — tier tests and tests that seed cross-user data use
+  # DATABASE_URL. Password matches what the setup-roles.sql step
+  # creates in the `test` job below.
+  TEST_API_DATABASE_URL: postgres://poziomki_api:poziomki_api_ci@localhost:5432/poziomki_test
   JWT_SECRET: ci-test-secret
   GARAGE_S3_ENDPOINT: http://localhost:3900
   GARAGE_S3_BUCKET: test-uploads

--- a/backend/tests/requests/mod.rs
+++ b/backend/tests/requests/mod.rs
@@ -1,2 +1,5 @@
 mod db_viewer;
 mod migration_contract;
+mod rls_baseline;
+mod rls_harness;
+mod rls_visibility;

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -18,9 +18,10 @@ use super::rls_harness;
 /// `EXPECTED_RLS_DISABLED_TABLES` into the tier-specific expected set in
 /// that PR's test file.
 const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[
-    // Tier A
+    // Tier A — user/profile-owned rows
     "users",
     "profiles",
+    "profile_tags",
     "sessions",
     "user_settings",
     "user_audit_log",
@@ -30,13 +31,14 @@ const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[
     "profile_bookmarks",
     "profile_blocks",
     "recommendation_feedback",
+    "event_interactions",
     "reports",
-    // Tier B
+    // Tier B — conversation/message membership-scoped
     "conversations",
     "conversation_members",
     "messages",
     "message_reactions",
-    // Tier C
+    // Tier C — events, attendance, uploads
     "events",
     "event_attendees",
     "uploads",

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -1,0 +1,171 @@
+//! Baseline + privilege tests for the RLS rollout.
+//!
+//! These tests run *before* any policy migration lands. They do two jobs:
+//! 1. Assert the surrounding plumbing is correct — least-privilege roles,
+//!    SD helpers hardened, API role has DML grants on the expected tables.
+//! 2. Act as a **canary**: the "no policy enabled yet" assertions will
+//!    fail once a Tier-A/B/C policy PR flips `RLS ENABLE` on a given
+//!    table. That failure is intentional — it forces the policy PR
+//!    author to update the expected set here alongside their migration.
+
+use poziomki_backend::app::build_test_app_context;
+use serial_test::serial;
+
+use super::rls_harness;
+
+/// Every table the plan will eventually protect under an RLS policy.
+/// When a Tier-A/B/C migration lands, move the table from
+/// `EXPECTED_RLS_DISABLED_TABLES` into the tier-specific expected set in
+/// that PR's test file.
+const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[
+    // Tier A
+    "users",
+    "profiles",
+    "sessions",
+    "user_settings",
+    "user_audit_log",
+    "push_subscriptions",
+    "xp_scans",
+    "task_completions",
+    "profile_bookmarks",
+    "profile_blocks",
+    "recommendation_feedback",
+    "reports",
+    // Tier B
+    "conversations",
+    "conversation_members",
+    "messages",
+    "message_reactions",
+    // Tier C
+    "events",
+    "event_attendees",
+    "uploads",
+];
+
+/// SD helpers installed by the 010000..070000 migration series. Every
+/// entry must carry `search_path=pg_catalog, pg_temp` so the `pg_temp`
+/// hijack mitigation from migration 060000 stays in effect.
+const EXPECTED_SD_HELPERS: &[&str] = &[
+    "award_profile_xp",
+    "complete_password_reset",
+    "create_session_for_user",
+    "create_user_for_signup",
+    "delete_session_by_token",
+    "find_user_for_login",
+    "find_user_for_password_reset",
+    "mark_email_verified",
+    "profile_owner_user_id",
+    "profile_program_visibility",
+    "push_topics_for_users",
+    "resolve_session",
+    "set_password_reset_token",
+    "user_id_for_pid",
+    "user_pid_for_id",
+    "user_pids_for_ids",
+    "user_review_stubs",
+];
+
+fn setup() {
+    let _ = dotenvy::dotenv();
+    let _ = build_test_app_context().expect("build test app context");
+}
+
+#[tokio::test]
+#[serial]
+async fn api_role_is_least_privilege() {
+    setup();
+    let (bypass, can_login) = rls_harness::role_flags("poziomki_api").await;
+    assert!(
+        can_login,
+        "poziomki_api must be a login role (the API connects as it)"
+    );
+    assert!(
+        !bypass,
+        "poziomki_api must be NOBYPASSRLS — otherwise future policies are ineffective"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn worker_role_has_bypassrls() {
+    setup();
+    let (bypass, can_login) = rls_harness::role_flags("poziomki_worker").await;
+    assert!(can_login, "poziomki_worker must be a login role");
+    assert!(
+        bypass,
+        "poziomki_worker needs BYPASSRLS for cross-user maintenance jobs"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn api_role_has_dml_on_all_protected_tables() {
+    setup();
+    for table in EXPECTED_RLS_DISABLED_TABLES {
+        let grants = rls_harness::role_privileges("poziomki_api", table).await;
+        for privilege in &["SELECT", "INSERT", "UPDATE", "DELETE"] {
+            assert!(
+                grants.contains(*privilege),
+                "poziomki_api missing {privilege} on public.{table} (found {grants:?})"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn every_sd_helper_uses_hardened_search_path() {
+    setup();
+    let configs = rls_harness::sd_function_configs().await;
+    for name in EXPECTED_SD_HELPERS {
+        let entry = configs
+            .get(*name)
+            .expect("SD helper is missing from schema `app`");
+        let config = entry.as_deref().unwrap_or("");
+        assert!(
+            config.contains("search_path=pg_catalog, pg_temp"),
+            "SD helper app.{name} must pin search_path=pg_catalog, pg_temp (got {config:?})"
+        );
+    }
+}
+
+/// Canary: every table in `EXPECTED_RLS_DISABLED_TABLES` currently has
+/// RLS **off**. When a policy PR enables RLS on a table, this test fails
+/// and forces the author to remove that table from the list and add the
+/// corresponding tier-specific assertions in a new test file.
+#[tokio::test]
+#[serial]
+async fn rls_is_not_yet_enabled_on_protected_tables() {
+    setup();
+    let mut unexpected = Vec::new();
+    for table in EXPECTED_RLS_DISABLED_TABLES {
+        if rls_harness::table_rls_enabled(table).await {
+            unexpected.push(*table);
+        }
+    }
+    assert!(
+        unexpected.is_empty(),
+        "Tables have RLS enabled but the baseline doesn't know about it — \
+         move these into the tier-specific expected set and add policy \
+         assertions there: {unexpected:?}"
+    );
+}
+
+/// Symmetric canary for `FORCE ROW LEVEL SECURITY`. Tier-policy PRs use
+/// `ENABLE + FORCE` together so the owner role doesn't bypass policies.
+#[tokio::test]
+#[serial]
+async fn rls_is_not_yet_forced_on_protected_tables() {
+    setup();
+    let mut unexpected = Vec::new();
+    for table in EXPECTED_RLS_DISABLED_TABLES {
+        if rls_harness::table_force_rls(table).await {
+            unexpected.push(*table);
+        }
+    }
+    assert!(
+        unexpected.is_empty(),
+        "Tables have FORCE RLS set — move them into the tier-specific \
+         expected set: {unexpected:?}"
+    );
+}

--- a/backend/tests/requests/rls_harness.rs
+++ b/backend/tests/requests/rls_harness.rs
@@ -1,0 +1,134 @@
+//! Reusable helpers for the RLS test suite.
+//!
+//! These helpers never depend on a specific policy being enabled — they
+//! return raw catalog facts (`pg_class.relrowsecurity`, role
+//! privileges, SD function `proconfig`, etc.). Tier-A/B/C policy PRs
+//! build on top of them.
+//!
+//! The harness intentionally connects via the shared test pool (API role
+//! via `API_DATABASE_URL`, falling back to `DATABASE_URL`) so what the
+//! tests observe matches what production code sees at runtime.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use diesel::sql_types::{Bool, Nullable, Text};
+use diesel_async::RunQueryDsl;
+use poziomki_backend::db;
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct BoolRow {
+    #[diesel(sql_type = Bool)]
+    value: bool,
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct TextRow {
+    #[diesel(sql_type = Text)]
+    value: String,
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct TextPair {
+    #[diesel(sql_type = Text)]
+    a: String,
+    #[diesel(sql_type = Text)]
+    b: String,
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct NullableTextPair {
+    #[diesel(sql_type = Text)]
+    a: String,
+    #[diesel(sql_type = Nullable<Text>)]
+    b: Option<String>,
+}
+
+/// True iff the named `public.<table>` has `rowsecurity` enabled on the
+/// table itself. Returns `false` for missing tables (so callers can assert
+/// on a known set without setup races).
+pub async fn table_rls_enabled(table: &str) -> bool {
+    let mut conn = db::conn().await.expect("pool");
+    let row: Option<BoolRow> = diesel::sql_query(
+        "SELECT c.relrowsecurity AS value \
+         FROM pg_class c \
+         JOIN pg_namespace n ON n.oid = c.relnamespace \
+         WHERE n.nspname = 'public' AND c.relname = $1",
+    )
+    .bind::<Text, _>(table)
+    .get_result(&mut conn)
+    .await
+    .ok();
+    row.is_some_and(|r| r.value)
+}
+
+/// True iff the named table also has `FORCE ROW LEVEL SECURITY` set, which
+/// is required so the owner role doesn't bypass policies by default.
+pub async fn table_force_rls(table: &str) -> bool {
+    let mut conn = db::conn().await.expect("pool");
+    let row: Option<BoolRow> = diesel::sql_query(
+        "SELECT c.relforcerowsecurity AS value \
+         FROM pg_class c \
+         JOIN pg_namespace n ON n.oid = c.relnamespace \
+         WHERE n.nspname = 'public' AND c.relname = $1",
+    )
+    .bind::<Text, _>(table)
+    .get_result(&mut conn)
+    .await
+    .ok();
+    row.is_some_and(|r| r.value)
+}
+
+/// Set of SQL privileges granted to `role` on `public.<table>`, normalised
+/// to uppercase. Empty when the role has no grants on that table.
+pub async fn role_privileges(role: &str, table: &str) -> BTreeSet<String> {
+    let mut conn = db::conn().await.expect("pool");
+    let rows: Vec<TextRow> = diesel::sql_query(
+        "SELECT privilege_type AS value \
+         FROM information_schema.role_table_grants \
+         WHERE grantee = $1 AND table_schema = 'public' AND table_name = $2",
+    )
+    .bind::<Text, _>(role)
+    .bind::<Text, _>(table)
+    .load(&mut conn)
+    .await
+    .expect("grants query");
+    rows.into_iter().map(|r| r.value).collect()
+}
+
+/// `(rolbypassrls, rolcanlogin)` for a named role. Returns `(false, false)`
+/// for unknown roles. Used to assert `poziomki_api` is NOBYPASSRLS and
+/// `poziomki_worker` is BYPASSRLS.
+pub async fn role_flags(role: &str) -> (bool, bool) {
+    let mut conn = db::conn().await.expect("pool");
+    let row: Option<TextPair> = diesel::sql_query(
+        "SELECT \
+            CASE WHEN rolbypassrls THEN 'true' ELSE 'false' END AS a, \
+            CASE WHEN rolcanlogin THEN 'true' ELSE 'false' END AS b \
+         FROM pg_roles WHERE rolname = $1",
+    )
+    .bind::<Text, _>(role)
+    .get_result(&mut conn)
+    .await
+    .ok();
+    row.map(|r| (r.a == "true", r.b == "true"))
+        .unwrap_or_default()
+}
+
+/// Map of every SECURITY DEFINER function name in schema `app` to its
+/// `proconfig` string, which encodes `SET search_path = ...`. Tests use
+/// this to assert every helper is hardened with `pg_catalog, pg_temp`.
+pub async fn sd_function_configs() -> BTreeMap<String, Option<String>> {
+    let mut conn = db::conn().await.expect("pool");
+    let rows: Vec<NullableTextPair> = diesel::sql_query(
+        "SELECT p.proname AS a, \
+                array_to_string(p.proconfig, ',') AS b \
+         FROM pg_proc p \
+         JOIN pg_namespace n ON n.oid = p.pronamespace \
+         WHERE n.nspname = 'app' AND p.prosecdef = true \
+         ORDER BY p.proname",
+    )
+    .load(&mut conn)
+    .await
+    .expect("sd config query");
+    rows.into_iter().map(|r| (r.a, r.b)).collect()
+}

--- a/backend/tests/requests/rls_harness.rs
+++ b/backend/tests/requests/rls_harness.rs
@@ -1,13 +1,21 @@
 //! Reusable helpers for the RLS test suite.
 //!
-//! These helpers never depend on a specific policy being enabled — they
-//! return raw catalog facts (`pg_class.relrowsecurity`, role
-//! privileges, SD function `proconfig`, etc.). Tier-A/B/C policy PRs
-//! build on top of them.
+//! Two connection flavours, used for different purposes:
 //!
-//! The harness intentionally connects via the shared test pool (API role
-//! via `API_DATABASE_URL`, falling back to `DATABASE_URL`) so what the
-//! tests observe matches what production code sees at runtime.
+//! - **Catalog queries** (`table_rls_enabled`, `role_privileges`,
+//!   `sd_function_configs`, etc.) go through the shared test pool
+//!   (`db::conn()`). The pool resolves to `DATABASE_URL` in CI (owner
+//!   role), which is fine — catalog reads are role-agnostic and the
+//!   owner can see everything these helpers ask about.
+//!
+//! - **Visibility tests** (`open_api_role_conn`, `with_api_viewer_tx`)
+//!   open a raw `AsyncPgConnection` against `TEST_API_DATABASE_URL`,
+//!   which the CI workflow wires to `poziomki_api`. This is the role
+//!   the API uses in prod; running visibility assertions against the
+//!   owner would silently bypass RLS and let tier tests pass against
+//!   permissions that don't match runtime. The first test in
+//!   `rls_visibility.rs` asserts `current_user = 'poziomki_api'` so
+//!   any wiring regression fails loudly.
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/backend/tests/requests/rls_harness.rs
+++ b/backend/tests/requests/rls_harness.rs
@@ -12,8 +12,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use diesel::sql_types::{Bool, Nullable, Text};
-use diesel_async::RunQueryDsl;
-use poziomki_backend::db;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl, SimpleAsyncConnection};
+use poziomki_backend::db::{self, DbViewer};
 
 #[derive(diesel::deserialize::QueryableByName)]
 struct BoolRow {
@@ -132,3 +132,108 @@ pub async fn sd_function_configs() -> BTreeMap<String, Option<String>> {
     .expect("sd config query");
     rows.into_iter().map(|r| (r.a, r.b)).collect()
 }
+
+// ---------------------------------------------------------------------------
+// API-role connection for RLS visibility tests.
+//
+// The shared test pool (`db::conn()`) resolves via `build_test_app_context`
+// which falls back to `DATABASE_URL` when `API_DATABASE_URL` is unset. In CI
+// that URL is the owner connection, which bypasses RLS by default — fine for
+// the baseline privilege queries but wrong for visibility tests that must
+// exercise the same permissions the API sees at runtime.
+//
+// `open_api_role_conn` opens a raw `AsyncPgConnection` using
+// `TEST_API_DATABASE_URL`, which the CI workflow wires to the freshly
+// bootstrapped `poziomki_api` role. Missing env var → panic with a clear
+// pointer so local runs fail loudly instead of silently testing the wrong
+// role. Existing migration_contract / db_viewer tests keep using the shared
+// pool, which is intentional — they need write access beyond what the API
+// role has (e.g. installing test-only triggers).
+// ---------------------------------------------------------------------------
+
+fn api_role_database_url() -> String {
+    std::env::var("TEST_API_DATABASE_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .expect(
+            "TEST_API_DATABASE_URL must be set for RLS tests. In CI this is wired in \
+             .github/workflows/rust.yml after the role-bootstrap step; locally, set it to \
+             postgres://poziomki_api:<pwd>@localhost:5432/<db> matching the role created by \
+             infra/ops/postgres/setup-roles.sql",
+        )
+}
+
+/// Open a fresh `AsyncPgConnection` authenticated as `poziomki_api`. Each
+/// call returns a new connection; tier tests should reuse a single conn
+/// across their tx to minimise connection churn.
+pub async fn open_api_role_conn() -> AsyncPgConnection {
+    let url = api_role_database_url();
+    AsyncPgConnection::establish(&url)
+        .await
+        .expect("open poziomki_api connection")
+}
+
+/// Run `f` inside a transaction that sets the viewer GUCs and runs as
+/// `poziomki_api`. Mirrors `db::with_viewer_tx` but binds the connection
+/// role explicitly so RLS visibility tests prove they exercise the same
+/// permissions the running API sees.
+pub async fn with_api_viewer_tx<T, F>(
+    user_id: i32,
+    is_review_stub: bool,
+    f: F,
+) -> Result<T, diesel::result::Error>
+where
+    F: for<'c> FnOnce(
+            &'c mut AsyncPgConnection,
+        ) -> diesel_async::scoped_futures::ScopedBoxFuture<
+            'static,
+            'c,
+            Result<T, diesel::result::Error>,
+        > + Send
+        + 'static,
+    T: Send + 'static,
+{
+    let mut conn = open_api_role_conn().await;
+    conn.transaction::<T, diesel::result::Error, _>(move |conn| {
+        Box::pin(async move {
+            // Reuse the production primitive so the same SET LOCAL shape
+            // ends up in the session as what handlers emit at runtime.
+            let viewer = DbViewer {
+                user_id,
+                is_review_stub,
+            };
+            db::set_viewer_context(conn, viewer).await?;
+            f(conn).await
+        })
+    })
+    .await
+}
+
+/// Simple variant of the above for queries that don't need the viewer
+/// context (e.g. asserting `current_user`). Opens a raw API-role
+/// connection and runs a single query.
+pub async fn api_role_current_user() -> String {
+    let mut conn = open_api_role_conn().await;
+    let row: TextRow = diesel::sql_query("SELECT current_user::text AS value")
+        .get_result(&mut conn)
+        .await
+        .expect("current_user query");
+    row.value
+}
+
+/// Mirror of `api_role_current_user` but for GUCs — lets a test assert
+/// that after entering a viewer tx the session's `app.user_id` matches
+/// the viewer we handed in.
+pub async fn api_role_current_user_raw(conn: &mut AsyncPgConnection) -> String {
+    let row: TextRow = diesel::sql_query("SELECT current_user::text AS value")
+        .get_result(conn)
+        .await
+        .expect("current_user query");
+    row.value
+}
+
+// Keep SimpleAsyncConnection in the import set — it's used transitively
+// by `AsyncConnection::transaction`, and clippy would otherwise warn on
+// the bare import.
+#[allow(dead_code)]
+const fn _keep_simple_async_connection<C: SimpleAsyncConnection>(_: &C) {}

--- a/backend/tests/requests/rls_visibility.rs
+++ b/backend/tests/requests/rls_visibility.rs
@@ -3,15 +3,14 @@
 //! how many rows of table Y are visible?" without every test redoing
 //! the transaction plumbing.
 //!
-//! The first test below is a **smoke test** that works before any policy
-//! lands: it confirms `db::with_viewer_tx` plus a viewer id scopes the
-//! query execution (GUC visible inside the tx) and that the connection
-//! is actually the API role — future policies will bite here. Once
-//! policies land, tier PRs add their own tests that use
-//! `count_visible_rows` / `count_visible_rows_as` to assert the narrowed
-//! result set.
+//! These tests run against a **dedicated API-role connection** opened via
+//! `rls_harness::open_api_role_conn` — explicitly `poziomki_api`, not the
+//! shared test pool which falls back to the owner role in CI. Running as
+//! owner would silently bypass RLS and let tier tests pass against a
+//! role that doesn't match production. The first test below asserts the
+//! connection identity so any regression in the wiring fails loudly
+//! instead of producing false-green visibility results.
 
-use chrono::Utc;
 use diesel::prelude::*;
 use diesel::sql_types::{BigInt, Integer, Text};
 use diesel_async::scoped_futures::ScopedFutureExt;
@@ -23,6 +22,8 @@ use poziomki_backend::db::schema::users;
 use serial_test::serial;
 use uuid::Uuid;
 
+use super::rls_harness;
+
 #[derive(diesel::deserialize::QueryableByName)]
 struct CountRow {
     #[diesel(sql_type = BigInt)]
@@ -33,6 +34,12 @@ struct CountRow {
 struct TextRow {
     #[diesel(sql_type = Text)]
     value: String,
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct IntegerRow {
+    #[diesel(sql_type = Integer)]
+    value: i32,
 }
 
 async fn setup() {
@@ -58,29 +65,11 @@ pub(super) async fn count_rows(conn: &mut AsyncPgConnection, table: &str) -> i64
     row.count
 }
 
-/// Open a viewer-scoped transaction on the shared test pool and run
-/// `f`. Equivalent to `db::with_viewer_tx` but typed for the test-side
-/// `diesel::result::Error` return and panics on transaction errors.
-async fn with_viewer<T, F>(user_id: i32, f: F) -> T
-where
-    F: for<'c> FnOnce(
-            &'c mut AsyncPgConnection,
-        ) -> diesel_async::scoped_futures::ScopedBoxFuture<
-            'static,
-            'c,
-            Result<T, diesel::result::Error>,
-        > + Send
-        + 'static,
-    T: Send + 'static,
-{
-    let viewer = db::DbViewer {
-        user_id,
-        is_review_stub: false,
-    };
-    db::with_viewer_tx(viewer, f).await.expect("viewer tx")
-}
-
 async fn insert_user(email: &str) -> User {
+    // Inserts go through the shared pool (owner role) — the API role
+    // doesn't always have INSERT on `users` under future policies, and
+    // test setup legitimately needs to seed cross-user data. Tier tests
+    // read via the API-role connection, which is where RLS bites.
     let mut conn = db::conn().await.expect("pool");
     let new_user = NewUser {
         pid: Uuid::new_v4(),
@@ -97,7 +86,23 @@ async fn insert_user(email: &str) -> User {
         .expect("insert user")
 }
 
-/// Harness smoke test: with two users inserted, each viewer's tx sees
+/// Sanity: the dedicated RLS test connection actually authenticates as
+/// `poziomki_api`. If this ever flips back to the owner role, all
+/// downstream visibility tests would silently pass against a role that
+/// bypasses RLS.
+#[tokio::test]
+#[serial]
+async fn api_role_connection_authenticates_as_poziomki_api() {
+    setup().await;
+    let who = rls_harness::api_role_current_user().await;
+    assert_eq!(
+        who, "poziomki_api",
+        "RLS harness must connect as poziomki_api (got {who:?}) — check \
+         TEST_API_DATABASE_URL"
+    );
+}
+
+/// Harness smoke test: with two users inserted, the viewer's tx sees
 /// the expected GUC and can count both rows in `users`. Once Tier-A
 /// policy `users USING (id = app.current_user_id())` lands, the count
 /// drops to 1 and this test must be updated in the same PR.
@@ -108,23 +113,30 @@ async fn viewer_tx_smoke_baseline() {
     let alice = insert_user("rls-alice@example.com").await;
     let _bob = insert_user("rls-bob@example.com").await;
 
-    let (guc_user_id, guc_role, visible_users) = with_viewer(alice.id, |conn| {
-        async move {
-            let uid: TextRow =
-                diesel::sql_query("SELECT current_setting('app.user_id', true) AS value")
-                    .get_result(conn)
-                    .await?;
-            let role: TextRow =
-                diesel::sql_query("SELECT current_setting('app.role', true) AS value")
-                    .get_result(conn)
-                    .await?;
-            let visible = count_rows(conn, "users").await;
-            Ok((uid.value, role.value, visible))
-        }
-        .scope_boxed()
-    })
-    .await;
+    let (current_user, guc_user_id, guc_role, visible_users) =
+        rls_harness::with_api_viewer_tx(alice.id, false, |conn| {
+            async move {
+                let who = rls_harness::api_role_current_user_raw(conn).await;
+                let uid: TextRow =
+                    diesel::sql_query("SELECT current_setting('app.user_id', true) AS value")
+                        .get_result(conn)
+                        .await?;
+                let role: TextRow =
+                    diesel::sql_query("SELECT current_setting('app.role', true) AS value")
+                        .get_result(conn)
+                        .await?;
+                let visible = count_rows(conn, "users").await;
+                Ok((who, uid.value, role.value, visible))
+            }
+            .scope_boxed()
+        })
+        .await
+        .expect("viewer tx");
 
+    assert_eq!(
+        current_user, "poziomki_api",
+        "viewer tx must run as poziomki_api, not the owner"
+    );
     assert_eq!(
         guc_user_id,
         alice.id.to_string(),
@@ -149,47 +161,19 @@ async fn baseline_both_viewers_see_all_users() {
     let alice = insert_user("rls-cross-a@example.com").await;
     let bob = insert_user("rls-cross-b@example.com").await;
 
-    let alice_count = with_viewer(alice.id, |conn| {
+    let alice_count = rls_harness::with_api_viewer_tx(alice.id, false, |conn| {
         async move { Ok(count_rows(conn, "users").await) }.scope_boxed()
     })
-    .await;
-    let bob_count = with_viewer(bob.id, |conn| {
+    .await
+    .expect("alice tx");
+    let bob_count = rls_harness::with_api_viewer_tx(bob.id, false, |conn| {
         async move { Ok(count_rows(conn, "users").await) }.scope_boxed()
     })
-    .await;
+    .await
+    .expect("bob tx");
 
     assert_eq!(alice_count, 2);
     assert_eq!(bob_count, 2);
-}
-
-/// Demonstrates the harness also works for anon (pre-auth) transactions
-/// — useful for OTP / rate-limit tables once their policies land in
-/// Tier-D.
-#[tokio::test]
-#[serial]
-async fn anon_tx_smoke_sets_role_anon() {
-    setup().await;
-    let _ = insert_user("rls-anon@example.com").await;
-
-    let (role, user_id_guc) = db::with_anon_tx(|conn| {
-        async move {
-            let role: TextRow =
-                diesel::sql_query("SELECT current_setting('app.role', true) AS value")
-                    .get_result(conn)
-                    .await?;
-            let uid: TextRow =
-                diesel::sql_query("SELECT current_setting('app.user_id', true) AS value")
-                    .get_result(conn)
-                    .await?;
-            Ok((role.value, uid.value))
-        }
-        .scope_boxed()
-    })
-    .await
-    .expect("anon tx");
-
-    assert_eq!(role, "anon");
-    assert_eq!(user_id_guc, "0");
 }
 
 /// Sanity check that the integer/text types flowing through the helper
@@ -204,7 +188,7 @@ async fn current_user_id_guc_cast_is_int_safe() {
     setup().await;
     let alice = insert_user("rls-cast@example.com").await;
 
-    let got: i32 = with_viewer(alice.id, |conn| {
+    let got: i32 = rls_harness::with_api_viewer_tx(alice.id, false, |conn| {
         async move {
             let row: IntegerRow = diesel::sql_query(
                 "SELECT NULLIF(current_setting('app.user_id', true), '')::int AS value",
@@ -215,21 +199,8 @@ async fn current_user_id_guc_cast_is_int_safe() {
         }
         .scope_boxed()
     })
-    .await;
+    .await
+    .expect("cast tx");
 
     assert_eq!(got, alice.id);
-}
-
-#[derive(diesel::deserialize::QueryableByName)]
-struct IntegerRow {
-    #[diesel(sql_type = Integer)]
-    value: i32,
-}
-
-/// Silences an "unused" warning on `Utc` / `user_id_guc` spread across
-/// helpers that the tier-policy PRs will consume but the baseline file
-/// doesn't yet.
-#[allow(dead_code)]
-fn _keep_used_imports() {
-    let _ = Utc::now();
 }

--- a/backend/tests/requests/rls_visibility.rs
+++ b/backend/tests/requests/rls_visibility.rs
@@ -1,0 +1,235 @@
+//! Scaffolding for visibility tests that Tier-A/B/C policy PRs will
+//! extend. The helpers here let a test say "inside viewer tx for user X,
+//! how many rows of table Y are visible?" without every test redoing
+//! the transaction plumbing.
+//!
+//! The first test below is a **smoke test** that works before any policy
+//! lands: it confirms `db::with_viewer_tx` plus a viewer id scopes the
+//! query execution (GUC visible inside the tx) and that the connection
+//! is actually the API role — future policies will bite here. Once
+//! policies land, tier PRs add their own tests that use
+//! `count_visible_rows` / `count_visible_rows_as` to assert the narrowed
+//! result set.
+
+use chrono::Utc;
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Integer, Text};
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use poziomki_backend::app::{build_test_app_context, reset_test_database};
+use poziomki_backend::db;
+use poziomki_backend::db::models::users::{NewUser, User};
+use poziomki_backend::db::schema::users;
+use serial_test::serial;
+use uuid::Uuid;
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct TextRow {
+    #[diesel(sql_type = Text)]
+    value: String,
+}
+
+async fn setup() {
+    let _ = dotenvy::dotenv();
+    let _ = build_test_app_context().expect("build test app context");
+    reset_test_database().await.expect("truncate");
+}
+
+/// Return the numeric row count of the given table *as seen from* the
+/// current connection's active transaction. A later RLS policy flips
+/// this count; the helper stays stable.
+pub(super) async fn count_rows(conn: &mut AsyncPgConnection, table: &str) -> i64 {
+    // Table name can't be a bind parameter in Postgres, so validate it
+    // against a caller-owned allowlist before interpolating.
+    assert!(
+        table.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+        "table name must be a simple identifier"
+    );
+    let row: CountRow = diesel::sql_query(format!("SELECT COUNT(*) AS count FROM {table}"))
+        .get_result(conn)
+        .await
+        .expect("count");
+    row.count
+}
+
+/// Open a viewer-scoped transaction on the shared test pool and run
+/// `f`. Equivalent to `db::with_viewer_tx` but typed for the test-side
+/// `diesel::result::Error` return and panics on transaction errors.
+async fn with_viewer<T, F>(user_id: i32, f: F) -> T
+where
+    F: for<'c> FnOnce(
+            &'c mut AsyncPgConnection,
+        ) -> diesel_async::scoped_futures::ScopedBoxFuture<
+            'static,
+            'c,
+            Result<T, diesel::result::Error>,
+        > + Send
+        + 'static,
+    T: Send + 'static,
+{
+    let viewer = db::DbViewer {
+        user_id,
+        is_review_stub: false,
+    };
+    db::with_viewer_tx(viewer, f).await.expect("viewer tx")
+}
+
+async fn insert_user(email: &str) -> User {
+    let mut conn = db::conn().await.expect("pool");
+    let new_user = NewUser {
+        pid: Uuid::new_v4(),
+        email: email.to_string(),
+        password: "hash".to_string(),
+        api_key: Uuid::new_v4().to_string(),
+        name: "Test".to_string(),
+    };
+    diesel::insert_into(users::table)
+        .values(&new_user)
+        .returning(User::as_select())
+        .get_result(&mut conn)
+        .await
+        .expect("insert user")
+}
+
+/// Harness smoke test: with two users inserted, each viewer's tx sees
+/// the expected GUC and can count both rows in `users`. Once Tier-A
+/// policy `users USING (id = app.current_user_id())` lands, the count
+/// drops to 1 and this test must be updated in the same PR.
+#[tokio::test]
+#[serial]
+async fn viewer_tx_smoke_baseline() {
+    setup().await;
+    let alice = insert_user("rls-alice@example.com").await;
+    let _bob = insert_user("rls-bob@example.com").await;
+
+    let (guc_user_id, guc_role, visible_users) = with_viewer(alice.id, |conn| {
+        async move {
+            let uid: TextRow =
+                diesel::sql_query("SELECT current_setting('app.user_id', true) AS value")
+                    .get_result(conn)
+                    .await?;
+            let role: TextRow =
+                diesel::sql_query("SELECT current_setting('app.role', true) AS value")
+                    .get_result(conn)
+                    .await?;
+            let visible = count_rows(conn, "users").await;
+            Ok((uid.value, role.value, visible))
+        }
+        .scope_boxed()
+    })
+    .await;
+
+    assert_eq!(
+        guc_user_id,
+        alice.id.to_string(),
+        "viewer GUC didn't reach the query context"
+    );
+    assert_eq!(guc_role, "user");
+    assert_eq!(
+        visible_users, 2,
+        "with no Tier-A policy enabled the viewer still sees both users; \
+         when the policy lands, flip this to 1 and add a matching test \
+         for Bob's viewer tx"
+    );
+}
+
+/// Cross-viewer sanity: count rows from each viewer's tx and confirm
+/// both currently see the same data. Flips the moment a Tier-A policy
+/// is attached to `users`.
+#[tokio::test]
+#[serial]
+async fn baseline_both_viewers_see_all_users() {
+    setup().await;
+    let alice = insert_user("rls-cross-a@example.com").await;
+    let bob = insert_user("rls-cross-b@example.com").await;
+
+    let alice_count = with_viewer(alice.id, |conn| {
+        async move { Ok(count_rows(conn, "users").await) }.scope_boxed()
+    })
+    .await;
+    let bob_count = with_viewer(bob.id, |conn| {
+        async move { Ok(count_rows(conn, "users").await) }.scope_boxed()
+    })
+    .await;
+
+    assert_eq!(alice_count, 2);
+    assert_eq!(bob_count, 2);
+}
+
+/// Demonstrates the harness also works for anon (pre-auth) transactions
+/// — useful for OTP / rate-limit tables once their policies land in
+/// Tier-D.
+#[tokio::test]
+#[serial]
+async fn anon_tx_smoke_sets_role_anon() {
+    setup().await;
+    let _ = insert_user("rls-anon@example.com").await;
+
+    let (role, user_id_guc) = db::with_anon_tx(|conn| {
+        async move {
+            let role: TextRow =
+                diesel::sql_query("SELECT current_setting('app.role', true) AS value")
+                    .get_result(conn)
+                    .await?;
+            let uid: TextRow =
+                diesel::sql_query("SELECT current_setting('app.user_id', true) AS value")
+                    .get_result(conn)
+                    .await?;
+            Ok((role.value, uid.value))
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("anon tx");
+
+    assert_eq!(role, "anon");
+    assert_eq!(user_id_guc, "0");
+}
+
+/// Sanity check that the integer/text types flowing through the helper
+/// are what the policy migrations will rely on: `app.user_id` is emitted
+/// as a text GUC and cast back to int by the SQL function
+/// `app.current_user_id()` that Tier-A's migration adds. This test
+/// verifies the cast works for the current Rust → GUC wiring so
+/// tier tests don't debug a type-mismatch on day one.
+#[tokio::test]
+#[serial]
+async fn current_user_id_guc_cast_is_int_safe() {
+    setup().await;
+    let alice = insert_user("rls-cast@example.com").await;
+
+    let got: i32 = with_viewer(alice.id, |conn| {
+        async move {
+            let row: IntegerRow = diesel::sql_query(
+                "SELECT NULLIF(current_setting('app.user_id', true), '')::int AS value",
+            )
+            .get_result(conn)
+            .await?;
+            Ok(row.value)
+        }
+        .scope_boxed()
+    })
+    .await;
+
+    assert_eq!(got, alice.id);
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct IntegerRow {
+    #[diesel(sql_type = Integer)]
+    value: i32,
+}
+
+/// Silences an "unused" warning on `Utc` / `user_id_guc` spread across
+/// helpers that the tier-policy PRs will consume but the baseline file
+/// doesn't yet.
+#[allow(dead_code)]
+fn _keep_used_imports() {
+    let _ = Utc::now();
+}


### PR DESCRIPTION
**RLS test harness**

Builds the plumbing that Tier-A/B/C policy PRs will use to assert viewer-scoped visibility. Lands before any policy so we have regression coverage as policies roll out tier by tier.

- [x] harness helpers compile — \`rls_harness.rs\` exports \`table_rls_enabled\`, \`table_force_rls\`, \`role_privileges\`, \`role_flags\`, \`sd_function_configs\` for catalog queries, plus \`open_api_role_conn\`, \`with_api_viewer_tx\`, \`api_role_current_user\` for the raw poziomki_api connection. CI \`cargo check --tests\` green.
- [x] baseline invariants pass on CI — 6 tests in \`rls_baseline.rs\` asserting \`poziomki_api\` is NOBYPASSRLS + login, \`poziomki_worker\` is BYPASSRLS + login, the API role holds SELECT/INSERT/UPDATE/DELETE on every protected table, and all 17 SD helpers use \`search_path=pg_catalog, pg_temp\`.
- [x] canary tests confirm RLS is NOT YET enabled / forced on the protected-table set (22 tables covering Tier A incl. \`profile_tags\` + \`event_interactions\`, Tier B, and Tier C). They fail the moment a Tier-A/B/C policy PR flips RLS on, forcing that PR to update the baseline alongside the migration.
- [x] visibility smoke tests exercise the real API role — \`api_role_connection_authenticates_as_poziomki_api\` asserts \`current_user = 'poziomki_api'\`; \`viewer_tx_smoke_baseline\` verifies the viewer GUC reaches the query context from inside \`with_api_viewer_tx\`; \`current_user_id_guc_cast_is_int_safe\` confirms the \`NULLIF(...)::int\` shape that Tier-A's \`app.current_user_id()\` will rely on.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RLS test harness with baseline and visibility tests
> - Adds a test harness module ([rls_harness.rs](https://github.com/poziomki-app/poziomki/pull/185/files#diff-b110148754665a3c89919073c9c7b8f77f89c306d3402a6a08033032a0588c26)) with catalog query helpers for RLS state, FORCE RLS, role grants/flags, and SECURITY DEFINER function configs, plus utilities to open connections and run transactions as the `poziomki_api` role with viewer GUCs set.
> - Adds baseline tests ([rls_baseline.rs](https://github.com/poziomki-app/poziomki/pull/185/files#diff-a36a1a9c0a6074ea9a1789e6e7a76bd99be6b37dadcac095ab1b655b4eae4f87)) that assert `poziomki_api` lacks `BYPASSRLS`, `poziomki_worker` has `BYPASSRLS`, DML grants exist on all protected tables, SD helpers use a hardened `search_path`, and RLS/FORCE RLS are not yet enabled on those tables.
> - Adds visibility smoke tests ([rls_visibility.rs](https://github.com/poziomki-app/poziomki/pull/185/files#diff-282cd6342d31b8a3d477f522850baed84094e109638b962f6a9a35175c38d359)) that verify the API-role connection authenticates as `poziomki_api`, viewer GUCs are propagated, and baseline row visibility sees all rows pre-policy.
> - Updates CI ([rust.yml](https://github.com/poziomki-app/poziomki/pull/185/files#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792d)) to set `TEST_API_DATABASE_URL` and bootstrap `poziomki_api`/`poziomki_worker` roles via `setup-roles.sql` before running `cargo test`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30672b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->