### PR TITLE
ci(security): expand scanning, run CodeQL on PRs, add dependabot

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,3 +1,13 @@
+# CodeQL scan config. `security-extended` adds ~60 extra security rules on top
+# of the default pack — including e.g. java/android/implicit-pendingintents.
+# See https://codeql.github.com/codeql-query-help/ for rule lists.
+name: Poziomki CodeQL config
+
+queries:
+  - uses: security-extended
+
 paths-ignore:
   - "**/tests/**"
   - "**/test/**"
+  - "**/build/**"
+  - "**/target/**"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot auto-PRs for security + version updates.
+# Security alerts also feed the GitHub Security tab; Dependabot then opens PRs
+# to resolve them.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: gradle
+    directory: /mobile
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      all:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,17 @@
 name: CodeQL
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: "0 6 * * 1"
 
 permissions:
   security-events: write
+  contents: read
+  actions: read
 
 jobs:
   analyze:
@@ -15,8 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # CodeQL 2.25+ uses source-only extraction for Rust — `build-mode: none`
+          # (no cargo build needed). The manual mode was deprecated upstream.
           - language: rust
-            build-mode: manual
+            build-mode: none
           - language: java-kotlin
             build-mode: manual
 
@@ -29,24 +37,7 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           config-file: .github/codeql-config.yml
 
-      # Rust: `build-mode: manual` requires an explicit cargo build so
-      # CodeQL can observe MIR. Swatinem/rust-cache keeps weekly runs
-      # under a few minutes after the first green build.
-      - name: Rust toolchain
-        if: matrix.language == 'rust'
-        uses: dtolnay/rust-toolchain@stable
-      - name: Rust cache
-        if: matrix.language == 'rust'
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: backend
-      - name: Build Rust
-        if: matrix.language == 'rust'
-        working-directory: backend
-        run: cargo build --all-targets --locked
-
-      # Kotlin/Java: gradle produces the JAR / class files CodeQL
-      # reads. Uses the same task the mobile PR checks already run.
+      # Kotlin/Java: gradle produces the JAR / class files CodeQL reads.
       - name: JDK 21
         if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: aquasecurity/trivy-action@0.28.0
+      - uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: fs
           scan-ref: backend
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: aquasecurity/trivy-action@0.28.0
+      - uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: fs
           scan-ref: mobile
@@ -135,10 +135,10 @@ jobs:
           fail-on-severity: high
           deny-licenses: AGPL-1.0, AGPL-3.0, GPL-2.0, GPL-3.0
 
-  # OSV-Scanner — Google's cross-ecosystem vulnerability scanner. Reads each
-  # ecosystem's lockfiles directly (Cargo.lock, Gradle resolution output, etc.)
-  # and checks against osv.dev. Explicit scan paths are required — a bare
-  # repo-root scan exits with "No package sources found".
+  # OSV-Scanner — Google's cross-ecosystem vulnerability scanner. Reads
+  # lockfiles (Cargo.lock etc.) and checks against osv.dev. Only scans
+  # backend — mobile has no gradle.lockfile and OSV can't walk
+  # build.gradle.kts alone. Gradle advisories come via Trivy-fs instead.
   osv-scanner:
     runs-on: ubuntu-latest
     steps:
@@ -146,11 +146,9 @@ jobs:
       - uses: google/osv-scanner-action/osv-scanner-action@v2.0.2
         with:
           scan-args: |-
-            --recursive
+            --lockfile=./backend/Cargo.lock
             --format=sarif
             --output=osv.sarif
-            ./backend
-            ./mobile
       - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
@@ -163,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@0.28.0
+      - uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: config
           scan-ref: .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,43 +14,41 @@ permissions:
   pull-requests: read
 
 jobs:
-  trivy-backend:
+  # Trivy (fs + config). Installs the CLI directly — the Marketplace action
+  # has had broken tag-to-SHA resolutions lately (tarball 404s).
+  trivy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: aquasecurity/trivy-action@v0.28.0
-        with:
-          scan-type: fs
-          scan-ref: backend
-          severity: MEDIUM,HIGH,CRITICAL
-          format: sarif
-          output: trivy-backend.sarif
-
+      - name: Install Trivy
+        env:
+          TRIVY_VERSION: "0.58.1"
+        run: |
+          curl -sSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+            | tar -xz trivy
+          chmod +x trivy
+          ./trivy --version
+      - name: Scan backend (fs)
+        run: ./trivy fs backend --severity MEDIUM,HIGH,CRITICAL --format sarif --output trivy-backend.sarif --exit-code 0
+      - name: Scan mobile (fs)
+        run: ./trivy fs mobile --severity MEDIUM,HIGH,CRITICAL --format sarif --output trivy-mobile.sarif --exit-code 0
+      - name: Scan repo config (Dockerfiles, compose, workflows)
+        run: ./trivy config . --severity MEDIUM,HIGH,CRITICAL --format sarif --output trivy-config.sarif --exit-code 0
       - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: trivy-backend.sarif
           category: trivy-backend
