### PR TITLE
build(backend): harden Dockerfile shell + ack apt pinning

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,7 @@ COPY . /app/
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
+# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y --no-install-recommends pkg-config libssl-dev libpq-dev libwebp-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -20,6 +21,8 @@ RUN cargo build --release --bin poziomki_backend-cli --bin worker
 
 # debian:bookworm-slim
 FROM debian@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS runtime-deps
+SHELL ["/bin/sh", "-o", "pipefail", "-c"]
+# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libpq5 libwebp7 ca-certificates \
     && apt-get clean \


### PR DESCRIPTION
**Close the three open Hadolint alerts on backend/Dockerfile.**

Adds `SHELL -o pipefail` on the runtime-deps stage (DL4006) and inline `hadolint ignore=DL3008` above the two `apt-get install` lines — debian-slim rotates point versions out of the archive weekly, so hard-pinning apt packages would break builds. Supply-chain integrity is carried by the pinned base-image digest and distroless runtime.

- [ ] verify backend image still builds in CI
- [ ] next Security run: confirm the 3 Hadolint alerts clear

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden backend Dockerfile shell options and acknowledge apt package pinning
> - Sets the shell to `["/bin/sh", "-o", "pipefail", "-c"]` in the runtime-deps stage of [Dockerfile](https://github.com/poziomki-app/poziomki/pull/222/files#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486) so pipe failures are caught during image builds.
> - Adds `hadolint` directives to suppress `DL3008` (unpinned apt packages) in both builder and runtime-deps stages.
> - Expands apt cleanup to also remove `/var/cache/apt/archives/*` in addition to the existing `/var/lib/apt/lists/*` removal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc298d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->