### PR TITLE
Add includeSubDomains + preload to HSTS header

### DIFF
--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -1,6 +1,13 @@
 (secure_headers) {
 	header {
-		Strict-Transport-Security "max-age=31536000"
+		# Full HSTS preload form. includeSubDomains applies HTTPS-only
+		# to every *.poziomki.app; preload signals we're willing to ship
+		# on Chrome's preload list. Actual submission at hstspreload.org
+		# is a manual human step AFTER this header has been live for a
+		# week with no HTTP-only subdomain breakage. Removal from the
+		# preload list takes weeks-to-months, so don't submit until we
+		# are sure every current + near-term subdomain serves HTTPS.
+		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
 		X-Content-Type-Options "nosniff"
 		Referrer-Policy "strict-origin-when-cross-origin"
 		# Clickjacking: refuse to be framed, in both the legacy and


### PR DESCRIPTION
**Add includeSubDomains + preload to HSTS header**

Header-only change; submission to hstspreload.org is a separate manual step to run after the header has been live for a week with no subdomain breakage.

- [ ] deploy + wait ≥7 days
- [ ] confirm every *.poziomki.app subdomain serves HTTPS
- [ ] submit at https://hstspreload.org

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `includeSubDomains; preload` to HSTS header in Caddy secure headers
> Updates the `Strict-Transport-Security` header in [Caddyfile.prod](https://github.com/poziomki-app/poziomki/pull/208/files#diff-507ac62fa8220af2d08c3d8f2ef5aee0806600e1d1085fc4c641c643ea9f4e36) from `max-age=31536000` to `max-age=31536000; includeSubDomains; preload`, making the site eligible for HSTS preload list submission. Risk: `includeSubDomains` enforces HTTPS on all subdomains for returning clients, which is irreversible without a long wait period — all subdomains must serve valid HTTPS before submitting to the preload list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9807ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->