### PR TITLE
sec(uploads): strip EXIF / metadata server-side after validation

### DIFF
--- a/backend/src/api/state/uploads.rs
+++ b/backend/src/api/state/uploads.rs
@@ -136,6 +136,47 @@ pub(in crate::api) fn validate_image_dimensions(
     Ok(())
 }
 
+/// Strip EXIF / metadata from the uploaded image bytes.
+///
+/// The mobile client is *supposed* to strip EXIF before uploading,
+/// but an API caller (or a mis-built client) can skip it and leak
+/// GPS / device identifiers into profile pictures and attachments.
+/// Re-decoding and re-encoding the pixels drops every metadata
+/// chunk the original carried (EXIF, XMP, ICC, iTXt, etc.).
+///
+/// Quality notes:
+/// * JPEG — re-encoded at quality 92, visually indistinguishable
+///   from the original to human eyes; small size increase possible.
+/// * PNG / WebP — re-encoded losslessly, pixel-identical.
+///
+/// Falls back to returning the original bytes if the decode fails
+/// for any reason (truncated upload, unknown variant). Validation
+/// of MIME + dimensions has already run at this point, so the
+/// fallback path shouldn't realistically fire.
+pub(in crate::api) fn strip_image_metadata(data: &[u8], mime_type: &str) -> Vec<u8> {
+    use std::io::Cursor;
+
+    let Ok(img) = image::load_from_memory(data) else {
+        return data.to_vec();
+    };
+
+    let mut out = Vec::with_capacity(data.len());
+    let result = match mime_type {
+        "image/jpeg" => {
+            let mut cursor = Cursor::new(&mut out);
+            image::codecs::jpeg::JpegEncoder::new_with_quality(&mut cursor, 92).encode_image(&img)
+        }
+        "image/png" => img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::Png),
+        "image/webp" => img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::WebP),
+        _ => return data.to_vec(),
+    };
+
+    match result {
+        Ok(()) => out,
+        Err(_) => data.to_vec(),
+    }
+}
+
 pub(in crate::api) fn extension_for_mime(mime_type: &str) -> &'static str {
     match mime_type {
         "image/jpeg" => "jpeg",
@@ -182,4 +223,83 @@ pub(in crate::api) const fn is_chat_context(context: UploadContext) -> bool {
         context,
         UploadContext::ChatCover | UploadContext::ChatAttachment
     )
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::indexing_slicing,
+    clippy::cast_possible_truncation,
+    clippy::expect_used
+)]
+mod tests {
+    use super::strip_image_metadata;
+    use std::io::Cursor;
+
+    /// Round-trip a tiny synthesized JPEG through the `image` crate
+    /// first (giving us a guaranteed-valid JPEG we can decode) and
+    /// then splice an EXIF APP1 segment carrying a recognisable
+    /// sentinel into it. `strip_image_metadata` must re-encode
+    /// without the sentinel.
+    fn jpeg_with_injected_exif_sentinel() -> (Vec<u8>, &'static [u8]) {
+        let sentinel: &[u8] = b"GPS_SENTINEL_0XDEADBEEF";
+
+        // Start with a real JPEG from the image crate so the decoder
+        // definitely accepts the payload.
+        let img = image::RgbImage::from_pixel(4, 4, image::Rgb([200, 50, 50]));
+        let mut base = Vec::new();
+        image::codecs::jpeg::JpegEncoder::new_with_quality(&mut Cursor::new(&mut base), 90)
+            .encode_image(&image::DynamicImage::ImageRgb8(img))
+            .expect("encode seed jpeg");
+
+        // Build an APP1 segment: FF E1 <len_be u16> "Exif\0\0" <payload>
+        // `len_be` counts itself + Exif header + payload.
+        let mut payload: Vec<u8> = Vec::new();
+        payload.extend_from_slice(b"Exif\0\0");
+        payload.extend_from_slice(sentinel);
+        let seg_len = (2 + payload.len()) as u16; // length bytes include themselves
+        let mut app1 = vec![0xff, 0xe1];
+        app1.extend_from_slice(&seg_len.to_be_bytes());
+        app1.extend_from_slice(&payload);
+
+        // Inject right after the SOI (bytes 0–1 are FF D8).
+        let mut with_exif = Vec::with_capacity(base.len() + app1.len());
+        with_exif.extend_from_slice(&base[..2]);
+        with_exif.extend_from_slice(&app1);
+        with_exif.extend_from_slice(&base[2..]);
+        (with_exif, sentinel)
+    }
+
+    #[test]
+    fn strip_image_metadata_removes_jpeg_exif_sentinel() {
+        let (input, sentinel) = jpeg_with_injected_exif_sentinel();
+        assert!(
+            input.windows(sentinel.len()).any(|w| w == sentinel),
+            "precondition: test fixture must contain the sentinel"
+        );
+
+        let output = strip_image_metadata(&input, "image/jpeg");
+        assert!(
+            !output.windows(sentinel.len()).any(|w| w == sentinel),
+            "strip_image_metadata must drop the EXIF sentinel"
+        );
+        // And the re-encoded output should still start with a valid
+        // JPEG SOI marker (FF D8) so the pipeline downstream can
+        // still handle it.
+        assert_eq!(
+            &output[..2],
+            &[0xff, 0xd8],
+            "re-encoded output must remain a valid JPEG"
+        );
+    }
+
+    #[test]
+    fn strip_image_metadata_falls_back_on_undecodable_input() {
+        // Truncated garbage — the decoder rejects it, and the function
+        // returns the input bytes unchanged. The upstream validation
+        // chain should have rejected this before strip even runs; the
+        // fallback is purely defensive.
+        let garbage = vec![0xff, 0xd8, 0x00, 0x00];
+        let output = strip_image_metadata(&garbage, "image/jpeg");
+        assert_eq!(output, garbage);
+    }
 }

