### PR TITLE
sec(infra): rename backend vhost rs → api consistently

### DIFF
--- a/infra/.env.example
+++ b/infra/.env.example
@@ -5,7 +5,7 @@ POSTGRES_DB=poziomki
 
 # API / Worker
 JWT_SECRET=
-SERVER_HOST=https://rs.poziomki.app
+SERVER_HOST=https://api.poziomki.app
 ALLOWED_EMAIL_DOMAIN=*
 
 # Garage S3

--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -89,10 +89,10 @@ cdn.poziomki.app {
 	respond 404
 }
 
-rs.poziomki.app {
+api.poziomki.app {
 	import secure_headers
 	log {
-		output file /var/log/caddy/rs-access.log {
+		output file /var/log/caddy/api-access.log {
 			roll_size 50MiB
 			roll_keep 3
 			roll_keep_for 720h

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -116,7 +116,7 @@ services:
       PORT: 5150
       METRICS_PORT: 9092
       SERVER_BINDING: 0.0.0.0
-      SERVER_HOST: ${SERVER_HOST:-https://rs.poziomki.app}
+      SERVER_HOST: ${SERVER_HOST:-https://api.poziomki.app}
       # Owner URL used ONLY for migrations (schema changes need the owner role).
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki}:${POSTGRES_PASSWORD}@pgdog:6432/${POSTGRES_DB:-poziomki}
       # Least-privilege URL the API pool connects as. Leave unset in .env until
@@ -180,7 +180,7 @@ services:
     environment:
       RUST_ENV: production
       METRICS_PORT: 9093
-      SERVER_HOST: ${SERVER_HOST:-https://rs.poziomki.app}
+      SERVER_HOST: ${SERVER_HOST:-https://api.poziomki.app}
       # Owner URL used ONLY for migrations (worker also runs pending migrations
       # on boot via build_app_context).
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki}:${POSTGRES_PASSWORD}@pgdog:6432/${POSTGRES_DB:-poziomki}


### PR DESCRIPTION
**Rename backend vhost rs → api across Caddy + compose + env**

The earlier Caddyfile change renamed the backend vhost from `rs.poziomki.app` to `api.poziomki.app` but left docker-compose + .env.example + the Caddy log filename still pointing at the old name. Fresh operators would get broken self-referential URLs (password reset email, OAuth callback, etc.).

- [x] Caddyfile.prod: vhost `rs.poziomki.app` → `api.poziomki.app`
- [x] Caddyfile.prod: log file `rs-access.log` → `api-access.log`
- [x] docker-compose.prod.yml: `SERVER_HOST` default (api + worker)
- [x] .env.example: `SERVER_HOST` default

MTA-STS vhost removal deferred to a separate PR (needs DNS rollover coordination).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename backend vhost from `rs` to `api` subdomain in production infrastructure
> Updates the Caddy site block, Docker Compose service defaults, and `.env.example` to use `api.poziomki.app` instead of `rs.poziomki.app`. Access logs are also renamed from `rs-access.log` to `api-access.log`. Behavioral Change: requests to `rs.poziomki.app` will no longer be handled by the Caddy site block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8204d0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->