### PR TITLE
sec(rls): enable Tier-A row-level-security policies

### DIFF
--- a/backend/migrations/2026-04-19-010000_rls_tier_a_policies/down.sql
+++ b/backend/migrations/2026-04-19-010000_rls_tier_a_policies/down.sql
@@ -45,6 +45,7 @@ ALTER TABLE public.profiles DISABLE ROW LEVEL SECURITY;
 ALTER TABLE public.users NO FORCE ROW LEVEL SECURITY;
 ALTER TABLE public.users DISABLE ROW LEVEL SECURITY;
 
+DROP FUNCTION IF EXISTS app.profiles_in_current_bucket();
 DROP FUNCTION IF EXISTS app.viewer_profile_ids();
 DROP FUNCTION IF EXISTS app.current_is_stub();
 DROP FUNCTION IF EXISTS app.current_user_id();

--- a/backend/migrations/2026-04-19-010000_rls_tier_a_policies/down.sql
+++ b/backend/migrations/2026-04-19-010000_rls_tier_a_policies/down.sql
@@ -1,0 +1,50 @@
+-- Drop Tier A policies + disable RLS. `DROP POLICY` is idempotent only
+-- via `IF EXISTS`; `ALTER TABLE ... DISABLE ROW LEVEL SECURITY` is safe
+-- whether or not the table currently has RLS enabled.
+DROP POLICY IF EXISTS reports_viewer ON public.reports;
+DROP POLICY IF EXISTS event_interactions_viewer ON public.event_interactions;
+DROP POLICY IF EXISTS recommendation_feedback_viewer ON public.recommendation_feedback;
+DROP POLICY IF EXISTS profile_blocks_viewer ON public.profile_blocks;
+DROP POLICY IF EXISTS profile_bookmarks_viewer ON public.profile_bookmarks;
+DROP POLICY IF EXISTS task_completions_viewer ON public.task_completions;
+DROP POLICY IF EXISTS xp_scans_viewer ON public.xp_scans;
+DROP POLICY IF EXISTS push_subscriptions_viewer ON public.push_subscriptions;
+DROP POLICY IF EXISTS user_audit_log_viewer ON public.user_audit_log;
+DROP POLICY IF EXISTS user_settings_viewer ON public.user_settings;
+DROP POLICY IF EXISTS sessions_viewer ON public.sessions;
+DROP POLICY IF EXISTS profile_tags_viewer ON public.profile_tags;
+DROP POLICY IF EXISTS profiles_viewer ON public.profiles;
+DROP POLICY IF EXISTS users_viewer ON public.users;
+
+ALTER TABLE public.reports NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.reports DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_interactions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.event_interactions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.recommendation_feedback NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.recommendation_feedback DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_blocks NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_blocks DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_bookmarks NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_bookmarks DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_completions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.task_completions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.xp_scans NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.xp_scans DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.push_subscriptions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.push_subscriptions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_audit_log NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.user_audit_log DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_settings NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.user_settings DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sessions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.sessions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_tags NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_tags DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profiles NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.profiles DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.users DISABLE ROW LEVEL SECURITY;
+
+DROP FUNCTION IF EXISTS app.viewer_profile_ids();
+DROP FUNCTION IF EXISTS app.current_is_stub();
+DROP FUNCTION IF EXISTS app.current_user_id();

--- a/backend/migrations/2026-04-19-010000_rls_tier_a_policies/down.sql
+++ b/backend/migrations/2026-04-19-010000_rls_tier_a_policies/down.sql
@@ -4,6 +4,9 @@
 DROP POLICY IF EXISTS reports_viewer ON public.reports;
 DROP POLICY IF EXISTS event_interactions_viewer ON public.event_interactions;
 DROP POLICY IF EXISTS recommendation_feedback_viewer ON public.recommendation_feedback;
+DROP POLICY IF EXISTS profile_blocks_delete ON public.profile_blocks;
+DROP POLICY IF EXISTS profile_blocks_update ON public.profile_blocks;
+DROP POLICY IF EXISTS profile_blocks_insert ON public.profile_blocks;
 DROP POLICY IF EXISTS profile_blocks_viewer ON public.profile_blocks;
 DROP POLICY IF EXISTS profile_bookmarks_viewer ON public.profile_bookmarks;
 DROP POLICY IF EXISTS task_completions_viewer ON public.task_completions;
@@ -12,7 +15,13 @@ DROP POLICY IF EXISTS push_subscriptions_viewer ON public.push_subscriptions;
 DROP POLICY IF EXISTS user_audit_log_viewer ON public.user_audit_log;
 DROP POLICY IF EXISTS user_settings_viewer ON public.user_settings;
 DROP POLICY IF EXISTS sessions_viewer ON public.sessions;
+DROP POLICY IF EXISTS profile_tags_delete ON public.profile_tags;
+DROP POLICY IF EXISTS profile_tags_update ON public.profile_tags;
+DROP POLICY IF EXISTS profile_tags_insert ON public.profile_tags;
 DROP POLICY IF EXISTS profile_tags_viewer ON public.profile_tags;
+DROP POLICY IF EXISTS profiles_delete ON public.profiles;
+DROP POLICY IF EXISTS profiles_update ON public.profiles;
+DROP POLICY IF EXISTS profiles_insert ON public.profiles;
 DROP POLICY IF EXISTS profiles_viewer ON public.profiles;
 DROP POLICY IF EXISTS users_viewer ON public.users;
 

--- a/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
+++ b/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
@@ -54,9 +54,18 @@ $$;
 COMMENT ON FUNCTION app.current_is_stub() IS
     'Viewer stub flag from the app.is_stub GUC. Defaults to false; review-stub and real-user buckets never mix.';
 
+-- `viewer_profile_ids()` is SECURITY DEFINER so policies that reference it
+-- (xp_scans, task_completions, profile_bookmarks, profile_blocks,
+-- recommendation_feedback, event_interactions, reports) aren't blocked by
+-- the recursive `profiles` RLS check when the policy body evaluates.
+-- Without BYPASSRLS here, "SELECT id FROM profiles WHERE user_id = me"
+-- would be filtered to the viewer's own row (fine for own-scoped
+-- policies) but also trips when evaluating table policies that share
+-- the subquery — cleanest is a definer-level helper.
 CREATE OR REPLACE FUNCTION app.viewer_profile_ids()
 RETURNS TABLE (id uuid)
 LANGUAGE sql
+SECURITY DEFINER
 STABLE
 SET search_path = pg_catalog, pg_temp
 AS $$
@@ -64,11 +73,33 @@ AS $$
 $$;
 
 COMMENT ON FUNCTION app.viewer_profile_ids() IS
-    'Profile ids owned by the current viewer. Consumed by policies that scope access to "profiles I own" (profile_tags, profile_bookmarks, profile_blocks, xp_scans, task_completions, recommendation_feedback, event_interactions, reports).';
+    'Profile ids owned by the current viewer. SECURITY DEFINER so policy expressions that embed it aren''t re-filtered by the profiles RLS policy.';
+
+-- `profiles_in_current_bucket()` is the cross-user read primitive. Its
+-- SECURITY DEFINER bypass lets policies on profiles + profile_tags see
+-- every profile in the same stub bucket (matching / attendee previews
+-- / DM resolution depend on this). Narrow returns — only `id` — so no
+-- sensitive column leaks even if a caller could invoke it unexpectedly.
+CREATE OR REPLACE FUNCTION app.profiles_in_current_bucket()
+RETURNS TABLE (id uuid)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT p.id
+    FROM public.profiles p
+    JOIN public.users u ON u.id = p.user_id
+    WHERE u.is_review_stub = app.current_is_stub()
+$$;
+
+COMMENT ON FUNCTION app.profiles_in_current_bucket() IS
+    'All profile ids whose owner is in the viewer''s stub bucket. Bypasses RLS on users + profiles so policies that embed it don''t recursively self-filter.';
 
 REVOKE EXECUTE ON FUNCTION app.current_user_id() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.current_is_stub() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_profile_ids() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.profiles_in_current_bucket() FROM PUBLIC;
 
 DO $$
 BEGIN
