### PR TITLE
Fail startup on missing least-privilege DB URL

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -126,19 +126,46 @@ enum PoolRole {
     Worker,
 }
 
+impl PoolRole {
+    const fn env_var(self) -> &'static str {
+        match self {
+            Self::Api => "API_DATABASE_URL",
+            Self::Worker => "WORKER_DATABASE_URL",
+        }
+    }
+
+    const fn expected_db_user(self) -> &'static str {
+        match self {
+            Self::Api => "poziomki_api",
+            Self::Worker => "poziomki_worker",
+        }
+    }
+}
+
+fn is_production() -> bool {
+    std::env::var("RUST_ENV").unwrap_or_default() == "production"
+}
+
 // The pool URL is chosen per-process so the API and worker can connect as
 // least-privilege roles (poziomki_api / poziomki_worker) while migrations
-// keep using the owner role via DATABASE_URL. When the role-specific var is
-// unset we fall back to DATABASE_URL, which preserves current dev behaviour.
+// keep using the owner role via DATABASE_URL.
+//
+// In dev/test we fall back to DATABASE_URL when the role-specific var is
+// unset. In production an empty role-specific var is a hard failure: the
+// fallback would silently connect as the owner role (BYPASSRLS), which
+// invalidates every RLS policy we ship.
 fn resolve_pool_url(role: PoolRole) -> crate::error::AppResult<String> {
-    let primary = match role {
-        PoolRole::Api => "API_DATABASE_URL",
-        PoolRole::Worker => "WORKER_DATABASE_URL",
-    };
+    let primary = role.env_var();
     if let Ok(value) = std::env::var(primary) {
         if !value.trim().is_empty() {
             return Ok(value);
         }
+    }
+    if is_production() {
+        return Err(crate::error::AppError::message(format!(
+            "{primary} must be set in production (no fallback to DATABASE_URL — the owner \
+             role bypasses RLS)"
+        )));
     }
     std::env::var("DATABASE_URL")
         .map_err(|_| crate::error::AppError::message("DATABASE_URL must be set"))
@@ -147,6 +174,40 @@ fn resolve_pool_url(role: PoolRole) -> crate::error::AppResult<String> {
 fn init_diesel_pool(role: PoolRole) -> crate::error::AppResult<()> {
     let url = resolve_pool_url(role)?;
     crate::db::init_pool(&url).map_err(crate::error::AppError::Message)
+}
+
+// In production, verify the pool actually connected as the expected
+// least-privilege role. If pgdog / env / password misconfig routes us to
+// the owner role instead, RLS is silently disabled — fail startup.
+#[derive(diesel::deserialize::QueryableByName)]
+struct CurrentDbUser {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    current_user: String,
+}
+
+async fn assert_pool_role(role: PoolRole) -> crate::error::AppResult<()> {
+    use diesel_async::RunQueryDsl;
+
+    if !is_production() {
+        return Ok(());
+    }
+    let mut conn = crate::db::conn()
+        .await
+        .map_err(|e| crate::error::AppError::Message(format!("pool role check: {e}")))?;
+    let row: CurrentDbUser = diesel::sql_query("SELECT current_user::text AS current_user")
+        .get_result(&mut conn)
+        .await
+        .map_err(|e| crate::error::AppError::Message(format!("pool role check: {e}")))?;
+    let expected = role.expected_db_user();
+    if row.current_user != expected {
+        return Err(crate::error::AppError::Message(format!(
+            "pool connected as db user {actual:?}, expected {expected:?} — refusing to start \
+             (RLS would be bypassed)",
+            actual = row.current_user,
+        )));
+    }
+    tracing::info!(db_user = %row.current_user, "pool role verified");
+    Ok(())
 }
 
 fn build_app_context(role: PoolRole) -> crate::error::AppResult<AppContext> {
@@ -177,6 +238,7 @@ pub async fn run_api_server() -> crate::error::AppResult<()> {
     crate::telemetry::init_metrics_exporter(crate::telemetry::ProcessKind::Api)?;
     let cfg = load_runtime_config()?;
     let ctx = build_app_context(PoolRole::Api)?;
+    assert_pool_role(PoolRole::Api).await?;
     let router = build_router_with_state(ctx);
 
     let listener = tokio::net::TcpListener::bind((cfg.binding.as_str(), cfg.port))
@@ -202,6 +264,7 @@ pub async fn run_outbox_worker_process() -> crate::error::AppResult<()> {
     crate::telemetry::init_metrics_exporter(crate::telemetry::ProcessKind::Worker)?;
     let _cfg = load_runtime_config()?;
     let ctx = build_app_context(PoolRole::Worker)?;
+    assert_pool_role(PoolRole::Worker).await?;
 
     crate::jobs::start_background_workers(&ctx)?;
     tracing::info!("Poziomki outbox worker process started");

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -119,10 +119,12 @@ services:
       SERVER_HOST: ${SERVER_HOST:-https://api.poziomki.app}
       # Owner URL used ONLY for migrations (schema changes need the owner role).
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki}:${POSTGRES_PASSWORD}@pgdog:6432/${POSTGRES_DB:-poziomki}
-      # Least-privilege URL the API pool connects as. Leave unset in .env until
-      # roles have been bootstrapped via infra/ops/postgres/setup-roles.sh; the
-      # Rust pool falls back to DATABASE_URL when this is empty.
-      API_DATABASE_URL: ${API_DATABASE_URL:-}
+      # Least-privilege URL the API pool connects as (role poziomki_api,
+      # NOBYPASSRLS). Required in production — startup fails if unset, and
+      # the API asserts current_user = 'poziomki_api' after connecting so a
+      # misrouted pool can't silently bypass RLS. Bootstrap roles first via
+      # infra/ops/postgres/setup-roles.sh.
+      API_DATABASE_URL: ${API_DATABASE_URL:?API_DATABASE_URL must be set (least-privilege pool URL)}
       DB_POOL_MAX_SIZE: ${API_DB_POOL_MAX_SIZE:-16}
       DB_POOL_WAIT_TIMEOUT_MS: ${API_DB_POOL_WAIT_TIMEOUT_MS:-3000}
       DB_POOL_CREATE_TIMEOUT_MS: ${API_DB_POOL_CREATE_TIMEOUT_MS:-5000}
@@ -185,10 +187,11 @@ services:
       # Owner URL used ONLY for migrations (worker also runs pending migrations
       # on boot via build_app_context).
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki}:${POSTGRES_PASSWORD}@pgdog:6432/${POSTGRES_DB:-poziomki}
-      # Worker pool URL. Worker has BYPASSRLS because outbox dispatch and
-      # cleanup legitimately act across users. Leave unset in .env until roles
-      # have been bootstrapped; Rust falls back to DATABASE_URL when empty.
-      WORKER_DATABASE_URL: ${WORKER_DATABASE_URL:-}
+      # Worker pool URL (role poziomki_worker, BYPASSRLS — outbox dispatch
+      # and cleanup legitimately act across users). Required in production;
+      # startup asserts current_user = 'poziomki_worker'. Bootstrap roles
+      # first via infra/ops/postgres/setup-roles.sh.
+      WORKER_DATABASE_URL: ${WORKER_DATABASE_URL:?WORKER_DATABASE_URL must be set (least-privilege pool URL)}
       DB_POOL_MAX_SIZE: ${WORKER_DB_POOL_MAX_SIZE:-8}
       DB_POOL_WAIT_TIMEOUT_MS: ${WORKER_DB_POOL_WAIT_TIMEOUT_MS:-3000}
       DB_POOL_CREATE_TIMEOUT_MS: ${WORKER_DB_POOL_CREATE_TIMEOUT_MS:-5000}


### PR DESCRIPTION
**Fail startup on missing least-privilege DB URL**

Production API / worker must connect via the role-specific pool URLs. Falling back to `DATABASE_URL` connects as the owner role (BYPASSRLS) and silently invalidates every RLS policy we shipped.

- [ ] ship to prod and confirm API logs `pool role verified` on boot

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail startup on missing or incorrect least-privilege DB credentials in production
> - In production, `resolve_pool_url` now returns an error if `API_DATABASE_URL` or `WORKER_DATABASE_URL` is unset or empty, with no fallback to `DATABASE_URL`.
> - After building the pool, `assert_pool_role` queries `SELECT current_user` and fails startup if the connected DB user does not match the expected least-privilege role.
> - [docker-compose.prod.yml](https://github.com/poziomki-app/poziomki/pull/203/files#diff-2eeee385263c859a8fc9d0a455c48137ba77b00bde682f9a7208b0aad1d3f864) marks `API_DATABASE_URL` and `WORKER_DATABASE_URL` as required, so `docker-compose` itself will refuse to start the services if either variable is missing.
> - Behavioral Change: non-production environments retain the `DATABASE_URL` fallback and skip the role assertion entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccac102.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->