### PR TITLE
sec(infra): fail2ban jail for /api/v1/auth brute-force

### DIFF
--- a/infra/ops/fail2ban/filter.d/poziomki-auth.conf
+++ b/infra/ops/fail2ban/filter.d/poziomki-auth.conf
@@ -1,0 +1,26 @@
+# Poziomki API auth-endpoint filter.
+#
+# Matches Caddy's JSON access log entries for the authentication
+# routes (/api/v1/auth/*) that returned a 401 (bad credentials),
+# 403 (email not verified), or 429 (per-IP rate-limited). The
+# application-layer `auth_rate_limits` table limits per email +
+# per IP; this jail adds an OS-level backstop that drops the
+# offending IP at the firewall after too many failures.
+#
+# Caddy's default JSON log does not guarantee key ordering, so the
+# regex uses a permissive two-step match: remote_ip anywhere on the
+# line, and a separate match on the request URI + status in the
+# structured request payload.
+#
+# Tested against Caddy v2 JSON format.
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+failregex = ^.*"remote_ip":"<HOST>".*"uri":"/api/v1/auth/[^"]*".*"status":(401|403|429).*$
+            ^.*"uri":"/api/v1/auth/[^"]*".*"status":(401|403|429).*"remote_ip":"<HOST>".*$
+
+ignoreregex =
+
+datepattern = "ts":%%s(?:\.%%f)?

--- a/infra/ops/fail2ban/jail.d/poziomki-auth.local
+++ b/infra/ops/fail2ban/jail.d/poziomki-auth.local
@@ -1,0 +1,29 @@
+# Poziomki auth-endpoint jail.
+#
+# Adds an OS-level (iptables) ban after repeated failures on the
+# API auth routes. Application-layer rate limits in
+# `backend/src/api/state/auth.rs` already reject per-email brute
+# force; this jail catches per-IP brute force that spreads across
+# many target emails (credential stuffing).
+#
+# Tuning notes:
+# * maxretry = 8 — tolerant enough for the legitimate "I typed
+#   my password wrong 3 times" case; tight enough to bite a
+#   credential stuffer within seconds.
+# * findtime = 10m — short window so legit users who get rate-
+#   limited once don't accumulate banpoints across hours.
+# * bantime = 1h — fastest path to good-faith unban, matches the
+#   existing `caddy-auth` jail's cadence.
+# * logpath = /var/log/caddy/*access.log — glob so the rename
+#   from rs-access.log → api-access.log doesn't require a
+#   follow-up fail2ban config change.
+
+[poziomki-auth]
+enabled  = true
+filter   = poziomki-auth
+logpath  = /var/log/caddy/*access.log
+maxretry = 8
+findtime = 10m
+bantime  = 1h
+port     = http,https
+action   = iptables-allports[name=poziomki-auth]


### PR DESCRIPTION
**fail2ban jail watching Caddy access logs for /api/v1/auth failures**

Application-layer \`auth_rate_limits\` catches per-email brute force. This jail adds the per-IP credential-stuffing backstop (many emails, same IP).

- [x] Filter matches Caddy v2 JSON access log on any /api/v1/auth/* URI with 401 / 403 / 429
- [x] `maxretry=8` in `findtime=10m`, `bantime=1h` — tolerant of legit typos, bites a stuffing run fast
- [x] `logpath=/var/log/caddy/*access.log` glob so the pending rs → api log rename doesn't break this

Deploy (not in CI):

    scp infra/ops/fail2ban/filter.d/poziomki-auth.conf poziomki:/etc/fail2ban/filter.d/
    scp infra/ops/fail2ban/jail.d/poziomki-auth.local poziomki:/etc/fail2ban/jail.d/
    ssh poziomki 'sudo fail2ban-client reload'

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fail2ban jail to block brute-force attempts on `/api/v1/auth`
> - Adds a fail2ban filter in [`poziomki-auth.conf`](https://github.com/poziomki-app/poziomki/pull/196/files#diff-4240ef3c0d44304a2c8be41164ce5559f8df0c99c171d03b13acdb483b29f1d1) that matches Caddy v2 JSON access log entries for `/api/v1/auth/*` routes returning HTTP 401, 403, or 429, keyed on `remote_ip` and the JSON `ts` date field.
> - Adds a jail in [`poziomki-auth.local`](https://github.com/poziomki-app/poziomki/pull/196/files#diff-54995adcca3d3bc871a967550ff6a493e883af1eb4a7e936da06f25ee2662a1d) that bans offending IPs on all ports via `iptables-allports` for 1 hour after 8 failures within 10 minutes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 923f24d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->