### PR TITLE
sec(auth): bump OTP entropy 6 → 8 decimal digits

### DIFF
--- a/backend/src/api/auth/service.rs
+++ b/backend/src/api/auth/service.rs
@@ -41,8 +41,12 @@ pub(super) fn env_truthy(key: &str) -> bool {
 }
 
 pub(super) fn generate_otp_code() -> String {
-    let value = (uuid::Uuid::new_v4().as_u128() % 1_000_000) as u32;
-    format!("{value:06}")
+    // 8 decimal digits ≈ 26.5 bits of entropy — up from ~20 at
+    // 6 digits. The auth_rate_limits table already caps guesses per
+    // email, but widening the code space makes the cap easier to
+    // tune without crowding the brute-force horizon.
+    let value = (uuid::Uuid::new_v4().as_u128() % 100_000_000) as u32;
+    format!("{value:08}")
 }
 
 pub(super) fn invalid_otp_response(headers: &HeaderMap) -> Response {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
@@ -72,10 +72,10 @@ fun VerifyScreen(
         focusRequester.requestFocus()
     }
 
-    // Auto-submit when 6 digits entered (with guard against double-submit)
+    // Auto-submit when 8 digits entered (with guard against double-submit)
     var hasSubmitted by remember { mutableStateOf(false) }
     LaunchedEffect(otp) {
-        if (otp.length < 6) {
+        if (otp.length < 8) {
             hasSubmitted = false
         } else if (!hasSubmitted && !uiState.isLoading) {
             hasSubmitted = true
@@ -136,7 +136,7 @@ fun VerifyScreen(
         // OTP input boxes
         OtpInput(
             value = otp,
-            onValueChange = { if (it.length <= 6 && it.all { c -> c.isDigit() }) otp = it },
+            onValueChange = { if (it.length <= 8 && it.all { c -> c.isDigit() }) otp = it },
             modifier = Modifier.focusRequester(focusRequester),
         )
 
@@ -145,7 +145,7 @@ fun VerifyScreen(
         AppButton(
             text = "potwierd\u017a",
             onClick = submit,
-            enabled = otp.length == 6,
+            enabled = otp.length == 8,
             loading = uiState.isLoading,
         )
 
@@ -202,7 +202,7 @@ private fun OtpInput(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                repeat(6) { index ->
+                repeat(8) { index ->
                     val char = value.getOrNull(index)
                     val isFocused = value.length == index
                     Box(


### PR DESCRIPTION
**Widen the OTP brute-force horizon**

6-digit OTPs give ~20 bits of entropy; `auth_rate_limits` caps guesses but the margin is small. 8 digits ≈ 26.5 bits — 64× harder to brute force in the same attempt budget, no UX impact that matters.

- [x] backend: `generate_otp_code` → 100_000_000 mod, :08 format
- [x] mobile: OtpInput accepts 8 chars, submit waits for 8, decoration paints 8 boxes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump OTP entropy from 6 to 8 decimal digits in auth and verification UI
> - Increases the OTP modulus in [`generate_otp_code`](https://github.com/poziomki-app/poziomki/pull/199/files#diff-4076fae22632ad328c0000a2ee78682f1f6b920b02569de551de24a83d812126) from 1,000,000 to 100,000,000 and updates zero-padding to 8 digits.
> - Updates [`VerifyScreen`](https://github.com/poziomki-app/poziomki/pull/199/files#diff-57c2d29996eb02009a6c66508839dff1b1f0fa91bac775455f5444708dbe0a78) to require exactly 8 digits before enabling submit, auto-submit on 8 digits, and cap input at 8 characters.
> - Updates the `OtpInput` composable to render 8 input boxes instead of 6.
> - Behavioral Change: existing in-flight 6-digit OTPs will be rejected; users must request a new code after this change is deployed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a1432a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->