### PR TITLE
ci(security): scope security-events per-job, unblock Scorecard

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,11 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           config-file: .github/codeql-config.yml
 
-      # Kotlin/Java: gradle produces the JAR / class files CodeQL reads.
+      # Kotlin/Java: gradle must actually invoke kotlinc so CodeQL's trace
+      # wrapper can see it. If everything comes from the task build cache
+      # (FROM-CACHE / UP-TO-DATE) CodeQL sees zero compilation and fails
+      # with "no source code seen". `--no-build-cache --rerun-tasks` forces
+      # real recompilation. Dep cache (gradle home) is still used for speed.
       - name: JDK 21
         if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@v4
@@ -47,9 +51,11 @@ jobs:
       - name: Gradle cache
         if: matrix.language == 'java-kotlin'
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
       - name: Build mobile
         if: matrix.language == 'java-kotlin'
         working-directory: mobile
-        run: ./gradlew :androidApp:assembleDebug --no-daemon
+        run: ./gradlew :androidApp:assembleDebug --no-daemon --no-build-cache --rerun-tasks
 
       - uses: github/codeql-action/analyze@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,16 +8,21 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+# Top-level perms are the minimum. Scorecard's webapp publisher rejects
+# uploads when workflow-level `security-events: write` is set — see the
+# "workflow-restrictions" section of ossf/scorecard-action. Jobs that need
+# to upload SARIF override with their own `permissions:` block.
 permissions:
-  security-events: write
   contents: read
-  pull-requests: read
 
 jobs:
   # Trivy (fs + config). Installs the CLI directly — the Marketplace action
   # has had broken tag-to-SHA resolutions lately (tarball 404s).
   trivy:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Install Trivy
@@ -52,6 +57,8 @@ jobs:
 
   cargo-deny:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
@@ -66,6 +73,9 @@ jobs:
   # scanner itself crashed.
   semgrep:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -101,6 +111,9 @@ jobs:
   # SARIF to the Security tab.
   gitleaks:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -126,6 +139,9 @@ jobs:
   dependency-review:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4.5.0
@@ -140,6 +156,9 @@ jobs:
   # osv-scanner-action's quirky multi-line scan-args parsing.
   osv-scanner:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Generate Cargo.lock (gitignored in this repo)
@@ -170,6 +189,9 @@ jobs:
   # Hadolint — Dockerfile best-practice + security linter, SARIF to Security tab.
   hadolint:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: hadolint/hadolint-action@v3.1.0
@@ -190,6 +212,10 @@ jobs:
   # native SARIF output, so we skip the Security-tab upload for this one.
   actionlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: reviewdog/action-actionlint@v1.65.2


### PR DESCRIPTION
Scorecard's webapp rejects uploads when workflow-level \`security-events: write\` is set. Moving perms per-job so the push-event Scorecard run succeeds.

Failed run: https://github.com/poziomki-app/poziomki/actions/runs/24676629856

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope `security-events: write` per-job in security workflow to unblock Scorecard
> - Removes the top-level `security-events: write` permission from [security.yml](.github/workflows/security.yml) and adds it only to jobs that upload SARIF results (trivy, semgrep, gitleaks, osv-scanner, hadolint).
> - Non-upload jobs (cargo-deny, dependency-review, actionlint) now run with reduced privileges.
> - Forces a non-cached recompilation in the CodeQL Java/Kotlin matrix job by passing `--no-build-cache --rerun-tasks` and setting Gradle cache to read-only, ensuring CodeQL tracing observes actual compilation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f023eeb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->