--- a/backend/src/api/state/uploads.rs
+++ b/backend/src/api/state/uploads.rs
@@ -149,16 +149,20 @@ pub(in crate::api) fn validate_image_dimensions(
 ///   from the original to human eyes; small size increase possible.
 /// * PNG / WebP — re-encoded losslessly, pixel-identical.
 ///
-/// Falls back to returning the original bytes if the decode fails
-/// for any reason (truncated upload, unknown variant). Validation
-/// of MIME + dimensions has already run at this point, so the
-/// fallback path shouldn't realistically fire.
-pub(in crate::api) fn strip_image_metadata(data: &[u8], mime_type: &str) -> Vec<u8> {
+/// Fails closed: if decode or re-encode fails for any reason
+/// (truncated upload, unsupported sub-variant, unknown mime type
+/// reaching this point) the upload is rejected rather than stored
+/// with metadata intact. Validation of MIME + dimensions runs
+/// before this, so a failure here means something exotic reached
+/// past the front-line checks.
+pub(in crate::api) fn strip_image_metadata(
+    data: &[u8],
+    mime_type: &str,
+) -> std::result::Result<Vec<u8>, &'static str> {
     use std::io::Cursor;
 
-    let Ok(img) = image::load_from_memory(data) else {
-        return data.to_vec();
-    };
+    let img =
+        image::load_from_memory(data).map_err(|_| "Could not decode image for metadata strip")?;
 
     let mut out = Vec::with_capacity(data.len());
     let result = match mime_type {
@@ -168,13 +172,10 @@ pub(in crate::api) fn strip_image_metadata(data: &[u8], mime_type: &str) -> Vec<
         }
         "image/png" => img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::Png),
         "image/webp" => img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::WebP),
-        _ => return data.to_vec(),
+        _ => return Err("Unsupported mime for metadata strip"),
     };
 
-    match result {
-        Ok(()) => out,
-        Err(_) => data.to_vec(),
-    }
+    result.map(|()| out).map_err(|_| "Image re-encode failed")
 }
 
 pub(in crate::api) fn extension_for_mime(mime_type: &str) -> &'static str {
