### PR TITLE
Bump QR scan XP reward to 25 per side

### DIFF
--- a/backend/src/api/xp/handler.rs
+++ b/backend/src/api/xp/handler.rs
@@ -267,10 +267,10 @@ pub(in crate::api) async fn scan_token(
 
     if awarded {
         tokio::spawn(async move {
-            if let Err(e) = service::award_xp(my_profile_id, 5).await {
+            if let Err(e) = service::award_xp(my_profile_id, SCAN_XP_REWARD).await {
                 tracing::warn!(error = %e, profile_id = %my_profile_id, "failed to award XP to scanner");
             }
-            if let Err(e) = service::award_xp(scanned_id, 5).await {
+            if let Err(e) = service::award_xp(scanned_id, SCAN_XP_REWARD).await {
                 tracing::warn!(error = %e, profile_id = %scanned_id, "failed to award XP to scanned");
             }
         });
@@ -278,8 +278,10 @@ pub(in crate::api) async fn scan_token(
 
     Ok(Json(DataResponse {
         data: ScanResponse {
-            xp_gained: if awarded { 5 } else { 0 },
+            xp_gained: if awarded { SCAN_XP_REWARD } else { 0 },
         },
     })
     .into_response())
 }
+
+const SCAN_XP_REWARD: i32 = 25;


### PR DESCRIPTION
**Bump QR scan reward from +5 to +25 XP per side**

Daily in-app tasks give +5 XP. Meeting someone in person via QR should weigh more — single constant bump so both scanner and scanned profile get +25.

## Todos
- [ ] deploy backend after merge

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump QR scan XP reward from 5 to 25 per side
> Replaces the hardcoded value `5` with a constant `SCAN_XP_REWARD = 25` in [handler.rs](https://github.com/poziomki-app/poziomki/pull/215/files#diff-952bfdfa8e523e782cbb1d0d2d34dadb45d1ac46f263d2b912970687d8732e82). Both the scanner and scanned profiles now receive 25 XP per scan, and the `xp_gained` field in the API response reflects the new value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f7733b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->