### PR TITLE
Re-add X-Origin-Secret injection to imgproxy /img/* block

### DIFF
--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -137,7 +137,14 @@ api.poziomki.app {
 		header {
 			X-Robots-Tag "noindex, nofollow, noarchive"
 		}
-		reverse_proxy localhost:3080
+		# imgproxy refuses any request without a matching X-Origin-Secret
+		# (so a direct hit on port 3080 can't serve images if ever exposed).
+		# Strip any client-supplied value first so the caller can't forge
+		# it, then inject the configured one before forwarding upstream.
+		request_header -X-Origin-Secret
+		reverse_proxy localhost:3080 {
+			header_up X-Origin-Secret {$IMGPROXY_ORIGIN_SECRET}
+		}
 	}
 
 	handle {


### PR DESCRIPTION
**Re-add X-Origin-Secret injection**

imgproxy refuses requests without a matching origin secret. A deploy that copied the repo Caddyfile over the live one dropped the injection and broke every image with a 403.

- [ ] confirm repo Caddyfile is now the single source of truth

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-add X-Origin-Secret injection to imgproxy `/img/*` block in Caddy
> Updates [Caddyfile.prod](https://github.com/poziomki-app/poziomki/pull/211/files#diff-507ac62fa8220af2d08c3d8f2ef5aee0806600e1d1085fc4c641c643ea9f4e36) to strip any client-supplied `X-Origin-Secret` header and inject the `{$IMGPROXY_ORIGIN_SECRET}` value when proxying requests to `localhost:3080`. This prevents clients from spoofing the secret while ensuring imgproxy receives the correct authentication header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 529bcf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->