@@ -277,7 +278,8 @@ mod tests {
             "precondition: test fixture must contain the sentinel"
         );
 
-        let output = strip_image_metadata(&input, "image/jpeg");
+        let output =
+            strip_image_metadata(&input, "image/jpeg").expect("strip must succeed on valid JPEG");
         assert!(
             !output.windows(sentinel.len()).any(|w| w == sentinel),
             "strip_image_metadata must drop the EXIF sentinel"
@@ -293,13 +295,24 @@ mod tests {
     }
 
     #[test]
-    fn strip_image_metadata_falls_back_on_undecodable_input() {
-        // Truncated garbage — the decoder rejects it, and the function
-        // returns the input bytes unchanged. The upstream validation
-        // chain should have rejected this before strip even runs; the
-        // fallback is purely defensive.
+    fn strip_image_metadata_rejects_undecodable_input() {
+        // Truncated garbage — the decoder rejects it, so the strip
+        // function returns an error. The handler path propagates
+        // this to a 400 rather than silently storing the bytes with
+        // metadata intact.
         let garbage = vec![0xff, 0xd8, 0x00, 0x00];
-        let output = strip_image_metadata(&garbage, "image/jpeg");
-        assert_eq!(output, garbage);
+        assert!(strip_image_metadata(&garbage, "image/jpeg").is_err());
+    }
+
+    #[test]
+    fn strip_image_metadata_rejects_unsupported_mime() {
+        // Even if decode succeeds on a crafted payload the function
+        // won't encode an unknown mime. No bytes reach storage.
+        let img = image::RgbImage::from_pixel(2, 2, image::Rgb([10, 20, 30]));
+        let mut bytes = Vec::new();
+        image::codecs::jpeg::JpegEncoder::new_with_quality(&mut Cursor::new(&mut bytes), 80)
+            .encode_image(&image::DynamicImage::ImageRgb8(img))
+            .expect("encode seed");
+        assert!(strip_image_metadata(&bytes, "image/heic").is_err());
     }
 }

--- a/backend/src/api/state/uploads.rs
+++ b/backend/src/api/state/uploads.rs
@@ -161,8 +161,7 @@ pub(in crate::api) fn strip_image_metadata(
 ) -> std::result::Result<Vec<u8>, &'static str> {
     use std::io::Cursor;
 
-    let img =
-        image::load_from_memory(data).map_err(|_| "Could not decode image for metadata strip")?;
+    let img = image::load_from_memory(data).map_err(|_| "Image could not be decoded safely")?;
 
     let mut out = Vec::with_capacity(data.len());
     let result = match mime_type {
@@ -172,10 +171,12 @@ pub(in crate::api) fn strip_image_metadata(
         }
         "image/png" => img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::Png),
         "image/webp" => img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::WebP),
-        _ => return Err("Unsupported mime for metadata strip"),
+        _ => return Err("Image could not be sanitized"),
     };
 
-    result.map(|()| out).map_err(|_| "Image re-encode failed")
+    result
+        .map(|()| out)
+        .map_err(|_| "Image could not be sanitized")
 }
 
 pub(in crate::api) fn extension_for_mime(mime_type: &str) -> &'static str {
