### PR TITLE
sec(android): fix implicit PendingIntent (CodeQL #358)

### DIFF
--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
@@ -77,7 +77,7 @@ class NotificationHelper(
         roomId
             ?.takeIf { it.isNotBlank() }
             ?.let { targetRoomId ->
-                builder.setContentIntent(buildChatPendingIntent(targetRoomId))
+                buildChatPendingIntent(targetRoomId)?.let(builder::setContentIntent)
             }
 
         if (avatarUrl != null) {
@@ -114,14 +114,19 @@ class NotificationHelper(
         notificationManager.notify(summaryId, summary)
     }
 
-    private fun buildChatPendingIntent(roomId: String): PendingIntent {
+    /**
+     * Builds an EXPLICIT PendingIntent that opens the launcher activity.
+     *
+     * Returns null if — for any reason — the package manager cannot resolve our own
+     * launch intent. An implicit fallback would be a CWE-927 vulnerability (a malicious
+     * app could hijack the wrapped Intent), so we drop the content intent instead.
+     */
+    private fun buildChatPendingIntent(roomId: String): PendingIntent? {
         val intent =
-            context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
-                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                putExtra(NotificationChatTarget.EXTRA_OPEN_CHAT_ROOM_ID, roomId)
-            } ?: Intent().apply {
-                putExtra(NotificationChatTarget.EXTRA_OPEN_CHAT_ROOM_ID, roomId)
-            }
+            context.packageManager.getLaunchIntentForPackage(context.packageName)
+                ?: return null
+        intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        intent.putExtra(NotificationChatTarget.EXTRA_OPEN_CHAT_ROOM_ID, roomId)
         return PendingIntent.getActivity(
             context,
             roomId.hashCode(),


### PR DESCRIPTION
**Closes CodeQL alert #358** (java/android/implicit-pendingintents, high / CWE-927).

Fallback path in \`buildChatPendingIntent\` wrapped an implicit Intent inside the PendingIntent — hijackable. Drop the fallback: return nullable, skip \`setContentIntent\` if launcher intent is somehow unresolvable.

## Todos
- [ ] verify CodeQL alert auto-closes after merge

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix implicit `PendingIntent` in `NotificationHelper.buildChatPendingIntent` (CodeQL #358)
> Resolves a CodeQL security finding by replacing the implicit `Intent` fallback with an explicit one resolved via `PackageManager`. `buildChatPendingIntent` now returns `null` when the launch intent cannot be resolved, and the notification content intent is only set when a non-null `PendingIntent` is available. Risk: notifications will have no content intent on devices where the launch intent cannot be resolved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbff314.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->