-
-  trivy-mobile:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: aquasecurity/trivy-action@v0.28.0
-        with:
-          scan-type: fs
-          scan-ref: mobile
-          severity: MEDIUM,HIGH,CRITICAL
-          format: sarif
-          output: trivy-mobile.sarif
-
       - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: trivy-mobile.sarif
           category: trivy-mobile
+      - uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config
 
   cargo-deny:
     runs-on: ubuntu-latest
@@ -136,43 +134,30 @@ jobs:
           deny-licenses: AGPL-1.0, AGPL-3.0, GPL-2.0, GPL-3.0
 
   # OSV-Scanner — Google's cross-ecosystem vulnerability scanner. Reads
-  # lockfiles (Cargo.lock etc.) and checks against osv.dev. Only scans
-  # backend — mobile has no gradle.lockfile and OSV can't walk
-  # build.gradle.kts alone. Gradle advisories come via Trivy-fs instead.
+  # lockfiles (Cargo.lock etc.) and checks against osv.dev. Scans backend's
+  # Cargo.lock — mobile has no gradle.lockfile (lockfile generation disabled)
+  # so gradle coverage comes via Trivy-fs instead. CLI install avoids the
+  # osv-scanner-action's quirky multi-line scan-args parsing.
   osv-scanner:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: google/osv-scanner-action/osv-scanner-action@v2.0.2
-        with:
-          scan-args: |-
-            --lockfile=./backend/Cargo.lock
-            --format=sarif
-            --output=osv.sarif
+      - name: Install OSV-Scanner
+        env:
+          OSV_VERSION: "2.0.2"
+        run: |
+          curl -sSL -o osv-scanner "https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_amd64"
+          chmod +x osv-scanner
+          ./osv-scanner --version
+      - name: Scan
+        run: |
+          ./osv-scanner --lockfile=./backend/Cargo.lock --format=sarif --output=osv.sarif || true
+          test -s osv.sarif
       - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: osv.sarif
           category: osv-scanner
-
-  # Trivy config scan — misconfigurations in Dockerfiles, docker-compose,
-  # GitHub Actions workflows, etc. Complements the fs scans above.
-  trivy-config:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@v0.28.0
-        with:
-          scan-type: config
-          scan-ref: .
-          severity: MEDIUM,HIGH,CRITICAL
-          format: sarif
-          output: trivy-config.sarif
-      - uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: trivy-config.sarif
-          category: trivy-config
 
   # Hadolint — Dockerfile best-practice + security linter, SARIF to Security tab.
   hadolint:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -142,6 +142,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Generate Cargo.lock (gitignored in this repo)
+        working-directory: backend
+        run: cargo generate-lockfile
       - name: Install OSV-Scanner
         env:
           OSV_VERSION: "2.0.2"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Trivy
         env:
-          TRIVY_VERSION: "0.58.1"
+          TRIVY_VERSION: "0.70.0"
         run: |
           curl -sSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
             | tar -xz trivy
@@ -151,8 +151,13 @@ jobs:
           ./osv-scanner --version
       - name: Scan
         run: |
-          ./osv-scanner --lockfile=./backend/Cargo.lock --format=sarif --output=osv.sarif || true
-          test -s osv.sarif
+          # v2 CLI: `scan source` replaces v1's bare `osv-scanner`.
+          set +e
+          ./osv-scanner scan source --lockfile=./backend/Cargo.lock --format=sarif --output=osv.sarif
+          rc=$?
+          set -e
+          # rc=0 no vulns, rc=1 vulns found — both write SARIF.
+          test -s osv.sarif || { echo "::error::osv-scanner did not produce SARIF (exit $rc)"; exit 1; }
       - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,11 +3,15 @@ name: Security
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: "0 6 * * 1"
 
 permissions:
   security-events: write
+  contents: read
+  pull-requests: read
 
 jobs:
   trivy-backend:
@@ -15,11 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: fs
           scan-ref: backend
-          severity: HIGH,CRITICAL
+          severity: MEDIUM,HIGH,CRITICAL
           format: sarif
           output: trivy-backend.sarif
 
@@ -34,11 +38,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: fs
           scan-ref: mobile
-          severity: HIGH,CRITICAL
+          severity: MEDIUM,HIGH,CRITICAL
           format: sarif
           output: trivy-mobile.sarif
 
@@ -57,3 +61,174 @@ jobs:
           manifest-path: backend/Cargo.toml
           command: check advisories licenses bans sources
           arguments: ""
