### PR TITLE
Fix RLS cross-bucket joins (matching + message search)

### DIFF
--- a/backend/src/api/matching/repo.rs
+++ b/backend/src/api/matching/repo.rs
@@ -233,11 +233,17 @@ impl MatchingRepository {
                 .collect()
         };
 
+        // No INNER JOIN to users: under RLS, the users policy is own-row
+        // only, so joining here would silently drop every other-bucket
+        // profile. Bucket scoping is already enforced by the
+        // `profiles_viewer` RLS policy via `app.profiles_in_current_bucket()`,
+        // so the redundant `users.is_review_stub = viewer_is_stub` filter
+        // is unnecessary here. `viewer_is_stub` is still resolved above
+        // because some callers depend on it; matching itself doesn't.
+        let _ = viewer_is_stub;
         profiles::table
-            .inner_join(users::table.on(users::id.eq(profiles::user_id)))
             .left_join(user_settings::table.on(user_settings::user_id.eq(profiles::user_id)))
             .filter(profiles::user_id.ne(user_id))
-            .filter(users::is_review_stub.eq(viewer_is_stub))
             .filter(
                 user_settings::privacy_discoverable
                     .eq(true)

--- a/backend/src/search.rs
+++ b/backend/src/search.rs
@@ -1,6 +1,5 @@
 use diesel::deserialize::QueryableByName;
 use diesel::sql_types::{Array, BigInt, Float8, Integer, Nullable, Text, Uuid as DieselUuid};
-use diesel::OptionalExtension;
 use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 
@@ -308,12 +307,6 @@ struct RoomIdRow {
     room_id: String,
 }
 
-#[derive(Debug, Clone, QueryableByName)]
-struct UserIdRow {
-    #[diesel(sql_type = Integer)]
-    id: i32,
-}
-
 #[allow(clippy::similar_names)]
 pub async fn search_message_rooms(
     query: &str,
@@ -334,13 +327,13 @@ pub async fn search_message_rooms(
     // Resolve caller's internal user id up front — the DM + event
     // branches both need it to constrain results to rooms the viewer
     // is actually a member of.
+    //
+    // Use the SECURITY DEFINER helper instead of a plain SELECT FROM
+    // users: under RLS, `users` is own-row-only with no viewer GUC set
+    // here, so a direct query returns nothing and search degrades to
+    // empty for everyone.
     let mut conn = crate::db::conn().await?;
-    let user_id: Option<i32> = diesel::sql_query("SELECT id FROM users WHERE pid = $1")
-        .bind::<DieselUuid, _>(user_pid)
-        .get_result::<UserIdRow>(&mut conn)
-        .await
-        .optional()?
-        .map(|r| r.id);
+    let user_id: Option<i32> = crate::db::user_id_for_pid(&mut conn, *user_pid).await?;
     drop(conn);
     let Some(user_id) = user_id else {
         return Ok(Vec::new());
@@ -391,10 +384,14 @@ async fn search_dm_room_ids(
         JOIN conversation_members cm ON cm.conversation_id = c.id AND cm.user_id = $3
         WHERE c.kind = 'dm'
           AND EXISTS (
+            -- Drop the JOIN to users: the users RLS policy is own-row
+            -- only so joining other-bucket users returns zero rows and
+            -- DM search degrades to empty. profiles is bucket-readable
+            -- via RLS so we can hop straight from conversation_members
+            -- to profiles via the shared user_id.
             SELECT 1 FROM conversation_members cm2
-            JOIN users u2 ON u2.id = cm2.user_id
-            JOIN profiles p ON p.user_id = u2.id
-            LEFT JOIN user_settings us ON us.user_id = u2.id
+            JOIN profiles p ON p.user_id = cm2.user_id
+            LEFT JOIN user_settings us ON us.user_id = cm2.user_id
             WHERE cm2.conversation_id = c.id
               AND cm2.user_id != $3
               AND (


### PR DESCRIPTION
**Fix RLS cross-bucket joins**

Matching returned no profiles and message search returned empty for everyone — both from queries that tried to JOIN `users`, which RLS hides for anyone except the viewer themselves.

- [ ] prod: poznaj shows candidates
- [ ] prod: message search returns rooms

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLS cross-bucket join errors in matching and message search
> - Removes the `INNER JOIN` to the `users` table in [repo.rs](https://github.com/poziomki-app/poziomki/pull/210/files#diff-fe2cacd26eb8e974a5e780381831fead540ac7b253e064e48b07dd2ceef85ba9), eliminating the `is_review_stub` equality filter from the profiles query so results no longer depend on the `users` table.
> - Rewrites the DM room search SQL in [search.rs](https://github.com/poziomki-app/poziomki/pull/210/files#diff-f157aaca4d578281c5d617b3970ba00ee9a8915ac4d1d1251a5744e61ff62fe1) to join `profiles` and `user_settings` directly via `conversation_members.user_id` instead of going through a `users` join.
> - Replaces inline `SELECT id FROM users WHERE pid = $1` with a call to `crate::db::user_id_for_pid` for user-id resolution in `search_message_rooms`.
> - Behavioral Change: profiles returned by matching and DM rooms returned by message search may differ from before, as the `users`-table join constraints are removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9678855.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->