@@ -77,6 +108,7 @@ BEGIN
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.current_user_id() TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.current_is_stub() TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_profile_ids() TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.profiles_in_current_bucket() TO poziomki_api';
     END IF;
 END
 $$;
@@ -108,13 +140,7 @@ ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.profiles FORCE ROW LEVEL SECURITY;
 CREATE POLICY profiles_viewer ON public.profiles
     FOR ALL TO poziomki_api
-    USING (
-        EXISTS (
-            SELECT 1 FROM public.users u
-            WHERE u.id = profiles.user_id
-              AND u.is_review_stub = app.current_is_stub()
-        )
-    )
+    USING (id IN (SELECT id FROM app.profiles_in_current_bucket()))
     WITH CHECK (user_id = app.current_user_id());
 
 -- ---------------------------------------------------------------------------
@@ -128,13 +154,7 @@ ALTER TABLE public.profile_tags ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.profile_tags FORCE ROW LEVEL SECURITY;
 CREATE POLICY profile_tags_viewer ON public.profile_tags
     FOR ALL TO poziomki_api
-    USING (
-        profile_id IN (
-            SELECT p.id FROM public.profiles p
-            JOIN public.users u ON u.id = p.user_id
-            WHERE u.is_review_stub = app.current_is_stub()
-        )
-    )
+    USING (profile_id IN (SELECT id FROM app.profiles_in_current_bucket()))
     WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
 
 -- ---------------------------------------------------------------------------

--- a/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
+++ b/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
@@ -80,6 +80,12 @@ COMMENT ON FUNCTION app.viewer_profile_ids() IS
 -- every profile in the same stub bucket (matching / attendee previews
 -- / DM resolution depend on this). Narrow returns — only `id` — so no
 -- sensitive column leaks even if a caller could invoke it unexpectedly.
+--
+-- The `app.current_user_id() > 0` guard is load-bearing: `current_is_stub`
+-- defaults to false, and `with_anon_tx` emits `app.user_id = '0'`, so
+-- without this check an anon API-role tx would satisfy the bucket
+-- predicate and read every non-stub profile. Real viewers have a
+-- positive user_id; anon (user_id 0 or NULL) gets an empty set.
 CREATE OR REPLACE FUNCTION app.profiles_in_current_bucket()
 RETURNS TABLE (id uuid)
 LANGUAGE sql
@@ -90,11 +96,12 @@ AS $$
     SELECT p.id
     FROM public.profiles p
     JOIN public.users u ON u.id = p.user_id
-    WHERE u.is_review_stub = app.current_is_stub()
+    WHERE app.current_user_id() > 0
+      AND u.is_review_stub = app.current_is_stub()
 $$;
 
 COMMENT ON FUNCTION app.profiles_in_current_bucket() IS
-    'All profile ids whose owner is in the viewer''s stub bucket. Bypasses RLS on users + profiles so policies that embed it don''t recursively self-filter.';
+    'All profile ids whose owner is in the viewer''s stub bucket. Bypasses RLS on users + profiles so policies that embed it don''t recursively self-filter. Returns empty for anon (user_id ≤ 0) to prevent cross-user reads without a real viewer.';
 
 REVOKE EXECUTE ON FUNCTION app.current_user_id() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.current_is_stub() FROM PUBLIC;

