### PR TITLE
sec(rls): Tier B membership-scoped policies on chat tables

### DIFF
--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -21,8 +21,6 @@ DROP POLICY IF EXISTS conversation_members_viewer ON public.conversation_members
 
 DROP TRIGGER IF EXISTS conversations_identity_immutable ON public.conversations;
 DROP FUNCTION IF EXISTS app.reject_conversations_identity_change();
-DROP POLICY IF EXISTS conversations_delete ON public.conversations;
-DROP POLICY IF EXISTS conversations_update ON public.conversations;
 DROP POLICY IF EXISTS conversations_insert ON public.conversations;
 DROP POLICY IF EXISTS conversations_viewer ON public.conversations;
 
@@ -35,6 +33,7 @@ ALTER TABLE public.conversation_members DISABLE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations NO FORCE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations DISABLE ROW LEVEL SECURITY;
 
+DROP FUNCTION IF EXISTS app.delete_event_and_chat(uuid);
 DROP FUNCTION IF EXISTS app.conversation_meta_for_insert(uuid);
 DROP FUNCTION IF EXISTS app.find_event_conversation(uuid);
 DROP FUNCTION IF EXISTS app.find_dm_conversation(int, int);

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -19,6 +19,8 @@ DROP POLICY IF EXISTS conversation_members_update ON public.conversation_members
 DROP POLICY IF EXISTS conversation_members_insert ON public.conversation_members;
 DROP POLICY IF EXISTS conversation_members_viewer ON public.conversation_members;
 
+DROP TRIGGER IF EXISTS conversations_title_authoritative ON public.conversations;
+DROP FUNCTION IF EXISTS app.enforce_conversation_title();
 DROP TRIGGER IF EXISTS conversations_identity_immutable ON public.conversations;
 DROP FUNCTION IF EXISTS app.reject_conversations_identity_change();
 DROP POLICY IF EXISTS conversations_insert ON public.conversations;
@@ -33,12 +35,22 @@ ALTER TABLE public.conversation_members DISABLE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations NO FORCE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations DISABLE ROW LEVEL SECURITY;
 
+-- Order matters — drop dependents before their callees. The call graph
+-- is:
+--   delete_event_and_chat          → session_bypasses_rls, current_user_id
+--   conversation_meta_for_insert   → viewer_can_access_event
+--   find_event_conversation        → session_bypasses_rls, viewer_can_access_event
+--   find_dm_conversation           → session_bypasses_rls, current_user_id
+--   event_creator_user_id          → session_bypasses_rls, viewer_can_access_event
+--   viewer_can_access_event        → current_user_id
+--   viewer_can_see_message         → current_user_id
+--   viewer_conversation_ids        → current_user_id
 DROP FUNCTION IF EXISTS app.delete_event_and_chat(uuid);
 DROP FUNCTION IF EXISTS app.conversation_meta_for_insert(uuid);
 DROP FUNCTION IF EXISTS app.find_event_conversation(uuid);
 DROP FUNCTION IF EXISTS app.find_dm_conversation(int, int);
-DROP FUNCTION IF EXISTS app.session_bypasses_rls();
 DROP FUNCTION IF EXISTS app.event_creator_user_id(uuid);
 DROP FUNCTION IF EXISTS app.viewer_can_access_event(uuid);
 DROP FUNCTION IF EXISTS app.viewer_can_see_message(uuid);
 DROP FUNCTION IF EXISTS app.viewer_conversation_ids();
+DROP FUNCTION IF EXISTS app.session_bypasses_rls();

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -3,6 +3,8 @@ DROP POLICY IF EXISTS message_reactions_update ON public.message_reactions;
 DROP POLICY IF EXISTS message_reactions_insert ON public.message_reactions;
 DROP POLICY IF EXISTS message_reactions_viewer ON public.message_reactions;
 
+DROP TRIGGER IF EXISTS messages_conversation_immutable ON public.messages;
+DROP FUNCTION IF EXISTS app.reject_messages_conversation_change();
 DROP POLICY IF EXISTS messages_delete ON public.messages;
 DROP POLICY IF EXISTS messages_update ON public.messages;
 DROP POLICY IF EXISTS messages_insert ON public.messages;

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -1,3 +1,5 @@
+DROP TRIGGER IF EXISTS message_reactions_key_immutable ON public.message_reactions;
+DROP FUNCTION IF EXISTS app.reject_message_reactions_key_change();
 DROP POLICY IF EXISTS message_reactions_delete ON public.message_reactions;
 DROP POLICY IF EXISTS message_reactions_update ON public.message_reactions;
 DROP POLICY IF EXISTS message_reactions_insert ON public.message_reactions;

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -19,6 +19,8 @@ DROP POLICY IF EXISTS conversation_members_update ON public.conversation_members
 DROP POLICY IF EXISTS conversation_members_insert ON public.conversation_members;
 DROP POLICY IF EXISTS conversation_members_viewer ON public.conversation_members;
 
+DROP TRIGGER IF EXISTS conversations_identity_immutable ON public.conversations;
+DROP FUNCTION IF EXISTS app.reject_conversations_identity_change();
 DROP POLICY IF EXISTS conversations_delete ON public.conversations;
 DROP POLICY IF EXISTS conversations_update ON public.conversations;
 DROP POLICY IF EXISTS conversations_insert ON public.conversations;

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -29,6 +29,8 @@ ALTER TABLE public.conversation_members DISABLE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations NO FORCE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations DISABLE ROW LEVEL SECURITY;
 
+DROP FUNCTION IF EXISTS app.find_event_conversation(uuid);
+DROP FUNCTION IF EXISTS app.find_dm_conversation(int, int);
 DROP FUNCTION IF EXISTS app.event_creator_user_id(uuid);
 DROP FUNCTION IF EXISTS app.viewer_can_access_event(uuid);
 DROP FUNCTION IF EXISTS app.viewer_can_see_message(uuid);

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -29,6 +29,7 @@ ALTER TABLE public.conversation_members DISABLE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations NO FORCE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations DISABLE ROW LEVEL SECURITY;
 
+DROP FUNCTION IF EXISTS app.conversation_meta_for_insert(uuid);
 DROP FUNCTION IF EXISTS app.find_event_conversation(uuid);
 DROP FUNCTION IF EXISTS app.find_dm_conversation(int, int);
 DROP FUNCTION IF EXISTS app.event_creator_user_id(uuid);

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -38,6 +38,7 @@ ALTER TABLE public.conversations DISABLE ROW LEVEL SECURITY;
 DROP FUNCTION IF EXISTS app.conversation_meta_for_insert(uuid);
 DROP FUNCTION IF EXISTS app.find_event_conversation(uuid);
 DROP FUNCTION IF EXISTS app.find_dm_conversation(int, int);
+DROP FUNCTION IF EXISTS app.session_bypasses_rls();
 DROP FUNCTION IF EXISTS app.event_creator_user_id(uuid);
 DROP FUNCTION IF EXISTS app.viewer_can_access_event(uuid);
 DROP FUNCTION IF EXISTS app.viewer_can_see_message(uuid);

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -8,6 +8,8 @@ DROP POLICY IF EXISTS messages_update ON public.messages;
 DROP POLICY IF EXISTS messages_insert ON public.messages;
 DROP POLICY IF EXISTS messages_viewer ON public.messages;
 
+DROP TRIGGER IF EXISTS conversation_members_pk_immutable ON public.conversation_members;
+DROP FUNCTION IF EXISTS app.reject_conversation_members_pk_change();
 DROP POLICY IF EXISTS conversation_members_delete ON public.conversation_members;
 DROP POLICY IF EXISTS conversation_members_update ON public.conversation_members;
 DROP POLICY IF EXISTS conversation_members_insert ON public.conversation_members;
@@ -27,5 +29,7 @@ ALTER TABLE public.conversation_members DISABLE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations NO FORCE ROW LEVEL SECURITY;
 ALTER TABLE public.conversations DISABLE ROW LEVEL SECURITY;
 
+DROP FUNCTION IF EXISTS app.event_creator_user_id(uuid);
+DROP FUNCTION IF EXISTS app.viewer_can_access_event(uuid);
 DROP FUNCTION IF EXISTS app.viewer_can_see_message(uuid);
 DROP FUNCTION IF EXISTS app.viewer_conversation_ids();

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/down.sql
@@ -1,0 +1,31 @@
+DROP POLICY IF EXISTS message_reactions_delete ON public.message_reactions;
+DROP POLICY IF EXISTS message_reactions_update ON public.message_reactions;
+DROP POLICY IF EXISTS message_reactions_insert ON public.message_reactions;
+DROP POLICY IF EXISTS message_reactions_viewer ON public.message_reactions;
+
+DROP POLICY IF EXISTS messages_delete ON public.messages;
+DROP POLICY IF EXISTS messages_update ON public.messages;
+DROP POLICY IF EXISTS messages_insert ON public.messages;
+DROP POLICY IF EXISTS messages_viewer ON public.messages;
+
+DROP POLICY IF EXISTS conversation_members_delete ON public.conversation_members;
+DROP POLICY IF EXISTS conversation_members_update ON public.conversation_members;
+DROP POLICY IF EXISTS conversation_members_insert ON public.conversation_members;
+DROP POLICY IF EXISTS conversation_members_viewer ON public.conversation_members;
+
+DROP POLICY IF EXISTS conversations_delete ON public.conversations;
+DROP POLICY IF EXISTS conversations_update ON public.conversations;
+DROP POLICY IF EXISTS conversations_insert ON public.conversations;
+DROP POLICY IF EXISTS conversations_viewer ON public.conversations;
+
+ALTER TABLE public.message_reactions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.message_reactions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.messages NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.messages DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.conversation_members NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.conversation_members DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.conversations NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.conversations DISABLE ROW LEVEL SECURITY;
+
+DROP FUNCTION IF EXISTS app.viewer_can_see_message(uuid);
+DROP FUNCTION IF EXISTS app.viewer_conversation_ids();

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -323,6 +323,35 @@ CREATE POLICY conversations_insert ON public.conversations
         )
     );
 
+-- Title on event chats is user-facing (rendered in the room list),
+-- and the INSERT policy can't verify it against events.title without
+-- a subquery — cheaper and safer to normalise it in a BEFORE INSERT
+-- trigger. DMs have no legitimate title, so we force NULL. Event
+-- chats copy the authoritative title from public.events, ignoring
+-- whatever the client supplied.
+CREATE OR REPLACE FUNCTION app.enforce_conversation_title()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.kind = 'dm' THEN
+        NEW.title := NULL;
+    ELSIF NEW.kind = 'event' AND NEW.event_id IS NOT NULL THEN
+        SELECT e.title INTO NEW.title
+        FROM public.events e
+        WHERE e.id = NEW.event_id;
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS conversations_title_authoritative ON public.conversations;
+CREATE TRIGGER conversations_title_authoritative
+    BEFORE INSERT ON public.conversations
+    FOR EACH ROW
+    EXECUTE FUNCTION app.enforce_conversation_title();
+
 -- Event cleanup path: the API role has no direct DELETE privilege on
 -- conversations (see policy block below), so legitimate event deletion
 -- routes through this SD helper. It validates the caller is the event

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -124,9 +124,33 @@ COMMENT ON FUNCTION app.event_creator_user_id(uuid) IS
 -- concurrent request that hasn't yet added the viewer as member.
 -- Without this, the handler's race-fallback SELECT would be filtered
 -- to empty by conversations_viewer and bubble up as NotFound.
+-- Helper: does the session-level caller already have BYPASSRLS? The
+-- worker process connects as `poziomki_worker` which has BYPASSRLS on
+-- real tables, but inside a SECURITY DEFINER function `current_user`
+-- resolves to the definer (owner), so the SD lookup helpers need an
+-- explicit out for the worker. `session_user` preserves the role the
+-- connection authenticated as. Future BYPASSRLS roles inherit this
+-- without a code change.
+CREATE OR REPLACE FUNCTION app.session_bypasses_rls()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT COALESCE(
+        (SELECT rolbypassrls FROM pg_catalog.pg_roles WHERE rolname = session_user),
+        false
+    )
+$$;
+
+COMMENT ON FUNCTION app.session_bypasses_rls() IS
+    'True iff the session authentication role has BYPASSRLS. Used inside SD helpers to give worker processes a trust bypass that the policy guards would otherwise block.';
+
 -- DM lookup gates on the viewer being one of the pair — without that
 -- guard the SD bypass would let any API-role caller enumerate DM
--- conversation ids by iterating over (low, high) pairs.
+-- conversation ids by iterating over (low, high) pairs. Worker
+-- sessions (poziomki_worker / BYPASSRLS) are trusted and skip the
+-- check so background jobs like event membership sync still work.
 CREATE OR REPLACE FUNCTION app.find_dm_conversation(p_low int, p_high int)
 RETURNS SETOF public.conversations
 LANGUAGE sql
@@ -138,8 +162,11 @@ AS $$
     WHERE kind = 'dm'
       AND user_low_id = p_low
       AND user_high_id = p_high
-      AND app.current_user_id() > 0
-      AND app.current_user_id() IN (p_low, p_high)
+      AND (
+          app.session_bypasses_rls()
+          OR (app.current_user_id() > 0
+              AND app.current_user_id() IN (p_low, p_high))
+      )
     LIMIT 1
 $$;
 
@@ -160,7 +187,10 @@ AS $$
     SELECT * FROM public.conversations
     WHERE kind = 'event'
       AND event_id = p_event_id
-      AND app.viewer_can_access_event(p_event_id)
+      AND (
+          app.session_bypasses_rls()
+          OR app.viewer_can_access_event(p_event_id)
+      )
     LIMIT 1
 $$;
 
