### PR TITLE
sec(rls): DB invariants, generic audit trigger, schema hardening

### DIFF
--- a/backend/migrations/2026-04-19-040000_invariants_and_audit/down.sql
+++ b/backend/migrations/2026-04-19-040000_invariants_and_audit/down.sql
@@ -1,0 +1,22 @@
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'ALTER ROLE poziomki_api RESET statement_timeout';
+    END IF;
+END
+$$;
+
+-- Re-grant the PG default so rollback lands the cluster back where it
+-- was regardless of which PG version installed the original default.
+GRANT USAGE ON SCHEMA public TO PUBLIC;
+
+DROP TRIGGER IF EXISTS user_settings_audit ON public.user_settings;
+DROP TRIGGER IF EXISTS users_audit ON public.users;
+DROP FUNCTION IF EXISTS audit.log_change();
+DROP TABLE IF EXISTS audit.events;
+DROP SCHEMA IF EXISTS audit CASCADE;
+
+ALTER TABLE public.conversations
+    DROP CONSTRAINT IF EXISTS event_chat_pair_null;
+ALTER TABLE public.conversations
+    DROP CONSTRAINT IF EXISTS dm_canonical_pair;

--- a/backend/migrations/2026-04-19-040000_invariants_and_audit/up.sql
+++ b/backend/migrations/2026-04-19-040000_invariants_and_audit/up.sql
@@ -1,0 +1,199 @@
+-- Final phase: DB-level invariants + generic audit trigger + schema
+-- hardening. Complements the Tier A/B/C policies by locking
+-- assumptions the RLS policies already rely on (e.g. DM pair is
+-- canonical + distinct) and gives forensic coverage over the two
+-- highest-sensitivity mutation surfaces: users.email /
+-- users.password and user_settings. Finally tightens the schema's
+-- default privileges.
+
+-- ---------------------------------------------------------------------------
+-- DM shape invariants on conversations. Tier-B's conversations_insert
+-- policy already enforces the same predicate for poziomki_api, but the
+-- owner role + migrations + future BYPASSRLS callers need the same
+-- invariant too. Declare it as a CHECK so it can never be bypassed.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'dm_canonical_pair'
+          AND conrelid = 'public.conversations'::regclass
+    ) THEN
+        ALTER TABLE public.conversations
+            ADD CONSTRAINT dm_canonical_pair
+            CHECK (
+                kind <> 'dm'
+                OR (user_low_id IS NOT NULL
+                    AND user_high_id IS NOT NULL
+                    AND user_low_id < user_high_id)
+            );
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'event_chat_pair_null'
+          AND conrelid = 'public.conversations'::regclass
+    ) THEN
+        ALTER TABLE public.conversations
+            ADD CONSTRAINT event_chat_pair_null
+            CHECK (
+                kind <> 'event'
+                OR (user_low_id IS NULL AND user_high_id IS NULL)
+            );
+    END IF;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- audit.events — generic forensic log. Captures the columns that
+-- changed, old + new JSONB snapshots, the viewer id from the GUC,
+-- and the SQL operation. Only attached to the handful of tables
+-- where after-the-fact review matters (users, user_settings).
+-- ---------------------------------------------------------------------------
+CREATE SCHEMA IF NOT EXISTS audit;
+
+CREATE TABLE IF NOT EXISTS audit.events (
+    id BIGSERIAL PRIMARY KEY,
+    table_name TEXT NOT NULL,
+    row_pk TEXT NOT NULL,
+    op CHAR(1) NOT NULL CHECK (op IN ('I', 'U', 'D')),
+    changed_columns TEXT[],
+    old_data JSONB,
+    new_data JSONB,
+    actor_user_id INT4,
+    session_user_name TEXT NOT NULL DEFAULT session_user,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_table_row
+    ON audit.events (table_name, row_pk, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_created_at
+    ON audit.events (created_at DESC);
+
+-- Revoke public access; the table is INSERT-only for the app roles
+-- (the trigger function writes it) and SELECT-only for the owner.
+REVOKE ALL ON audit.events FROM PUBLIC;
+REVOKE ALL ON SCHEMA audit FROM PUBLIC;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA audit TO poziomki_api';
+        EXECUTE 'GRANT INSERT ON audit.events TO poziomki_api';
+        EXECUTE 'GRANT USAGE, SELECT ON SEQUENCE audit.events_id_seq TO poziomki_api';
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_worker') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA audit TO poziomki_worker';
+        EXECUTE 'GRANT INSERT ON audit.events TO poziomki_worker';
+        EXECUTE 'GRANT USAGE, SELECT ON SEQUENCE audit.events_id_seq TO poziomki_worker';
+    END IF;
+END
+$$;
+
+-- Generic audit trigger function. SECURITY DEFINER so it can always
+-- write to audit.events even when the caller's role lacks INSERT
+-- (future-proofs against new least-privilege roles).
+CREATE OR REPLACE FUNCTION audit.log_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+DECLARE
+    v_row_pk       text;
+    v_op           char(1);
+    v_old_jsonb    jsonb;
+    v_new_jsonb    jsonb;
+    v_changed      text[];
+    v_actor        int;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        v_op := 'I';
+        v_old_jsonb := NULL;
+        v_new_jsonb := to_jsonb(NEW);
+        v_changed := NULL;
+        v_row_pk := (v_new_jsonb ->> 'id');
+    ELSIF TG_OP = 'UPDATE' THEN
+        v_op := 'U';
+        v_old_jsonb := to_jsonb(OLD);
+        v_new_jsonb := to_jsonb(NEW);
+        SELECT ARRAY(
+            SELECT key
+            FROM jsonb_each(v_new_jsonb)
+            WHERE v_new_jsonb -> key IS DISTINCT FROM v_old_jsonb -> key
+        ) INTO v_changed;
+        IF array_length(v_changed, 1) IS NULL THEN
+            RETURN NEW;
+        END IF;
+        v_row_pk := (v_new_jsonb ->> 'id');
+    ELSIF TG_OP = 'DELETE' THEN
+        v_op := 'D';
+        v_old_jsonb := to_jsonb(OLD);
+        v_new_jsonb := NULL;
+        v_changed := NULL;
+        v_row_pk := (v_old_jsonb ->> 'id');
+    END IF;
+
+    BEGIN
+        v_actor := NULLIF(current_setting('app.user_id', true), '')::int;
+    EXCEPTION WHEN OTHERS THEN
+        v_actor := NULL;
+    END;
+
+    INSERT INTO audit.events
+        (table_name, row_pk, op, changed_columns, old_data, new_data, actor_user_id)
+    VALUES
+        (TG_TABLE_SCHEMA || '.' || TG_TABLE_NAME,
+         COALESCE(v_row_pk, ''),
+         v_op,
+         v_changed,
+         v_old_jsonb,
+         v_new_jsonb,
+         v_actor);
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    ELSE
+        RETURN NEW;
+    END IF;
+END
+$$;
+
+COMMENT ON FUNCTION audit.log_change() IS
+    'Generic audit trigger — captures op, changed columns, old/new JSONB snapshots, and the viewer id from the app.user_id GUC. Attach via AFTER INSERT/UPDATE/DELETE FOR EACH ROW.';
+
+REVOKE EXECUTE ON FUNCTION audit.log_change() FROM PUBLIC;
+
+-- users: track INSERT + UPDATE + DELETE. INSERT is rare (signup); the
+-- point of interest is UPDATE on email / password_hash plus DELETE
+-- (account termination). The trigger captures every column, but the
+-- `changed_columns` set lets readers filter for the sensitive ones.
+DROP TRIGGER IF EXISTS users_audit ON public.users;
+CREATE TRIGGER users_audit
+    AFTER INSERT OR UPDATE OR DELETE ON public.users
+    FOR EACH ROW
+    EXECUTE FUNCTION audit.log_change();
+
+-- user_settings: privacy toggles, notifications flag, etc. All
+-- changes worth auditing.
+DROP TRIGGER IF EXISTS user_settings_audit ON public.user_settings;
+CREATE TRIGGER user_settings_audit
+    AFTER INSERT OR UPDATE OR DELETE ON public.user_settings
+    FOR EACH ROW
+    EXECUTE FUNCTION audit.log_change();
+
+-- ---------------------------------------------------------------------------
+-- Schema hardening. `REVOKE ALL ON SCHEMA public FROM PUBLIC` is the
+-- PG15 default but not always applied to older clusters; asserting it
+-- is cheap and stops new roles from inheriting default creation
+-- privileges. Follow with an explicit statement_timeout on the API
+-- role so a single runaway query can't tie up the pool.
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'ALTER ROLE poziomki_api SET statement_timeout = ''5s''';
+    END IF;
+END
+$$;

--- a/backend/migrations/2026-04-19-040000_invariants_and_audit/up.sql
+++ b/backend/migrations/2026-04-19-040000_invariants_and_audit/up.sql
@@ -99,13 +99,28 @@ SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp
 AS $$
 DECLARE
-    v_row_pk       text;
-    v_op           char(1);
-    v_old_jsonb    jsonb;
-    v_new_jsonb    jsonb;
-    v_changed      text[];
-    v_actor        int;
+    v_row_pk          text;
+    v_op              char(1);
+    v_old_jsonb       jsonb;
+    v_new_jsonb       jsonb;
+    v_changed         text[];
+    v_actor           int;
+    v_sensitive_cols  text[] := ARRAY[]::text[];
 BEGIN
+    -- Never persist credential material in audit.events. We still
+    -- surface the column in `changed_columns` (so "password rotated"
+    -- is a visible event), but the JSONB snapshots get the sensitive
+    -- keys stripped before storage.
+    IF TG_TABLE_NAME = 'users' THEN
+        v_sensitive_cols := ARRAY[
+            'password',
+            'api_key',
+            'reset_token',
+            'email_verification_token',
+            'magic_link_token'
+        ];
+    END IF;
+
     IF TG_OP = 'INSERT' THEN
         v_op := 'I';
         v_old_jsonb := NULL;
@@ -131,6 +146,18 @@ BEGIN
         v_new_jsonb := NULL;
         v_changed := NULL;
         v_row_pk := (v_old_jsonb ->> 'id');
+    END IF;
+
+    -- Strip sensitive keys from the stored payload (changed_columns
+    -- is computed above against the unredacted row so rotation
+    -- events still surface).
+    IF array_length(v_sensitive_cols, 1) IS NOT NULL THEN
+        IF v_old_jsonb IS NOT NULL THEN
+            v_old_jsonb := v_old_jsonb - v_sensitive_cols;
+        END IF;
+        IF v_new_jsonb IS NOT NULL THEN
+            v_new_jsonb := v_new_jsonb - v_sensitive_cols;
+        END IF;
     END IF;
 
     BEGIN

--- a/backend/tests/requests/mod.rs
+++ b/backend/tests/requests/mod.rs
@@ -2,6 +2,7 @@ mod db_viewer;
 mod migration_contract;
 mod rls_baseline;
 mod rls_harness;
+mod rls_invariants;
 mod rls_tier_a;
 mod rls_tier_b;
 mod rls_tier_c;

--- a/backend/tests/requests/rls_invariants.rs
+++ b/backend/tests/requests/rls_invariants.rs
@@ -171,6 +171,44 @@ async fn users_audit_captures_email_update() {
     );
 }
 
+#[tokio::test]
+#[serial]
+async fn users_audit_redacts_password_and_tokens() {
+    setup();
+    let mut conn = db::conn().await.expect("pool");
+    let user = insert_user_raw(&mut conn, "audit-redact@example.com").await;
+    let user_id = user.id;
+
+    diesel::sql_query("DELETE FROM audit.events WHERE table_name = 'public.users' AND row_pk = $1")
+        .bind::<Text, _>(user_id.to_string())
+        .execute(&mut conn)
+        .await
+        .expect("clear prior");
+
+    diesel::update(users::table.filter(users::id.eq(user_id)))
+        .set(users::password.eq("new-secret-hash"))
+        .execute(&mut conn)
+        .await
+        .expect("update password");
+
+    let row: CountRow = diesel::sql_query(
+        "SELECT COUNT(*) AS count FROM audit.events \
+         WHERE table_name = 'public.users' \
+           AND row_pk = $1 \
+           AND 'password' = ANY(changed_columns) \
+           AND (new_data ? 'password') = false \
+           AND (old_data ? 'password') = false",
+    )
+    .bind::<Text, _>(user_id.to_string())
+    .get_result(&mut conn)
+    .await
+    .expect("redaction check");
+    assert_eq!(
+        row.count, 1,
+        "password rotation must surface in changed_columns but the password key must be stripped from old_data + new_data"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // poziomki_api role has a bounded statement_timeout so a runaway
 // query can't exhaust the pool.

--- a/backend/tests/requests/rls_invariants.rs
+++ b/backend/tests/requests/rls_invariants.rs
@@ -1,0 +1,241 @@
+//! PR #13 — DB-level invariants, generic audit trigger, schema
+//! hardening. Asserts the migration actually installed what it
+//! claims: conversation CHECK constraints, `audit.events` writes on
+//! `users` / `user_settings`, `REVOKE ALL ON SCHEMA public FROM PUBLIC`,
+//! and the `statement_timeout` knob on `poziomki_api`.
+
+use chrono::Utc;
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Text};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use poziomki_backend::app::build_test_app_context;
+use poziomki_backend::db;
+use poziomki_backend::db::models::users::{NewUser, User};
+use poziomki_backend::db::schema::users;
+use serial_test::serial;
+use uuid::Uuid;
+
+fn setup() {
+    let _ = dotenvy::dotenv();
+    let _ = build_test_app_context().expect("build test app ctx");
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct TextRow {
+    #[diesel(sql_type = Text)]
+    value: String,
+}
+
+#[derive(diesel::deserialize::QueryableByName)]
+struct BoolRow {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    value: bool,
+}
+
+async fn insert_user_raw(conn: &mut AsyncPgConnection, email: &str) -> User {
+    let new_user = NewUser {
+        pid: Uuid::new_v4(),
+        email: email.to_string(),
+        password: "hash".to_string(),
+        api_key: Uuid::new_v4().to_string(),
+        name: "Invariant Test".to_string(),
+    };
+    diesel::insert_into(users::table)
+        .values(&new_user)
+        .returning(User::as_select())
+        .get_result(conn)
+        .await
+        .expect("insert user")
+}
+
+// ---------------------------------------------------------------------------
+// conversations CHECK constraints. Tier-B RLS enforces the same shape
+// for the API role, but these guards apply to every writer (owner,
+// worker, future BYPASSRLS roles).
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn dm_canonical_pair_rejects_inverted_order() {
+    setup();
+    let mut conn = db::conn().await.expect("pool");
+    let now = Utc::now();
+    let result = diesel::sql_query(
+        "INSERT INTO public.conversations \
+         (id, kind, user_low_id, user_high_id, created_at, updated_at) \
+         VALUES ($1, 'dm', 5, 3, $2, $2)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(Uuid::new_v4())
+    .bind::<diesel::sql_types::Timestamptz, _>(now)
+    .execute(&mut conn)
+    .await;
+
+    assert!(
+        result.is_err(),
+        "dm_canonical_pair CHECK must reject user_low_id > user_high_id"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn dm_canonical_pair_rejects_self_dm() {
+    setup();
+    let mut conn = db::conn().await.expect("pool");
+    let now = Utc::now();
+    let result = diesel::sql_query(
+        "INSERT INTO public.conversations \
+         (id, kind, user_low_id, user_high_id, created_at, updated_at) \
+         VALUES ($1, 'dm', 7, 7, $2, $2)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(Uuid::new_v4())
+    .bind::<diesel::sql_types::Timestamptz, _>(now)
+    .execute(&mut conn)
+    .await;
+
+    assert!(
+        result.is_err(),
+        "dm_canonical_pair CHECK must reject self-DM (low == high)"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn event_chat_pair_null_rejects_pair_on_event_row() {
+    setup();
+    let mut conn = db::conn().await.expect("pool");
+    let now = Utc::now();
+    // Fabricate an event id via a valid insert first — the attempt
+    // below doesn't hit FK because we just assert the CHECK fires
+    // before FK validation (it runs on the new row itself).
+    let result = diesel::sql_query(
+        "INSERT INTO public.conversations \
+         (id, kind, event_id, user_low_id, user_high_id, created_at, updated_at) \
+         VALUES ($1, 'event', $2, 1, 2, $3, $3)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(Uuid::new_v4())
+    .bind::<diesel::sql_types::Uuid, _>(Uuid::new_v4())
+    .bind::<diesel::sql_types::Timestamptz, _>(now)
+    .execute(&mut conn)
+    .await;
+
+    assert!(
+        result.is_err(),
+        "event_chat_pair_null CHECK must reject event row with non-null pair ids"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Audit trigger on users: an UPDATE on email or password_hash writes
+// exactly one audit.events row with op='U' and the column in
+// changed_columns.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn users_audit_captures_email_update() {
+    setup();
+    let mut conn = db::conn().await.expect("pool");
+    let user = insert_user_raw(&mut conn, "audit-email@example.com").await;
+    let user_id = user.id;
+
+    diesel::sql_query("DELETE FROM audit.events WHERE table_name = 'public.users' AND row_pk = $1")
+        .bind::<Text, _>(user_id.to_string())
+        .execute(&mut conn)
+        .await
+        .expect("clear prior audit rows for the fixture");
+
+    diesel::update(users::table.filter(users::id.eq(user_id)))
+        .set(users::email.eq("audit-email-changed@example.com"))
+        .execute(&mut conn)
+        .await
+        .expect("update email");
+
+    let row: CountRow = diesel::sql_query(
+        "SELECT COUNT(*) AS count FROM audit.events \
+         WHERE table_name = 'public.users' \
+           AND row_pk = $1 \
+           AND op = 'U' \
+           AND 'email' = ANY(changed_columns)",
+    )
+    .bind::<Text, _>(user_id.to_string())
+    .get_result(&mut conn)
+    .await
+    .expect("audit count");
+    assert_eq!(
+        row.count, 1,
+        "email UPDATE must produce one audit.events row with 'email' in changed_columns"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// poziomki_api role has a bounded statement_timeout so a runaway
+// query can't exhaust the pool.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn poziomki_api_has_statement_timeout() {
+    setup();
+    let mut conn = db::conn().await.expect("pool");
+    let row: TextRow = diesel::sql_query(
+        "SELECT COALESCE( \
+             (SELECT option_value FROM pg_options_to_table( \
+                 (SELECT rolconfig FROM pg_roles WHERE rolname = 'poziomki_api')) \
+              WHERE option_name = 'statement_timeout'), \
+             '' \
+         ) AS value",
+    )
+    .get_result(&mut conn)
+    .await
+    .expect("role config query");
+
+    assert!(
+        !row.value.is_empty(),
+        "poziomki_api must carry a statement_timeout setting (got empty)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PUBLIC must have no privileges on schema `public`. Older clusters
+// shipped with USAGE granted by default; we asserted REVOKE ALL so
+// new roles can't inherit the old defaults.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn public_schema_has_no_public_privileges() {
+    setup();
+    let mut conn = db::conn().await.expect("pool");
+    let row: BoolRow =
+        diesel::sql_query("SELECT has_schema_privilege('public', 'public', 'USAGE') AS value")
+            .get_result(&mut conn)
+            .await
+            .expect("public usage probe");
+    assert!(
+        !row.value,
+        "PUBLIC must not retain USAGE on schema public after REVOKE ALL"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// audit.events is INSERT-only for app roles; SELECT is denied so a
+// compromised API-role caller can't dump the forensic log.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[serial]
+async fn poziomki_api_cannot_select_audit_events() {
+    setup();
+    let mut conn = db::conn().await.expect("pool");
+    let row: BoolRow = diesel::sql_query(
+        "SELECT has_table_privilege('poziomki_api', 'audit.events', 'SELECT') AS value",
+    )
+    .get_result(&mut conn)
+    .await
+    .expect("select privilege probe");
+    assert!(
+        !row.value,
+        "poziomki_api must not have SELECT on audit.events (INSERT-only)"
+    );
+}


### PR DESCRIPTION
**DB invariants + forensic audit + schema hardening**

Final phase of the RLS rollout. Four independent improvements that complement the Tier A/B/C policies.

- [x] migration `2026-04-19-040000_invariants_and_audit` applies cleanly
- [x] `conversations.dm_canonical_pair` CHECK — DMs require distinct, ordered (`low < high`) pair
- [x] `conversations.event_chat_pair_null` CHECK — event rows forbid pair fields
- [x] `audit.events` + `audit.log_change` trigger attached to `users` and `user_settings`; captures op / changed_columns / old+new JSONB / actor_user_id
- [x] `audit.events` is INSERT-only for `poziomki_api` (no SELECT leak)
- [x] `REVOKE ALL ON SCHEMA public FROM PUBLIC` — asserts PG15+ default
- [x] `statement_timeout = '5s'` on `poziomki_api` — bounds runaway query cost
- [x] credential columns on `public.users` (password, api_key, reset_token, email_verification_token, magic_link_token) stripped from the audit JSONB payload