### PR TITLE
Enable HTTP/3 + pin TLS 1.3 minimum in Caddy

### DIFF
--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -1,4 +1,24 @@
+{
+	# Advertise HTTP/3 (QUIC) alongside h1/h2, and pin TLS minimum to
+	# 1.3. HTTP/3 helps on lossy mobile networks via QUIC's per-stream
+	# loss recovery; browsers fall back to h2 transparently if UDP/443
+	# is blocked upstream. Pinning TLS 1.3 drops downgrade-prone 1.2
+	# cipher suites with no client-compat cost for Android 7+ / iOS 12+.
+	# Requires UDP/443 open in the host firewall + any cloud SG.
+	servers {
+		protocols h1 h2 h3
+	}
+}
+
 (secure_headers) {
+	# Pin TLS minimum to 1.3. Default is 1.2, which still permits
+	# cipher suites with known downgrade attacks; 1.3 has no client-
+	# compat cost for Android 7+ / iOS 12+. Applied per-site via this
+	# shared snippet so every vhost gets it.
+	tls {
+		protocols tls1.3
+	}
+
 	header {
 		Strict-Transport-Security "max-age=31536000"
 		X-Content-Type-Options "nosniff"


### PR DESCRIPTION
**Enable HTTP/3 + pin TLS 1.3 minimum in Caddy**

Global options opt into h1/h2/h3; the shared secure_headers snippet pins each vhost to TLS 1.3 only.

- [ ] open UDP/443 in host firewall / cloud SG before reload
- [ ] after reload, confirm `curl --http3 -I https://api.poziomki.app/health` 200s with `alt-svc` set
- [ ] confirm `openssl s_client -connect api.poziomki.app:443 -tls1_2` fails

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable HTTP/3 and enforce TLS 1.3 minimum in Caddy
> - Adds a global `servers` block in [Caddyfile.prod](https://github.com/poziomki-app/poziomki/pull/207/files#diff-507ac62fa8220af2d08c3d8f2ef5aee0806600e1d1085fc4c641c643ea9f4e36) that advertises `h1`, `h2`, and `h3` protocols, enabling HTTP/3 for all servers.
> - Adds a `tls` block inside the `(secure_headers)` snippet that pins the minimum TLS version to `tls1.3`, disabling TLS 1.2 and below for any site importing the snippet.
> - Behavioral Change: TLS 1.2 clients connecting to sites using `(secure_headers)` will be rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e6e3d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->