### PR TITLE
ci: pin actions to SHAs, scope workflow token permissions

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: android-release-${{ github.ref }}
@@ -22,21 +22,26 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     defaults:
       run:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 
       - name: Validate tag matches versionName
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
         run: |
           version_name="$(sed -n 's/.*versionName = "\(.*\)"/\1/p' mobile/androidApp/build.gradle.kts | head -n1)"
           if [[ -z "$version_name" ]]; then
@@ -44,7 +49,7 @@ jobs:
             exit 1
           fi
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            release_tag="${{ github.event.inputs.tag_name }}"
+            release_tag="${INPUT_TAG_NAME}"
             if [[ -z "$release_tag" ]]; then
               release_tag="v${version_name}"
             fi
@@ -70,19 +75,23 @@ jobs:
 
       - name: Build signed Android release
         working-directory: mobile
+        env:
+          RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
         run: |
           ./gradlew \
             :androidApp:assembleRelease \
             -PreleaseStoreFile="$RUNNER_TEMP/android-release.jks" \
-            -PreleaseStorePassword="${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}" \
-            -PreleaseKeyAlias="${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}" \
-            -PreleaseKeyPassword="${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}"
+            -PreleaseStorePassword="$RELEASE_STORE_PASSWORD" \
+            -PreleaseKeyAlias="$RELEASE_KEY_ALIAS" \
+            -PreleaseKeyPassword="$RELEASE_KEY_PASSWORD"
 
       - name: Prepare release assets
         run: bash scripts/prepare_android_release.sh
 
       - name: Upload GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           tag_name: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,13 +9,16 @@ on:
     - cron: "0 6 * * 1"
 
 permissions:
-  security-events: write
   contents: read
-  actions: read
 
 jobs:
   analyze:
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
 
     strategy:
       fail-fast: false
@@ -29,9 +32,9 @@ jobs:
             build-mode: manual
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -40,16 +43,16 @@ jobs:
       # Kotlin/Java: gradle produces the JAR / class files CodeQL reads.
       - name: JDK 21
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: "21"
       - name: Gradle cache
         if: matrix.language == 'java-kotlin'
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
       - name: Build mobile
         if: matrix.language == 'java-kotlin'
         working-directory: mobile
         run: ./gradlew :androidApp:assembleDebug --no-daemon
 
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -10,6 +10,9 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: mobile-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -23,14 +26,14 @@ jobs:
         working-directory: mobile
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 
       - run: ./gradlew :androidApp:assembleDebug
 
@@ -42,14 +45,14 @@ jobs:
         working-directory: mobile
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 
       - run: ./gradlew detekt
       - run: ./gradlew ktlintCheck