@@ -302,6 +303,46 @@ mod tests {
         // metadata intact.
         let garbage = vec![0xff, 0xd8, 0x00, 0x00];
         assert!(strip_image_metadata(&garbage, "image/jpeg").is_err());
+    }
+
+    #[test]
+    fn strip_image_metadata_round_trips_small_png() {
+        // Minimal 1x1 grayscale PNG (proper IDAT CRC). Same fixture
+        // shape used by tests/requests/migration_contract.rs so a
+        // regression that breaks PNG strip would fail here first.
+        let bytes: &[u8] = &[
+            0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, b'I', b'H',
+            b'D', b'R', 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x00, 0x00, 0x00,
+            0x00, 0x3a, 0x7e, 0x9b, 0x55, 0x00, 0x00, 0x00, 0x0a, b'I', b'D', b'A', b'T', 0x78,
+            0x9c, 0x63, 0xf8, 0x0f, 0x00, 0x01, 0x01, 0x01, 0x00, 0xb1, 0x38, 0xf6, 0x14, 0x00,
+            0x00, 0x00, 0x00, b'I', b'E', b'N', b'D', 0xae, 0x42, 0x60, 0x82,
+        ];
+        let result = strip_image_metadata(bytes, "image/png");
+        assert!(
+            result.is_ok(),
+            "1x1 grayscale PNG must strip OK; got {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn strip_image_metadata_round_trips_webp() {
+        // Exercise the WebP encoder branch. `image::ImageFormat::WebP`
+        // uses a lossless encoder by default in 0.25.x; if the build
+        // features ever drop the WebP encoder we want a loud test
+        // failure before prod ships uploads that silently 400.
+        let img = image::RgbImage::from_pixel(8, 8, image::Rgb([0, 128, 255]));
+        let mut webp = Vec::new();
+        img.write_to(&mut Cursor::new(&mut webp), image::ImageFormat::WebP)
+            .expect("seed webp");
+
+        let out =
+            strip_image_metadata(&webp, "image/webp").expect("strip must succeed on a valid webp");
+        assert!(!out.is_empty(), "stripped webp must have bytes");
+        assert!(
+            out.starts_with(b"RIFF"),
+            "stripped webp must remain a valid RIFF container"
+        );
     }
 
     #[test]

--- a/backend/src/api/uploads/multipart.rs
+++ b/backend/src/api/uploads/multipart.rs
@@ -123,8 +123,19 @@ fn validate_upload_payload(headers: &HeaderMap, parsed: &ParsedUpload) -> Handle
 /// validation chain so the cheap rejections (MIME / size / magic /
 /// dimensions) fire first and we don't waste decode cycles on
 /// already-rejected input.
-fn strip_parsed_metadata(parsed: &mut ParsedUpload) {
-    parsed.bytes = strip_image_metadata(&parsed.bytes, &parsed.mime_type);
+///
+/// Fails closed: if the decode or re-encode step errors, the upload
+/// is rejected rather than stored with metadata intact. The earlier
+/// validation means this should only fire for genuinely exotic
+/// input that passed magic-bytes but not the full decoder.
+fn strip_parsed_metadata(headers: &HeaderMap, parsed: &mut ParsedUpload) -> HandlerResult<()> {
+    match strip_image_metadata(&parsed.bytes, &parsed.mime_type) {
+        Ok(stripped) => {
+            parsed.bytes = stripped;
+            Ok(())
+        }
+        Err(msg) => Err(Box::new(bad_request(headers, "INVALID_FILE_CONTENT", msg))),
+    }
 }
 
 fn classify_field(name: Option<&str>) -> UploadFieldKind {
@@ -259,7 +270,7 @@ fn build_parsed_upload(headers: &HeaderMap, draft: UploadDraft) -> HandlerResult
         bytes,
     };
     validate_upload_payload(headers, &parsed)?;
-    strip_parsed_metadata(&mut parsed);
+    strip_parsed_metadata(headers, &mut parsed)?;
     Ok(parsed)
 }
 

--- a/backend/src/api/uploads/multipart.rs
+++ b/backend/src/api/uploads/multipart.rs
@@ -8,7 +8,7 @@ use crate::api::{
     error_response,
     state::{
         allowed_upload_mime, is_chat_context, max_upload_size_bytes, parse_upload_context,
-        validate_image_dimensions, validate_magic_bytes, UploadContext,
+        strip_image_metadata, validate_image_dimensions, validate_magic_bytes, UploadContext,
     },
     ErrorSpec,
 };
@@ -116,6 +116,15 @@ fn validate_upload_payload(headers: &HeaderMap, parsed: &ParsedUpload) -> Handle
     validate_upload_size(headers, parsed)?;
     validate_upload_content(headers, parsed)?;
     validate_upload_dimensions(headers, parsed)
+}
+
+/// Re-encode the parsed payload without metadata before it moves
+/// downstream to storage or variant generation. Runs last in the
+/// validation chain so the cheap rejections (MIME / size / magic /
+/// dimensions) fire first and we don't waste decode cycles on
+/// already-rejected input.
+fn strip_parsed_metadata(parsed: &mut ParsedUpload) {
+    parsed.bytes = strip_image_metadata(&parsed.bytes, &parsed.mime_type);
 }
 
 fn classify_field(name: Option<&str>) -> UploadFieldKind {
@@ -243,13 +252,14 @@ fn build_parsed_upload(headers: &HeaderMap, draft: UploadDraft) -> HandlerResult
         ))
     })?;
 
