### PR TITLE
sec(rls): Tier C policies on events, event_attendees, uploads

### DIFF
--- a/backend/migrations/2026-04-19-030000_rls_tier_c_policies/down.sql
+++ b/backend/migrations/2026-04-19-030000_rls_tier_c_policies/down.sql
@@ -13,6 +13,7 @@ DROP POLICY IF EXISTS event_attendees_insert ON public.event_attendees;
 DROP POLICY IF EXISTS event_attendees_viewer ON public.event_attendees;
 ALTER TABLE public.event_attendees
     DROP CONSTRAINT IF EXISTS event_attendees_status_valid;
+DROP FUNCTION IF EXISTS app.event_auto_approves(uuid);
 DROP FUNCTION IF EXISTS app.viewer_owns_event(uuid);
 
 DROP TRIGGER IF EXISTS events_identity_immutable ON public.events;

--- a/backend/migrations/2026-04-19-030000_rls_tier_c_policies/down.sql
+++ b/backend/migrations/2026-04-19-030000_rls_tier_c_policies/down.sql
@@ -11,6 +11,9 @@ DROP POLICY IF EXISTS event_attendees_delete ON public.event_attendees;
 DROP POLICY IF EXISTS event_attendees_update ON public.event_attendees;
 DROP POLICY IF EXISTS event_attendees_insert ON public.event_attendees;
 DROP POLICY IF EXISTS event_attendees_viewer ON public.event_attendees;
+ALTER TABLE public.event_attendees
+    DROP CONSTRAINT IF EXISTS event_attendees_status_valid;
+DROP FUNCTION IF EXISTS app.viewer_owns_event(uuid);
 
 DROP TRIGGER IF EXISTS events_identity_immutable ON public.events;
 DROP FUNCTION IF EXISTS app.reject_events_identity_change();

--- a/backend/migrations/2026-04-19-030000_rls_tier_c_policies/down.sql
+++ b/backend/migrations/2026-04-19-030000_rls_tier_c_policies/down.sql
@@ -1,0 +1,27 @@
+DROP TRIGGER IF EXISTS uploads_identity_immutable ON public.uploads;
+DROP FUNCTION IF EXISTS app.reject_uploads_identity_change();
+DROP POLICY IF EXISTS uploads_delete ON public.uploads;
+DROP POLICY IF EXISTS uploads_update ON public.uploads;
+DROP POLICY IF EXISTS uploads_insert ON public.uploads;
+DROP POLICY IF EXISTS uploads_viewer ON public.uploads;
+
+DROP TRIGGER IF EXISTS event_attendees_pk_immutable ON public.event_attendees;
+DROP FUNCTION IF EXISTS app.reject_event_attendees_pk_change();
+DROP POLICY IF EXISTS event_attendees_delete ON public.event_attendees;
+DROP POLICY IF EXISTS event_attendees_update ON public.event_attendees;
+DROP POLICY IF EXISTS event_attendees_insert ON public.event_attendees;
+DROP POLICY IF EXISTS event_attendees_viewer ON public.event_attendees;
+
+DROP TRIGGER IF EXISTS events_identity_immutable ON public.events;
+DROP FUNCTION IF EXISTS app.reject_events_identity_change();
+DROP POLICY IF EXISTS events_delete ON public.events;
+DROP POLICY IF EXISTS events_update ON public.events;
+DROP POLICY IF EXISTS events_insert ON public.events;
+DROP POLICY IF EXISTS events_viewer ON public.events;
+
+ALTER TABLE public.uploads NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.uploads DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_attendees NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.event_attendees DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.events NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.events DISABLE ROW LEVEL SECURITY;

--- a/backend/migrations/2026-04-19-030000_rls_tier_c_policies/up.sql
+++ b/backend/migrations/2026-04-19-030000_rls_tier_c_policies/up.sql
@@ -64,12 +64,65 @@ CREATE TRIGGER events_identity_immutable
     FOR EACH ROW
     EXECUTE FUNCTION app.reject_events_identity_change();
 
+-- Event ownership helper — true iff the viewer's profile is the
+-- creator of the given event. Used by event_attendees write policies
+-- so the creator can approve / reject / delete pending attendees even
+-- though the affected row isn't their own attendance.
+CREATE OR REPLACE FUNCTION app.viewer_owns_event(p_event_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT app.current_user_id() > 0 AND EXISTS (
+        SELECT 1
+        FROM public.events e
+        JOIN public.profiles p ON p.id = e.creator_id
+        WHERE e.id = p_event_id
+          AND p.user_id = app.current_user_id()
+    )
+$$;
+
+COMMENT ON FUNCTION app.viewer_owns_event(uuid) IS
+    'True iff the viewer owns the given event. Narrower than viewer_can_access_event (which also admits going attendees) — used for creator-only mutations on the attendee roster.';
+
+REVOKE EXECUTE ON FUNCTION app.viewer_owns_event(uuid) FROM PUBLIC;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_owns_event(uuid) TO poziomki_api';
+    END IF;
+END
+$$;
+
+-- Row-level status shape check so a direct API-role caller can't set
+-- status to an unknown value; transition semantics (approval,
+-- capacity) stay app-layer, but the allowed-status set is constrained
+-- at the DB so RLS + this CHECK cover the raw DML surface.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'event_attendees_status_valid'
+          AND conrelid = 'public.event_attendees'::regclass
+    ) THEN
+        ALTER TABLE public.event_attendees
+            ADD CONSTRAINT event_attendees_status_valid
+            CHECK (status IN ('pending', 'going', 'declined', 'waitlist'));
+    END IF;
+END
+$$;
+
 -- ---------------------------------------------------------------------------
 -- event_attendees
 --
 -- Reads same-bucket so an attendee roster is answerable for any event
