### PR TITLE
sec(ci): CodeQL build-mode manual — analyse source, not just deps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         include:
           - language: rust
-            build-mode: none
+            build-mode: manual
           - language: java-kotlin
-            build-mode: none
+            build-mode: manual
 
     steps:
       - uses: actions/checkout@v4
@@ -28,5 +28,37 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: .github/codeql-config.yml
+
+      # Rust: `build-mode: manual` requires an explicit cargo build so
+      # CodeQL can observe MIR. Swatinem/rust-cache keeps weekly runs
+      # under a few minutes after the first green build.
+      - name: Rust toolchain
+        if: matrix.language == 'rust'
+        uses: dtolnay/rust-toolchain@stable
+      - name: Rust cache
+        if: matrix.language == 'rust'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+      - name: Build Rust
+        if: matrix.language == 'rust'
+        working-directory: backend
+        run: cargo build --all-targets --locked
+
+      # Kotlin/Java: gradle produces the JAR / class files CodeQL
+      # reads. Uses the same task the mobile PR checks already run.
+      - name: JDK 21
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - name: Gradle cache
+        if: matrix.language == 'java-kotlin'
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build mobile
+        if: matrix.language == 'java-kotlin'
+        working-directory: mobile
+        run: gradle :androidApp:assembleDebug --no-daemon
 
       - uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,6 +59,6 @@ jobs:
       - name: Build mobile
         if: matrix.language == 'java-kotlin'
         working-directory: mobile
-        run: gradle :androidApp:assembleDebug --no-daemon
+        run: ./gradlew :androidApp:assembleDebug --no-daemon
 
       - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
**Switch CodeQL from build-mode:none → manual**

`build-mode=none` made CodeQL a dependency scanner only. Now it actually analyses source — Rust MIR + Kotlin/Java class files.

- [x] Rust: cargo build --all-targets --locked with Swatinem/rust-cache
- [x] Kotlin/Java: gradle :androidApp:assembleDebug with gradle/actions cache
- [x] Weekly cron unchanged; first run will be slow, subsequent cached

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch CodeQL build-mode from `none` to `manual` to analyse compiled source
> - Changes the CodeQL matrix config in [codeql.yml](.github/workflows/codeql.yml) from `build-mode: none` to `build-mode: manual` for both `rust` and `java-kotlin` language entries.
> - For Rust: installs the stable toolchain, enables `Swatinem/rust-cache` scoped to the `backend` workspace, and runs `cargo build --all-targets --locked`.
> - For Java/Kotlin: sets up JDK 21 (Temurin), configures Gradle caching, and runs `./gradlew :androidApp:assembleDebug --no-daemon` in the `mobile` directory.
> - Behavioral Change: CodeQL now analyzes compiled artifacts rather than raw source, which improves detection coverage but increases CI build time for both language jobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c711f4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->