### PR TITLE
sec(mobile): set FLAG_SECURE on MainActivity

### DIFF
--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -2,6 +2,7 @@ package com.poziomki.app
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -11,6 +12,16 @@ import com.poziomki.app.chat.push.NotificationChatTarget
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Block screenshots + recent-apps previews of the whole app.
+        // Chat messages, profile edit, and password-reset flows all
+        // surface PII that shouldn't leak to a device's recents
+        // carousel, screen-record apps, or untrusted projections.
+        // Set once on MainActivity because the app is single-activity;
+        // every screen inherits the window flag.
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE,
+        )
         if (savedInstanceState == null) {
             handleIntent(intent)
         }


### PR DESCRIPTION
**Block screenshots / recents previews / MediaProjection on the app window**

Without FLAG_SECURE, chat messages, profile edits, and password-reset flows all leak into the Android recents carousel + screenshots + screen recording + MediaProjection (including malicious apps). Set the flag once on the single-activity host so every Compose screen inherits it.

- [x] FLAG_SECURE set in MainActivity.onCreate
- [x] detekt + ktlint pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set FLAG_SECURE on MainActivity to prevent screenshots and screen recordings
> Sets `WindowManager.LayoutParams.FLAG_SECURE` on the activity window in [`MainActivity.onCreate`](https://github.com/poziomki-app/poziomki/pull/194/files#diff-0dc0e89d06a64256b11f1c03d87cfff6ec833769c071ed2ac45e35ed37b34bc0). Since the app is single-activity, this prevents screenshots, screen recordings, and recent-apps previews across all screens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7282640.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->