### PR TITLE
Serve full/2000px image variant by default

### DIFF
--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -131,10 +131,16 @@ pub fn extract_filename(value: &str) -> String {
 }
 
 /// Resolve a stored image value (filename or legacy presigned URL) to a fresh signed URL.
-/// Prefers imgproxy (feed/800px, webp) when configured; otherwise uses app-routed media URL.
+/// Prefers imgproxy (full/2000px, webp) when configured; otherwise uses app-routed media URL.
+///
+/// 2000px WebP looks sharp on a 1080px high-DPI phone screen at any
+/// rendered size up to full-bleed. 800px (the prior default) was
+/// visibly soft on matching cards and bio galleries. Bandwidth cost
+/// is ~3× per image but a WebP-compressed 2000px photo is still
+/// ~200-400 KiB — acceptable for a beta audience on wifi.
 pub async fn resolve_image_url(stored: &str) -> String {
     let filename = extract_filename(stored);
-    if let Some(url) = super::imgproxy_signing::signed_url(&filename, "feed", "webp") {
+    if let Some(url) = super::imgproxy_signing::signed_url(&filename, "full", "webp") {
         return url;
     }
     format!("/api/v1/uploads/{filename}")

--- a/backend/src/api/uploads/read_handler.rs
+++ b/backend/src/api/uploads/read_handler.rs
@@ -212,7 +212,10 @@ pub(in crate::api) async fn file_status(
         let (thumbnail_url, standard_url) = if imgproxy {
             (
                 crate::api::imgproxy_signing::signed_avatar_url(&upload.filename),
-                crate::api::imgproxy_signing::signed_url(&upload.filename, "feed", "webp"),
+                // `standard_url` is what clients use for the main image
+                // render; full/2000px WebP keeps it sharp on high-DPI
+                // phones (200-400 KiB, fine on wifi).
+                crate::api::imgproxy_signing::signed_url(&upload.filename, "full", "webp"),
             )
         } else if upload.has_variants {
             let thumb_name = uploads_resize::variant_filename(&upload.filename, "thumb");

--- a/backend/src/api/uploads/url_service.rs
+++ b/backend/src/api/uploads/url_service.rs
@@ -6,7 +6,9 @@ fn dev_upload_url(filename: &str) -> String {
 }
 
 pub(super) async fn public_upload_url(headers: &HeaderMap, filename: &str) -> String {
-    if let Some(url) = crate::api::imgproxy_signing::signed_url(filename, "feed", "webp") {
+    // Match resolve_image_url: serve the full/2000px WebP variant so
+    // profile + event cover images stay sharp on high-DPI phones.
+    if let Some(url) = crate::api::imgproxy_signing::signed_url(filename, "full", "webp") {
         return url;
     }
     let _ = headers;
@@ -18,9 +20,12 @@ pub(super) async fn fallback_variant_urls(
     original_filename: &str,
 ) -> (Option<String>, Option<String>) {
     if crate::api::imgproxy_signing::is_configured() {
+        // Upload response's thumbnail_url + standard_url. thumbnail stays
+        // at 200px for avatar-sized renders; standard is the full 2000px
+        // WebP so swipe cards / detail views look sharp.
         let thumb = crate::api::imgproxy_signing::signed_avatar_url(original_filename);
-        let feed = crate::api::imgproxy_signing::signed_url(original_filename, "feed", "webp");
-        return (thumb, feed);
+        let full = crate::api::imgproxy_signing::signed_url(original_filename, "full", "webp");
+        return (thumb, full);
     }
     let fallback = public_upload_url(headers, original_filename).await;
     (Some(fallback.clone()), Some(fallback))


### PR DESCRIPTION
**Serve full/2000px image variant by default**

feed/800px looks soft when rendered at full-bleed on high-DPI phones. Bumping the default variant to full/2000px keeps images sharp; WebP compression keeps size reasonable (200–400 KiB typical).

- [ ] verify profile pics look sharp on matching cards

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serve full/2000px image variant by default instead of feed/800px
> Updates imgproxy URL generation across `resolve_image_url`, `public_upload_url`, and `fallback_variant_urls` to use the `full` (2000px WebP) variant instead of `feed` (800px WebP). Fallback behavior for non-imgproxy deployments is unchanged.
>
> Behavioral Change: Clients that previously received 800px images from imgproxy-configured deployments will now receive 2000px images, increasing bandwidth usage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 615284e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->