--- a/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
+++ b/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
@@ -23,11 +23,11 @@
 -- = '…'`. Missing GUC → NULL / false; `NULL = id` never matches, so the
 -- anon case falls through to "sees nothing".
 --
--- `viewer_profile_ids()` is a pure convenience: the same
--- `(SELECT id FROM profiles WHERE user_id = …)` subquery would
--- otherwise repeat across every policy. Regular (non-SD) function so
--- it still runs under the caller's privileges and RLS; the profiles
--- policy below explicitly allows the viewer to see their own row.
+-- `viewer_profile_ids()` is a SECURITY DEFINER helper that returns the
+-- profile ids owned by the current viewer. Definer rights are required
+-- so policy expressions that embed the subquery aren't re-filtered by
+-- the profiles RLS policy during evaluation. Returns only `id`, so no
+-- sensitive columns leak even if a caller could invoke it unexpectedly.
 -- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION app.current_user_id()

--- a/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
+++ b/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
@@ -131,31 +131,50 @@ CREATE POLICY users_viewer ON public.users
 -- ---------------------------------------------------------------------------
 -- profiles
 --
--- Cross-viewer reads within the same stub bucket so matching, attendee
--- previews, DM member resolution, etc. can continue to read other
--- users' rows. WITH CHECK is own-profile-only so a viewer can't create
--- or mutate someone else's profile.
+-- Reads span the viewer's stub bucket (matching, attendee previews, DM
+-- member resolution all read other users' rows). Writes are locked to
+-- the viewer's own row — splitting the policies is what prevents
+-- cross-user UPDATE/DELETE: a single `FOR ALL USING (bucket)` would
+-- let Alice DELETE Bob's row because USING gates DELETE too.
 -- ---------------------------------------------------------------------------
 ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.profiles FORCE ROW LEVEL SECURITY;
 CREATE POLICY profiles_viewer ON public.profiles
-    FOR ALL TO poziomki_api
-    USING (id IN (SELECT id FROM app.profiles_in_current_bucket()))
+    FOR SELECT TO poziomki_api
+    USING (id IN (SELECT id FROM app.profiles_in_current_bucket()));
+CREATE POLICY profiles_insert ON public.profiles
+    FOR INSERT TO poziomki_api
     WITH CHECK (user_id = app.current_user_id());
+CREATE POLICY profiles_update ON public.profiles
+    FOR UPDATE TO poziomki_api
+    USING (user_id = app.current_user_id())
+    WITH CHECK (user_id = app.current_user_id());
+CREATE POLICY profiles_delete ON public.profiles
+    FOR DELETE TO poziomki_api
+    USING (user_id = app.current_user_id());
 
 -- ---------------------------------------------------------------------------
 -- profile_tags
 --
--- Same bucket for reads (profile interest lookups drive matching /
--- onboarding / export). Writes restricted to the viewer's own
--- profile.
+-- Same shape as profiles: bucket reads, own-profile writes. Without the
+-- split, any viewer could DELETE or UPDATE another same-bucket user's
+-- tag rows since FOR ALL makes USING gate every command.
 -- ---------------------------------------------------------------------------
 ALTER TABLE public.profile_tags ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.profile_tags FORCE ROW LEVEL SECURITY;
 CREATE POLICY profile_tags_viewer ON public.profile_tags
-    FOR ALL TO poziomki_api
-    USING (profile_id IN (SELECT id FROM app.profiles_in_current_bucket()))
+    FOR SELECT TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.profiles_in_current_bucket()));
+CREATE POLICY profile_tags_insert ON public.profile_tags
+    FOR INSERT TO poziomki_api
     WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+CREATE POLICY profile_tags_update ON public.profile_tags
+    FOR UPDATE TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+CREATE POLICY profile_tags_delete ON public.profile_tags
+    FOR DELETE TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
 
 -- ---------------------------------------------------------------------------
 -- sessions
@@ -246,17 +265,30 @@ CREATE POLICY profile_bookmarks_viewer ON public.profile_bookmarks
 --
 -- Chat reads blocks in both directions — it needs to know "A blocked
 -- B" AND "B blocked A" to gate a DM. Writes are always initiated by
--- the blocker.
+-- the blocker, so UPDATE/DELETE are restricted to rows where the
+-- viewer owns the blocker side. Without splitting FOR SELECT from
+-- FOR UPDATE/DELETE, Alice could delete Bob's outbound block (the
+-- row that makes her invisible to Bob) simply because the SELECT
+-- predicate matches it.
 -- ---------------------------------------------------------------------------
 ALTER TABLE public.profile_blocks ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.profile_blocks FORCE ROW LEVEL SECURITY;
 CREATE POLICY profile_blocks_viewer ON public.profile_blocks
-    FOR ALL TO poziomki_api
+    FOR SELECT TO poziomki_api
     USING (
         blocker_id IN (SELECT id FROM app.viewer_profile_ids())
         OR blocked_id IN (SELECT id FROM app.viewer_profile_ids())
-    )
+    );
+CREATE POLICY profile_blocks_insert ON public.profile_blocks
+    FOR INSERT TO poziomki_api
     WITH CHECK (blocker_id IN (SELECT id FROM app.viewer_profile_ids()));
+CREATE POLICY profile_blocks_update ON public.profile_blocks
+    FOR UPDATE TO poziomki_api
+    USING (blocker_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (blocker_id IN (SELECT id FROM app.viewer_profile_ids()));
+CREATE POLICY profile_blocks_delete ON public.profile_blocks
+    FOR DELETE TO poziomki_api
+    USING (blocker_id IN (SELECT id FROM app.viewer_profile_ids()));
 
 -- ---------------------------------------------------------------------------
 -- recommendation_feedback

--- a/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
+++ b/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
@@ -1,0 +1,275 @@
+-- Tier A: enable RLS on every per-user / per-profile table and attach
+-- "own row only" policies (with a same-stub-bucket relaxation for the
+-- profile-lookup tables that matching + attendee listing require).
+--
+-- Every handler has already been wrapped in `db::with_viewer_tx` in PRs
+-- #3-#8, so `app.user_id` + `app.is_stub` are set on every API request
+-- before any query touches these tables. This migration adds the
+-- policies that enforce those GUCs at the DB layer.
+--
+-- Roles:
+-- * poziomki_api — NOBYPASSRLS; the running API. Policies bite here.
+-- * poziomki_worker — BYPASSRLS; background jobs that legitimately act
+--   cross-user (outbox dispatch, variant generation, etc). Unaffected.
+-- * poziomki (owner / migrations) — superuser in every environment we
+--   operate, so it bypasses RLS regardless of `FORCE ROW LEVEL SECURITY`.
+--   Migrations and test fixtures keep working.
+
+-- ---------------------------------------------------------------------------
+-- Helper functions consumed by the policies below.
+--
+-- `current_user_id()` / `current_is_stub()` surface the GUCs that
+-- `with_viewer_tx` emits via `SET LOCAL app.user_id = '…' / app.is_stub
+-- = '…'`. Missing GUC → NULL / false; `NULL = id` never matches, so the
+-- anon case falls through to "sees nothing".
+--
+-- `viewer_profile_ids()` is a pure convenience: the same
+-- `(SELECT id FROM profiles WHERE user_id = …)` subquery would
+-- otherwise repeat across every policy. Regular (non-SD) function so
+-- it still runs under the caller's privileges and RLS; the profiles
+-- policy below explicitly allows the viewer to see their own row.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION app.current_user_id()
+RETURNS int
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT NULLIF(current_setting('app.user_id', true), '')::int
+$$;
+
+COMMENT ON FUNCTION app.current_user_id() IS
+    'Viewer user_id from the app.user_id GUC set by with_viewer_tx. NULL when unset — policies using `= current_user_id()` then match nothing.';
+
+CREATE OR REPLACE FUNCTION app.current_is_stub()
+RETURNS bool
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT COALESCE(NULLIF(current_setting('app.is_stub', true), ''), 'false')::bool
+$$;
+
+COMMENT ON FUNCTION app.current_is_stub() IS
+    'Viewer stub flag from the app.is_stub GUC. Defaults to false; review-stub and real-user buckets never mix.';
+
+CREATE OR REPLACE FUNCTION app.viewer_profile_ids()
+RETURNS TABLE (id uuid)
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT id FROM public.profiles WHERE user_id = app.current_user_id()
+$$;
+
+COMMENT ON FUNCTION app.viewer_profile_ids() IS
+    'Profile ids owned by the current viewer. Consumed by policies that scope access to "profiles I own" (profile_tags, profile_bookmarks, profile_blocks, xp_scans, task_completions, recommendation_feedback, event_interactions, reports).';
+
+REVOKE EXECUTE ON FUNCTION app.current_user_id() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.current_is_stub() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.viewer_profile_ids() FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.current_user_id() TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.current_is_stub() TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_profile_ids() TO poziomki_api';
+    END IF;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- users
+--
+-- Own row only AND matching stub-bucket. WITH CHECK is narrower than
+-- USING because INSERTs happen only via `app.create_user_for_signup`
+-- (SECURITY DEFINER, bypasses RLS); the API role should never insert
+-- directly, so WITH CHECK is effectively a belt-and-suspenders.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users FORCE ROW LEVEL SECURITY;
+CREATE POLICY users_viewer ON public.users
+    FOR ALL TO poziomki_api
+    USING (id = app.current_user_id() AND is_review_stub = app.current_is_stub())
+    WITH CHECK (id = app.current_user_id());
+
+-- ---------------------------------------------------------------------------
+-- profiles
+--
+-- Cross-viewer reads within the same stub bucket so matching, attendee
+-- previews, DM member resolution, etc. can continue to read other
+-- users' rows. WITH CHECK is own-profile-only so a viewer can't create
+-- or mutate someone else's profile.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profiles FORCE ROW LEVEL SECURITY;
+CREATE POLICY profiles_viewer ON public.profiles
+    FOR ALL TO poziomki_api
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.users u
+            WHERE u.id = profiles.user_id
+              AND u.is_review_stub = app.current_is_stub()
+        )
+    )
+    WITH CHECK (user_id = app.current_user_id());
+
+-- ---------------------------------------------------------------------------
+-- profile_tags
+--
+-- Same bucket for reads (profile interest lookups drive matching /
+-- onboarding / export). Writes restricted to the viewer's own
+-- profile.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.profile_tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_tags FORCE ROW LEVEL SECURITY;
+CREATE POLICY profile_tags_viewer ON public.profile_tags
+    FOR ALL TO poziomki_api
+    USING (
+        profile_id IN (
+            SELECT p.id FROM public.profiles p
+            JOIN public.users u ON u.id = p.user_id
+            WHERE u.is_review_stub = app.current_is_stub()
+        )
+    )
+    WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+-- ---------------------------------------------------------------------------
+-- sessions
+--
+-- Own user_id only. Authentication reads (`app.resolve_session`) run
+-- SECURITY DEFINER and bypass RLS by design — this policy gates the
+-- authenticated code paths that list / invalidate / audit sessions.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sessions FORCE ROW LEVEL SECURITY;
+CREATE POLICY sessions_viewer ON public.sessions
+    FOR ALL TO poziomki_api
+    USING (user_id = app.current_user_id())
+    WITH CHECK (user_id = app.current_user_id());
+
+-- ---------------------------------------------------------------------------
+-- user_settings
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.user_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_settings FORCE ROW LEVEL SECURITY;
+CREATE POLICY user_settings_viewer ON public.user_settings
+    FOR ALL TO poziomki_api
+    USING (user_id = app.current_user_id())
+    WITH CHECK (user_id = app.current_user_id());
+
+-- ---------------------------------------------------------------------------
+-- user_audit_log
+--
+-- Column is `user_pid uuid`, so the policy resolves the viewer's pid
+-- via a one-row subquery on users (already same-row-scoped via the
+-- users policy above).
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.user_audit_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_audit_log FORCE ROW LEVEL SECURITY;
+CREATE POLICY user_audit_log_viewer ON public.user_audit_log
+    FOR ALL TO poziomki_api
+    USING (user_pid = (SELECT pid FROM public.users WHERE id = app.current_user_id()))
+    WITH CHECK (user_pid = (SELECT pid FROM public.users WHERE id = app.current_user_id()));
+
+-- ---------------------------------------------------------------------------
+-- push_subscriptions
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.push_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.push_subscriptions FORCE ROW LEVEL SECURITY;
+CREATE POLICY push_subscriptions_viewer ON public.push_subscriptions
+    FOR ALL TO poziomki_api
+    USING (user_id = app.current_user_id())
+    WITH CHECK (user_id = app.current_user_id());
+
+-- ---------------------------------------------------------------------------
+-- xp_scans
+--
+-- Scanner owns the row. Viewing your own scan history; filing a scan
+-- record requires that you're the scanner (not the scanned).
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.xp_scans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.xp_scans FORCE ROW LEVEL SECURITY;
+CREATE POLICY xp_scans_viewer ON public.xp_scans
+    FOR ALL TO poziomki_api
+    USING (scanner_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (scanner_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+-- ---------------------------------------------------------------------------
+-- task_completions
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.task_completions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_completions FORCE ROW LEVEL SECURITY;
+CREATE POLICY task_completions_viewer ON public.task_completions
+    FOR ALL TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+-- ---------------------------------------------------------------------------
+-- profile_bookmarks
+--
+-- `profile_id` is the bookmarker; `target_profile_id` is whom they
+-- saved. Policy scopes to "bookmarks I made" for both reads and writes.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.profile_bookmarks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_bookmarks FORCE ROW LEVEL SECURITY;
+CREATE POLICY profile_bookmarks_viewer ON public.profile_bookmarks
+    FOR ALL TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+-- ---------------------------------------------------------------------------
+-- profile_blocks
+--
+-- Chat reads blocks in both directions — it needs to know "A blocked
+-- B" AND "B blocked A" to gate a DM. Writes are always initiated by
+-- the blocker.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.profile_blocks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_blocks FORCE ROW LEVEL SECURITY;
+CREATE POLICY profile_blocks_viewer ON public.profile_blocks
+    FOR ALL TO poziomki_api
+    USING (
+        blocker_id IN (SELECT id FROM app.viewer_profile_ids())
+        OR blocked_id IN (SELECT id FROM app.viewer_profile_ids())
+    )
+    WITH CHECK (blocker_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+-- ---------------------------------------------------------------------------
+-- recommendation_feedback
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.recommendation_feedback ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.recommendation_feedback FORCE ROW LEVEL SECURITY;
+CREATE POLICY recommendation_feedback_viewer ON public.recommendation_feedback
+    FOR ALL TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+-- ---------------------------------------------------------------------------
+-- event_interactions
+--
+-- Personal event state (saved / joined). Used by export + matching
+-- exclusion sets; always viewer-scoped.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.event_interactions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_interactions FORCE ROW LEVEL SECURITY;
+CREATE POLICY event_interactions_viewer ON public.event_interactions
+    FOR ALL TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+-- ---------------------------------------------------------------------------
+-- reports
+--
+-- Reporter owns the row. Moderator / admin reads will arrive later via
+-- a dedicated DB role or SECURITY DEFINER path, not via anon.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.reports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.reports FORCE ROW LEVEL SECURITY;
+CREATE POLICY reports_viewer ON public.reports
+    FOR ALL TO poziomki_api
+    USING (reporter_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (reporter_id IN (SELECT id FROM app.viewer_profile_ids()));

--- a/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
+++ b/backend/migrations/2026-04-19-010000_rls_tier_a_policies/up.sql
@@ -130,10 +130,14 @@ $$;
 -- ---------------------------------------------------------------------------
 ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.users FORCE ROW LEVEL SECURITY;
+-- WITH CHECK mirrors USING on `is_review_stub` so a viewer can't flip
+-- their own stub flag via UPDATE and jump buckets — otherwise a real
+-- user could run `UPDATE users SET is_review_stub = true` on their own
+-- row and then read the stub bucket via `profiles_in_current_bucket()`.
 CREATE POLICY users_viewer ON public.users
     FOR ALL TO poziomki_api
     USING (id = app.current_user_id() AND is_review_stub = app.current_is_stub())
-    WITH CHECK (id = app.current_user_id());
+    WITH CHECK (id = app.current_user_id() AND is_review_stub = app.current_is_stub());
 
 -- ---------------------------------------------------------------------------
 -- profiles

--- a/backend/tests/requests/mod.rs
+++ b/backend/tests/requests/mod.rs
@@ -2,4 +2,5 @@ mod db_viewer;
 mod migration_contract;
 mod rls_baseline;
 mod rls_harness;
+mod rls_tier_a;
 mod rls_visibility;

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -17,8 +17,11 @@ use super::rls_harness;
 /// When a Tier-A/B/C migration lands, move the table from
 /// `EXPECTED_RLS_DISABLED_TABLES` into the tier-specific expected set in
 /// that PR's test file.
-const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[
-    // Tier A — user/profile-owned rows
+/// Tables that have Tier-A RLS policies attached (user/profile-owned
+/// rows). Each must have RLS enabled, FORCE set, and a policy named
+/// `<table>_viewer` in schema public. Moved here from the "disabled"
+/// canary in the Tier-A migration 2026-04-19-010000.
+const EXPECTED_TIER_A_TABLES: &[&str] = &[
     "users",
     "profiles",
     "profile_tags",
@@ -33,6 +36,9 @@ const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[
     "recommendation_feedback",
     "event_interactions",
     "reports",
+];
+
+const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[
     // Tier B — conversation/message membership-scoped
     "conversations",
     "conversation_members",
@@ -66,6 +72,13 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "user_pids_for_ids",
     "user_review_stubs",
 ];
+
+/// Policy-support helpers added by the Tier-A migration. These run as
+/// the caller (not SECURITY DEFINER) so they show up in a separate
+/// catalog scan; the hardened-search_path test would ignore them, but
+/// we still assert their presence so a dropped helper surfaces here.
+const EXPECTED_POLICY_HELPERS: &[&str] =
+    &["current_is_stub", "current_user_id", "viewer_profile_ids"];
 
 fn setup() {
     let _ = dotenvy::dotenv();
@@ -103,7 +116,10 @@ async fn worker_role_has_bypassrls() {
 #[serial]
 async fn api_role_has_dml_on_all_protected_tables() {
     setup();
-    for table in EXPECTED_RLS_DISABLED_TABLES {
+    let all_tables = EXPECTED_TIER_A_TABLES
+        .iter()
+        .chain(EXPECTED_RLS_DISABLED_TABLES.iter());
+    for table in all_tables {
         let grants = rls_harness::role_privileges("poziomki_api", table).await;
         for privilege in &["SELECT", "INSERT", "UPDATE", "DELETE"] {
             assert!(
@@ -170,4 +186,73 @@ async fn rls_is_not_yet_forced_on_protected_tables() {
         "Tables have FORCE RLS set — move them into the tier-specific \
          expected set: {unexpected:?}"
     );
+}
+
+/// Every Tier-A table has `ROW LEVEL SECURITY` ENABLED and FORCED. If
+/// the Tier-A migration ever regresses (a DROP POLICY sneaks in, a
+/// DISABLE lands on a table) this test fails loudly instead of leaving
+/// silent unprotected rows.
+#[tokio::test]
+#[serial]
+async fn tier_a_tables_have_rls_enabled_and_forced() {
+    setup();
+    let mut missing_enabled = Vec::new();
+    let mut missing_forced = Vec::new();
+    for table in EXPECTED_TIER_A_TABLES {
+        if !rls_harness::table_rls_enabled(table).await {
+            missing_enabled.push(*table);
+        }
+        if !rls_harness::table_force_rls(table).await {
+            missing_forced.push(*table);
+        }
+    }
+    assert!(
+        missing_enabled.is_empty(),
+        "Tier-A tables missing RLS ENABLE: {missing_enabled:?}"
+    );
+    assert!(
+        missing_forced.is_empty(),
+        "Tier-A tables missing FORCE ROW LEVEL SECURITY (owner role would bypass): {missing_forced:?}"
+    );
+}
+
+/// Every Tier-A table has a policy named `<table>_viewer` attached to
+/// `poziomki_api`. Detects accidental policy drops or role-retargeting.
+#[tokio::test]
+#[serial]
+async fn tier_a_tables_have_named_policy_on_api_role() {
+    setup();
+    let attachments = rls_harness::policies_for_tables(EXPECTED_TIER_A_TABLES).await;
+    for table in EXPECTED_TIER_A_TABLES {
+        let policies = attachments
+            .get(*table)
+            .expect("policy catalog query must return an entry per table");
+        let expected_name = format!("{table}_viewer");
+        let matched = policies.iter().find(|p| p.name == expected_name);
+        assert!(
+            matched.is_some(),
+            "Tier-A table public.{table} is missing policy {expected_name}; found {policies:?}"
+        );
+        let matched = matched.unwrap();
+        assert!(
+            matched.roles.iter().any(|r| r == "poziomki_api"),
+            "Tier-A policy {expected_name} on public.{table} must target poziomki_api (targets: {:?})",
+            matched.roles
+        );
+    }
+}
+
+/// The Tier-A migration installs three policy-support helpers in
+/// schema `app`. Drop-regression canary.
+#[tokio::test]
+#[serial]
+async fn tier_a_policy_helpers_exist() {
+    setup();
+    let configs = rls_harness::policy_helper_names().await;
+    for name in EXPECTED_POLICY_HELPERS {
+        assert!(
+            configs.iter().any(|n| n == name),
+            "policy helper app.{name} missing (found {configs:?})"
+        );
+    }
 }

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -64,6 +64,10 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "mark_email_verified",
     "profile_owner_user_id",
     "profile_program_visibility",
+    // Tier-A policy-support helpers. These return narrow viewer-scoped
+    // row sets and are SECURITY DEFINER so policy expressions that embed
+    // them don't recursively self-filter against RLS.
+    "profiles_in_current_bucket",
     "push_topics_for_users",
     "resolve_session",
     "set_password_reset_token",
@@ -71,14 +75,14 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "user_pid_for_id",
     "user_pids_for_ids",
     "user_review_stubs",
+    "viewer_profile_ids",
 ];
 
-/// Policy-support helpers added by the Tier-A migration. These run as
-/// the caller (not SECURITY DEFINER) so they show up in a separate
-/// catalog scan; the hardened-search_path test would ignore them, but
-/// we still assert their presence so a dropped helper surfaces here.
-const EXPECTED_POLICY_HELPERS: &[&str] =
-    &["current_is_stub", "current_user_id", "viewer_profile_ids"];
+/// Non-SECURITY-DEFINER helpers in schema `app`. These only consult GUCs
+/// (no table reads), so they don't need definer rights. Listed
+/// separately so a dropped helper surfaces loudly even though it won't
+/// appear in the hardened-search_path test.
+const EXPECTED_POLICY_HELPERS: &[&str] = &["current_is_stub", "current_user_id"];
 
 fn setup() {
     let _ = dotenvy::dotenv();

--- a/backend/tests/requests/rls_harness.rs
+++ b/backend/tests/requests/rls_harness.rs
@@ -122,6 +122,68 @@ pub async fn role_flags(role: &str) -> (bool, bool) {
         .unwrap_or_default()
 }
 
+/// A policy attached to a table.
+#[derive(Debug, Clone)]
+pub struct Policy {
+    pub name: String,
+    pub roles: Vec<String>,
+}
+
+/// Fetch the `<table> → Vec<Policy>` map for a set of tables in
+/// `public`, in one catalog query. Empty vec when a table has no
+/// policies attached.
+pub async fn policies_for_tables(tables: &[&str]) -> BTreeMap<String, Vec<Policy>> {
+    let mut conn = db::conn().await.expect("pool");
+    let owned: Vec<String> = tables.iter().map(|s| (*s).to_string()).collect();
+    let rows: Vec<TextPair> = diesel::sql_query(
+        "SELECT p.tablename AS a, \
+                p.policyname || '\t' || COALESCE(array_to_string(p.roles, ','), '') AS b \
+         FROM pg_policies p \
+         WHERE p.schemaname = 'public' AND p.tablename = ANY($1)",
+    )
+    .bind::<diesel::sql_types::Array<Text>, _>(&owned)
+    .load(&mut conn)
+    .await
+    .expect("policies query");
+
+    let mut out: BTreeMap<String, Vec<Policy>> = tables
+        .iter()
+        .map(|t| ((*t).to_string(), Vec::new()))
+        .collect();
+    for row in rows {
+        if let Some((name, roles)) = row.b.split_once('\t') {
+            let roles = roles
+                .split(',')
+                .filter(|s| !s.is_empty())
+                .map(|s| s.trim().to_string())
+                .collect();
+            out.entry(row.a).or_default().push(Policy {
+                name: name.to_string(),
+                roles,
+            });
+        }
+    }
+    out
+}
+
+/// Names of every function in schema `app`, regardless of security
+/// mode. Used by tier tests to assert policy-support helpers
+/// (non-SECURITY-DEFINER) are installed.
+pub async fn policy_helper_names() -> Vec<String> {
+    let mut conn = db::conn().await.expect("pool");
+    let rows: Vec<TextRow> = diesel::sql_query(
+        "SELECT p.proname AS value \
+         FROM pg_proc p \
+         JOIN pg_namespace n ON n.oid = p.pronamespace \
+         WHERE n.nspname = 'app' AND p.prosecdef = false \
+         ORDER BY p.proname",
+    )
+    .load(&mut conn)
+    .await
+    .expect("helper query");
+    rows.into_iter().map(|r| r.value).collect()
+}
+
 /// Map of every SECURITY DEFINER function name in schema `app` to its
 /// `proconfig` string, which encodes `SET search_path = ...`. Tests use
 /// this to assert every helper is hardened with `pg_catalog, pg_temp`.

--- a/backend/tests/requests/rls_tier_a.rs
+++ b/backend/tests/requests/rls_tier_a.rs
@@ -793,3 +793,70 @@ async fn anon_tx_sees_zero_users() {
     .expect("anon tx");
     assert_eq!(visible, 0, "anon viewer must not see any users");
 }
+
+// ---------------------------------------------------------------------------
+// Anon must not satisfy the bucket-relaxation on profiles / profile_tags.
+// `app.current_is_stub()` defaults to false, so without the explicit
+// `current_user_id() > 0` guard in `profiles_in_current_bucket()` an
+// anon tx would read every non-stub profile. Keep these tests pointed
+// directly at that exposure.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn anon_tx_sees_zero_profiles() {
+    let (_alice, _bob) = setup_two_parties().await;
+
+    let visible = rls_harness::with_api_viewer_tx(0, false, |conn| {
+        async move { Ok(count_rows(conn, "profiles").await) }.scope_boxed()
+    })
+    .await
+    .expect("anon tx");
+    assert_eq!(
+        visible, 0,
+        "anon viewer must not see same-bucket profiles — \
+         profiles_in_current_bucket() gates on current_user_id() > 0"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn anon_tx_sees_zero_profile_tags() {
+    let (alice, bob) = setup_two_parties().await;
+
+    let tag_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(tags::table)
+            .values((
+                tags::id.eq(tag_id),
+                tags::name.eq("Rock"),
+                tags::scope.eq("interest"),
+                tags::created_at.eq(now),
+                tags::updated_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed tag");
+        for p in [alice.profile_id, bob.profile_id] {
+            diesel::insert_into(profile_tags::table)
+                .values((
+                    profile_tags::profile_id.eq(p),
+                    profile_tags::tag_id.eq(tag_id),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed profile_tag");
+        }
+    }
+
+    let visible = rls_harness::with_api_viewer_tx(0, false, |conn| {
+        async move { Ok(count_rows(conn, "profile_tags").await) }.scope_boxed()
+    })
+    .await
+    .expect("anon tx");
+    assert_eq!(
+        visible, 0,
+        "anon viewer must not see same-bucket profile_tags"
+    );
+}

--- a/backend/tests/requests/rls_tier_a.rs
+++ b/backend/tests/requests/rls_tier_a.rs
@@ -607,6 +607,175 @@ async fn reports_viewer_sees_only_own_reports() {
 }
 
 // ---------------------------------------------------------------------------
+// Negative tests: broadened SELECT predicates must NOT leak into write
+// permissions. A `FOR ALL USING (bucket)` policy would let Alice DELETE
+// or UPDATE Bob's same-bucket rows because USING gates DELETE and
+// UPDATE. The split into FOR SELECT + per-command write policies is
+// what prevents that — these tests lock that split in.
+// ---------------------------------------------------------------------------
+
+async fn execute_count(conn: &mut AsyncPgConnection, sql: &str) -> usize {
+    diesel::sql_query(sql)
+        .execute(conn)
+        .await
+        .expect("statement must succeed (RLS silently filters, not errors)")
+}
+
+#[tokio::test]
+#[serial]
+async fn profiles_viewer_cannot_delete_other_bucket_row() {
+    let (alice, bob) = setup_two_parties().await;
+    let bob_profile_id = bob.profile_id;
+
+    let affected = rls_harness::with_api_viewer_tx(alice.user.id, false, move |conn| {
+        async move {
+            let sql = format!("DELETE FROM public.profiles WHERE id = '{bob_profile_id}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 0,
+        "profiles_delete policy must reject cross-user DELETE even though SELECT sees the row"
+    );
+
+    let mut conn = db::conn().await.expect("pool");
+    let remaining = count_rows(&mut conn, "profiles").await;
+    assert_eq!(
+        remaining, 2,
+        "Bob's profile must survive the DELETE attempt"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn profiles_viewer_cannot_update_other_bucket_row() {
+    let (alice, bob) = setup_two_parties().await;
+    let bob_profile_id = bob.profile_id;
+
+    let affected = rls_harness::with_api_viewer_tx(alice.user.id, false, move |conn| {
+        async move {
+            let sql =
+                format!("UPDATE public.profiles SET name = 'pwned' WHERE id = '{bob_profile_id}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 0,
+        "profiles_update policy must reject cross-user UPDATE"
+    );
+
+    let mut conn = db::conn().await.expect("pool");
+    let row: CountRow = diesel::sql_query(
+        "SELECT COUNT(*) AS count FROM public.profiles WHERE id = $1 AND name = 'Bob'",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(bob_profile_id)
+    .get_result(&mut conn)
+    .await
+    .expect("post-check query");
+    assert_eq!(row.count, 1, "Bob's name must be untouched");
+}
+
+#[tokio::test]
+#[serial]
+async fn profile_tags_viewer_cannot_delete_other_bucket_tag() {
+    let (alice, bob) = setup_two_parties().await;
+
+    let tag_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(tags::table)
+            .values((
+                tags::id.eq(tag_id),
+                tags::name.eq("Jazz"),
+                tags::scope.eq("interest"),
+                tags::created_at.eq(now),
+                tags::updated_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed tag");
+        for p in [alice.profile_id, bob.profile_id] {
+            diesel::insert_into(profile_tags::table)
+                .values((
+                    profile_tags::profile_id.eq(p),
+                    profile_tags::tag_id.eq(tag_id),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed profile_tag");
+        }
+    }
+
+    let bob_profile_id = bob.profile_id;
+    let affected = rls_harness::with_api_viewer_tx(alice.user.id, false, move |conn| {
+        async move {
+            let sql =
+                format!("DELETE FROM public.profile_tags WHERE profile_id = '{bob_profile_id}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 0,
+        "profile_tags_delete policy must reject cross-user DELETE"
+    );
+
+    let mut conn = db::conn().await.expect("pool");
+    let remaining = count_rows(&mut conn, "profile_tags").await;
+    assert_eq!(remaining, 2, "both profile_tag rows must still exist");
+}
+
+#[tokio::test]
+#[serial]
+async fn profile_blocks_viewer_cannot_delete_inbound_block() {
+    let (alice, bob) = setup_two_parties().await;
+
+    {
+        let mut conn = db::conn().await.expect("pool");
+        // Bob blocks Alice — visible to Alice under the SELECT policy
+        // (so chat can gate DMs), but Alice must NOT be able to delete
+        // it.
+        diesel::insert_into(profile_blocks::table)
+            .values((
+                profile_blocks::blocker_id.eq(bob.profile_id),
+                profile_blocks::blocked_id.eq(alice.profile_id),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("bob blocks alice");
+    }
+
+    let bob_profile_id = bob.profile_id;
+    let affected = rls_harness::with_api_viewer_tx(alice.user.id, false, move |conn| {
+        async move {
+            let sql =
+                format!("DELETE FROM public.profile_blocks WHERE blocker_id = '{bob_profile_id}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 0,
+        "profile_blocks_delete policy must reject deletion of an inbound block"
+    );
+
+    let mut conn = db::conn().await.expect("pool");
+    let remaining = count_rows(&mut conn, "profile_blocks").await;
+    assert_eq!(remaining, 1, "Bob's block of Alice must survive");
+}
+
+// ---------------------------------------------------------------------------
 // Anon: no viewer context → policies evaluate to NULL → zero visible rows.
 // ---------------------------------------------------------------------------
 #[tokio::test]

--- a/backend/tests/requests/rls_tier_a.rs
+++ b/backend/tests/requests/rls_tier_a.rs
@@ -623,6 +623,45 @@ async fn execute_count(conn: &mut AsyncPgConnection, sql: &str) -> usize {
 
 #[tokio::test]
 #[serial]
+async fn users_viewer_cannot_flip_own_stub_flag() {
+    let (alice, _bob) = setup_two_parties().await;
+    let alice_id = alice.user.id;
+
+    // WITH CHECK must reject setting is_review_stub = true for a
+    // non-stub viewer — otherwise the viewer could jump stub buckets
+    // and read the other side via profiles_in_current_bucket().
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+            async move {
+                diesel::sql_query(format!(
+                    "UPDATE public.users SET is_review_stub = true WHERE id = {alice_id}"
+                ))
+                .execute(conn)
+                .await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "UPDATE flipping is_review_stub must be rejected by the users_viewer WITH CHECK"
+    );
+
+    let mut conn = db::conn().await.expect("pool");
+    let row: CountRow = diesel::sql_query(
+        "SELECT COUNT(*) AS count FROM public.users WHERE id = $1 AND is_review_stub = false",
+    )
+    .bind::<diesel::sql_types::Integer, _>(alice_id)
+    .get_result(&mut conn)
+    .await
+    .expect("post-check query");
+    assert_eq!(row.count, 1, "Alice must still be a real (non-stub) user");
+}
+
+#[tokio::test]
+#[serial]
 async fn profiles_viewer_cannot_delete_other_bucket_row() {
     let (alice, bob) = setup_two_parties().await;
     let bob_profile_id = bob.profile_id;

--- a/backend/tests/requests/rls_tier_a.rs
+++ b/backend/tests/requests/rls_tier_a.rs
@@ -1,0 +1,618 @@
+//! Tier-A RLS visibility tests.
+//!
+//! Seeds two users (Alice + Bob), each with their own profile, and
+//! asserts that a viewer-scoped tx as Alice can see only her own rows
+//! across every Tier-A table. Mirrors the migration in
+//! `2026-04-19-010000_rls_tier_a_policies`.
+//!
+//! Seed writes go through the shared pool (owner / superuser), so
+//! FORCE ROW LEVEL SECURITY is bypassed for setup; the visibility
+//! assertions open a fresh `poziomki_api` connection and run inside
+//! `with_api_viewer_tx`, which is where policies actually bite.
+
+use chrono::{Duration, Utc};
+use diesel::prelude::*;
+use diesel::sql_types::BigInt;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use poziomki_backend::app::{build_test_app_context, reset_test_database};
+use poziomki_backend::db;
+use poziomki_backend::db::models::profiles::NewProfile;
+use poziomki_backend::db::models::users::{NewUser, User};
+use poziomki_backend::db::schema::{
+    event_interactions, events, profile_blocks, profile_bookmarks, profile_tags, profiles,
+    push_subscriptions, recommendation_feedback, reports, sessions, tags, task_completions,
+    user_audit_log, user_settings, users, xp_scans,
+};
+use serial_test::serial;
+use uuid::Uuid;
+
+use super::rls_harness;
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}
+
+/// Per-party fixture: user id, profile id, plus anything else a test
+/// might need (pid for `user_audit_log`).
+struct Party {
+    user: User,
+    profile_id: Uuid,
+}
+
+async fn count_rows(conn: &mut AsyncPgConnection, table: &str) -> i64 {
+    assert!(
+        table.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+        "table name must be a simple identifier"
+    );
+    let row: CountRow = diesel::sql_query(format!("SELECT COUNT(*) AS count FROM {table}"))
+        .get_result(conn)
+        .await
+        .expect("count");
+    row.count
+}
+
+async fn insert_user(email: &str) -> User {
+    let mut conn = db::conn().await.expect("pool");
+    let new_user = NewUser {
+        pid: Uuid::new_v4(),
+        email: email.to_string(),
+        password: "hash".to_string(),
+        api_key: Uuid::new_v4().to_string(),
+        name: "Test".to_string(),
+    };
+    diesel::insert_into(users::table)
+        .values(&new_user)
+        .returning(User::as_select())
+        .get_result(&mut conn)
+        .await
+        .expect("insert user")
+}
+
+async fn insert_profile(user: &User, name: &str) -> Uuid {
+    let mut conn = db::conn().await.expect("pool");
+    let now = Utc::now();
+    let new_profile = NewProfile {
+        id: Uuid::new_v4(),
+        user_id: user.id,
+        name: name.to_string(),
+        bio: None,
+        profile_picture: None,
+        images: None,
+        program: None,
+        gradient_start: None,
+        gradient_end: None,
+        created_at: now,
+        updated_at: now,
+    };
+    diesel::insert_into(profiles::table)
+        .values(&new_profile)
+        .returning(profiles::id)
+        .get_result(&mut conn)
+        .await
+        .expect("insert profile")
+}
+
+async fn setup_two_parties() -> (Party, Party) {
+    let _ = dotenvy::dotenv();
+    let _ = build_test_app_context().expect("test app ctx");
+    reset_test_database().await.expect("truncate");
+
+    let alice_u = insert_user("tier-a-alice@example.com").await;
+    let alice_pid = insert_profile(&alice_u, "Alice").await;
+    let bob_u = insert_user("tier-a-bob@example.com").await;
+    let bob_pid = insert_profile(&bob_u, "Bob").await;
+    (
+        Party {
+            user: alice_u,
+            profile_id: alice_pid,
+        },
+        Party {
+            user: bob_u,
+            profile_id: bob_pid,
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// users: own row only, scoped by stub bucket
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn users_viewer_sees_only_own_row() {
+    let (alice, _bob) = setup_two_parties().await;
+
+    let visible = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "users").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+
+    assert_eq!(visible, 1, "Tier-A users policy: viewer sees only own row");
+}
+
+// ---------------------------------------------------------------------------
+// profiles: same-stub-bucket cross-visibility, own-row write
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn profiles_viewer_sees_same_stub_bucket() {
+    let (alice, _bob) = setup_two_parties().await;
+
+    // Alice + Bob are both non-stub — Alice's viewer tx should see both
+    // profile rows (same bucket) even though profiles has RLS on.
+    let visible = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "profiles").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        visible, 2,
+        "Tier-A profiles policy should allow same-bucket cross-profile reads"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// sessions: own user_id only
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn sessions_viewer_sees_only_own_user() {
+    let (alice, bob) = setup_two_parties().await;
+
+    // Seed a session per user via owner pool (superuser bypasses FORCE).
+    {
+        let mut conn = db::conn().await.expect("pool");
+        for u in [&alice.user, &bob.user] {
+            diesel::insert_into(sessions::table)
+                .values((
+                    sessions::user_id.eq(u.id),
+                    sessions::token.eq(format!("token-{}", u.id)),
+                    sessions::expires_at.eq(Utc::now() + Duration::days(7)),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed session");
+        }
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "sessions").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(alice_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// user_settings
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn user_settings_viewer_sees_only_own_row() {
+    let (alice, bob) = setup_two_parties().await;
+
+    {
+        let mut conn = db::conn().await.expect("pool");
+        for u in [&alice.user, &bob.user] {
+            diesel::insert_into(user_settings::table)
+                .values((user_settings::user_id.eq(u.id),))
+                .execute(&mut conn)
+                .await
+                .expect("seed settings");
+        }
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "user_settings").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(alice_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// user_audit_log: resolves user_pid via subquery in policy
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn user_audit_log_viewer_sees_only_own_pid() {
+    let (alice, bob) = setup_two_parties().await;
+
+    {
+        let mut conn = db::conn().await.expect("pool");
+        for u in [&alice.user, &bob.user] {
+            diesel::insert_into(user_audit_log::table)
+                .values((
+                    user_audit_log::id.eq(Uuid::new_v4()),
+                    user_audit_log::user_pid.eq(u.pid),
+                    user_audit_log::action.eq("test_action"),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed audit");
+        }
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "user_audit_log").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(alice_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// push_subscriptions
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn push_subscriptions_viewer_sees_only_own_row() {
+    let (alice, bob) = setup_two_parties().await;
+
+    {
+        let mut conn = db::conn().await.expect("pool");
+        for u in [&alice.user, &bob.user] {
+            diesel::insert_into(push_subscriptions::table)
+                .values((
+                    push_subscriptions::user_id.eq(u.id),
+                    push_subscriptions::ntfy_topic.eq(format!("topic-{}", u.id)),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed push_subscription");
+        }
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "push_subscriptions").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(alice_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// xp_scans
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn xp_scans_viewer_sees_only_own_scans() {
+    let (alice, bob) = setup_two_parties().await;
+
+    {
+        let mut conn = db::conn().await.expect("pool");
+        diesel::insert_into(xp_scans::table)
+            .values((
+                xp_scans::scanner_id.eq(alice.profile_id),
+                xp_scans::scanned_id.eq(bob.profile_id),
+                xp_scans::day.eq(Utc::now().date_naive()),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed alice->bob scan");
+        diesel::insert_into(xp_scans::table)
+            .values((
+                xp_scans::scanner_id.eq(bob.profile_id),
+                xp_scans::scanned_id.eq(alice.profile_id),
+                xp_scans::day.eq(Utc::now().date_naive()),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed bob->alice scan");
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "xp_scans").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        alice_count, 1,
+        "Alice only sees the scan she issued, not Bob's scan of her"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// task_completions
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn task_completions_viewer_sees_only_own_row() {
+    let (alice, bob) = setup_two_parties().await;
+
+    {
+        let mut conn = db::conn().await.expect("pool");
+        for p in [alice.profile_id, bob.profile_id] {
+            diesel::insert_into(task_completions::table)
+                .values((
+                    task_completions::profile_id.eq(p),
+                    task_completions::task_id.eq("daily"),
+                    task_completions::day.eq(Utc::now().date_naive()),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed task_completion");
+        }
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "task_completions").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(alice_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// profile_bookmarks
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn profile_bookmarks_viewer_sees_only_own_bookmarks() {
+    let (alice, bob) = setup_two_parties().await;
+
+    {
+        let mut conn = db::conn().await.expect("pool");
+        diesel::insert_into(profile_bookmarks::table)
+            .values((
+                profile_bookmarks::profile_id.eq(alice.profile_id),
+                profile_bookmarks::target_profile_id.eq(bob.profile_id),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed alice bookmark");
+        diesel::insert_into(profile_bookmarks::table)
+            .values((
+                profile_bookmarks::profile_id.eq(bob.profile_id),
+                profile_bookmarks::target_profile_id.eq(alice.profile_id),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed bob bookmark");
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "profile_bookmarks").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(alice_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// profile_blocks (policy allows both directions)
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn profile_blocks_viewer_sees_both_directions() {
+    let (alice, bob) = setup_two_parties().await;
+
+    {
+        let mut conn = db::conn().await.expect("pool");
+        // Alice blocked Bob, AND Bob blocked a fictional third party.
+        diesel::insert_into(profile_blocks::table)
+            .values((
+                profile_blocks::blocker_id.eq(alice.profile_id),
+                profile_blocks::blocked_id.eq(bob.profile_id),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("alice blocks bob");
+        diesel::insert_into(profile_blocks::table)
+            .values((
+                profile_blocks::blocker_id.eq(bob.profile_id),
+                profile_blocks::blocked_id.eq(alice.profile_id),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("bob blocks alice");
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "profile_blocks").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        alice_count, 2,
+        "profile_blocks policy lets the viewer see both directions \
+         (own blocks AND blocks targeting them) — chat needs both"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// recommendation_feedback
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn recommendation_feedback_viewer_sees_only_own_row() {
+    let (alice, bob) = setup_two_parties().await;
+
+    // Seed a fake event we can reference — recommendation_feedback FKs it.
+    let event_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(events::table)
+            .values((
+                events::id.eq(event_id),
+                events::title.eq("Test Event"),
+                events::starts_at.eq(now + Duration::days(1)),
+                events::creator_id.eq(alice.profile_id),
+                events::created_at.eq(now),
+                events::updated_at.eq(now),
+                events::requires_approval.eq(false),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed event");
+
+        for p in [alice.profile_id, bob.profile_id] {
+            diesel::insert_into(recommendation_feedback::table)
+                .values((
+                    recommendation_feedback::profile_id.eq(p),
+                    recommendation_feedback::event_id.eq(event_id),
+                    recommendation_feedback::feedback.eq("more"),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed feedback");
+        }
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "recommendation_feedback").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(alice_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// event_interactions
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn event_interactions_viewer_sees_only_own_row() {
+    let (alice, bob) = setup_two_parties().await;
+
+    let event_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(events::table)
+            .values((
+                events::id.eq(event_id),
+                events::title.eq("Test Event"),
+                events::starts_at.eq(now + Duration::days(1)),
+                events::creator_id.eq(alice.profile_id),
+                events::created_at.eq(now),
+                events::updated_at.eq(now),
+                events::requires_approval.eq(false),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed event");
+
+        for p in [alice.profile_id, bob.profile_id] {
+            diesel::insert_into(event_interactions::table)
+                .values((
+                    event_interactions::profile_id.eq(p),
+                    event_interactions::event_id.eq(event_id),
+                    event_interactions::kind.eq("saved"),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed interaction");
+        }
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "event_interactions").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(alice_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// profile_tags (same-stub-bucket read)
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn profile_tags_viewer_sees_same_bucket() {
+    let (alice, bob) = setup_two_parties().await;
+
+    let tag_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(tags::table)
+            .values((
+                tags::id.eq(tag_id),
+                tags::name.eq("Music"),
+                tags::scope.eq("interest"),
+                tags::created_at.eq(now),
+                tags::updated_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed tag");
+        for p in [alice.profile_id, bob.profile_id] {
+            diesel::insert_into(profile_tags::table)
+                .values((
+                    profile_tags::profile_id.eq(p),
+                    profile_tags::tag_id.eq(tag_id),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed profile_tag");
+        }
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "profile_tags").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        alice_count, 2,
+        "profile_tags policy allows reading other users' tags within \
+         the same stub bucket (matching needs this)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// reports
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn reports_viewer_sees_only_own_reports() {
+    let (alice, bob) = setup_two_parties().await;
+
+    {
+        let mut conn = db::conn().await.expect("pool");
+        for p in [alice.profile_id, bob.profile_id] {
+            diesel::insert_into(reports::table)
+                .values((
+                    reports::reporter_id.eq(p),
+                    reports::target_type.eq("profile"),
+                    reports::target_id.eq(Uuid::new_v4()),
+                    reports::reason.eq("spam"),
+                    reports::description.eq::<Option<String>>(None),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed report");
+        }
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(alice.user.id, false, |conn| {
+        async move { Ok(count_rows(conn, "reports").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(alice_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Anon: no viewer context → policies evaluate to NULL → zero visible rows.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn anon_tx_sees_zero_users() {
+    let (_alice, _bob) = setup_two_parties().await;
+
+    // `with_api_viewer_tx` with user_id = 0 emits app.user_id = '0',
+    // which `app.current_user_id()` returns as NULLIF('0','')::int = 0.
+    // No user has id = 0, so the viewer sees no rows.
+    let visible = rls_harness::with_api_viewer_tx(0, false, |conn| {
+        async move { Ok(count_rows(conn, "users").await) }.scope_boxed()
+    })
+    .await
+    .expect("anon tx");
+    assert_eq!(visible, 0, "anon viewer must not see any users");
+}

--- a/backend/tests/requests/rls_tier_a.rs
+++ b/backend/tests/requests/rls_tier_a.rs
@@ -198,7 +198,14 @@ async fn user_settings_viewer_sees_only_own_row() {
         let mut conn = db::conn().await.expect("pool");
         for u in [&alice.user, &bob.user] {
             diesel::insert_into(user_settings::table)
-                .values((user_settings::user_id.eq(u.id),))
+                .values((
+                    user_settings::user_id.eq(u.id),
+                    user_settings::theme.eq("system"),
+                    user_settings::language.eq("en"),
+                    user_settings::notifications_enabled.eq(true),
+                    user_settings::privacy_show_program.eq(true),
+                    user_settings::privacy_discoverable.eq(true),
+                ))
                 .execute(&mut conn)
                 .await
                 .expect("seed settings");
@@ -258,6 +265,7 @@ async fn push_subscriptions_viewer_sees_only_own_row() {
             diesel::insert_into(push_subscriptions::table)
                 .values((
                     push_subscriptions::user_id.eq(u.id),
+                    push_subscriptions::device_id.eq(format!("device-{}", u.id)),
                     push_subscriptions::ntfy_topic.eq(format!("topic-{}", u.id)),
                 ))
                 .execute(&mut conn)

--- a/backend/tests/requests/rls_visibility.rs
+++ b/backend/tests/requests/rls_visibility.rs
@@ -103,9 +103,8 @@ async fn api_role_connection_authenticates_as_poziomki_api() {
 }
 
 /// Harness smoke test: with two users inserted, the viewer's tx sees
-/// the expected GUC and can count both rows in `users`. Once Tier-A
-/// policy `users USING (id = app.current_user_id())` lands, the count
-/// drops to 1 and this test must be updated in the same PR.
+/// the expected GUC and can count its **own** row only. Tier-A policy
+/// `users USING (id = app.current_user_id())` is now enforced.
 #[tokio::test]
 #[serial]
 async fn viewer_tx_smoke_baseline() {
@@ -144,19 +143,15 @@ async fn viewer_tx_smoke_baseline() {
     );
     assert_eq!(guc_role, "user");
     assert_eq!(
-        visible_users, 2,
-        "with no Tier-A policy enabled the viewer still sees both users; \
-         when the policy lands, flip this to 1 and add a matching test \
-         for Bob's viewer tx"
+        visible_users, 1,
+        "Tier-A users policy: viewer sees only own row"
     );
 }
 
-/// Cross-viewer sanity: count rows from each viewer's tx and confirm
-/// both currently see the same data. Flips the moment a Tier-A policy
-/// is attached to `users`.
+/// Each viewer sees only their own users row (Tier-A enforced).
 #[tokio::test]
 #[serial]
-async fn baseline_both_viewers_see_all_users() {
+async fn baseline_each_viewer_sees_only_own_user() {
     setup().await;
     let alice = insert_user("rls-cross-a@example.com").await;
     let bob = insert_user("rls-cross-b@example.com").await;
@@ -172,8 +167,8 @@ async fn baseline_both_viewers_see_all_users() {
     .await
     .expect("bob tx");
 
-    assert_eq!(alice_count, 2);
-    assert_eq!(bob_count, 2);
+    assert_eq!(alice_count, 1);
+    assert_eq!(bob_count, 1);
 }
 
 /// Sanity check that the integer/text types flowing through the helper


### PR DESCRIPTION
**Tier-A policies — RLS goes live for user/profile-owned tables**

First tier of actual row-level-security enforcement. Every handler is already wrapped in `db::with_viewer_tx` from prior PRs, so flipping policies on doesn't require API code changes.

- [x] migration `2026-04-19-010000_rls_tier_a_policies` applies cleanly (helpers + ENABLE/FORCE/CREATE POLICY × 14 tables)
- [x] existing integration tests (migration_contract, db_viewer) still pass — owner/superuser bypasses FORCE RLS by design
- [x] `rls_baseline` canaries confirm Tier-A tables have RLS ENABLED + FORCED + have named policies attached to `poziomki_api`
- [x] `rls_tier_a` visibility tests: viewer sees own row only across sessions / user_settings / user_audit_log / push_subscriptions / xp_scans / task_completions / profile_bookmarks / recommendation_feedback / event_interactions / reports
- [x] `profiles` + `profile_tags`: same-stub-bucket cross-viewer reads work (matching / attendee previews depend on it)
- [x] `profile_blocks`: viewer sees blocks in BOTH directions (chat needs it)
- [x] anon viewer (`app.user_id = 0`) sees zero rows