### PR TITLE
Weekly Gradle dependency-updates report

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -3,6 +3,12 @@ name: Mobile CI
 on:
   pull_request:
     paths: [mobile/**]
+  schedule:
+    # Weekly dependency-update report. Monday 06:00 UTC avoids overlapping
+    # with backend security audit (Sunday) and keeps the report fresh at
+    # the start of the work week.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 concurrency:
   group: mobile-${{ github.head_ref || github.ref }}
@@ -47,3 +53,33 @@ jobs:
 
       - run: ./gradlew detekt
       - run: ./gradlew ktlintCheck
+
+  dependency-updates:
+    # Only runs on the weekly schedule and manual dispatch — pull-request
+    # runs skip it to avoid gating merges on an upstream version bump we
+    # haven't had time to triage.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: ./gradlew dependencyUpdates -Drevision=release
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: gradle-dependency-updates
+          path: mobile/build/dependencyUpdates/
+          retention-days: 30

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -6,4 +6,19 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kotlinxSerialization) apply false
     alias(libs.plugins.sqldelight) apply false
+    alias(libs.plugins.versions)
+}
+
+// Reject non-stable candidates (alpha / beta / RC / milestone) so the
+// dependencyUpdates report points at real releases instead of
+// pre-release noise. Mirrors the upstream plugin's recommended filter.
+tasks.named(
+    "dependencyUpdates",
+    com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask::class.java,
+).configure {
+    rejectVersionIf {
+        val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { candidate.version.uppercase().contains(it) }
+        val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+        !stableKeyword && !regex.matches(candidate.version)
+    }
 }

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -64,5 +64,6 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-mu
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "14.0.1" }
+versions = { id = "com.github.ben-manes.versions", version = "0.52.0" }
 kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }


### PR DESCRIPTION
**Weekly Gradle dependency-updates report**

Adds the ben-manes versions plugin and a weekly CI job that uploads the dependency-updates report as an artifact. Non-blocking by design — closes the gap Rust's cargo-audit already covers on the backend side.

- [ ] verify the first scheduled run produces a report artifact

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add weekly Gradle dependency update report to mobile CI workflow
> - Adds a new `dependency-updates` job to [mobile.yml](.github/workflows/mobile.yml) that runs on a weekly Monday schedule (06:00 UTC) or manual dispatch, skipping PR builds.
> - Applies the `com.github.ben-manes.versions` plugin (v0.52.0) in [build.gradle.kts](mobile/build.gradle.kts) and configures the `dependencyUpdates` task to exclude non-stable versions (alpha/beta/RC/milestone).
> - The generated report is uploaded as a workflow artifact with a 30-day retention period.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd5b8b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->