--- in the viewer's bucket. Writes own-profile only — a viewer can add,
--- update (status), or remove their own attendance, nothing else.
+-- in the viewer's bucket. Writes allowed when:
+--   * profile_id is one of the viewer's own profiles (self attendance
+--     — join, leave, update own status), OR
+--   * the viewer owns the event (creator approves / rejects / deletes
+--     pending attendees; handler enforces capacity + approval rules).
 -- ---------------------------------------------------------------------------
 ALTER TABLE public.event_attendees ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.event_attendees FORCE ROW LEVEL SECURITY;
@@ -82,17 +135,29 @@ CREATE POLICY event_attendees_insert ON public.event_attendees
     FOR INSERT TO poziomki_api
     WITH CHECK (
         app.current_user_id() > 0
-        AND profile_id IN (SELECT id FROM app.viewer_profile_ids())
+        AND (
+            profile_id IN (SELECT id FROM app.viewer_profile_ids())
+            OR app.viewer_owns_event(event_id)
+        )
     );
 
 CREATE POLICY event_attendees_update ON public.event_attendees
     FOR UPDATE TO poziomki_api
-    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()))
-    WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+    USING (
+        profile_id IN (SELECT id FROM app.viewer_profile_ids())
+        OR app.viewer_owns_event(event_id)
+    )
+    WITH CHECK (
+        profile_id IN (SELECT id FROM app.viewer_profile_ids())
+        OR app.viewer_owns_event(event_id)
+    );
 
 CREATE POLICY event_attendees_delete ON public.event_attendees
     FOR DELETE TO poziomki_api
-    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+    USING (
+        profile_id IN (SELECT id FROM app.viewer_profile_ids())
+        OR app.viewer_owns_event(event_id)
+    );
 
 CREATE OR REPLACE FUNCTION app.reject_event_attendees_pk_change()
 RETURNS trigger

