### PR TITLE
IP rate-limit admin + ops endpoints

### DIFF
--- a/backend/src/api/admin.rs
+++ b/backend/src/api/admin.rs
@@ -81,6 +81,17 @@ pub(super) async fn ban_user(
     Path(pid): Path<Uuid>,
     Json(body): Json<BanBody>,
 ) -> Response {
+    // Rate limit by caller IP before token compare — caps online
+    // brute-force of ADMIN_TOKEN from any single source even though
+    // the compare itself is constant time.
+    if let Err(resp) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::AdminAuth,
+    )
+    .await
+    {
+        return *resp;
+    }
     if let Err(resp) = admin_auth(&headers) {
         return *resp;
     }

--- a/backend/src/api/ip_rate_limit.rs
+++ b/backend/src/api/ip_rate_limit.rs
@@ -39,6 +39,11 @@ const SEARCH_MAX_PER_MIN: u32 = 20;
 const XP_ACTION_MAX_PER_MIN: u32 = 30;
 const XP_TOKEN_GEN_MAX_PER_MIN: u32 = 10;
 const UPLOAD_WRITE_MAX_PER_MIN: u32 = 30;
+// Admin + ops endpoints are gated by a shared token — rate limit
+// caps online brute-force of the token. Tight budget because both
+// surfaces are single-operator, low-frequency by design.
+const ADMIN_AUTH_MAX_PER_MIN: u32 = 10;
+const OPS_AUTH_MAX_PER_MIN: u32 = 20;
 
 /// Bucket name used when no trustworthy client IP can be parsed from the
 /// proxy headers. A shared bucket still caps the endpoint, so missing
@@ -53,6 +58,8 @@ pub enum IpRateLimitAction {
     XpAction,
     XpTokenGen,
     UploadWrite,
+    AdminAuth,
+    OpsAuth,
 }
 
 impl IpRateLimitAction {
@@ -64,6 +71,8 @@ impl IpRateLimitAction {
             Self::XpAction => XP_ACTION_MAX_PER_MIN,
             Self::XpTokenGen => XP_TOKEN_GEN_MAX_PER_MIN,
             Self::UploadWrite => UPLOAD_WRITE_MAX_PER_MIN,
+            Self::AdminAuth => ADMIN_AUTH_MAX_PER_MIN,
+            Self::OpsAuth => OPS_AUTH_MAX_PER_MIN,
         }
     }
 
@@ -75,6 +84,8 @@ impl IpRateLimitAction {
             Self::XpAction => "ip_xp_action",
             Self::XpTokenGen => "ip_xp_token_gen",
             Self::UploadWrite => "ip_upload_write",
+            Self::AdminAuth => "ip_admin_auth",
+            Self::OpsAuth => "ip_ops_auth",
         }
     }
 }

--- a/backend/src/api/root.rs
+++ b/backend/src/api/root.rs
@@ -5,6 +5,7 @@ use axum::{
     Json,
 };
 use serde::Serialize;
+use subtle::ConstantTimeEq;
 
 use crate::app::AppContext;
 
@@ -43,10 +44,13 @@ fn ops_token_matches(headers: &HeaderMap) -> bool {
     let Some(expected) = ops_status_token() else {
         return false;
     };
-    headers
+    let actual = headers
         .get("x-ops-token")
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|actual| actual == expected)
+        .unwrap_or("");
+    // Constant-time compare so response timing doesn't leak bytes of
+    // the expected token to an attacker probing /ops/*.
+    expected.as_bytes().ct_eq(actual.as_bytes()).unwrap_u8() == 1
 }
 
 pub(super) async fn outbox_status(
@@ -55,6 +59,17 @@ pub(super) async fn outbox_status(
 ) -> Result<Response> {
     if ops_status_token().is_none() {
         return Ok((axum::http::StatusCode::NOT_FOUND, "not found").into_response());
+    }
+
+    // Rate limit by caller IP before token compare — caps online
+    // brute-force of OPS_STATUS_TOKEN.
+    if let Err(resp) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::OpsAuth,
+    )
+    .await
+    {
+        return Ok(*resp);
     }
 
     if !ops_token_matches(&headers) {


### PR DESCRIPTION
**IP rate-limit admin + ops endpoints**

Shared-token endpoints now rate-limit by caller IP before the token compare runs, capping online brute-force. Ops also switches to a constant-time compare.

- [ ] verify repeated bad tokens from one IP get a 429 after the cap

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add IP rate limiting to admin and ops endpoints
> - Adds per-IP rate limiting to the `ban_user` (admin) and `outbox_status` (ops) endpoints, enforced before token validation using new `AdminAuth` (10/min) and `OpsAuth` (20/min) `IpRateLimitAction` variants in [ip_rate_limit.rs](https://github.com/poziomki-app/poziomki/pull/206/files#diff-b24a2d1728b014ee0e49e0c1191930457a5d5de97252671fc82f4c34b3444819).
> - Switches token comparison in the `ops_token_matches` helper in [root.rs](https://github.com/poziomki-app/poziomki/pull/206/files#diff-39a891ceed102b721ad41f723f2f2f958aedfd75dc90c0ce2115cb5c1f18ccc5) from string equality to constant-time comparison via `subtle::ConstantTimeEq` to reduce timing side-channel leakage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18ac9b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->