@@ -66,18 +69,18 @@ jobs:
         working-directory: mobile
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 
       - run: ./gradlew dependencyUpdates -Drevision=release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: gradle-dependency-updates

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -11,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR by size
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { additions, deletions } = context.payload.pull_request;

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths: [backend/**]
 
+permissions:
+  contents: read
+
 concurrency:
   group: rust-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -31,8 +34,8 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -43,16 +46,16 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libpq-dev libwebp-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: backend
 
@@ -81,14 +84,14 @@ jobs:
         working-directory: backend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libpq-dev libwebp-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: backend
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,17 +9,18 @@ on:
     - cron: "0 6 * * 1"
 
 permissions:
-  security-events: write
   contents: read
-  pull-requests: read
 
 jobs:
   # Trivy (fs + config). Installs the CLI directly — the Marketplace action
   # has had broken tag-to-SHA resolutions lately (tarball 404s).
   trivy:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Trivy
         env:
           TRIVY_VERSION: "0.70.0"
@@ -34,17 +35,17 @@ jobs:
         run: ./trivy fs mobile --severity MEDIUM,HIGH,CRITICAL --format sarif --output trivy-mobile.sarif --exit-code 0
       - name: Scan repo config (Dockerfiles, compose, workflows)
         run: ./trivy config . --severity MEDIUM,HIGH,CRITICAL --format sarif --output trivy-config.sarif --exit-code 0
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         if: always()
         with:
           sarif_file: trivy-backend.sarif
           category: trivy-backend
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         if: always()
         with:
           sarif_file: trivy-mobile.sarif
           category: trivy-mobile
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         if: always()
         with:
           sarif_file: trivy-config.sarif
@@ -53,8 +54,8 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2
         with:
           manifest-path: backend/Cargo.toml
           command: check advisories licenses bans sources
@@ -66,9 +67,12 @@ jobs:
   # scanner itself crashed.
   semgrep:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install --upgrade semgrep
@@ -90,7 +94,7 @@ jobs:
             exit 1
           fi
           # Findings (rc=1) are fine — SARIF is uploaded and GitHub shows them.
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         if: always()
         with:
           sarif_file: semgrep.sarif
@@ -101,8 +105,11 @@ jobs:
   # SARIF to the Security tab.
   gitleaks:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Install gitleaks
@@ -114,7 +121,7 @@ jobs:
           chmod +x gitleaks
       - name: Scan repo
         run: ./gitleaks detect --source . --report-format sarif --report-path gitleaks.sarif --exit-code 0
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         if: always()
         with:
           sarif_file: gitleaks.sarif
@@ -127,8 +134,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4.5.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
         with:
           fail-on-severity: high
           deny-licenses: AGPL-1.0, AGPL-3.0, GPL-2.0, GPL-3.0
@@ -140,8 +147,11 @@ jobs:
   # osv-scanner-action's quirky multi-line scan-args parsing.
   osv-scanner:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate Cargo.lock (gitignored in this repo)
         working-directory: backend
         run: cargo generate-lockfile
@@ -161,7 +171,7 @@ jobs:
           set -e
           # rc=0 no vulns, rc=1 vulns found — both write SARIF.
           test -s osv.sarif || { echo "::error::osv-scanner did not produce SARIF (exit $rc)"; exit 1; }
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         if: always()
         with:
           sarif_file: osv.sarif
@@ -170,15 +180,18 @@ jobs:
   # Hadolint — Dockerfile best-practice + security linter, SARIF to Security tab.
   hadolint:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v3.1.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           recursive: true
           format: sarif
           output-file: hadolint.sarif
           no-fail: true
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         if: always()
         with:
           sarif_file: hadolint.sarif
@@ -190,9 +203,12 @@ jobs:
   # native SARIF output, so we skip the Security-tab upload for this one.
   actionlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: reviewdog/action-actionlint@v1.65.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65.2
         with:
           reporter: github-check
           level: warning
@@ -210,15 +226,15 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2.4.0
+      - uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: scorecard.sarif
           results_format: sarif
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         if: always()
         with:
           sarif_file: scorecard.sarif


### PR DESCRIPTION
**Workflow hardening to close Scorecard alerts**

Pins every third-party action to a full-commit SHA, scopes top-level `GITHUB_TOKEN` permissions to read-only, and moves secret/input interpolations in `android-release.yml` into `env:` vars to satisfy the Semgrep shell-injection rule.

- [ ] verify Rust CI runs green against the pinned toolchain SHA
- [ ] verify CodeQL + OSSF Scorecard jobs still upload SARIF
- [ ] next Security run: confirm the 52 PinnedDependencies and 6 TokenPermissions alerts clear

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin GitHub Actions to SHAs and scope workflow token permissions
> - All actions across the five CI/CD workflows are now pinned to specific commit SHAs instead of mutable version tags, preventing supply-chain attacks via tag mutation.
> - Top-level `permissions` blocks are reduced to `contents: read` by default, with elevated permissions (e.g. `contents: write`, `security-events: write`) moved to the specific jobs that require them.
> - In [android-release.yml](.github/workflows/android-release.yml), Gradle signing parameters are now passed via environment variables rather than inline secret expressions, and the `workflow_dispatch` tag is resolved via an env var.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b6ced0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->