### PR TITLE
sec(auth): POST /auth/sessions/revoke-all — sign out everywhere

### DIFF
--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -284,6 +284,29 @@ pub(super) async fn sign_out(
     Ok(Json(SuccessResponse { success: true }).into_response())
 }
 
+/// Terminate every active session for the authenticated user — the
+/// "sign out everywhere" button.
+///
+/// Used when a token is suspected of leaking, a device was lost, or
+/// the user wants a clean slate. Scoped to the caller's own
+/// `user_id`, not a target; the admin ban endpoint is the
+/// cross-user equivalent.
+pub(super) async fn sign_out_all(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+) -> Result<Response> {
+    use crate::db::schema::sessions;
+    let (_session, user) = auth_or_respond!(headers);
+    let Ok(mut conn) = crate::db::conn().await else {
+        return Ok(Json(SuccessResponse { success: false }).into_response());
+    };
+    let _ = diesel::delete(sessions::table.filter(sessions::user_id.eq(user.id)))
+        .execute(&mut conn)
+        .await;
+    crate::api::state::invalidate_auth_cache_for_user_id(user.id).await;
+    Ok(Json(SuccessResponse { success: true }).into_response())
+}
+
 pub(super) async fn sessions(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,

--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -291,20 +291,38 @@ pub(super) async fn sign_out(
 /// the user wants a clean slate. Scoped to the caller's own
 /// `user_id`, not a target; the admin ban endpoint is the
 /// cross-user equivalent.
+///
+/// Runs the DELETE inside `db::with_viewer_tx` so RLS on `sessions`
+/// (policy `sessions_viewer` requires `user_id = app.current_user_id()`)
+/// sees the viewer and actually purges the rows. Without the viewer
+/// context the DELETE would filter to zero rows and the endpoint
+/// would lie — a 200 with nothing revoked except the in-memory cache.
 pub(super) async fn sign_out_all(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
     use crate::db::schema::sessions;
+    use diesel_async::scoped_futures::ScopedFutureExt;
     let (_session, user) = auth_or_respond!(headers);
-    let Ok(mut conn) = crate::db::conn().await else {
-        return Ok(Json(SuccessResponse { success: false }).into_response());
+    let viewer = crate::db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
     };
-    let _ = diesel::delete(sessions::table.filter(sessions::user_id.eq(user.id)))
-        .execute(&mut conn)
-        .await;
+    let user_id = user.id;
+    let deleted = crate::db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            diesel::delete(sessions::table.filter(sessions::user_id.eq(user_id)))
+                .execute(conn)
+                .await
+        }
+        .scope_boxed()
+    })
+    .await;
     crate::api::state::invalidate_auth_cache_for_user_id(user.id).await;
-    Ok(Json(SuccessResponse { success: true }).into_response())
+    match deleted {
+        Ok(_) => Ok(Json(SuccessResponse { success: true }).into_response()),
+        Err(_) => Ok(Json(SuccessResponse { success: false }).into_response()),
+    }
 }
 
 pub(super) async fn sessions(

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -44,6 +44,7 @@ fn auth_routes() -> Router<AppContext> {
         .route("/verify-otp", post(auth::verify_otp))
         .route("/resend-otp", post(auth::resend_otp))
         .route("/sign-out", post(auth::sign_out))
+        .route("/sessions/revoke-all", post(auth::sign_out_all))
         .route("/sessions", get(auth::sessions))
         .route("/account", delete(auth::delete_account))
         .route("/account/password", patch(auth::change_password))


### PR DESCRIPTION
**Self-serve sign-out-everywhere endpoint**

Leaked-token recovery without admin intervention. Scoped to caller's own user_id; admin ban endpoint (#197) is the cross-user equivalent.

- [x] deletes all sessions where user_id = caller
- [x] invalidates auth cache entries for that user_id
- [x] reuses the same invalidate helper as the admin ban path

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add POST /auth/sessions/revoke-all endpoint to sign out all sessions
> Adds a `sign_out_all` handler that deletes all sessions for the authenticated user from the database, then invalidates the user's auth cache. The delete runs inside a viewer-scoped transaction (RLS enforced) and returns a JSON `{success: true/false}` response.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1820af9. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->