### PR TITLE
sec(mobile): certificate pinning on api.poziomki.app

### DIFF
--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/di/PlatformModule.android.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/di/PlatformModule.android.kt
@@ -17,13 +17,55 @@ import com.poziomki.app.session.SessionTokenStore
 import com.poziomki.app.session.createDataStore
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
+import okhttp3.CertificatePinner
 import org.koin.core.module.Module
 import org.koin.dsl.module
+
+/**
+ * Certificate pinning for the Poziomki API. Pins the Let's Encrypt
+ * intermediates (E7 is what the prod leaf currently chains through)
+ * plus both ISRG roots as fallbacks so a routine LE rotation onto a
+ * different intermediate doesn't brick the app.
+ *
+ * Rotation runbook:
+ * 1. Inspect the live chain: `openssl s_client -connect api.poziomki.app:443
+ *    -showcerts </dev/null`
+ * 2. For each cert in the chain, compute its SPKI pin:
+ *    `openssl x509 -in cert.pem -pubkey -noout | openssl pkey -pubin -outform DER |
+ *     openssl dgst -sha256 -binary | openssl base64`
+ * 3. Add the new intermediate pin to API_CERT_PINS (keep the old one
+ *    during the rollover window so already-installed builds still
+ *    connect).
+ * 4. Ship a new APK before the old pin's intermediate rotates out.
+ */
+private val API_CERT_PINS =
+    listOf(
+        // Let's Encrypt E7 (current prod intermediate, ECDSA P-384).
+        "sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=",
+        // ISRG Root X1 (RSA 4096) — LE's primary trust anchor.
+        "sha256/C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=",
+        // ISRG Root X2 (ECDSA P-384) — LE's secondary trust anchor.
+        "sha256/diGVwiVYbubAI3RW4hB9xU8e/CH2GnkuvVFZE8zmgzI=",
+    )
+
+private const val API_HOST = "api.poziomki.app"
+
+private fun buildApiCertificatePinner(): CertificatePinner {
+    val builder = CertificatePinner.Builder()
+    API_CERT_PINS.forEach { pin -> builder.add(API_HOST, pin) }
+    return builder.build()
+}
 
 actual fun platformModule(): Module =
     module {
         single<HttpClientEngine> {
             val apiUrl = getProperty("API_BASE_URL", "http://localhost:5150")
+            // Only pin when the app is actually talking to the prod
+            // API — dev builds hit http://localhost and would hit a
+            // different cert chain under any HTTPS dev setup. The
+            // pin is scoped to api.poziomki.app only; any other host
+            // the client hits goes through the normal trust store.
+            val pinningEnabled = apiUrl.startsWith("https://$API_HOST")
             OkHttp.create {
                 addInterceptor { chain ->
                     val request =
@@ -33,6 +75,11 @@ actual fun platformModule(): Module =
                             .header("Origin", apiUrl)
                             .build()
                     chain.proceed(request)
+                }
+                if (pinningEnabled) {
+                    config {
+                        certificatePinner(buildApiCertificatePinner())
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Certificate pinning for the API host**

OkHttp engine had no cert pinning, so any rogue CA could MITM session tokens. Scoped pinner for `api.poziomki.app` only (dev builds to localhost unaffected).

Pinned keys:
- Let's Encrypt E7 (current intermediate)
- ISRG Root X1 (RSA fallback)
- ISRG Root X2 (ECDSA fallback)

Normal LE rotations validate against the pinned roots. Leaf cert renewal is not a problem. Rotation runbook in source comment.

- [x] Scoped to api.poziomki.app; other hosts use default trust store
- [x] detekt + ktlint pass
- [x] androidApp:assembleDebug builds green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add certificate pinning for `api.poziomki.app` in the Android OkHttp client
> Pins SPKI SHA-256 hashes for Let's Encrypt E7 intermediate and ISRG Root X1/X2 certificates in [PlatformModule.android.kt](https://github.com/poziomki-app/poziomki/pull/195/files#diff-b6131fa4969c5bf08b782252de58c5ff1a09889c89478386492025ddcd395445). Pinning is only applied when `API_BASE_URL` starts with `https://api.poziomki.app`; other hosts and non-HTTPS URLs are unaffected. Risk: any certificate rotation outside the pinned set will cause all HTTPS requests to `api.poziomki.app` to fail until pins are updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b142c9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->