-    let parsed = ParsedUpload {
+    let mut parsed = ParsedUpload {
         context: context.unwrap_or(UploadContext::ProfileGallery),
         context_id,
         mime_type,
         bytes,
     };
     validate_upload_payload(headers, &parsed)?;
+    strip_parsed_metadata(&mut parsed);
     Ok(parsed)
 }
 

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -30,8 +30,13 @@ fn sign_up_json(email: &str, password: &str) -> serde_json::Value {
 }
 
 fn tiny_png_bytes() -> Vec<u8> {
+    // Minimal 1x1 grayscale PNG with a correct IDAT CRC. The previous
+    // fixture had a mismatched CRC — the image crate's dimension
+    // parser tolerated it but the full decoder (used by the
+    // EXIF-strip step) rejects the chunk. Replacement generated via
+    // python: png.chunk('IHDR', IHDR bytes) + valid-crc IDAT + IEND.
     base64::engine::general_purpose::STANDARD
-        .decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2p9N8AAAAASUVORK5CYII=")
+        .decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGP4DwABAQEAsTj2FAAAAABJRU5ErkJggg==")
         .expect("valid embedded png")
 }
 


### PR DESCRIPTION
**Strip EXIF / metadata server-side after validation**

Client was responsible for EXIF stripping, but a misbuilt client or a direct API caller can skip that step and leak GPS + device IDs. Server now re-decodes and re-encodes to drop every metadata chunk — and fails closed when it can't.

- [x] JPEG re-encoded at quality 92 (visually identical)
- [x] PNG / WebP re-encoded losslessly
- [x] decode / re-encode failure → 400 INVALID_FILE_CONTENT (no silent fallback)
- [x] tests: injected APP1 "GPS_SENTINEL" removed; undecodable input + unsupported mime both rejected

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip EXIF and metadata from uploaded images server-side after validation
> - Adds `strip_image_metadata` in [uploads.rs](https://github.com/poziomki-app/poziomki/pull/192/files#diff-05659f8654b139af1b8f398d14e5b3310e80e3db73a95d4ff0a4809ebc4a28e9) that decodes image bytes with the `image` crate and re-encodes them (JPEG at quality 92, PNG/WebP losslessly) to discard all metadata.
> - Integrates stripping into the upload pipeline via a new `strip_parsed_metadata` helper in [multipart.rs](https://github.com/poziomki-app/poziomki/pull/192/files#diff-f35db40c939f48f2f9053c69f5c9d51796f03816d25ccdfed0b322475f4e2c12), called after validation succeeds and replacing `ParsedUpload.bytes` in-place.
> - Fixes the test PNG fixture in [migration_contract.rs](https://github.com/poziomki-app/poziomki/pull/192/files#diff-461eaef6bf3981b134937e871fd2baef0d22bf4ae43a878a78cfdb6da58190fd) to use a valid 1×1 grayscale PNG with a correct IDAT CRC, required for the full decode/encode path.
> - Behavioral Change: uploads that pass magic/MIME/dimension checks but fail full decode or re-encode now return a `400 INVALID_FILE_CONTENT` error instead of proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef3cb3b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->