@@ -202,6 +232,7 @@ REVOKE EXECUTE ON FUNCTION app.viewer_conversation_ids() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_access_event(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.event_creator_user_id(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.session_bypasses_rls() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.find_dm_conversation(int, int) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.find_event_conversation(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.conversation_meta_for_insert(uuid) FROM PUBLIC;
@@ -209,6 +240,7 @@ REVOKE EXECUTE ON FUNCTION app.conversation_meta_for_insert(uuid) FROM PUBLIC;
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.session_bypasses_rls() TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_conversation_ids() TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_can_access_event(uuid) TO poziomki_api';
@@ -216,6 +248,16 @@ BEGIN
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_dm_conversation(int, int) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_event_conversation(uuid) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.conversation_meta_for_insert(uuid) TO poziomki_api';
+    END IF;
+    -- Worker process (BYPASSRLS) reaches the resolve-or-create event
+    -- chat path via sync_event_membership — it needs execute on the
+    -- lookup helpers even though its row-level bypass means the
+    -- INSERT policies are irrelevant to it.
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_worker') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_worker';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.session_bypasses_rls() TO poziomki_worker';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_dm_conversation(int, int) TO poziomki_worker';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_event_conversation(uuid) TO poziomki_worker';
     END IF;
 END
 $$;

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -117,10 +117,49 @@ $$;
 COMMENT ON FUNCTION app.event_creator_user_id(uuid) IS
     'User id of the given event''s creator, or NULL if missing. SECURITY DEFINER so policy expressions can resolve it without tripping events / profiles RLS.';
 
+-- Helpers for the chat resolve-or-create paths (resolve_or_create_dm
+-- and resolve_or_create_event_conversation). They look up an existing
+-- conversation row by pair / event regardless of viewer membership so
+-- the caller can discover and reuse a row that was created by a
+-- concurrent request that hasn't yet added the viewer as member.
+-- Without this, the handler's race-fallback SELECT would be filtered
+-- to empty by conversations_viewer and bubble up as NotFound.
+CREATE OR REPLACE FUNCTION app.find_dm_conversation(p_low int, p_high int)
+RETURNS SETOF public.conversations
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT * FROM public.conversations
+    WHERE kind = 'dm' AND user_low_id = p_low AND user_high_id = p_high
+    LIMIT 1
+$$;
+
+COMMENT ON FUNCTION app.find_dm_conversation(int, int) IS
+    'Canonical DM conversation row for the (low, high) user pair, or empty set. SECURITY DEFINER so the chat resolve path can read the row before the viewer''s membership has been inserted.';
+
+CREATE OR REPLACE FUNCTION app.find_event_conversation(p_event_id uuid)
+RETURNS SETOF public.conversations
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT * FROM public.conversations
+    WHERE kind = 'event' AND event_id = p_event_id
+    LIMIT 1
+$$;
+
+COMMENT ON FUNCTION app.find_event_conversation(uuid) IS
+    'Event chat conversation row for the given event, or empty set. SECURITY DEFINER so the resolve-or-create path can detect concurrent creation without relying on viewer membership.';
+
 REVOKE EXECUTE ON FUNCTION app.viewer_conversation_ids() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_access_event(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.event_creator_user_id(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.find_dm_conversation(int, int) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.find_event_conversation(uuid) FROM PUBLIC;
 
 DO $$
 BEGIN
@@ -129,6 +168,8 @@ BEGIN
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_can_access_event(uuid) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.event_creator_user_id(uuid) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_dm_conversation(int, int) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_event_conversation(uuid) TO poziomki_api';
     END IF;
 END
 $$;

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -262,6 +262,39 @@ CREATE POLICY conversations_delete ON public.conversations
     FOR DELETE TO poziomki_api
     USING (id IN (SELECT conversation_id FROM app.viewer_conversation_ids()));
 
+-- conversations.(kind, event_id, user_low_id, user_high_id) are
+-- identity columns — the policy branches below decide what an
+-- INSERT is allowed to be, but a subsequent UPDATE could mutate
+-- those fields and sidestep the intent. Concrete attacks:
+--   * flip kind='dm' → 'event' to switch which policy branch
+--     conversation_members_insert applies
+--   * rewrite user_low/high on a DM to silently enrol a third party
+--   * rewrite event_id to attach the chat to a different event
+-- RLS can't compare old-row vs new-row values, so a BEFORE UPDATE
+-- trigger pins them; title / timestamp columns remain mutable.
+CREATE OR REPLACE FUNCTION app.reject_conversations_identity_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.kind IS DISTINCT FROM OLD.kind
+       OR NEW.event_id IS DISTINCT FROM OLD.event_id
+       OR NEW.user_low_id IS DISTINCT FROM OLD.user_low_id
+       OR NEW.user_high_id IS DISTINCT FROM OLD.user_high_id THEN
+        RAISE EXCEPTION
+            'conversations identity columns (kind, event_id, user_low_id, user_high_id) are immutable';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS conversations_identity_immutable ON public.conversations;
+CREATE TRIGGER conversations_identity_immutable
+    BEFORE UPDATE ON public.conversations
+    FOR EACH ROW
+    EXECUTE FUNCTION app.reject_conversations_identity_change();
+
 -- ---------------------------------------------------------------------------
 -- conversation_members
 --

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -60,6 +60,32 @@ $$;
 COMMENT ON FUNCTION app.viewer_can_see_message(uuid) IS
     'True iff the viewer is a member of the conversation the given message belongs to. SECURITY DEFINER so it bypasses the messages + conversation_members policies installed by this migration.';
 
+-- Helper: does the session-level caller already have BYPASSRLS? The
+-- worker process connects as `poziomki_worker` which has BYPASSRLS on
+-- real tables, but inside a SECURITY DEFINER function `current_user`
+-- resolves to the definer (owner), so the SD lookup helpers need an
+-- explicit out for the worker. `session_user` preserves the role the
+-- connection authenticated as. Future BYPASSRLS roles inherit this
+-- without a code change.
+--
+-- Defined early so other helpers below (event_creator_user_id,
+-- find_dm_conversation, find_event_conversation, delete_event_and_chat)
+-- can reference it.
+CREATE OR REPLACE FUNCTION app.session_bypasses_rls()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT COALESCE(
+        (SELECT rolbypassrls FROM pg_catalog.pg_roles WHERE rolname = session_user),
+        false
+    )
+$$;
+
+COMMENT ON FUNCTION app.session_bypasses_rls() IS
+    'True iff the session authentication role has BYPASSRLS. Used inside SD helpers to give worker processes a trust bypass that the policy guards would otherwise block.';
+
 -- Helper: "can the viewer access this event?" Gate for creating event
 -- conversations — without this the conversations_insert policy would
 -- accept any `kind='event'` row and let a compromised API-role caller
@@ -101,6 +127,13 @@ COMMENT ON FUNCTION app.viewer_can_access_event(uuid) IS
 -- before the viewer's own, so the conversation_members INSERT policy
 -- needs to recognise that specific target user_id as legitimate — not
 -- just the viewer's own id.
+--
+-- Access is gated on session_bypasses_rls() OR viewer_can_access_event
+-- so a direct poziomki_api caller can't use this function to look up
+-- the internal user_id of event creators for events they have no
+-- relationship to. Policy expressions supply their own access check
+-- before invoking this, but the guard means direct SQL abuse is
+-- blocked too.
 CREATE OR REPLACE FUNCTION app.event_creator_user_id(p_event_id uuid)
 RETURNS int
 LANGUAGE sql
@@ -112,10 +145,14 @@ AS $$
     FROM public.events e
     JOIN public.profiles p ON p.id = e.creator_id
     WHERE e.id = p_event_id
+      AND (
+          app.session_bypasses_rls()
+          OR app.viewer_can_access_event(p_event_id)
+      )
 $$;
 
 COMMENT ON FUNCTION app.event_creator_user_id(uuid) IS
-    'User id of the given event''s creator, or NULL if missing. SECURITY DEFINER so policy expressions can resolve it without tripping events / profiles RLS.';
+    'User id of the given event''s creator, or NULL if the viewer has no event access. SECURITY DEFINER so policy expressions can resolve it without tripping events / profiles RLS; access is gated so direct API-role calls can''t enumerate creator identity.';
 
 -- Helpers for the chat resolve-or-create paths (resolve_or_create_dm
 -- and resolve_or_create_event_conversation). They look up an existing
@@ -124,28 +161,6 @@ COMMENT ON FUNCTION app.event_creator_user_id(uuid) IS
 -- concurrent request that hasn't yet added the viewer as member.
 -- Without this, the handler's race-fallback SELECT would be filtered
 -- to empty by conversations_viewer and bubble up as NotFound.
--- Helper: does the session-level caller already have BYPASSRLS? The
--- worker process connects as `poziomki_worker` which has BYPASSRLS on
--- real tables, but inside a SECURITY DEFINER function `current_user`
--- resolves to the definer (owner), so the SD lookup helpers need an
--- explicit out for the worker. `session_user` preserves the role the
--- connection authenticated as. Future BYPASSRLS roles inherit this
--- without a code change.
-CREATE OR REPLACE FUNCTION app.session_bypasses_rls()
-RETURNS boolean
-LANGUAGE sql
-STABLE
-SET search_path = pg_catalog, pg_temp
-AS $$
-    SELECT COALESCE(
-        (SELECT rolbypassrls FROM pg_catalog.pg_roles WHERE rolname = session_user),
-        false
-    )
-$$;
-
-COMMENT ON FUNCTION app.session_bypasses_rls() IS
-    'True iff the session authentication role has BYPASSRLS. Used inside SD helpers to give worker processes a trust bypass that the policy guards would otherwise block.';
-
 -- DM lookup gates on the viewer being one of the pair — without that
 -- guard the SD bypass would let any API-role caller enumerate DM
 -- conversation ids by iterating over (low, high) pairs. Worker
@@ -232,7 +247,6 @@ REVOKE EXECUTE ON FUNCTION app.viewer_conversation_ids() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_access_event(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.event_creator_user_id(uuid) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION app.delete_event_and_chat(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.session_bypasses_rls() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.find_dm_conversation(int, int) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.find_event_conversation(uuid) FROM PUBLIC;
@@ -249,7 +263,6 @@ BEGIN
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_dm_conversation(int, int) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_event_conversation(uuid) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.conversation_meta_for_insert(uuid) TO poziomki_api';
-        EXECUTE 'GRANT EXECUTE ON FUNCTION app.delete_event_and_chat(uuid) TO poziomki_api';
     END IF;
     -- Worker process (BYPASSRLS) reaches the resolve-or-create event
     -- chat path via sync_event_membership — it needs execute on the
@@ -284,15 +297,28 @@ CREATE POLICY conversations_viewer ON public.conversations
 -- Relying on the handler for event access was insufficient — a
 -- compromised API-role caller could fabricate chat rooms for arbitrary
 -- events and then add themselves via conversation_members_insert.
+-- INSERT WITH CHECK enforces well-formed shapes directly in the
+-- policy, so a direct API-role SQL path can't skip the handler's
+-- canonicalisation:
+--   * DM — both pair ids present, distinct, canonically ordered,
+--     viewer is one of the pair, event_id NULL
+--   * Event — event_id NOT NULL, pair ids NULL, viewer has access
+--     (creator or going attendee)
 CREATE POLICY conversations_insert ON public.conversations
     FOR INSERT TO poziomki_api
     WITH CHECK (
         app.current_user_id() > 0
         AND (
             (kind = 'dm'
+             AND event_id IS NULL
+             AND user_low_id IS NOT NULL
+             AND user_high_id IS NOT NULL
+             AND user_low_id < user_high_id
              AND app.current_user_id() IN (user_low_id, user_high_id))
             OR (kind = 'event'
                 AND event_id IS NOT NULL
+                AND user_low_id IS NULL
+                AND user_high_id IS NULL
                 AND app.viewer_can_access_event(event_id))
         )
     );
@@ -339,6 +365,15 @@ $$;
 
 COMMENT ON FUNCTION app.delete_event_and_chat(uuid) IS
     'Event deletion + chat cleanup. Auth check pins access to the event creator or a BYPASSRLS role. FK cascades handle the rest of the chat fan-out.';
+
+REVOKE EXECUTE ON FUNCTION app.delete_event_and_chat(uuid) FROM PUBLIC;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.delete_event_and_chat(uuid) TO poziomki_api';
+    END IF;
+END
+$$;
 
 -- No general UPDATE or DELETE policy for poziomki_api on conversations.
 -- A member-only UPDATE would permit mutation of title / metadata
@@ -444,6 +479,9 @@ CREATE POLICY conversation_members_delete ON public.conversation_members
     FOR DELETE TO poziomki_api
     USING (user_id = app.current_user_id());
 
+-- Only last_read_message_id is legitimately mutable. PK pinned
+-- (conversation_id, user_id) prevents membership row migration; joined_at
+-- pinned keeps the audit signal honest.
 CREATE OR REPLACE FUNCTION app.reject_conversation_members_pk_change()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -451,10 +489,10 @@ SET search_path = pg_catalog, pg_temp
 AS $$
 BEGIN
     IF NEW.conversation_id IS DISTINCT FROM OLD.conversation_id
-       OR NEW.user_id IS DISTINCT FROM OLD.user_id THEN
+       OR NEW.user_id IS DISTINCT FROM OLD.user_id
+       OR NEW.joined_at IS DISTINCT FROM OLD.joined_at THEN
         RAISE EXCEPTION
-            'conversation_members primary key is immutable (old=%,% new=%,%)',
-            OLD.conversation_id, OLD.user_id, NEW.conversation_id, NEW.user_id;
+            'conversation_members: only last_read_message_id is mutable';
     END IF;
     RETURN NEW;
 END
@@ -511,12 +549,13 @@ CREATE POLICY messages_delete ON public.messages
         AND conversation_id IN (SELECT conversation_id FROM app.viewer_conversation_ids())
     );
 
--- messages.conversation_id + sender_id are immutable. RLS can't
--- compare old-row vs new-row values, so without this trigger a
--- member of two conversations could `UPDATE messages SET
--- conversation_id = <other>` and inject their message into the
--- second room — both USING (old conversation membership) and WITH
--- CHECK (new conversation membership) would pass.
+-- messages identity / immutable columns. RLS can't compare old-row vs
+-- new-row values, so only the application-editable fields (body,
+-- edited_at, deleted_at) are left mutable. Everything else — sender,
+-- conversation, kind, attachment, reply target, client id, created_at
+-- — is pinned so a direct UPDATE from the API role can't recast a
+-- message into another shape (cross-convo injection, undelete,
+-- attachment swap, etc.).
 CREATE OR REPLACE FUNCTION app.reject_messages_conversation_change()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -524,10 +563,14 @@ SET search_path = pg_catalog, pg_temp
 AS $$
 BEGIN
     IF NEW.conversation_id IS DISTINCT FROM OLD.conversation_id
-       OR NEW.sender_id IS DISTINCT FROM OLD.sender_id THEN
+       OR NEW.sender_id IS DISTINCT FROM OLD.sender_id
+       OR NEW.kind IS DISTINCT FROM OLD.kind
+       OR NEW.reply_to_id IS DISTINCT FROM OLD.reply_to_id
+       OR NEW.attachment_upload_id IS DISTINCT FROM OLD.attachment_upload_id
+       OR NEW.client_id IS DISTINCT FROM OLD.client_id
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
         RAISE EXCEPTION
-            'messages (conversation_id, sender_id) are immutable (old=%,% new=%,%)',
-            OLD.conversation_id, OLD.sender_id, NEW.conversation_id, NEW.sender_id;
+            'messages: only body / edited_at / deleted_at are mutable (identity columns are pinned)';
     END IF;
     RETURN NEW;
 END

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -124,6 +124,9 @@ COMMENT ON FUNCTION app.event_creator_user_id(uuid) IS
 -- concurrent request that hasn't yet added the viewer as member.
 -- Without this, the handler's race-fallback SELECT would be filtered
 -- to empty by conversations_viewer and bubble up as NotFound.
+-- DM lookup gates on the viewer being one of the pair — without that
+-- guard the SD bypass would let any API-role caller enumerate DM
+-- conversation ids by iterating over (low, high) pairs.
 CREATE OR REPLACE FUNCTION app.find_dm_conversation(p_low int, p_high int)
 RETURNS SETOF public.conversations
 LANGUAGE sql
@@ -132,13 +135,21 @@ STABLE
 SET search_path = pg_catalog, pg_temp
 AS $$
     SELECT * FROM public.conversations
-    WHERE kind = 'dm' AND user_low_id = p_low AND user_high_id = p_high
+    WHERE kind = 'dm'
+      AND user_low_id = p_low
+      AND user_high_id = p_high
+      AND app.current_user_id() > 0
+      AND app.current_user_id() IN (p_low, p_high)
     LIMIT 1
 $$;
 
 COMMENT ON FUNCTION app.find_dm_conversation(int, int) IS
-    'Canonical DM conversation row for the (low, high) user pair, or empty set. SECURITY DEFINER so the chat resolve path can read the row before the viewer''s membership has been inserted.';
+    'Canonical DM conversation row for the (low, high) user pair, restricted to viewers who are one of the pair. SECURITY DEFINER so it works before the viewer''s membership row has been inserted.';
 
+-- Event lookup gates on viewer event access (creator or going
+-- attendee) via the existing helper, so the SD bypass can't be used
+-- to discover the conversation id of an event the viewer has no
+-- relationship to.
 CREATE OR REPLACE FUNCTION app.find_event_conversation(p_event_id uuid)
 RETURNS SETOF public.conversations
 LANGUAGE sql
@@ -147,12 +158,37 @@ STABLE
 SET search_path = pg_catalog, pg_temp
 AS $$
     SELECT * FROM public.conversations
-    WHERE kind = 'event' AND event_id = p_event_id
+    WHERE kind = 'event'
+      AND event_id = p_event_id
+      AND app.viewer_can_access_event(p_event_id)
     LIMIT 1
 $$;
 
 COMMENT ON FUNCTION app.find_event_conversation(uuid) IS
-    'Event chat conversation row for the given event, or empty set. SECURITY DEFINER so the resolve-or-create path can detect concurrent creation without relying on viewer membership.';
+    'Event chat conversation row for the given event, restricted to viewers with event access (owner or going attendee). SECURITY DEFINER so the resolve-or-create path can detect concurrent creation before the viewer''s membership row exists.';
+
+-- conversation_members_insert has to look up the target conversation
+-- to decide if the proposed (conversation_id, user_id) pair is
+-- legitimate. A plain subquery on public.conversations would be
+-- filtered by conversations_viewer — fine for viewers already in the
+-- room, but the resolve-or-create event-chat bootstrap reaches the
+-- INSERT before the viewer's membership row exists. This SD helper
+-- returns just the fields the INSERT policy needs, without membership
+-- filtering, so going attendees can self-join.
+CREATE OR REPLACE FUNCTION app.conversation_meta_for_insert(p_conversation_id uuid)
+RETURNS TABLE (kind text, event_id uuid, user_low_id int, user_high_id int)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT c.kind, c.event_id, c.user_low_id, c.user_high_id
+    FROM public.conversations c
+    WHERE c.id = p_conversation_id
+$$;
+
+COMMENT ON FUNCTION app.conversation_meta_for_insert(uuid) IS
+    'Metadata the conversation_members INSERT policy needs to decide if a (conversation_id, user_id) pair is legitimate. SECURITY DEFINER so it doesn''t self-filter through conversations_viewer.';
 
 REVOKE EXECUTE ON FUNCTION app.viewer_conversation_ids() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) FROM PUBLIC;
@@ -160,6 +196,7 @@ REVOKE EXECUTE ON FUNCTION app.viewer_can_access_event(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.event_creator_user_id(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.find_dm_conversation(int, int) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.find_event_conversation(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.conversation_meta_for_insert(uuid) FROM PUBLIC;
 
 DO $$
 BEGIN
@@ -170,6 +207,7 @@ BEGIN
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.event_creator_user_id(uuid) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_dm_conversation(int, int) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_event_conversation(uuid) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.conversation_meta_for_insert(uuid) TO poziomki_api';
     END IF;
 END
 $$;
@@ -252,9 +290,8 @@ CREATE POLICY conversation_members_insert ON public.conversation_members
         app.current_user_id() > 0
         AND EXISTS (
             SELECT 1
-            FROM public.conversations c
-            WHERE c.id = conversation_id
-              AND (
+            FROM app.conversation_meta_for_insert(conversation_id) c
+            WHERE (
                   (c.kind = 'dm'
                    AND app.current_user_id() IN (c.user_low_id, c.user_high_id)
                    AND conversation_members.user_id IN (c.user_low_id, c.user_high_id))

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -186,6 +186,13 @@ AS $$
     FROM public.conversations c
     WHERE app.current_user_id() > 0
       AND c.id = p_conversation_id
+      AND (
+          (c.kind = 'dm'
+           AND app.current_user_id() IN (c.user_low_id, c.user_high_id))
+          OR (c.kind = 'event'
+              AND c.event_id IS NOT NULL
+              AND app.viewer_can_access_event(c.event_id))
+      )
 $$;
 
 COMMENT ON FUNCTION app.conversation_meta_for_insert(uuid) IS
@@ -453,3 +460,31 @@ CREATE POLICY message_reactions_delete ON public.message_reactions
         user_id = app.current_user_id()
         AND app.viewer_can_see_message(message_id)
     );
+
+-- message_reactions.message_id + user_id are immutable for the same
+-- reason as messages and conversation_members: RLS evaluates USING
+-- against the old row and WITH CHECK against the new row
+-- independently, so a viewer who can see two different messages can
+-- move their reaction between them (cross-conversation reaction
+-- injection) without either predicate catching it.
+CREATE OR REPLACE FUNCTION app.reject_message_reactions_key_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.message_id IS DISTINCT FROM OLD.message_id
+       OR NEW.user_id IS DISTINCT FROM OLD.user_id THEN
+        RAISE EXCEPTION
+            'message_reactions (message_id, user_id) are immutable (old=%,% new=%,%)',
+            OLD.message_id, OLD.user_id, NEW.message_id, NEW.user_id;
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS message_reactions_key_immutable ON public.message_reactions;
+CREATE TRIGGER message_reactions_key_immutable
+    BEFORE UPDATE ON public.message_reactions
+    FOR EACH ROW
+    EXECUTE FUNCTION app.reject_message_reactions_key_change();

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -184,7 +184,8 @@ SET search_path = pg_catalog, pg_temp
 AS $$
     SELECT c.kind, c.event_id, c.user_low_id, c.user_high_id
     FROM public.conversations c
-    WHERE c.id = p_conversation_id
+    WHERE app.current_user_id() > 0
+      AND c.id = p_conversation_id
 $$;
 
 COMMENT ON FUNCTION app.conversation_meta_for_insert(uuid) IS
@@ -381,6 +382,34 @@ CREATE POLICY messages_delete ON public.messages
         sender_id = app.current_user_id()
         AND conversation_id IN (SELECT conversation_id FROM app.viewer_conversation_ids())
     );
+
+-- messages.conversation_id + sender_id are immutable. RLS can't
+-- compare old-row vs new-row values, so without this trigger a
+-- member of two conversations could `UPDATE messages SET
+-- conversation_id = <other>` and inject their message into the
+-- second room — both USING (old conversation membership) and WITH
+-- CHECK (new conversation membership) would pass.
+CREATE OR REPLACE FUNCTION app.reject_messages_conversation_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.conversation_id IS DISTINCT FROM OLD.conversation_id
+       OR NEW.sender_id IS DISTINCT FROM OLD.sender_id THEN
+        RAISE EXCEPTION
+            'messages (conversation_id, sender_id) are immutable (old=%,% new=%,%)',
+            OLD.conversation_id, OLD.sender_id, NEW.conversation_id, NEW.sender_id;
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS messages_conversation_immutable ON public.messages;
+CREATE TRIGGER messages_conversation_immutable
+    BEFORE UPDATE ON public.messages
+    FOR EACH ROW
+    EXECUTE FUNCTION app.reject_messages_conversation_change();
 
 -- ---------------------------------------------------------------------------
 -- message_reactions

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -60,14 +60,72 @@ $$;
 COMMENT ON FUNCTION app.viewer_can_see_message(uuid) IS
     'True iff the viewer is a member of the conversation the given message belongs to. SECURITY DEFINER so it bypasses the messages + conversation_members policies installed by this migration.';
 
+-- Helper: "can the viewer access this event?" Gate for creating event
+-- conversations — without this the conversations_insert policy would
+-- accept any `kind='event'` row and let a compromised API-role caller
+-- fabricate chat rooms for events they have no right to. Grants access
+-- to the event creator and any confirmed attendee.
+CREATE OR REPLACE FUNCTION app.viewer_can_access_event(p_event_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT app.current_user_id() > 0 AND (
+        EXISTS (
+            SELECT 1
+            FROM public.events e
+            JOIN public.profiles p ON p.id = e.creator_id
+            WHERE e.id = p_event_id
+              AND p.user_id = app.current_user_id()
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM public.event_attendees ea
+            JOIN public.profiles p ON p.id = ea.profile_id
+            WHERE ea.event_id = p_event_id
+              AND p.user_id = app.current_user_id()
+        )
+    )
+$$;
+
+COMMENT ON FUNCTION app.viewer_can_access_event(uuid) IS
+    'True iff the viewer owns the event or is a confirmed attendee. Used by conversations_insert to prevent arbitrary event chat creation.';
+
+-- Helper: user_id behind an event's creator. The event-chat bootstrap
+-- (resolve_or_create_event_conversation) inserts the creator membership
+-- before the viewer's own, so the conversation_members INSERT policy
+-- needs to recognise that specific target user_id as legitimate — not
+-- just the viewer's own id.
+CREATE OR REPLACE FUNCTION app.event_creator_user_id(p_event_id uuid)
+RETURNS int
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT p.user_id
+    FROM public.events e
+    JOIN public.profiles p ON p.id = e.creator_id
+    WHERE e.id = p_event_id
+$$;
+
+COMMENT ON FUNCTION app.event_creator_user_id(uuid) IS
+    'User id of the given event''s creator, or NULL if missing. SECURITY DEFINER so policy expressions can resolve it without tripping events / profiles RLS.';
+
 REVOKE EXECUTE ON FUNCTION app.viewer_conversation_ids() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.viewer_can_access_event(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.event_creator_user_id(uuid) FROM PUBLIC;
 
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_conversation_ids() TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_can_access_event(uuid) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.event_creator_user_id(uuid) TO poziomki_api';
     END IF;
 END
 $$;
@@ -87,11 +145,11 @@ CREATE POLICY conversations_viewer ON public.conversations
     FOR SELECT TO poziomki_api
     USING (id IN (SELECT conversation_id FROM app.viewer_conversation_ids()));
 
--- DM creation writes a row with `kind='dm'` and the viewer as one of
--- the pair; event chat creation writes a row with `kind='event'` on
--- behalf of an authenticated user (handler verifies event access).
--- The anon guard (`current_user_id > 0`) blocks unset-GUC callers
--- from creating rows.
+-- DM creation requires the viewer to be one of the pair; event chat
+-- creation requires the viewer to own or attend the referenced event.
+-- Relying on the handler for event access was insufficient — a
+-- compromised API-role caller could fabricate chat rooms for arbitrary
+-- events and then add themselves via conversation_members_insert.
 CREATE POLICY conversations_insert ON public.conversations
     FOR INSERT TO poziomki_api
     WITH CHECK (
@@ -99,7 +157,9 @@ CREATE POLICY conversations_insert ON public.conversations
         AND (
             (kind = 'dm'
              AND app.current_user_id() IN (user_low_id, user_high_id))
-            OR kind = 'event'
+            OR (kind = 'event'
+                AND event_id IS NOT NULL
+                AND app.viewer_can_access_event(event_id))
         )
     );
 
@@ -117,10 +177,20 @@ CREATE POLICY conversations_delete ON public.conversations
 --
 -- Reads cover: own rows + rows in conversations the viewer is in
 -- (so "who else is in this DM / event chat" is answerable). Writes
--- are own-row-only for UPDATE/DELETE (viewer bumps their own
--- last_read_message_id, viewer leaves a chat). INSERT supports the
--- two legitimate bootstraps: adding yourself, or adding the DM
--- counterpart when you're one of the pair.
+-- are own-row-only for UPDATE/DELETE and INSERT must name a valid
+-- bootstrap shape:
+--   * DM — viewer is one of the pair AND the inserted user_id is
+--     also one of the pair (blocks third-party injection).
+--   * Event — the conversation is a legitimate event chat (creator
+--     or attendee can resolve), and the inserted user_id is either
+--     the viewer themselves or the event's creator (the chat
+--     bootstrap inserts creator first, then attendee self-join).
+--
+-- A BEFORE UPDATE trigger pins (conversation_id, user_id) — they're
+-- the primary key and must never move — because RLS predicates can't
+-- compare old-row vs new-row values, only the final row. Without the
+-- trigger a viewer could `UPDATE ... SET conversation_id = <target>`
+-- and migrate their membership row into a conversation they aren't in.
 -- ---------------------------------------------------------------------------
 ALTER TABLE public.conversation_members ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.conversation_members FORCE ROW LEVEL SECURITY;
@@ -136,15 +206,22 @@ CREATE POLICY conversation_members_insert ON public.conversation_members
     FOR INSERT TO poziomki_api
     WITH CHECK (
         app.current_user_id() > 0
-        AND (
-            user_id = app.current_user_id()
-            OR EXISTS (
-                SELECT 1
-                FROM public.conversations c
-                WHERE c.id = conversation_id
-                  AND c.kind = 'dm'
-                  AND app.current_user_id() IN (c.user_low_id, c.user_high_id)
-            )
+        AND EXISTS (
+            SELECT 1
+            FROM public.conversations c
+            WHERE c.id = conversation_id
+              AND (
+                  (c.kind = 'dm'
+                   AND app.current_user_id() IN (c.user_low_id, c.user_high_id)
+                   AND conversation_members.user_id IN (c.user_low_id, c.user_high_id))
+                  OR (c.kind = 'event'
+                      AND c.event_id IS NOT NULL
+                      AND app.viewer_can_access_event(c.event_id)
+                      AND (
+                          conversation_members.user_id = app.current_user_id()
+                          OR conversation_members.user_id = app.event_creator_user_id(c.event_id)
+                      ))
+              )
         )
     );
 
@@ -156,6 +233,28 @@ CREATE POLICY conversation_members_update ON public.conversation_members
 CREATE POLICY conversation_members_delete ON public.conversation_members
     FOR DELETE TO poziomki_api
     USING (user_id = app.current_user_id());
+
+CREATE OR REPLACE FUNCTION app.reject_conversation_members_pk_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.conversation_id IS DISTINCT FROM OLD.conversation_id
+       OR NEW.user_id IS DISTINCT FROM OLD.user_id THEN
+        RAISE EXCEPTION
+            'conversation_members primary key is immutable (old=%,% new=%,%)',
+            OLD.conversation_id, OLD.user_id, NEW.conversation_id, NEW.user_id;
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS conversation_members_pk_immutable ON public.conversation_members;
+CREATE TRIGGER conversation_members_pk_immutable
+    BEFORE UPDATE ON public.conversation_members
+    FOR EACH ROW
+    EXECUTE FUNCTION app.reject_conversation_members_pk_change();
 
 -- ---------------------------------------------------------------------------
 -- messages
@@ -180,14 +279,27 @@ CREATE POLICY messages_insert ON public.messages
         AND conversation_id IN (SELECT conversation_id FROM app.viewer_conversation_ids())
     );
 
+-- UPDATE / DELETE require current membership in addition to authorship,
+-- so a user who leaves a conversation loses edit rights to their own
+-- past messages there. Tightening to membership matches the invariant
+-- "writes are gated by current access, not historical authorship".
 CREATE POLICY messages_update ON public.messages
     FOR UPDATE TO poziomki_api
-    USING (sender_id = app.current_user_id())
-    WITH CHECK (sender_id = app.current_user_id());
+    USING (
+        sender_id = app.current_user_id()
+        AND conversation_id IN (SELECT conversation_id FROM app.viewer_conversation_ids())
+    )
+    WITH CHECK (
+        sender_id = app.current_user_id()
+        AND conversation_id IN (SELECT conversation_id FROM app.viewer_conversation_ids())
+    );
 
 CREATE POLICY messages_delete ON public.messages
     FOR DELETE TO poziomki_api
-    USING (sender_id = app.current_user_id());
+    USING (
+        sender_id = app.current_user_id()
+        AND conversation_id IN (SELECT conversation_id FROM app.viewer_conversation_ids())
+    );
 
 -- ---------------------------------------------------------------------------
 -- message_reactions
@@ -210,11 +322,24 @@ CREATE POLICY message_reactions_insert ON public.message_reactions
         AND app.viewer_can_see_message(message_id)
     );
 
+-- UPDATE / DELETE keep the user scoping AND require the viewer still
+-- sees the parent message. Without the viewer_can_see_message check a
+-- viewer who knows a message UUID could mutate their own reaction onto
+-- messages outside their conversations.
 CREATE POLICY message_reactions_update ON public.message_reactions
     FOR UPDATE TO poziomki_api
-    USING (user_id = app.current_user_id())
-    WITH CHECK (user_id = app.current_user_id());
+    USING (
+        user_id = app.current_user_id()
+        AND app.viewer_can_see_message(message_id)
+    )
+    WITH CHECK (
+        user_id = app.current_user_id()
+        AND app.viewer_can_see_message(message_id)
+    );
 
 CREATE POLICY message_reactions_delete ON public.message_reactions
     FOR DELETE TO poziomki_api
-    USING (user_id = app.current_user_id());
+    USING (
+        user_id = app.current_user_id()
+        AND app.viewer_can_see_message(message_id)
+    );

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -232,6 +232,7 @@ REVOKE EXECUTE ON FUNCTION app.viewer_conversation_ids() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.viewer_can_access_event(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.event_creator_user_id(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.delete_event_and_chat(uuid) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.session_bypasses_rls() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.find_dm_conversation(int, int) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION app.find_event_conversation(uuid) FROM PUBLIC;
@@ -248,6 +249,7 @@ BEGIN
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_dm_conversation(int, int) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_event_conversation(uuid) TO poziomki_api';
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.conversation_meta_for_insert(uuid) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.delete_event_and_chat(uuid) TO poziomki_api';
     END IF;
     -- Worker process (BYPASSRLS) reaches the resolve-or-create event
     -- chat path via sync_event_membership — it needs execute on the
@@ -295,14 +297,58 @@ CREATE POLICY conversations_insert ON public.conversations
         )
     );
 
-CREATE POLICY conversations_update ON public.conversations
-    FOR UPDATE TO poziomki_api
-    USING (id IN (SELECT conversation_id FROM app.viewer_conversation_ids()))
-    WITH CHECK (id IN (SELECT conversation_id FROM app.viewer_conversation_ids()));
+-- Event cleanup path: the API role has no direct DELETE privilege on
+-- conversations (see policy block below), so legitimate event deletion
+-- routes through this SD helper. It validates the caller is the event
+-- owner (or a BYPASSRLS worker), then issues the event DELETE — FK
+-- cascades handle conversations / conversation_members / messages /
+-- message_reactions. Report rows are cleaned up here too so they
+-- don't dangle after the event disappears.
+CREATE OR REPLACE FUNCTION app.delete_event_and_chat(p_event_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+DECLARE
+    v_allowed boolean;
+BEGIN
+    SELECT
+        app.session_bypasses_rls()
+        OR EXISTS (
+            SELECT 1
+            FROM public.events e
+            JOIN public.profiles p ON p.id = e.creator_id
+            WHERE e.id = p_event_id
+              AND p.user_id = app.current_user_id()
+              AND app.current_user_id() > 0
+        )
+    INTO v_allowed;
 
-CREATE POLICY conversations_delete ON public.conversations
-    FOR DELETE TO poziomki_api
-    USING (id IN (SELECT conversation_id FROM app.viewer_conversation_ids()));
+    IF NOT v_allowed THEN
+        RAISE EXCEPTION
+            'delete_event_and_chat: caller is neither event creator nor a BYPASSRLS role';
+    END IF;
+
+    DELETE FROM public.reports
+    WHERE target_type = 'event' AND target_id = p_event_id;
+
+    DELETE FROM public.events WHERE id = p_event_id;
+END
+$$;
+
+COMMENT ON FUNCTION app.delete_event_and_chat(uuid) IS
+    'Event deletion + chat cleanup. Auth check pins access to the event creator or a BYPASSRLS role. FK cascades handle the rest of the chat fan-out.';
+
+-- No general UPDATE or DELETE policy for poziomki_api on conversations.
+-- A member-only UPDATE would permit mutation of title / metadata
+-- across the room (no API feature uses this today); a member-only
+-- DELETE is worse — it would let any participant nuke an entire chat
+-- via CASCADE through conversation_members, messages, and
+-- message_reactions. The legitimate cleanup path is event deletion,
+-- which is routed through the SD helper app.delete_event_and_chat()
+-- below; DM rows are never deleted from the application — they're
+-- cleaned up at account-deletion time through a different path.
 
 -- conversations.(kind, event_id, user_low_id, user_high_id) are
 -- identity columns — the policy branches below decide what an

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -1,0 +1,220 @@
+-- Tier B: enable RLS on the chat tables (conversations,
+-- conversation_members, messages, message_reactions). Access is
+-- membership-scoped: a viewer can only see / mutate rows tied to a
+-- conversation they're a member of.
+--
+-- Every handler is already wrapped in `db::with_viewer_tx`, so
+-- `app.user_id` is set before any chat query runs.
+
+-- ---------------------------------------------------------------------------
+-- Helper: viewer's conversation ids.
+--
+-- Membership lookup is used by four different tables' SELECT policies
+-- and a couple of write policies, so pull it into a SECURITY DEFINER
+-- helper. Definer rights matter for two reasons:
+--   1. `conversation_members` will have its own policy after this
+--      migration, so a non-SD subquery on it would recursively
+--      self-filter and only expose the viewer's own row — fine for
+--      own-row checks but wrong for "every conversation I'm in".
+--   2. Sibling tables (messages, message_reactions) need membership
+--      info even though their own SELECT policies haven't bound yet.
+--
+-- The `current_user_id() > 0` guard blocks anon / unset-GUC callers.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION app.viewer_conversation_ids()
+RETURNS TABLE (conversation_id uuid)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT cm.conversation_id
+    FROM public.conversation_members cm
+    WHERE app.current_user_id() > 0
+      AND cm.user_id = app.current_user_id()
+$$;
+
+COMMENT ON FUNCTION app.viewer_conversation_ids() IS
+    'Conversation ids the current viewer is a member of. SECURITY DEFINER so policies on conversation_members / messages / reactions can embed it without tripping sibling RLS. Returns empty for anon.';
+
+-- Helper: "can the viewer see this message?" Used by message_reactions
+-- policies. Single-row EXISTS lookup keeps the check cheap and avoids
+-- materialising a full list of viewer-visible message ids.
+CREATE OR REPLACE FUNCTION app.viewer_can_see_message(p_message_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.messages m
+        JOIN public.conversation_members cm ON cm.conversation_id = m.conversation_id
+        WHERE m.id = p_message_id
+          AND app.current_user_id() > 0
+          AND cm.user_id = app.current_user_id()
+    )
+$$;
+
+COMMENT ON FUNCTION app.viewer_can_see_message(uuid) IS
+    'True iff the viewer is a member of the conversation the given message belongs to. SECURITY DEFINER so it bypasses the messages + conversation_members policies installed by this migration.';
+
+REVOKE EXECUTE ON FUNCTION app.viewer_conversation_ids() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_conversation_ids() TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_can_see_message(uuid) TO poziomki_api';
+    END IF;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- conversations
+--
+-- Reads limited to viewer's conversations. Writes scoped tight enough
+-- to cover the two legitimate creation flows (DM bootstrap + event chat
+-- resolve) without letting a compromised API-role caller fabricate
+-- arbitrary rows. UPDATE / DELETE remain membership-gated.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.conversations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.conversations FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY conversations_viewer ON public.conversations
+    FOR SELECT TO poziomki_api
+    USING (id IN (SELECT conversation_id FROM app.viewer_conversation_ids()));
+
+-- DM creation writes a row with `kind='dm'` and the viewer as one of
+-- the pair; event chat creation writes a row with `kind='event'` on
+-- behalf of an authenticated user (handler verifies event access).
+-- The anon guard (`current_user_id > 0`) blocks unset-GUC callers
+-- from creating rows.
+CREATE POLICY conversations_insert ON public.conversations
+    FOR INSERT TO poziomki_api
+    WITH CHECK (
+        app.current_user_id() > 0
+        AND (
+            (kind = 'dm'
+             AND app.current_user_id() IN (user_low_id, user_high_id))
+            OR kind = 'event'
+        )
+    );
+
+CREATE POLICY conversations_update ON public.conversations
+    FOR UPDATE TO poziomki_api
+    USING (id IN (SELECT conversation_id FROM app.viewer_conversation_ids()))
+    WITH CHECK (id IN (SELECT conversation_id FROM app.viewer_conversation_ids()));
+
+CREATE POLICY conversations_delete ON public.conversations
+    FOR DELETE TO poziomki_api
+    USING (id IN (SELECT conversation_id FROM app.viewer_conversation_ids()));
+
+-- ---------------------------------------------------------------------------
+-- conversation_members
+--
+-- Reads cover: own rows + rows in conversations the viewer is in
+-- (so "who else is in this DM / event chat" is answerable). Writes
+-- are own-row-only for UPDATE/DELETE (viewer bumps their own
+-- last_read_message_id, viewer leaves a chat). INSERT supports the
+-- two legitimate bootstraps: adding yourself, or adding the DM
+-- counterpart when you're one of the pair.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.conversation_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.conversation_members FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY conversation_members_viewer ON public.conversation_members
+    FOR SELECT TO poziomki_api
+    USING (
+        user_id = app.current_user_id()
+        OR conversation_id IN (SELECT conversation_id FROM app.viewer_conversation_ids())
+    );
+
+CREATE POLICY conversation_members_insert ON public.conversation_members
+    FOR INSERT TO poziomki_api
+    WITH CHECK (
+        app.current_user_id() > 0
+        AND (
+            user_id = app.current_user_id()
+            OR EXISTS (
+                SELECT 1
+                FROM public.conversations c
+                WHERE c.id = conversation_id
+                  AND c.kind = 'dm'
+                  AND app.current_user_id() IN (c.user_low_id, c.user_high_id)
+            )
+        )
+    );
+
+CREATE POLICY conversation_members_update ON public.conversation_members
+    FOR UPDATE TO poziomki_api
+    USING (user_id = app.current_user_id())
+    WITH CHECK (user_id = app.current_user_id());
+
+CREATE POLICY conversation_members_delete ON public.conversation_members
+    FOR DELETE TO poziomki_api
+    USING (user_id = app.current_user_id());
+
+-- ---------------------------------------------------------------------------
+-- messages
+--
+-- Reads limited to conversations the viewer belongs to. Writes are
+-- sender-only: only the viewer can send/edit/delete as themselves,
+-- and the INSERT WITH CHECK additionally requires the target
+-- conversation is one they're in (no blind cross-conversation
+-- message injection).
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.messages FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY messages_viewer ON public.messages
+    FOR SELECT TO poziomki_api
+    USING (conversation_id IN (SELECT conversation_id FROM app.viewer_conversation_ids()));
+
+CREATE POLICY messages_insert ON public.messages
+    FOR INSERT TO poziomki_api
+    WITH CHECK (
+        sender_id = app.current_user_id()
+        AND conversation_id IN (SELECT conversation_id FROM app.viewer_conversation_ids())
+    );
+
+CREATE POLICY messages_update ON public.messages
+    FOR UPDATE TO poziomki_api
+    USING (sender_id = app.current_user_id())
+    WITH CHECK (sender_id = app.current_user_id());
+
+CREATE POLICY messages_delete ON public.messages
+    FOR DELETE TO poziomki_api
+    USING (sender_id = app.current_user_id());
+
+-- ---------------------------------------------------------------------------
+-- message_reactions
+--
+-- Reads follow message visibility (you can see a reaction iff you can
+-- see the message). Writes are user-scoped: only your own reaction
+-- rows, and only on messages you can see.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.message_reactions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.message_reactions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY message_reactions_viewer ON public.message_reactions
+    FOR SELECT TO poziomki_api
+    USING (app.viewer_can_see_message(message_id));
+
+CREATE POLICY message_reactions_insert ON public.message_reactions
+    FOR INSERT TO poziomki_api
+    WITH CHECK (
+        user_id = app.current_user_id()
+        AND app.viewer_can_see_message(message_id)
+    );
+
+CREATE POLICY message_reactions_update ON public.message_reactions
+    FOR UPDATE TO poziomki_api
+    USING (user_id = app.current_user_id())
+    WITH CHECK (user_id = app.current_user_id());
+
+CREATE POLICY message_reactions_delete ON public.message_reactions
+    FOR DELETE TO poziomki_api
+    USING (user_id = app.current_user_id());

--- a/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
+++ b/backend/migrations/2026-04-19-020000_rls_tier_b_policies/up.sql
@@ -64,7 +64,9 @@ COMMENT ON FUNCTION app.viewer_can_see_message(uuid) IS
 -- conversations — without this the conversations_insert policy would
 -- accept any `kind='event'` row and let a compromised API-role caller
 -- fabricate chat rooms for events they have no right to. Grants access
--- to the event creator and any confirmed attendee.
+-- to the event creator and any `going` attendee; `pending`, `waitlist`,
+-- `declined`, etc. are rejected so attendance status maps one-to-one
+-- with chat access (same gate the HTTP handler uses in chat/mod.rs).
 CREATE OR REPLACE FUNCTION app.viewer_can_access_event(p_event_id uuid)
 RETURNS boolean
 LANGUAGE sql
@@ -85,13 +87,14 @@ AS $$
             FROM public.event_attendees ea
             JOIN public.profiles p ON p.id = ea.profile_id
             WHERE ea.event_id = p_event_id
+              AND ea.status = 'going'
               AND p.user_id = app.current_user_id()
         )
     )
 $$;
 
 COMMENT ON FUNCTION app.viewer_can_access_event(uuid) IS
-    'True iff the viewer owns the event or is a confirmed attendee. Used by conversations_insert to prevent arbitrary event chat creation.';
+    'True iff the viewer owns the event or has a `going` attendance row. Used by conversations_insert to prevent arbitrary event chat creation; mirrors the HTTP-layer gate.';
 
 -- Helper: user_id behind an event's creator. The event-chat bootstrap
 -- (resolve_or_create_event_conversation) inserts the creator membership

--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use diesel::prelude::*;
+use diesel::sql_types::{Integer, Uuid as SqlUuid};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
@@ -7,6 +8,36 @@ use crate::db;
 use crate::db::models::conversation_members::NewConversationMember;
 use crate::db::models::conversations::{Conversation, NewConversation};
 use crate::db::schema::{conversation_members, conversations, events, profile_blocks, profiles};
+
+/// Fetch the canonical DM conversation for `(low, high)` via the
+/// SECURITY DEFINER helper installed in the Tier-B migration. Bypasses
+/// `conversations_viewer` RLS so callers can discover a concurrently
+/// created row whose membership hasn't yet been inserted — the resolve
+/// flow would otherwise dead-end on `NotFound` after its race fallback.
+async fn find_dm_conversation(
+    conn: &mut AsyncPgConnection,
+    low: i32,
+    high: i32,
+) -> Result<Option<Conversation>, diesel::result::Error> {
+    diesel::sql_query("SELECT * FROM app.find_dm_conversation($1, $2)")
+        .bind::<Integer, _>(low)
+        .bind::<Integer, _>(high)
+        .get_result::<Conversation>(conn)
+        .await
+        .optional()
+}
+
+/// Event-chat counterpart to `find_dm_conversation`.
+async fn find_event_conversation(
+    conn: &mut AsyncPgConnection,
+    event_id: Uuid,
+) -> Result<Option<Conversation>, diesel::result::Error> {
+    diesel::sql_query("SELECT * FROM app.find_event_conversation($1)")
+        .bind::<SqlUuid, _>(event_id)
+        .get_result::<Conversation>(conn)
+        .await
+        .optional()
+}
 
 /// Resolve or create a DM conversation between two users.
 /// Uses canonical pair (lower id, higher id) for uniqueness.
@@ -22,16 +53,11 @@ pub async fn resolve_or_create_dm(
         (second_user_id, first_user_id)
     };
 
-    // Try to find existing DM
-    let existing = conversations::table
-        .filter(conversations::kind.eq("dm"))
-        .filter(conversations::user_low_id.eq(low))
-        .filter(conversations::user_high_id.eq(high))
-        .first::<Conversation>(conn)
-        .await
-        .optional()?;
-
-    if let Some(found) = existing {
+    // Try to find existing DM. The SD lookup bypasses
+    // `conversations_viewer` so viewers who aren't yet members (e.g.
+    // the resolve flow before membership is bootstrapped) still see
+    // the row.
+    if let Some(found) = find_dm_conversation(conn, low, high).await? {
         return Ok(found);
     }
 
@@ -55,17 +81,18 @@ pub async fn resolve_or_create_dm(
         .await
         .optional()?;
 
-    // Handle race condition: another request may have created it
+    // Handle race condition: another request may have created it. The
+    // fallback uses the SD helper so RLS doesn't filter the row out
+    // when the viewer's membership hasn't been inserted yet.
     let created = match inserted {
         Some(c) => c,
-        None => {
-            conversations::table
-                .filter(conversations::kind.eq("dm"))
-                .filter(conversations::user_low_id.eq(low))
-                .filter(conversations::user_high_id.eq(high))
-                .first::<Conversation>(conn)
-                .await?
-        }
+        None => find_dm_conversation(conn, low, high)
+            .await?
+            .ok_or_else(|| {
+                crate::error::AppError::message(format!(
+                    "DM conversation race-fallback lookup returned None for pair ({low}, {high})"
+                ))
+            })?,
     };
 
     // Ensure both users are members
@@ -97,14 +124,10 @@ pub async fn resolve_or_create_event_conversation(
     event_title: &str,
     creator_user_id: i32,
 ) -> Result<Conversation, crate::error::AppError> {
-    let existing = conversations::table
-        .filter(conversations::kind.eq("event"))
-        .filter(conversations::event_id.eq(event_id))
-        .first::<Conversation>(conn)
-        .await
-        .optional()?;
-
-    if let Some(found) = existing {
+    // Existing-row lookup via SD helper so an attendee resolving the
+    // chat before their membership has been inserted still sees the
+    // row created by the event owner (or an earlier attendee).
+    if let Some(found) = find_event_conversation(conn, event_id).await? {
         return Ok(found);
     }
 
@@ -129,13 +152,13 @@ pub async fn resolve_or_create_event_conversation(
 
     let created = match inserted {
         Some(c) => c,
-        None => {
-            conversations::table
-                .filter(conversations::kind.eq("event"))
-                .filter(conversations::event_id.eq(event_id))
-                .first::<Conversation>(conn)
-                .await?
-        }
+        None => find_event_conversation(conn, event_id)
+            .await?
+            .ok_or_else(|| {
+                crate::error::AppError::message(format!(
+                    "event conversation race-fallback lookup returned None for event {event_id}"
+                ))
+            })?,
     };
 
     // Add creator as first member

--- a/backend/src/api/events/write_repo.rs
+++ b/backend/src/api/events/write_repo.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::db::models::event_attendees::EventAttendee;
 use crate::db::models::event_interactions::EventInteraction;
 use crate::db::models::events::{Event, EventChangeset, NewEvent};
-use crate::db::schema::{conversations, event_attendees, event_interactions, events, reports};
+use crate::db::schema::{event_attendees, event_interactions, events};
 
 pub(in crate::api) const MAX_ATTEMPTS: usize = 3;
 
@@ -133,17 +133,14 @@ pub(in crate::api) async fn delete_event_with_conn(
     conn: &mut AsyncPgConnection,
     event_id: Uuid,
 ) -> std::result::Result<(), crate::error::AppError> {
-    diesel::delete(
-        reports::table
-            .filter(reports::target_type.eq("event"))
-            .filter(reports::target_id.eq(event_id)),
-    )
-    .execute(conn)
-    .await?;
-    diesel::delete(conversations::table.filter(conversations::event_id.eq(event_id)))
-        .execute(conn)
-        .await?;
-    diesel::delete(events::table.find(event_id))
+    // Route through the SD helper installed by Tier-B migration so
+    // the API role doesn't need broad DELETE on conversations. The
+    // helper auth-checks (event creator or BYPASSRLS), deletes
+    // reports, then deletes the event — FK cascades handle the chat
+    // fan-out (conversations → conversation_members → messages →
+    // message_reactions).
+    diesel::sql_query("SELECT app.delete_event_and_chat($1)")
+        .bind::<diesel::sql_types::Uuid, _>(event_id)
         .execute(conn)
         .await?;
     Ok(())

--- a/backend/src/db/models/conversations.rs
+++ b/backend/src/db/models/conversations.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::db::schema::conversations;
 
-#[derive(Debug, Clone, Queryable, Selectable, Identifiable)]
+#[derive(Debug, Clone, Queryable, QueryableByName, Selectable, Identifiable)]
 #[diesel(table_name = conversations)]
 pub struct Conversation {
     pub id: Uuid,

--- a/backend/tests/requests/mod.rs
+++ b/backend/tests/requests/mod.rs
@@ -3,4 +3,5 @@ mod migration_contract;
 mod rls_baseline;
 mod rls_harness;
 mod rls_tier_a;
+mod rls_tier_b;
 mod rls_visibility;

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -76,6 +76,7 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "push_topics_for_users",
     "resolve_session",
     // Tier-B policy-support helpers.
+    "conversation_meta_for_insert",
     "event_creator_user_id",
     "find_dm_conversation",
     "find_event_conversation",

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -76,6 +76,8 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "push_topics_for_users",
     "resolve_session",
     // Tier-B policy-support helpers.
+    "event_creator_user_id",
+    "viewer_can_access_event",
     "viewer_can_see_message",
     "viewer_conversation_ids",
     "set_password_reset_token",

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -95,7 +95,8 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
 /// (no table reads), so they don't need definer rights. Listed
 /// separately so a dropped helper surfaces loudly even though it won't
 /// appear in the hardened-search_path test.
-const EXPECTED_POLICY_HELPERS: &[&str] = &["current_is_stub", "current_user_id"];
+const EXPECTED_POLICY_HELPERS: &[&str] =
+    &["current_is_stub", "current_user_id", "session_bypasses_rls"];
 
 fn setup() {
     let _ = dotenvy::dotenv();

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -77,6 +77,8 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "resolve_session",
     // Tier-B policy-support helpers.
     "event_creator_user_id",
+    "find_dm_conversation",
+    "find_event_conversation",
     "viewer_can_access_event",
     "viewer_can_see_message",
     "viewer_conversation_ids",

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -38,12 +38,17 @@ const EXPECTED_TIER_A_TABLES: &[&str] = &[
     "reports",
 ];
 
-const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[
-    // Tier B — conversation/message membership-scoped
+/// Tables the Tier-B migration (2026-04-19-020000) locks down. Same
+/// shape as the Tier-A set: each table must have RLS enabled, FORCE
+/// set, and a `<table>_viewer` SELECT policy on `poziomki_api`.
+const EXPECTED_TIER_B_TABLES: &[&str] = &[
     "conversations",
     "conversation_members",
     "messages",
     "message_reactions",
+];
+
+const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[
     // Tier C — events, attendance, uploads
     "events",
     "event_attendees",
@@ -70,6 +75,9 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "profiles_in_current_bucket",
     "push_topics_for_users",
     "resolve_session",
+    // Tier-B policy-support helpers.
+    "viewer_can_see_message",
+    "viewer_conversation_ids",
     "set_password_reset_token",
     "user_id_for_pid",
     "user_pid_for_id",
@@ -122,6 +130,7 @@ async fn api_role_has_dml_on_all_protected_tables() {
     setup();
     let all_tables = EXPECTED_TIER_A_TABLES
         .iter()
+        .chain(EXPECTED_TIER_B_TABLES.iter())
         .chain(EXPECTED_RLS_DISABLED_TABLES.iter());
     for table in all_tables {
         let grants = rls_harness::role_privileges("poziomki_api", table).await;
@@ -241,6 +250,59 @@ async fn tier_a_tables_have_named_policy_on_api_role() {
         assert!(
             matched.roles.iter().any(|r| r == "poziomki_api"),
             "Tier-A policy {expected_name} on public.{table} must target poziomki_api (targets: {:?})",
+            matched.roles
+        );
+    }
+}
+
+/// Tier-B canary: chat tables (`conversations`, `conversation_members`,
+/// `messages`, `message_reactions`) have RLS ENABLED + FORCED.
+#[tokio::test]
+#[serial]
+async fn tier_b_tables_have_rls_enabled_and_forced() {
+    setup();
+    let mut missing_enabled = Vec::new();
+    let mut missing_forced = Vec::new();
+    for table in EXPECTED_TIER_B_TABLES {
+        if !rls_harness::table_rls_enabled(table).await {
+            missing_enabled.push(*table);
+        }
+        if !rls_harness::table_force_rls(table).await {
+            missing_forced.push(*table);
+        }
+    }
+    assert!(
+        missing_enabled.is_empty(),
+        "Tier-B tables missing RLS ENABLE: {missing_enabled:?}"
+    );
+    assert!(
+        missing_forced.is_empty(),
+        "Tier-B tables missing FORCE ROW LEVEL SECURITY: {missing_forced:?}"
+    );
+}
+
+/// Every Tier-B table has a `<table>_viewer` SELECT policy attached
+/// to `poziomki_api`. Separate write policies exist too but the
+/// read policy name is the stable canary handle.
+#[tokio::test]
+#[serial]
+async fn tier_b_tables_have_named_policy_on_api_role() {
+    setup();
+    let attachments = rls_harness::policies_for_tables(EXPECTED_TIER_B_TABLES).await;
+    for table in EXPECTED_TIER_B_TABLES {
+        let policies = attachments
+            .get(*table)
+            .expect("policy catalog query must return an entry per table");
+        let expected_name = format!("{table}_viewer");
+        let matched = policies.iter().find(|p| p.name == expected_name);
+        assert!(
+            matched.is_some(),
+            "Tier-B table public.{table} is missing policy {expected_name}; found {policies:?}"
+        );
+        let matched = matched.unwrap();
+        assert!(
+            matched.roles.iter().any(|r| r == "poziomki_api"),
+            "Tier-B policy {expected_name} on public.{table} must target poziomki_api (targets: {:?})",
             matched.roles
         );
     }

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -77,6 +77,7 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "resolve_session",
     // Tier-B policy-support helpers.
     "conversation_meta_for_insert",
+    "delete_event_and_chat",
     "event_creator_user_id",
     "find_dm_conversation",
     "find_event_conversation",

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -23,7 +23,8 @@ use poziomki_backend::db::models::messages::NewMessage;
 use poziomki_backend::db::models::profiles::NewProfile;
 use poziomki_backend::db::models::users::{NewUser, User};
 use poziomki_backend::db::schema::{
-    conversation_members, conversations, message_reactions, messages, profiles, users,
+    conversation_members, conversations, event_attendees, events, message_reactions, messages,
+    profiles, users,
 };
 use serial_test::serial;
 use uuid::Uuid;
@@ -674,6 +675,91 @@ async fn message_reactions_cannot_update_onto_hidden_message() {
             "message_reactions UPDATE must not move a reaction onto a hidden message"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// viewer_can_access_event status filter: pending attendees must NOT
+// be able to create an event chat — the HTTP handler gates on
+// `status = 'going'` and the RLS helper mirrors that.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn event_conversation_insert_rejects_pending_attendee() {
+    let fx = setup_fixture().await;
+    let carol_id = fx.carol.id;
+
+    // Carol has a `pending` attendance row on Bob's event. She's not
+    // the creator, not confirmed, so event chat creation must fail.
+    let event_id = Uuid::new_v4();
+    let bob_profile: Uuid = {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        let bob_profile_id = profiles::table
+            .filter(profiles::user_id.eq(fx.bob.id))
+            .select(profiles::id)
+            .first::<Uuid>(&mut conn)
+            .await
+            .expect("bob profile");
+        let carol_profile_id = profiles::table
+            .filter(profiles::user_id.eq(carol_id))
+            .select(profiles::id)
+            .first::<Uuid>(&mut conn)
+            .await
+            .expect("carol profile");
+        diesel::insert_into(events::table)
+            .values((
+                events::id.eq(event_id),
+                events::title.eq("Gathering"),
+                events::starts_at.eq(now + chrono::Duration::days(1)),
+                events::creator_id.eq(bob_profile_id),
+                events::created_at.eq(now),
+                events::updated_at.eq(now),
+                events::requires_approval.eq(true),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed event");
+        diesel::insert_into(event_attendees::table)
+            .values((
+                event_attendees::event_id.eq(event_id),
+                event_attendees::profile_id.eq(carol_profile_id),
+                event_attendees::status.eq("pending"),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed pending attendance");
+        bob_profile_id
+    };
+
+    let _ = bob_profile;
+
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(carol_id, false, move |conn| {
+            async move {
+                let now = Utc::now();
+                diesel::insert_into(conversations::table)
+                    .values(&NewConversation {
+                        id: Uuid::new_v4(),
+                        kind: "event".into(),
+                        title: Some("Gathering".into()),
+                        event_id: Some(event_id),
+                        user_low_id: None,
+                        user_high_id: None,
+                        created_at: now,
+                        updated_at: now,
+                    })
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "conversations_insert must reject event chat creation for a pending attendee"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -769,6 +769,59 @@ async fn event_conversation_insert_rejects_pending_attendee() {
 }
 
 // ---------------------------------------------------------------------------
+// conversations identity-column trigger: a DM member cannot silently
+// enrol a third party by swapping user_high_id, and cannot flip
+// kind / event_id to switch which conversation_members_insert branch
+// applies. These fields drive every downstream policy decision.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn conversations_identity_change_rejected() {
+    let fx = setup_fixture().await;
+    let alice_id = fx.alice.id;
+    let dm_id = fx.dm_id;
+    let carol_id = fx.carol.id;
+
+    // Alice tries to replace Bob with Carol as the DM's high-id peer.
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+            async move {
+                let sql = format!(
+                    "UPDATE public.conversations SET user_high_id = {carol_id} \
+                     WHERE id = '{dm_id}'"
+                );
+                diesel::sql_query(sql).execute(conn).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "conversations identity trigger must reject user_high_id UPDATE"
+    );
+
+    // Same viewer, different field — kind flip must also error.
+    let result2: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+            async move {
+                let sql =
+                    format!("UPDATE public.conversations SET kind = 'event' WHERE id = '{dm_id}'");
+                diesel::sql_query(sql).execute(conn).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result2.is_err(),
+        "conversations identity trigger must reject kind UPDATE"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // message_reactions PK-change trigger: a viewer cannot move their
 // reaction to another message — even one they can see in a shared
 // conversation. Defends against cross-conversation reaction injection

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -1,0 +1,426 @@
+//! Tier-B RLS visibility tests.
+//!
+//! Three users: Alice + Bob share a DM, Carol is in no conversation.
+//! Asserts that:
+//!   * DM members see the conversation, each other's membership rows,
+//!     and every message — while outsiders see nothing.
+//!   * Only the sender can UPDATE / DELETE their own message even
+//!     though the recipient can SELECT it.
+//!   * Message reactions follow the parent message's visibility, and
+//!     a user can only mutate their own reactions.
+//!   * Anon viewers see zero chat rows across all four tables.
+
+use chrono::Utc;
+use diesel::prelude::*;
+use diesel::sql_types::BigInt;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use poziomki_backend::app::{build_test_app_context, reset_test_database};
+use poziomki_backend::db;
+use poziomki_backend::db::models::conversation_members::NewConversationMember;
+use poziomki_backend::db::models::conversations::NewConversation;
+use poziomki_backend::db::models::messages::NewMessage;
+use poziomki_backend::db::models::profiles::NewProfile;
+use poziomki_backend::db::models::users::{NewUser, User};
+use poziomki_backend::db::schema::{
+    conversation_members, conversations, message_reactions, messages, profiles, users,
+};
+use serial_test::serial;
+use uuid::Uuid;
+
+use super::rls_harness;
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}
+
+struct Fixture {
+    alice: User,
+    bob: User,
+    carol: User,
+    dm_id: Uuid,
+    alice_msg_id: Uuid,
+    bob_msg_id: Uuid,
+}
+
+async fn count_rows(conn: &mut AsyncPgConnection, table: &str) -> i64 {
+    assert!(
+        table.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+        "table name must be a simple identifier"
+    );
+    let row: CountRow = diesel::sql_query(format!("SELECT COUNT(*) AS count FROM {table}"))
+        .get_result(conn)
+        .await
+        .expect("count");
+    row.count
+}
+
+async fn execute_count(conn: &mut AsyncPgConnection, sql: &str) -> usize {
+    diesel::sql_query(sql)
+        .execute(conn)
+        .await
+        .expect("statement must succeed (RLS silently filters, not errors)")
+}
+
+async fn insert_user(email: &str) -> User {
+    let mut conn = db::conn().await.expect("pool");
+    let new_user = NewUser {
+        pid: Uuid::new_v4(),
+        email: email.to_string(),
+        password: "hash".to_string(),
+        api_key: Uuid::new_v4().to_string(),
+        name: "Test".to_string(),
+    };
+    diesel::insert_into(users::table)
+        .values(&new_user)
+        .returning(User::as_select())
+        .get_result(&mut conn)
+        .await
+        .expect("insert user")
+}
+
+async fn insert_profile(user: &User, name: &str) -> Uuid {
+    let mut conn = db::conn().await.expect("pool");
+    let now = Utc::now();
+    let new_profile = NewProfile {
+        id: Uuid::new_v4(),
+        user_id: user.id,
+        name: name.to_string(),
+        bio: None,
+        profile_picture: None,
+        images: None,
+        program: None,
+        gradient_start: None,
+        gradient_end: None,
+        created_at: now,
+        updated_at: now,
+    };
+    diesel::insert_into(profiles::table)
+        .values(&new_profile)
+        .returning(profiles::id)
+        .get_result(&mut conn)
+        .await
+        .expect("insert profile")
+}
+
+async fn setup_fixture() -> Fixture {
+    let _ = dotenvy::dotenv();
+    let _ = build_test_app_context().expect("test app ctx");
+    reset_test_database().await.expect("truncate");
+
+    let alice = insert_user("tier-b-alice@example.com").await;
+    let _ = insert_profile(&alice, "Alice").await;
+    let bob = insert_user("tier-b-bob@example.com").await;
+    let _ = insert_profile(&bob, "Bob").await;
+    let carol = insert_user("tier-b-carol@example.com").await;
+    let _ = insert_profile(&carol, "Carol").await;
+
+    let (low, high) = if alice.id < bob.id {
+        (alice.id, bob.id)
+    } else {
+        (bob.id, alice.id)
+    };
+    let dm_id = Uuid::new_v4();
+    let alice_msg_id = Uuid::new_v4();
+    let bob_msg_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(conversations::table)
+            .values(&NewConversation {
+                id: dm_id,
+                kind: "dm".into(),
+                title: None,
+                event_id: None,
+                user_low_id: Some(low),
+                user_high_id: Some(high),
+                created_at: now,
+                updated_at: now,
+            })
+            .execute(&mut conn)
+            .await
+            .expect("seed dm");
+        for uid in [alice.id, bob.id] {
+            diesel::insert_into(conversation_members::table)
+                .values(&NewConversationMember {
+                    conversation_id: dm_id,
+                    user_id: uid,
+                    joined_at: now,
+                })
+                .execute(&mut conn)
+                .await
+                .expect("seed dm member");
+        }
+        for (id, sender) in [(alice_msg_id, alice.id), (bob_msg_id, bob.id)] {
+            diesel::insert_into(messages::table)
+                .values(&NewMessage {
+                    id,
+                    conversation_id: dm_id,
+                    sender_id: sender,
+                    body: format!("hello from {sender}"),
+                    kind: "text".into(),
+                    reply_to_id: None,
+                    client_id: None,
+                    created_at: now,
+                })
+                .execute(&mut conn)
+                .await
+                .expect("seed message");
+        }
+    }
+
+    Fixture {
+        alice,
+        bob,
+        carol,
+        dm_id,
+        alice_msg_id,
+        bob_msg_id,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// conversations: DM members see 1 row, outsiders see 0.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn conversations_dm_members_see_only_their_dm() {
+    let fx = setup_fixture().await;
+
+    let alice_count = rls_harness::with_api_viewer_tx(fx.alice.id, false, |conn| {
+        async move { Ok(count_rows(conn, "conversations").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    let carol_count = rls_harness::with_api_viewer_tx(fx.carol.id, false, |conn| {
+        async move { Ok(count_rows(conn, "conversations").await) }.scope_boxed()
+    })
+    .await
+    .expect("carol tx");
+
+    assert_eq!(alice_count, 1, "Alice is in the DM");
+    assert_eq!(carol_count, 0, "Carol is in no conversation");
+}
+
+// ---------------------------------------------------------------------------
+// conversation_members: DM members see both rows (self + peer),
+// outsiders see none.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn conversation_members_dm_members_see_both_rows() {
+    let fx = setup_fixture().await;
+
+    let alice_count = rls_harness::with_api_viewer_tx(fx.alice.id, false, |conn| {
+        async move { Ok(count_rows(conn, "conversation_members").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    let carol_count = rls_harness::with_api_viewer_tx(fx.carol.id, false, |conn| {
+        async move { Ok(count_rows(conn, "conversation_members").await) }.scope_boxed()
+    })
+    .await
+    .expect("carol tx");
+
+    assert_eq!(
+        alice_count, 2,
+        "Alice sees her own + Bob's membership row (shared conversation)"
+    );
+    assert_eq!(carol_count, 0, "Carol is in no conversation");
+}
+
+// ---------------------------------------------------------------------------
+// messages: members see every message, outsiders see none.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn messages_members_see_both_messages() {
+    let fx = setup_fixture().await;
+
+    let alice_count = rls_harness::with_api_viewer_tx(fx.alice.id, false, |conn| {
+        async move { Ok(count_rows(conn, "messages").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    let bob_count = rls_harness::with_api_viewer_tx(fx.bob.id, false, |conn| {
+        async move { Ok(count_rows(conn, "messages").await) }.scope_boxed()
+    })
+    .await
+    .expect("bob tx");
+    let carol_count = rls_harness::with_api_viewer_tx(fx.carol.id, false, |conn| {
+        async move { Ok(count_rows(conn, "messages").await) }.scope_boxed()
+    })
+    .await
+    .expect("carol tx");
+
+    assert_eq!(alice_count, 2);
+    assert_eq!(bob_count, 2);
+    assert_eq!(carol_count, 0, "Carol must not see the DM's messages");
+}
+
+// ---------------------------------------------------------------------------
+// messages UPDATE: only the sender can edit their own message even
+// though the recipient can SELECT it.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn messages_recipient_cannot_update_peers_message() {
+    let fx = setup_fixture().await;
+    let target = fx.bob_msg_id;
+
+    let affected = rls_harness::with_api_viewer_tx(fx.alice.id, false, move |conn| {
+        async move {
+            let sql = format!("UPDATE public.messages SET body = 'edit' WHERE id = '{target}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 0,
+        "messages_update must scope to sender only, not conversation membership"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn messages_recipient_cannot_delete_peers_message() {
+    let fx = setup_fixture().await;
+    let target = fx.bob_msg_id;
+
+    let affected = rls_harness::with_api_viewer_tx(fx.alice.id, false, move |conn| {
+        async move {
+            let sql = format!("DELETE FROM public.messages WHERE id = '{target}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(affected, 0, "messages_delete must scope to sender only");
+}
+
+// ---------------------------------------------------------------------------
+// message_reactions: visibility follows parent message; writes are
+// user-scoped.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn message_reactions_follow_message_visibility() {
+    let fx = setup_fixture().await;
+
+    // Seed: Alice reacts to Bob's message, Bob reacts to Alice's
+    // message. Both reactions live inside the DM.
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(message_reactions::table)
+            .values((
+                message_reactions::id.eq(Uuid::new_v4()),
+                message_reactions::message_id.eq(fx.bob_msg_id),
+                message_reactions::user_id.eq(fx.alice.id),
+                message_reactions::emoji.eq("👍"),
+                message_reactions::created_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("alice reaction");
+        diesel::insert_into(message_reactions::table)
+            .values((
+                message_reactions::id.eq(Uuid::new_v4()),
+                message_reactions::message_id.eq(fx.alice_msg_id),
+                message_reactions::user_id.eq(fx.bob.id),
+                message_reactions::emoji.eq("🙏"),
+                message_reactions::created_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("bob reaction");
+    }
+
+    let alice_count = rls_harness::with_api_viewer_tx(fx.alice.id, false, |conn| {
+        async move { Ok(count_rows(conn, "message_reactions").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    let carol_count = rls_harness::with_api_viewer_tx(fx.carol.id, false, |conn| {
+        async move { Ok(count_rows(conn, "message_reactions").await) }.scope_boxed()
+    })
+    .await
+    .expect("carol tx");
+
+    assert_eq!(
+        alice_count, 2,
+        "DM members see every reaction on the DM's messages"
+    );
+    assert_eq!(
+        carol_count, 0,
+        "Outsider sees no reactions even though the table has them"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Outsider cannot inject a message into a DM they aren't in.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn messages_outsider_cannot_insert() {
+    let fx = setup_fixture().await;
+    let dm_id = fx.dm_id;
+    let carol_id = fx.carol.id;
+
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(carol_id, false, move |conn| {
+            async move {
+                let now = Utc::now();
+                diesel::insert_into(messages::table)
+                    .values(&NewMessage {
+                        id: Uuid::new_v4(),
+                        conversation_id: dm_id,
+                        sender_id: carol_id,
+                        body: "intrusion".into(),
+                        kind: "text".into(),
+                        reply_to_id: None,
+                        client_id: None,
+                        created_at: now,
+                    })
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "messages_insert WITH CHECK must reject cross-conversation sends"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Anon: every chat table returns zero rows.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn anon_tx_sees_zero_chat_rows() {
+    let _ = setup_fixture().await;
+
+    for table in [
+        "conversations",
+        "conversation_members",
+        "messages",
+        "message_reactions",
+    ] {
+        let t = table.to_string();
+        let visible = rls_harness::with_api_viewer_tx(0, false, move |conn| {
+            async move { Ok(count_rows(conn, &t).await) }.scope_boxed()
+        })
+        .await
+        .expect("anon tx");
+        assert_eq!(visible, 0, "anon must see zero rows on public.{table}");
+    }
+}

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -402,6 +402,281 @@ async fn messages_outsider_cannot_insert() {
 }
 
 // ---------------------------------------------------------------------------
+// conversation_members INSERT is the most dangerous lever — if any
+// viewer can insert themselves into any conversation, the whole
+// membership boundary collapses. These negative tests pin the
+// tightened INSERT policy:
+//   * outsiders cannot self-join a random conversation
+//   * a DM participant cannot add a third party to their DM
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn conversation_members_outsider_cannot_self_join() {
+    let fx = setup_fixture().await;
+    let dm_id = fx.dm_id;
+    let carol_id = fx.carol.id;
+
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(carol_id, false, move |conn| {
+            async move {
+                let now = Utc::now();
+                diesel::insert_into(conversation_members::table)
+                    .values(&NewConversationMember {
+                        conversation_id: dm_id,
+                        user_id: carol_id,
+                        joined_at: now,
+                    })
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "conversation_members_insert must reject self-join into a DM the viewer isn't party to"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn conversation_members_dm_cannot_inject_third_party() {
+    let fx = setup_fixture().await;
+    let dm_id = fx.dm_id;
+    let alice_id = fx.alice.id;
+    let carol_id = fx.carol.id;
+
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+            async move {
+                let now = Utc::now();
+                diesel::insert_into(conversation_members::table)
+                    .values(&NewConversationMember {
+                        conversation_id: dm_id,
+                        user_id: carol_id,
+                        joined_at: now,
+                    })
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "conversation_members_insert DM branch must reject adding a user who isn't part of the DM pair"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PK-move trigger: a viewer UPDATEing their membership row to a
+// different conversation_id must fail loudly (RLS WITH CHECK can't
+// compare old vs new, so a BEFORE UPDATE trigger does the job).
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn conversation_members_pk_change_rejected() {
+    let fx = setup_fixture().await;
+    // Seed an unrelated conversation that Alice isn't a member of so
+    // she has a real target to try moving into.
+    let decoy_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(conversations::table)
+            .values(&NewConversation {
+                id: decoy_id,
+                kind: "dm".into(),
+                title: None,
+                event_id: None,
+                user_low_id: Some(fx.bob.id),
+                user_high_id: Some(fx.carol.id),
+                created_at: now,
+                updated_at: now,
+            })
+            .execute(&mut conn)
+            .await
+            .expect("seed decoy");
+    }
+
+    let alice_id = fx.alice.id;
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+            async move {
+                let sql = format!(
+                    "UPDATE public.conversation_members SET conversation_id = '{decoy_id}' \
+                     WHERE user_id = {alice_id}"
+                );
+                diesel::sql_query(sql).execute(conn).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "conversation_members PK-move trigger must reject conversation_id UPDATE"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Low-finding fix: leaving a conversation must revoke edit/delete
+// rights on past messages, not just SELECT visibility.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn messages_update_rejected_after_leaving_conversation() {
+    let fx = setup_fixture().await;
+    let alice_id = fx.alice.id;
+    let dm_id = fx.dm_id;
+    let alice_msg = fx.alice_msg_id;
+
+    // Alice leaves the DM via the owner pool (bypasses policies) so the
+    // test isolates the post-leave edit attempt from the "can Alice
+    // DELETE her own membership" policy question.
+    {
+        let mut conn = db::conn().await.expect("pool");
+        diesel::delete(
+            conversation_members::table
+                .filter(conversation_members::conversation_id.eq(dm_id))
+                .filter(conversation_members::user_id.eq(alice_id)),
+        )
+        .execute(&mut conn)
+        .await
+        .expect("remove alice membership");
+    }
+
+    let affected = rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+        async move {
+            let sql =
+                format!("UPDATE public.messages SET body = 'after-leave' WHERE id = '{alice_msg}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+
+    assert_eq!(
+        affected, 0,
+        "messages_update must require current membership, not just authorship"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Medium-finding fix: a viewer cannot update their own reaction onto
+// a message they cannot see. Attack shape: Alice owns a reaction on
+// Bob's message; there's also a hidden third-party message she
+// happens to know the UUID of. The UPDATE must fail.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn message_reactions_cannot_update_onto_hidden_message() {
+    let fx = setup_fixture().await;
+    let alice_id = fx.alice.id;
+    let bob_msg = fx.bob_msg_id;
+
+    // Seed a hidden conversation (Bob + Carol) + a message Alice can't see.
+    let hidden_conv = Uuid::new_v4();
+    let hidden_msg = Uuid::new_v4();
+    let reaction_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(conversations::table)
+            .values(&NewConversation {
+                id: hidden_conv,
+                kind: "dm".into(),
+                title: None,
+                event_id: None,
+                user_low_id: Some(fx.bob.id),
+                user_high_id: Some(fx.carol.id),
+                created_at: now,
+                updated_at: now,
+            })
+            .execute(&mut conn)
+            .await
+            .expect("seed hidden conv");
+        for uid in [fx.bob.id, fx.carol.id] {
+            diesel::insert_into(conversation_members::table)
+                .values(&NewConversationMember {
+                    conversation_id: hidden_conv,
+                    user_id: uid,
+                    joined_at: now,
+                })
+                .execute(&mut conn)
+                .await
+                .expect("seed hidden member");
+        }
+        diesel::insert_into(messages::table)
+            .values(&NewMessage {
+                id: hidden_msg,
+                conversation_id: hidden_conv,
+                sender_id: fx.bob.id,
+                body: "hidden".into(),
+                kind: "text".into(),
+                reply_to_id: None,
+                client_id: None,
+                created_at: now,
+            })
+            .execute(&mut conn)
+            .await
+            .expect("seed hidden message");
+
+        // Alice reacts to Bob's message in the DM she's in — fine.
+        diesel::insert_into(message_reactions::table)
+            .values((
+                message_reactions::id.eq(reaction_id),
+                message_reactions::message_id.eq(bob_msg),
+                message_reactions::user_id.eq(alice_id),
+                message_reactions::emoji.eq("👍"),
+                message_reactions::created_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed alice reaction");
+    }
+
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+            async move {
+                let sql = format!(
+                    "UPDATE public.message_reactions SET message_id = '{hidden_msg}' \
+                     WHERE id = '{reaction_id}'"
+                );
+                diesel::sql_query(sql).execute(conn).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    // WITH CHECK failure surfaces as a diesel::result::Error::DatabaseError;
+    // empty match + raw affected count both mean the row wasn't moved.
+    if result.is_ok() {
+        let mut conn = db::conn().await.expect("pool");
+        let row: CountRow = diesel::sql_query(
+            "SELECT COUNT(*) AS count FROM public.message_reactions \
+             WHERE id = $1 AND message_id = $2",
+        )
+        .bind::<diesel::sql_types::Uuid, _>(reaction_id)
+        .bind::<diesel::sql_types::Uuid, _>(hidden_msg)
+        .get_result(&mut conn)
+        .await
+        .expect("post-check query");
+        assert_eq!(
+            row.count, 0,
+            "message_reactions UPDATE must not move a reaction onto a hidden message"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Anon: every chat table returns zero rows.
 // ---------------------------------------------------------------------------
 #[tokio::test]

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -769,6 +769,60 @@ async fn event_conversation_insert_rejects_pending_attendee() {
 }
 
 // ---------------------------------------------------------------------------
+// message_reactions PK-change trigger: a viewer cannot move their
+// reaction to another message — even one they can see in a shared
+// conversation. Defends against cross-conversation reaction injection
+// where USING (old row visible) + WITH CHECK (new row visible) both
+// pass but the semantics shift.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn message_reactions_message_id_change_rejected() {
+    let fx = setup_fixture().await;
+    let alice_id = fx.alice.id;
+
+    // Alice reacts to Bob's message in their shared DM — both
+    // messages are visible to her, so the attack target is a valid
+    // move under RLS predicates alone.
+    let reaction_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        diesel::insert_into(message_reactions::table)
+            .values((
+                message_reactions::id.eq(reaction_id),
+                message_reactions::message_id.eq(fx.bob_msg_id),
+                message_reactions::user_id.eq(alice_id),
+                message_reactions::emoji.eq("🎉"),
+                message_reactions::created_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed reaction");
+    }
+
+    let target_msg = fx.alice_msg_id;
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+            async move {
+                let sql = format!(
+                    "UPDATE public.message_reactions SET message_id = '{target_msg}' \
+                     WHERE id = '{reaction_id}'"
+                );
+                diesel::sql_query(sql).execute(conn).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "message_reactions trigger must reject message_id UPDATE even to a visible message"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // messages PK-change trigger: the sender must not be able to move
 // their own message to another conversation they're also in. RLS can
 // only evaluate the final row, so a `BEFORE UPDATE` trigger enforces

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -769,6 +769,68 @@ async fn event_conversation_insert_rejects_pending_attendee() {
 }
 
 // ---------------------------------------------------------------------------
+// API role must not be able to UPDATE or DELETE whole conversation
+// rows. A naive member-only UPDATE/DELETE policy would let any chat
+// participant nuke the room for everyone via ON DELETE CASCADE
+// through conversation_members / messages / message_reactions.
+// Legitimate event-chat cleanup routes through
+// app.delete_event_and_chat() instead.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn conversations_member_cannot_delete() {
+    let fx = setup_fixture().await;
+    let alice_id = fx.alice.id;
+    let dm_id = fx.dm_id;
+
+    let affected = rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+        async move {
+            let sql = format!("DELETE FROM public.conversations WHERE id = '{dm_id}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 0,
+        "no conversations_delete policy — member DELETE must be a no-op"
+    );
+
+    let mut conn = db::conn().await.expect("pool");
+    let row: CountRow =
+        diesel::sql_query("SELECT COUNT(*) AS count FROM public.conversations WHERE id = $1")
+            .bind::<diesel::sql_types::Uuid, _>(dm_id)
+            .get_result(&mut conn)
+            .await
+            .expect("post-check");
+    assert_eq!(row.count, 1, "DM row must still exist");
+}
+
+#[tokio::test]
+#[serial]
+async fn conversations_member_cannot_update_metadata() {
+    let fx = setup_fixture().await;
+    let alice_id = fx.alice.id;
+    let dm_id = fx.dm_id;
+
+    let affected = rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+        async move {
+            let sql =
+                format!("UPDATE public.conversations SET title = 'tampered' WHERE id = '{dm_id}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 0,
+        "no conversations_update policy — member UPDATE must be a no-op"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // conversations identity-column trigger: a DM member cannot silently
 // enrol a third party by swapping user_high_id, and cannot flip
 // kind / event_id to switch which conversation_members_insert branch
@@ -782,42 +844,41 @@ async fn conversations_identity_change_rejected() {
     let dm_id = fx.dm_id;
     let carol_id = fx.carol.id;
 
-    // Alice tries to replace Bob with Carol as the DM's high-id peer.
-    let result: Result<(), diesel::result::Error> =
-        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
-            async move {
-                let sql = format!(
-                    "UPDATE public.conversations SET user_high_id = {carol_id} \
-                     WHERE id = '{dm_id}'"
-                );
-                diesel::sql_query(sql).execute(conn).await?;
-                Ok(())
-            }
-            .scope_boxed()
-        })
-        .await;
-
-    assert!(
-        result.is_err(),
-        "conversations identity trigger must reject user_high_id UPDATE"
+    // With no conversations_update policy, the member's UPDATE just
+    // filters to zero rows — the identity trigger doesn't fire at all
+    // from the API role path. We assert the mutation didn't land;
+    // that's the property that matters. (The trigger still defends
+    // owner / worker paths from accidental identity-column changes.)
+    let affected = rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+        async move {
+            let sql = format!(
+                "UPDATE public.conversations SET user_high_id = {carol_id} \
+                 WHERE id = '{dm_id}'"
+            );
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 0,
+        "API role must not be able to reassign DM pair members"
     );
 
-    // Same viewer, different field — kind flip must also error.
-    let result2: Result<(), diesel::result::Error> =
-        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
-            async move {
-                let sql =
-                    format!("UPDATE public.conversations SET kind = 'event' WHERE id = '{dm_id}'");
-                diesel::sql_query(sql).execute(conn).await?;
-                Ok(())
-            }
-            .scope_boxed()
-        })
-        .await;
-
-    assert!(
-        result2.is_err(),
-        "conversations identity trigger must reject kind UPDATE"
+    let affected_kind = rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+        async move {
+            let sql =
+                format!("UPDATE public.conversations SET kind = 'event' WHERE id = '{dm_id}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx 2");
+    assert_eq!(
+        affected_kind, 0,
+        "API role must not be able to flip conversation kind"
     );
 }
 

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -769,6 +769,78 @@ async fn event_conversation_insert_rejects_pending_attendee() {
 }
 
 // ---------------------------------------------------------------------------
+// messages PK-change trigger: the sender must not be able to move
+// their own message to another conversation they're also in. RLS can
+// only evaluate the final row, so a `BEFORE UPDATE` trigger enforces
+// conversation_id + sender_id immutability alongside the RLS policy.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn messages_conversation_id_change_rejected() {
+    let fx = setup_fixture().await;
+    let alice_id = fx.alice.id;
+    let alice_msg = fx.alice_msg_id;
+
+    // Spin up a second DM (Alice + Carol) that Alice is a member of,
+    // so her UPDATE has a legitimate target the WITH CHECK would
+    // otherwise accept.
+    let other_conv_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        let pair: [i32; 2] = if alice_id < fx.carol.id {
+            [alice_id, fx.carol.id]
+        } else {
+            [fx.carol.id, alice_id]
+        };
+        diesel::insert_into(conversations::table)
+            .values(&NewConversation {
+                id: other_conv_id,
+                kind: "dm".into(),
+                title: None,
+                event_id: None,
+                user_low_id: Some(pair[0]),
+                user_high_id: Some(pair[1]),
+                created_at: now,
+                updated_at: now,
+            })
+            .execute(&mut conn)
+            .await
+            .expect("seed second dm");
+        for uid in pair {
+            diesel::insert_into(conversation_members::table)
+                .values(&NewConversationMember {
+                    conversation_id: other_conv_id,
+                    user_id: uid,
+                    joined_at: now,
+                })
+                .execute(&mut conn)
+                .await
+                .expect("seed second dm member");
+        }
+    }
+
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+            async move {
+                let sql = format!(
+                    "UPDATE public.messages SET conversation_id = '{other_conv_id}' \
+                     WHERE id = '{alice_msg}'"
+                );
+                diesel::sql_query(sql).execute(conn).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "messages trigger must reject cross-conversation UPDATE of conversation_id"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Positive event-chat join flow: a going attendee who is not yet a
 // member of the event conversation can discover the existing row via
 // the SD lookup helper AND self-insert their membership. This

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -37,6 +37,12 @@ struct CountRow {
     count: i64,
 }
 
+#[derive(diesel::deserialize::QueryableByName)]
+struct NullableIdRow {
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Uuid>)]
+    id: Option<Uuid>,
+}
+
 struct Fixture {
     alice: User,
     bob: User,
@@ -760,6 +766,150 @@ async fn event_conversation_insert_rejects_pending_attendee() {
         result.is_err(),
         "conversations_insert must reject event chat creation for a pending attendee"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Positive event-chat join flow: a going attendee who is not yet a
+// member of the event conversation can discover the existing row via
+// the SD lookup helper AND self-insert their membership. This
+// exercises the intersection of:
+//   * find_event_conversation — must return the row even though the
+//     viewer isn't yet a member (access gated on `viewer_can_access_event`)
+//   * conversation_members_insert — must allow self-join for a going
+//     attendee via the `conversation_meta_for_insert` SD helper
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn event_conversation_going_attendee_can_join_existing() {
+    let fx = setup_fixture().await;
+    let bob_id = fx.bob.id;
+    let carol_id = fx.carol.id;
+
+    // Bob owns the event; the conversation already exists with Bob as
+    // the only member. Carol is a `going` attendee — she should be
+    // able to find the conversation and self-insert a membership row.
+    let event_id = Uuid::new_v4();
+    let event_conv_id = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+        let bob_profile_id = profiles::table
+            .filter(profiles::user_id.eq(bob_id))
+            .select(profiles::id)
+            .first::<Uuid>(&mut conn)
+            .await
+            .expect("bob profile");
+        let carol_profile_id = profiles::table
+            .filter(profiles::user_id.eq(carol_id))
+            .select(profiles::id)
+            .first::<Uuid>(&mut conn)
+            .await
+            .expect("carol profile");
+
+        diesel::insert_into(events::table)
+            .values((
+                events::id.eq(event_id),
+                events::title.eq("Join-Test"),
+                events::starts_at.eq(now + chrono::Duration::days(1)),
+                events::creator_id.eq(bob_profile_id),
+                events::created_at.eq(now),
+                events::updated_at.eq(now),
+                events::requires_approval.eq(false),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed event");
+        diesel::insert_into(event_attendees::table)
+            .values((
+                event_attendees::event_id.eq(event_id),
+                event_attendees::profile_id.eq(carol_profile_id),
+                event_attendees::status.eq("going"),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed carol attendance");
+
+        diesel::insert_into(conversations::table)
+            .values(&NewConversation {
+                id: event_conv_id,
+                kind: "event".into(),
+                title: Some("Join-Test".into()),
+                event_id: Some(event_id),
+                user_low_id: None,
+                user_high_id: None,
+                created_at: now,
+                updated_at: now,
+            })
+            .execute(&mut conn)
+            .await
+            .expect("seed event conv");
+        diesel::insert_into(conversation_members::table)
+            .values(&NewConversationMember {
+                conversation_id: event_conv_id,
+                user_id: bob_id,
+                joined_at: now,
+            })
+            .execute(&mut conn)
+            .await
+            .expect("seed bob membership");
+    }
+
+    let lookup_id = rls_harness::with_api_viewer_tx(carol_id, false, move |conn| {
+        async move {
+            let row: NullableIdRow =
+                diesel::sql_query("SELECT id FROM app.find_event_conversation($1) LIMIT 1")
+                    .bind::<diesel::sql_types::Uuid, _>(event_id)
+                    .get_result(conn)
+                    .await
+                    .unwrap_or(NullableIdRow { id: None });
+            Ok(row.id)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("carol lookup tx");
+    assert_eq!(
+        lookup_id,
+        Some(event_conv_id),
+        "find_event_conversation must return the existing row for a going attendee"
+    );
+
+    // Self-insert must succeed.
+    let insert_result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(carol_id, false, move |conn| {
+            async move {
+                let now = Utc::now();
+                diesel::insert_into(conversation_members::table)
+                    .values(&NewConversationMember {
+                        conversation_id: event_conv_id,
+                        user_id: carol_id,
+                        joined_at: now,
+                    })
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        insert_result.is_ok(),
+        "going attendee must be allowed to self-insert into the event conversation: {insert_result:?}"
+    );
+
+    // Confirm Carol is now visible as a member via the owner pool.
+    let mut conn = db::conn().await.expect("pool");
+    let row: CountRow = diesel::sql_query(
+        "SELECT COUNT(*) AS count FROM public.conversation_members \
+         WHERE conversation_id = $1 AND user_id = $2",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(event_conv_id)
+    .bind::<diesel::sql_types::Integer, _>(carol_id)
+    .get_result(&mut conn)
+    .await
+    .expect("post-check");
+    assert_eq!(row.count, 1, "Carol's membership row must be persisted");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**Tier-B policies — RLS goes live for chat**

Second tier of row-level-security enforcement. Every chat handler is already wrapped in `db::with_viewer_tx`, so turning on membership-scoped policies doesn't require API code changes.

- [x] migration `2026-04-19-020000_rls_tier_b_policies` applies cleanly (8 helpers + ENABLE/FORCE/per-command policies × 4 tables + 4 immutability triggers)
- [x] `rls_baseline` canaries assert Tier-B tables have RLS ENABLED + FORCED + `<table>_viewer` policy attached to `poziomki_api`
- [x] DM members see their conversation, both membership rows, and every message; outsiders see zero
- [x] sender-only `UPDATE`/`DELETE` on `messages` — recipient can read but not mutate peer's message
- [x] reactions follow parent-message visibility via `app.viewer_can_see_message`
- [x] outsider cannot `INSERT` a message into a DM they aren't in (WITH CHECK denies)
- [x] anon viewer sees zero rows across all four chat tables
- [x] DM INSERT branch validates both viewer-in-pair AND inserted user_id-in-pair; third-party injection rejected
- [x] event chat INSERT requires `status='going'` attendance via `app.viewer_can_access_event`; pending attendees rejected
- [x] going attendee can discover + self-join an existing event chat even before membership (SD lookup helpers bypass RLS)
- [x] PK / identity columns pinned by BEFORE UPDATE triggers on `conversations`, `conversation_members`, `messages`, `message_reactions`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Tier B membership-scoped RLS policies to chat tables
> - Enables and forces RLS on `conversations`, `conversation_members`, `messages`, and `message_reactions`, scoping SELECT/INSERT/UPDATE/DELETE to membership and authorship via named policies.
> - Adds `SECURITY DEFINER` helper functions in the `app` schema (e.g. `viewer_conversation_ids`, `find_dm_conversation`, `find_event_conversation`) to support policy predicates and resolve-or-create flows that must bypass RLS before membership exists.
> - Updates `resolve_or_create_dm` and `resolve_or_create_event_conversation` in [conversations.rs](https://github.com/poziomki-app/poziomki/pull/187/files#diff-5a9a538ec12a48526c8fde752b98cccf545f577ca7b816e6e57820607ce81c62) to use the new SD helpers instead of direct Diesel queries, ensuring existing conversations are found even before membership is inserted.
> - Replaces direct DML in [write_repo.rs](https://github.com/poziomki-app/poziomki/pull/187/files#diff-db34ea3d4fe3d1c25d8103cda5857d57ef21e7d5785cd6776f1873de31181b13) with a call to `app.delete_event_and_chat()`, which authorizes deletion by event creator and cascades chat cleanup via FKs.
> - Adds immutability triggers to pin PK and identity columns on all four tables, and a comprehensive [rls_tier_b.rs](https://github.com/poziomki-app/poziomki/pull/187/files#diff-a29745bb6d17f818e87f8df3f76ad0b08a1bd43a2d4a43e4a1eb3f8a887cb2a4) test suite covering visibility scoping, mutation constraints, and edge cases.
> - Behavioral Change: all chat table access is now gated by RLS; existing queries running as `poziomki_api` or `poziomki_worker` without membership will return zero rows instead of full table results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c03ad3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->