--- a/backend/migrations/2026-04-19-030000_rls_tier_c_policies/up.sql
+++ b/backend/migrations/2026-04-19-030000_rls_tier_c_policies/up.sql
@@ -1,0 +1,181 @@
+-- Tier C: enable RLS on events, event_attendees, and uploads. Reuses
+-- the Tier-A SD helpers (profiles_in_current_bucket, viewer_profile_ids)
+-- since these tables are scoped by profile ownership / stub bucket.
+--
+-- Shape of the policies (per-command so SELECT visibility doesn't
+-- leak into UPDATE / DELETE permission — same lesson as Tier A):
+--   * events — same-bucket read, creator-only write
+--   * event_attendees — same-bucket read, own-profile write
+--   * uploads — public / same-bucket read (anon avatars need to
+--     render without auth), owner-only write
+--
+-- Identity columns on events (id, creator_id) and event_attendees
+-- (event_id, profile_id) are pinned via BEFORE UPDATE triggers so a
+-- viewer can't retarget their own row into another creator's /
+-- event's namespace.
+
+-- ---------------------------------------------------------------------------
+-- events
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.events FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY events_viewer ON public.events
+    FOR SELECT TO poziomki_api
+    USING (creator_id IN (SELECT id FROM app.profiles_in_current_bucket()));
+
+CREATE POLICY events_insert ON public.events
+    FOR INSERT TO poziomki_api
+    WITH CHECK (
+        app.current_user_id() > 0
+        AND creator_id IN (SELECT id FROM app.viewer_profile_ids())
+    );
+
+CREATE POLICY events_update ON public.events
+    FOR UPDATE TO poziomki_api
+    USING (creator_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (creator_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+CREATE POLICY events_delete ON public.events
+    FOR DELETE TO poziomki_api
+    USING (creator_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+-- events.creator_id pinned — a viewer can't hand their event to
+-- another profile via UPDATE to escape later policy checks, and id
+-- must stay stable so attendees + conversations continue resolving.
+CREATE OR REPLACE FUNCTION app.reject_events_identity_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.creator_id IS DISTINCT FROM OLD.creator_id THEN
+        RAISE EXCEPTION
+            'events (id, creator_id) are immutable';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS events_identity_immutable ON public.events;
+CREATE TRIGGER events_identity_immutable
+    BEFORE UPDATE ON public.events
+    FOR EACH ROW
+    EXECUTE FUNCTION app.reject_events_identity_change();
+
+-- ---------------------------------------------------------------------------
+-- event_attendees
+--
+-- Reads same-bucket so an attendee roster is answerable for any event
+-- in the viewer's bucket. Writes own-profile only — a viewer can add,
+-- update (status), or remove their own attendance, nothing else.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.event_attendees ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_attendees FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY event_attendees_viewer ON public.event_attendees
+    FOR SELECT TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.profiles_in_current_bucket()));
+
+CREATE POLICY event_attendees_insert ON public.event_attendees
+    FOR INSERT TO poziomki_api
+    WITH CHECK (
+        app.current_user_id() > 0
+        AND profile_id IN (SELECT id FROM app.viewer_profile_ids())
+    );
+
+CREATE POLICY event_attendees_update ON public.event_attendees
+    FOR UPDATE TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+CREATE POLICY event_attendees_delete ON public.event_attendees
+    FOR DELETE TO poziomki_api
+    USING (profile_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+CREATE OR REPLACE FUNCTION app.reject_event_attendees_pk_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.event_id IS DISTINCT FROM OLD.event_id
+       OR NEW.profile_id IS DISTINCT FROM OLD.profile_id THEN
+        RAISE EXCEPTION
+            'event_attendees primary key is immutable';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS event_attendees_pk_immutable ON public.event_attendees;
+CREATE TRIGGER event_attendees_pk_immutable
+    BEFORE UPDATE ON public.event_attendees
+    FOR EACH ROW
+    EXECUTE FUNCTION app.reject_event_attendees_pk_change();
+
+-- ---------------------------------------------------------------------------
+-- uploads
+--
+-- SELECT is looser than events / attendees because anon avatar URLs
+-- (profile_picture on a profile that's in the viewer's bucket) need
+-- to resolve against uploads. owner_id NULL covers system / anon
+-- uploads; owner_id in the viewer's bucket covers real-user avatars.
+--
+-- Writes are owner-only: INSERT accepts NULL owner (for signup-time
+-- avatars where no profile exists yet) or the viewer's profile ids.
+-- UPDATE / DELETE require the viewer owns the row.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.uploads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.uploads FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY uploads_viewer ON public.uploads
+    FOR SELECT TO poziomki_api
+    USING (
+        owner_id IS NULL
+        OR owner_id IN (SELECT id FROM app.profiles_in_current_bucket())
+    );
+
+CREATE POLICY uploads_insert ON public.uploads
+    FOR INSERT TO poziomki_api
+    WITH CHECK (
+        app.current_user_id() > 0
+        AND (
+            owner_id IS NULL
+            OR owner_id IN (SELECT id FROM app.viewer_profile_ids())
+        )
+    );
+
+CREATE POLICY uploads_update ON public.uploads
+    FOR UPDATE TO poziomki_api
+    USING (owner_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (owner_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+CREATE POLICY uploads_delete ON public.uploads
+    FOR DELETE TO poziomki_api
+    USING (owner_id IN (SELECT id FROM app.viewer_profile_ids()));
+
+-- uploads.id + owner_id pinned. Letting owner_id drift via UPDATE
+-- would let a viewer adopt anon uploads or reassign to any profile
+-- they own; id must stay stable for the S3 key mapping.
+CREATE OR REPLACE FUNCTION app.reject_uploads_identity_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.owner_id IS DISTINCT FROM OLD.owner_id THEN
+        RAISE EXCEPTION
+            'uploads (id, owner_id) are immutable';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS uploads_identity_immutable ON public.uploads;
+CREATE TRIGGER uploads_identity_immutable
+    BEFORE UPDATE ON public.uploads
+    FOR EACH ROW
+    EXECUTE FUNCTION app.reject_uploads_identity_change();

--- a/backend/migrations/2026-04-19-030000_rls_tier_c_policies/up.sql
+++ b/backend/migrations/2026-04-19-030000_rls_tier_c_policies/up.sql
@@ -87,11 +87,33 @@ $$;
 COMMENT ON FUNCTION app.viewer_owns_event(uuid) IS
     'True iff the viewer owns the given event. Narrower than viewer_can_access_event (which also admits going attendees) — used for creator-only mutations on the attendee roster.';
 
+-- Auto-approval helper — true iff the event doesn't require approval.
+-- Used by the self-write branch so a raw API-role caller can't
+-- self-insert as status='going' for an approval-gated event (which
+-- would also unlock its event-chat via Tier-B's viewer_can_access_event).
+CREATE OR REPLACE FUNCTION app.event_auto_approves(p_event_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+    SELECT NOT COALESCE(
+        (SELECT requires_approval FROM public.events WHERE id = p_event_id),
+        true
+    )
+$$;
+
+COMMENT ON FUNCTION app.event_auto_approves(uuid) IS
+    'True iff the event exists and requires_approval = false — i.e. a join can land as `going` without creator approval.';
+
 REVOKE EXECUTE ON FUNCTION app.viewer_owns_event(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION app.event_auto_approves(uuid) FROM PUBLIC;
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
         EXECUTE 'GRANT EXECUTE ON FUNCTION app.viewer_owns_event(uuid) TO poziomki_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.event_auto_approves(uuid) TO poziomki_api';
     END IF;
 END
 $$;
@@ -109,7 +131,9 @@ BEGIN
     ) THEN
         ALTER TABLE public.event_attendees
             ADD CONSTRAINT event_attendees_status_valid
-            CHECK (status IN ('pending', 'going', 'declined', 'waitlist'));
+            CHECK (status IN (
+                'pending', 'going', 'declined', 'waitlist', 'interested', 'invited'
+            ));
     END IF;
 END
 $$;
@@ -131,13 +155,27 @@ CREATE POLICY event_attendees_viewer ON public.event_attendees
     FOR SELECT TO poziomki_api
     USING (profile_id IN (SELECT id FROM app.profiles_in_current_bucket()));
 
+-- Two write branches:
+--   * self — viewer writes own attendance row; status restricted so
+--     a direct API-role caller can't self-join as `going` into an
+--     approval-gated event (that also gates Tier-B event-chat
+--     access via viewer_can_access_event).
+--   * creator — event owner writes attendee rows for their event;
+--     status set is full (approval, rejection, invites), but
+--     profile_id must be in the viewer's stub bucket so a creator
+--     can't fabricate cross-bucket attendance rows.
 CREATE POLICY event_attendees_insert ON public.event_attendees
     FOR INSERT TO poziomki_api
     WITH CHECK (
         app.current_user_id() > 0
         AND (
-            profile_id IN (SELECT id FROM app.viewer_profile_ids())
-            OR app.viewer_owns_event(event_id)
+            (profile_id IN (SELECT id FROM app.viewer_profile_ids())
+             AND (
+                 status IN ('pending', 'declined', 'waitlist', 'interested')
+                 OR (status = 'going' AND app.event_auto_approves(event_id))
+             ))
+            OR (app.viewer_owns_event(event_id)
+                AND profile_id IN (SELECT id FROM app.profiles_in_current_bucket()))
         )
     );
 
@@ -145,18 +183,25 @@ CREATE POLICY event_attendees_update ON public.event_attendees
     FOR UPDATE TO poziomki_api
     USING (
         profile_id IN (SELECT id FROM app.viewer_profile_ids())
-        OR app.viewer_owns_event(event_id)
+        OR (app.viewer_owns_event(event_id)
+            AND profile_id IN (SELECT id FROM app.profiles_in_current_bucket()))
     )
     WITH CHECK (
-        profile_id IN (SELECT id FROM app.viewer_profile_ids())
-        OR app.viewer_owns_event(event_id)
+        (profile_id IN (SELECT id FROM app.viewer_profile_ids())
+         AND (
+             status IN ('pending', 'declined', 'waitlist', 'interested')
+             OR (status = 'going' AND app.event_auto_approves(event_id))
+         ))
+        OR (app.viewer_owns_event(event_id)
+            AND profile_id IN (SELECT id FROM app.profiles_in_current_bucket()))
     );
 
 CREATE POLICY event_attendees_delete ON public.event_attendees
     FOR DELETE TO poziomki_api
     USING (
         profile_id IN (SELECT id FROM app.viewer_profile_ids())
-        OR app.viewer_owns_event(event_id)
+        OR (app.viewer_owns_event(event_id)
+            AND profile_id IN (SELECT id FROM app.profiles_in_current_bucket()))
     );
 
 CREATE OR REPLACE FUNCTION app.reject_event_attendees_pk_change()

--- a/backend/tests/requests/mod.rs
+++ b/backend/tests/requests/mod.rs
@@ -4,4 +4,5 @@ mod rls_baseline;
 mod rls_harness;
 mod rls_tier_a;
 mod rls_tier_b;
+mod rls_tier_c;
 mod rls_visibility;

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -77,6 +77,8 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "profiles_in_current_bucket",
     "push_topics_for_users",
     "resolve_session",
+    // Tier-C policy-support helpers.
+    "viewer_owns_event",
     // Tier-B policy-support helpers.
     "conversation_meta_for_insert",
     "delete_event_and_chat",

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -78,6 +78,7 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     "push_topics_for_users",
     "resolve_session",
     // Tier-C policy-support helpers.
+    "event_auto_approves",
     "viewer_owns_event",
     // Tier-B policy-support helpers.
     "conversation_meta_for_insert",

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -48,12 +48,14 @@ const EXPECTED_TIER_B_TABLES: &[&str] = &[
     "message_reactions",
 ];
 
-const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[
-    // Tier C — events, attendance, uploads
-    "events",
-    "event_attendees",
-    "uploads",
-];
+/// Tier-C tables (events, attendance, uploads). Same shape as Tier-A
+/// and Tier-B: ENABLED + FORCED + `<table>_viewer` SELECT policy on
+/// `poziomki_api`.
+const EXPECTED_TIER_C_TABLES: &[&str] = &["events", "event_attendees", "uploads"];
+
+/// No tables remaining in the "RLS still off" canary — every table
+/// the plan protects is now locked down.
+const EXPECTED_RLS_DISABLED_TABLES: &[&str] = &[];
 
 /// SD helpers installed by the 010000..070000 migration series. Every
 /// entry must carry `search_path=pg_catalog, pg_temp` so the `pg_temp`
@@ -138,6 +140,7 @@ async fn api_role_has_dml_on_all_protected_tables() {
     let all_tables = EXPECTED_TIER_A_TABLES
         .iter()
         .chain(EXPECTED_TIER_B_TABLES.iter())
+        .chain(EXPECTED_TIER_C_TABLES.iter())
         .chain(EXPECTED_RLS_DISABLED_TABLES.iter());
     for table in all_tables {
         let grants = rls_harness::role_privileges("poziomki_api", table).await;
@@ -310,6 +313,56 @@ async fn tier_b_tables_have_named_policy_on_api_role() {
         assert!(
             matched.roles.iter().any(|r| r == "poziomki_api"),
             "Tier-B policy {expected_name} on public.{table} must target poziomki_api (targets: {:?})",
+            matched.roles
+        );
+    }
+}
+
+/// Tier-C canary: `events`, `event_attendees`, `uploads` have RLS
+/// ENABLED + FORCED + `<table>_viewer` SELECT policy.
+#[tokio::test]
+#[serial]
+async fn tier_c_tables_have_rls_enabled_and_forced() {
+    setup();
+    let mut missing_enabled = Vec::new();
+    let mut missing_forced = Vec::new();
+    for table in EXPECTED_TIER_C_TABLES {
+        if !rls_harness::table_rls_enabled(table).await {
+            missing_enabled.push(*table);
+        }
+        if !rls_harness::table_force_rls(table).await {
+            missing_forced.push(*table);
+        }
+    }
+    assert!(
+        missing_enabled.is_empty(),
+        "Tier-C tables missing RLS ENABLE: {missing_enabled:?}"
+    );
+    assert!(
+        missing_forced.is_empty(),
+        "Tier-C tables missing FORCE ROW LEVEL SECURITY: {missing_forced:?}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn tier_c_tables_have_named_policy_on_api_role() {
+    setup();
+    let attachments = rls_harness::policies_for_tables(EXPECTED_TIER_C_TABLES).await;
+    for table in EXPECTED_TIER_C_TABLES {
+        let policies = attachments
+            .get(*table)
+            .expect("policy catalog query must return an entry per table");
+        let expected_name = format!("{table}_viewer");
+        let matched = policies.iter().find(|p| p.name == expected_name);
+        assert!(
+            matched.is_some(),
+            "Tier-C table public.{table} is missing policy {expected_name}; found {policies:?}"
+        );
+        let matched = matched.unwrap();
+        assert!(
+            matched.roles.iter().any(|r| r == "poziomki_api"),
+            "Tier-C policy {expected_name} on public.{table} must target poziomki_api (targets: {:?})",
             matched.roles
         );
     }

--- a/backend/tests/requests/rls_tier_c.rs
+++ b/backend/tests/requests/rls_tier_c.rs
@@ -299,12 +299,15 @@ async fn event_attendees_viewer_sees_bucket_roster() {
 
 #[tokio::test]
 #[serial]
-async fn event_attendees_cannot_mutate_peer_attendance() {
+async fn event_attendees_non_creator_non_owner_cannot_mutate_peer() {
     let fx = setup_fixture().await;
     let event_id = fx.event_id;
     let bob_profile = fx.bob_profile;
+    let carol_id = fx.carol.id;
 
-    let affected = rls_harness::with_api_viewer_tx(fx.alice.id, false, move |conn| {
+    // Carol is not the event creator and not Bob — her UPDATE of
+    // Bob's attendance must be rejected.
+    let affected = rls_harness::with_api_viewer_tx(carol_id, false, move |conn| {
         async move {
             let sql = format!(
                 "UPDATE public.event_attendees SET status = 'declined' \
@@ -315,10 +318,61 @@ async fn event_attendees_cannot_mutate_peer_attendance() {
         .scope_boxed()
     })
     .await
-    .expect("alice tx");
+    .expect("carol tx");
     assert_eq!(
         affected, 0,
-        "viewer cannot flip another attendee's status; SELECT visibility doesn't grant UPDATE"
+        "non-creator non-owner cannot flip another attendee's status"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn event_attendees_creator_can_approve_pending_peer() {
+    let fx = setup_fixture().await;
+    let event_id = fx.event_id;
+    let carol_id = fx.carol.id;
+    let alice_id = fx.alice.id;
+
+    // Seed: Carol is pending on Alice's event (requires_approval
+    // irrelevant here — we're testing the RLS surface, not the
+    // business logic).
+    let carol_profile = {
+        let mut conn = db::conn().await.expect("pool");
+        let pid = profiles::table
+            .filter(profiles::user_id.eq(carol_id))
+            .select(profiles::id)
+            .first::<Uuid>(&mut conn)
+            .await
+            .expect("carol profile");
+        diesel::insert_into(event_attendees::table)
+            .values((
+                event_attendees::event_id.eq(event_id),
+                event_attendees::profile_id.eq(pid),
+                event_attendees::status.eq("pending"),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed carol pending");
+        pid
+    };
+
+    // Alice (event creator) approves Carol — must succeed under the
+    // viewer_owns_event branch.
+    let affected = rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+        async move {
+            let sql = format!(
+                "UPDATE public.event_attendees SET status = 'going' \
+                 WHERE event_id = '{event_id}' AND profile_id = '{carol_profile}'"
+            );
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 1,
+        "event creator must be able to approve a pending attendee (handler-level approval flow)"
     );
 }
 

--- a/backend/tests/requests/rls_tier_c.rs
+++ b/backend/tests/requests/rls_tier_c.rs
@@ -1,0 +1,467 @@
+//! Tier-C RLS visibility tests.
+//!
+//! Two parties: Alice (creator of event E1, owner of upload U1) and
+//! Bob (attendee of E1, owner of upload U2). A third user Carol
+//! exists but has no relationship to either — used to probe the
+//! write surface.
+//!
+//! Covers:
+//!   * `events`: bucket SELECT; only the creator can UPDATE / DELETE
+//!   * `event_attendees`: bucket SELECT; only the attendee can mutate
+//!     their own attendance
+//!   * `uploads`: SELECT allows anon-owned rows AND same-bucket owner
+//!     rows; only the owner can mutate
+//!   * Identity-column triggers on all three tables
+//!   * Anon sees zero rows on every Tier-C table
+
+use chrono::{Duration, Utc};
+use diesel::prelude::*;
+use diesel::sql_types::BigInt;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use poziomki_backend::app::{build_test_app_context, reset_test_database};
+use poziomki_backend::db;
+use poziomki_backend::db::models::profiles::NewProfile;
+use poziomki_backend::db::models::users::{NewUser, User};
+use poziomki_backend::db::schema::{event_attendees, events, profiles, uploads, users};
+use serial_test::serial;
+use uuid::Uuid;
+
+use super::rls_harness;
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}
+
+struct Fx {
+    alice: User,
+    alice_profile: Uuid,
+    bob: User,
+    bob_profile: Uuid,
+    carol: User,
+    event_id: Uuid,
+    alice_upload: Uuid,
+    anon_upload: Uuid,
+}
+
+async fn count_rows(conn: &mut AsyncPgConnection, table: &str) -> i64 {
+    assert!(
+        table.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+        "table name must be a simple identifier"
+    );
+    let row: CountRow = diesel::sql_query(format!("SELECT COUNT(*) AS count FROM {table}"))
+        .get_result(conn)
+        .await
+        .expect("count");
+    row.count
+}
+
+async fn execute_count(conn: &mut AsyncPgConnection, sql: &str) -> usize {
+    diesel::sql_query(sql)
+        .execute(conn)
+        .await
+        .expect("statement must succeed (RLS silently filters, not errors)")
+}
+
+async fn insert_user(email: &str) -> User {
+    let mut conn = db::conn().await.expect("pool");
+    let new_user = NewUser {
+        pid: Uuid::new_v4(),
+        email: email.to_string(),
+        password: "hash".to_string(),
+        api_key: Uuid::new_v4().to_string(),
+        name: "Test".to_string(),
+    };
+    diesel::insert_into(users::table)
+        .values(&new_user)
+        .returning(User::as_select())
+        .get_result(&mut conn)
+        .await
+        .expect("insert user")
+}
+
+async fn insert_profile(user: &User, name: &str) -> Uuid {
+    let mut conn = db::conn().await.expect("pool");
+    let now = Utc::now();
+    let new_profile = NewProfile {
+        id: Uuid::new_v4(),
+        user_id: user.id,
+        name: name.to_string(),
+        bio: None,
+        profile_picture: None,
+        images: None,
+        program: None,
+        gradient_start: None,
+        gradient_end: None,
+        created_at: now,
+        updated_at: now,
+    };
+    diesel::insert_into(profiles::table)
+        .values(&new_profile)
+        .returning(profiles::id)
+        .get_result(&mut conn)
+        .await
+        .expect("insert profile")
+}
+
+async fn setup_fixture() -> Fx {
+    let _ = dotenvy::dotenv();
+    let _ = build_test_app_context().expect("test app ctx");
+    reset_test_database().await.expect("truncate");
+
+    let alice = insert_user("tier-c-alice@example.com").await;
+    let alice_profile = insert_profile(&alice, "Alice").await;
+    let bob = insert_user("tier-c-bob@example.com").await;
+    let bob_profile = insert_profile(&bob, "Bob").await;
+    let carol = insert_user("tier-c-carol@example.com").await;
+    let _ = insert_profile(&carol, "Carol").await;
+
+    let event_id = Uuid::new_v4();
+    let alice_upload = Uuid::new_v4();
+    let anon_upload = Uuid::new_v4();
+    {
+        let mut conn = db::conn().await.expect("pool");
+        let now = Utc::now();
+
+        diesel::insert_into(events::table)
+            .values((
+                events::id.eq(event_id),
+                events::title.eq("E1"),
+                events::starts_at.eq(now + Duration::days(1)),
+                events::creator_id.eq(alice_profile),
+                events::created_at.eq(now),
+                events::updated_at.eq(now),
+                events::requires_approval.eq(false),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed event");
+
+        for (attendee_profile, status) in [(alice_profile, "going"), (bob_profile, "going")] {
+            diesel::insert_into(event_attendees::table)
+                .values((
+                    event_attendees::event_id.eq(event_id),
+                    event_attendees::profile_id.eq(attendee_profile),
+                    event_attendees::status.eq(status),
+                ))
+                .execute(&mut conn)
+                .await
+                .expect("seed attendee");
+        }
+
+        diesel::insert_into(uploads::table)
+            .values((
+                uploads::id.eq(alice_upload),
+                uploads::filename.eq("alice.webp"),
+                uploads::owner_id.eq(alice_profile),
+                uploads::context.eq("avatar"),
+                uploads::mime_type.eq("image/webp"),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed alice upload");
+
+        diesel::insert_into(uploads::table)
+            .values((
+                uploads::id.eq(anon_upload),
+                uploads::filename.eq("system.webp"),
+                uploads::owner_id.eq::<Option<Uuid>>(None),
+                uploads::context.eq("system"),
+                uploads::mime_type.eq("image/webp"),
+            ))
+            .execute(&mut conn)
+            .await
+            .expect("seed anon upload");
+    }
+
+    Fx {
+        alice,
+        alice_profile,
+        bob,
+        bob_profile,
+        carol,
+        event_id,
+        alice_upload,
+        anon_upload,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// events: bucket SELECT, creator-only writes.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn events_same_bucket_viewers_see_event() {
+    let fx = setup_fixture().await;
+
+    let alice_count = rls_harness::with_api_viewer_tx(fx.alice.id, false, |conn| {
+        async move { Ok(count_rows(conn, "events").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    let carol_count = rls_harness::with_api_viewer_tx(fx.carol.id, false, |conn| {
+        async move { Ok(count_rows(conn, "events").await) }.scope_boxed()
+    })
+    .await
+    .expect("carol tx");
+
+    assert_eq!(alice_count, 1, "creator sees own event");
+    assert_eq!(
+        carol_count, 1,
+        "non-creator in same stub bucket sees the event (discoverable)"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn events_non_creator_cannot_delete() {
+    let fx = setup_fixture().await;
+    let event_id = fx.event_id;
+
+    let affected = rls_harness::with_api_viewer_tx(fx.bob.id, false, move |conn| {
+        async move {
+            let sql = format!("DELETE FROM public.events WHERE id = '{event_id}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("bob tx");
+    assert_eq!(
+        affected, 0,
+        "only the creator can DELETE; same-bucket non-creator sees the row but has no write policy match"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn events_non_creator_cannot_update() {
+    let fx = setup_fixture().await;
+    let event_id = fx.event_id;
+
+    let affected = rls_harness::with_api_viewer_tx(fx.bob.id, false, move |conn| {
+        async move {
+            let sql =
+                format!("UPDATE public.events SET title = 'hijacked' WHERE id = '{event_id}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("bob tx");
+    assert_eq!(affected, 0, "only the creator can UPDATE");
+}
+
+#[tokio::test]
+#[serial]
+async fn events_creator_id_immutable() {
+    let fx = setup_fixture().await;
+    let event_id = fx.event_id;
+    let bob_profile = fx.bob_profile;
+
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(fx.alice.id, false, move |conn| {
+            async move {
+                let sql = format!(
+                    "UPDATE public.events SET creator_id = '{bob_profile}' WHERE id = '{event_id}'"
+                );
+                diesel::sql_query(sql).execute(conn).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "events identity trigger must reject creator_id change"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// event_attendees: bucket SELECT, own-profile writes.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn event_attendees_viewer_sees_bucket_roster() {
+    let fx = setup_fixture().await;
+
+    let alice_count = rls_harness::with_api_viewer_tx(fx.alice.id, false, |conn| {
+        async move { Ok(count_rows(conn, "event_attendees").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+
+    assert_eq!(alice_count, 2, "Alice sees both attendees (same bucket)");
+}
+
+#[tokio::test]
+#[serial]
+async fn event_attendees_cannot_mutate_peer_attendance() {
+    let fx = setup_fixture().await;
+    let event_id = fx.event_id;
+    let bob_profile = fx.bob_profile;
+
+    let affected = rls_harness::with_api_viewer_tx(fx.alice.id, false, move |conn| {
+        async move {
+            let sql = format!(
+                "UPDATE public.event_attendees SET status = 'declined' \
+                 WHERE event_id = '{event_id}' AND profile_id = '{bob_profile}'"
+            );
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+    assert_eq!(
+        affected, 0,
+        "viewer cannot flip another attendee's status; SELECT visibility doesn't grant UPDATE"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// uploads: public anon-owned rows + bucket-owner rows visible; only
+// the owner can mutate.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn uploads_viewer_sees_anon_and_bucket_owned() {
+    let fx = setup_fixture().await;
+
+    let alice_count = rls_harness::with_api_viewer_tx(fx.alice.id, false, |conn| {
+        async move { Ok(count_rows(conn, "uploads").await) }.scope_boxed()
+    })
+    .await
+    .expect("alice tx");
+
+    assert_eq!(
+        alice_count, 2,
+        "both Alice's own upload and the anon-owned row are visible"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn uploads_non_owner_cannot_delete_owned_row() {
+    let fx = setup_fixture().await;
+    let target = fx.alice_upload;
+
+    let affected = rls_harness::with_api_viewer_tx(fx.bob.id, false, move |conn| {
+        async move {
+            let sql = format!("DELETE FROM public.uploads WHERE id = '{target}'");
+            Ok(execute_count(conn, &sql).await)
+        }
+        .scope_boxed()
+    })
+    .await
+    .expect("bob tx");
+    assert_eq!(affected, 0, "only the owner can DELETE their upload");
+}
+
+#[tokio::test]
+#[serial]
+async fn uploads_owner_id_immutable() {
+    let fx = setup_fixture().await;
+    let target = fx.alice_upload;
+    let bob_profile = fx.bob_profile;
+
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(fx.alice.id, false, move |conn| {
+            async move {
+                let sql = format!(
+                    "UPDATE public.uploads SET owner_id = '{bob_profile}' WHERE id = '{target}'"
+                );
+                diesel::sql_query(sql).execute(conn).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "uploads identity trigger must reject owner_id change"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn uploads_nobody_can_claim_anon_upload() {
+    let fx = setup_fixture().await;
+    let target = fx.anon_upload;
+    let alice_profile = fx.alice_profile;
+
+    let result: Result<(), diesel::result::Error> =
+        rls_harness::with_api_viewer_tx(fx.alice.id, false, move |conn| {
+            async move {
+                let sql = format!(
+                    "UPDATE public.uploads SET owner_id = '{alice_profile}' WHERE id = '{target}'"
+                );
+                diesel::sql_query(sql).execute(conn).await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    // Either the immutability trigger fires (if USING passes) or RLS
+    // filters the row out (USING requires owner_id IN viewer_profile_ids,
+    // and NULL is not). Both outcomes mean "anon upload stays anon".
+    let mut conn = db::conn().await.expect("pool");
+    let row: CountRow = diesel::sql_query(
+        "SELECT COUNT(*) AS count FROM public.uploads WHERE id = $1 AND owner_id IS NULL",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(target)
+    .get_result(&mut conn)
+    .await
+    .expect("post-check");
+    assert_eq!(
+        row.count, 1,
+        "anon upload must remain anonymous regardless of which path blocked the UPDATE"
+    );
+    let _ = result; // don't care if Err vs Ok(0 rows)
+}
+
+// ---------------------------------------------------------------------------
+// Anon: every Tier-C table returns zero rows when no viewer is set.
+// Uploads specifically is non-trivial because the SELECT policy
+// accepts owner_id IS NULL — the current_user_id() > 0 guard on the
+// helper still makes anon see nothing for owner_id IN bucket, but
+// anon-owned rows would leak. This test pins the full behaviour.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn anon_tx_sees_zero_events_and_attendees() {
+    let _ = setup_fixture().await;
+
+    for table in ["events", "event_attendees"] {
+        let t = table.to_string();
+        let visible = rls_harness::with_api_viewer_tx(0, false, move |conn| {
+            async move { Ok(count_rows(conn, &t).await) }.scope_boxed()
+        })
+        .await
+        .expect("anon tx");
+        assert_eq!(visible, 0, "anon must see zero rows on public.{table}");
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn anon_tx_sees_only_anon_uploads() {
+    let _fx = setup_fixture().await;
+
+    // Only the anon-owned row (owner_id IS NULL) is visible to anon —
+    // the bucket branch requires current_user_id > 0.
+    let visible = rls_harness::with_api_viewer_tx(0, false, |conn| {
+        async move { Ok(count_rows(conn, "uploads").await) }.scope_boxed()
+    })
+    .await
+    .expect("anon tx");
+    assert_eq!(
+        visible, 1,
+        "anon sees only owner_id IS NULL uploads — bucket branch is gated"
+    );
+}


### PR DESCRIPTION
**Tier-C policies — final RLS rollout**

Last tier of row-level-security enforcement. Reuses Tier-A SD helpers (`profiles_in_current_bucket`, `viewer_profile_ids`) since these tables are profile-owned / stub-bucket-scoped.

- [x] migration `2026-04-19-030000_rls_tier_c_policies` applies cleanly (per-command policies × 3 tables + 3 identity triggers)
- [x] `rls_baseline` canaries assert Tier-C tables have RLS ENABLED + FORCED + `<table>_viewer` SELECT policy
- [x] events: same-bucket viewers see the event; non-creator cannot UPDATE/DELETE; creator_id immutable
- [x] event_attendees: same-bucket viewers see the roster; non-owner cannot flip peer's status; (event_id, profile_id) immutable
- [x] uploads: viewers see anon-owned AND same-bucket-owned rows; non-owner cannot DELETE; owner_id immutable; anon uploads cannot be claimed
- [x] anon tx sees zero events + attendees; sees only anon-owned uploads (bucket branch gated on current_user_id > 0)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Tier C RLS policies to `events`, `event_attendees`, and `uploads` tables
> - Enables and forces RLS on `public.events`, `public.event_attendees`, and `public.uploads` for the `poziomki_api` role.
> - Adds viewer/insert/update/delete policies scoped to bucket membership and profile ownership; event creators can manage their own events and attendees, upload owners control their own rows.
> - Adds helper functions `app.viewer_owns_event` and `app.event_auto_approves` for use in attendee insert/update policies.
> - Adds `BEFORE UPDATE` triggers on all three tables to enforce immutability of identity columns (`id`, `creator_id`, `owner_id`, and attendee PK).
> - Adds integration tests in [rls_tier_c.rs](https://github.com/poziomki-app/poziomki/pull/188/files#diff-c27594686f5a0aaebbff38d029538a1baa67bcbe17864902d241f4c7ed6582ae) covering visibility, mutation restrictions, and trigger enforcement; updates [rls_baseline.rs](https://github.com/poziomki-app/poziomki/pull/188/files#diff-a36a1a9c0a6074ea9a1789e6e7a76bd99be6b37dadcac095ab1b655b4eae4f87) to include Tier C tables in all RLS baseline assertions.
> - Behavioral Change: anonymous sessions now see zero events and event_attendees, and only `NULL`-owned uploads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92f0de3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->