+
+  # Semgrep — wide cross-language SAST. Free OSS via r2c's registry packs.
+  # Uses `semgrep scan` with SARIF output. Exit-code-on-findings is expected
+  # (rc=1) — we only fail the job when the SARIF file is missing, i.e. the
+  # scanner itself crashed.
+  semgrep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install --upgrade semgrep
+      - name: Run Semgrep
+        run: |
+          set +e
+          semgrep scan \
+            --config=p/security-audit \
+            --config=p/secrets \
+            --config=p/owasp-top-ten \
+            --config=p/rust \
+            --config=p/kotlin \
+            --config=p/java \
+            --sarif --output=semgrep.sarif
+          rc=$?
+          set -e
+          if [ ! -s semgrep.sarif ]; then
+            echo "::error::semgrep did not produce SARIF (exit $rc)"
+            exit 1
+          fi
+          # Findings (rc=1) are fine — SARIF is uploaded and GitHub shows them.
+      - uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+  # gitleaks — secret detection. Installs the CLI directly (the
+  # gitleaks-action marketplace variant has been unreliable) and uploads
+  # SARIF to the Security tab.
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        env:
+          GL_VERSION: "8.21.2"
+        run: |
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GL_VERSION}/gitleaks_${GL_VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          chmod +x gitleaks
+      - name: Scan repo
+        run: ./gitleaks detect --source . --report-format sarif --report-path gitleaks.sarif --exit-code 0
+      - uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+
+  # Dependency Review — blocks PRs that introduce vulnerable or GPL-licensed
+  # dependencies. Only fires on pull_request. Pinned to a specific release
+  # (floating `@v4` has 404'd on stale SHAs before).
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4.5.0
+        with:
+          fail-on-severity: high
+          deny-licenses: AGPL-1.0, AGPL-3.0, GPL-2.0, GPL-3.0
+
+  # OSV-Scanner — Google's cross-ecosystem vulnerability scanner. Reads each
+  # ecosystem's lockfiles directly (Cargo.lock, Gradle resolution output, etc.)
+  # and checks against osv.dev. Explicit scan paths are required — a bare
+  # repo-root scan exits with "No package sources found".
+  osv-scanner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google/osv-scanner-action/osv-scanner-action@v2.0.2
+        with:
+          scan-args: |-
+            --recursive
+            --format=sarif
+            --output=osv.sarif
+            ./backend
+            ./mobile
+      - uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: osv.sarif
+          category: osv-scanner
+
+  # Trivy config scan — misconfigurations in Dockerfiles, docker-compose,
+  # GitHub Actions workflows, etc. Complements the fs scans above.
+  trivy-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: config
+          scan-ref: .
+          severity: MEDIUM,HIGH,CRITICAL
+          format: sarif
+          output: trivy-config.sarif
+      - uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config
+
+  # Hadolint — Dockerfile best-practice + security linter, SARIF to Security tab.
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          recursive: true
+          format: sarif
+          output-file: hadolint.sarif
+          no-fail: true
+      - uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: hadolint.sarif
+          category: hadolint
+
+  # Actionlint — catches common mistakes in .github/workflows YAMLs
+  # (shellcheck integration, expression errors, deprecated actions).
+  # Uses reviewdog so findings appear inline on the PR; actionlint has no
+  # native SARIF output, so we skip the Security-tab upload for this one.
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@v1.65.2
+        with:
+          reporter: github-check
+          level: warning
+          fail_level: error
+
+  # OSSF Scorecard — open-source supply-chain health score (branch protection,
+  # pinned deps, token permissions, etc.). Runs on schedule + default-branch
+  # pushes; results flow to the Security tab.
+  scorecard:
+    if: github.event_name == 'schedule' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: scorecard.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: scorecard.sarif
+          category: scorecard


### PR DESCRIPTION
**CI-only security hardening.** Broadens what lands in the Security tab and runs CodeQL on PRs (not just weekly).

The original implicit-PendingIntent fix was pulled into its own PR #217 for reviewability.

## Todos
- [ ] verify each new job is green
- [ ] eyeball new findings the extra scanners surface

Addresses Macroscope review:
- pinned \`trivy-action\` to \`@0.28.0\`
- semgrep no longer masks crashes with \`|| true\` — only silent-failure is missing SARIF
- actionlint now uses reviewdog inline annotations (its JSON → SARIF conversion was fragile)
- OSV-scanner now gets explicit subproject paths (was exiting "no package sources found")

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand security scanning, run CodeQL on PRs, and add Dependabot
> - Adds Dependabot configuration for weekly grouped updates of Cargo (backend), Gradle (mobile), and GitHub Actions dependencies.
> - Extends [codeql.yml](https://github.com/poziomki-app/poziomki/pull/216/files#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27) to trigger on pushes and PRs to main; switches Rust analysis to `build-mode: none` (no cargo build required).
> - Expands [security.yml](https://github.com/poziomki-app/poziomki/pull/216/files#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dc) to run Trivy, cargo-deny, Semgrep, Gitleaks, OSV-Scanner, Hadolint, and Actionlint, uploading SARIF results to the Security tab.
> - Adds a dependency review gate on PRs that fails on high-severity vulnerabilities or GPL/AGPL-licensed dependencies.
> - Adds an OSSF Scorecard job that runs on push and schedule, publishing results to the Security tab.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c76622c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->