### PR TITLE
ci: scope workflow GITHUB_TOKEN permissions per-job

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: android-release-${{ github.ref }}
@@ -21,6 +21,9 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     defaults:
       run:

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -10,6 +10,9 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: mobile-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths: [backend/**]
 
+permissions:
+  contents: read
+
 concurrency:
   group: rust-${{ github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
**Strip write-scope GITHUB_TOKEN permissions from the top level of every workflow.**

Closes 6 Scorecard TokenPermissions alerts. Top-level defaults to `contents: read`; individual jobs grant the narrower scopes they need (SARIF upload, release write, actionlint checks).

- [ ] verify SARIF uploads still succeed
- [ ] verify android-release still has contents:write on the release job

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope GITHUB_TOKEN permissions per-job across CI workflows
> - Sets `contents: read` as the default top-level permission in [mobile.yml](.github/workflows/mobile.yml), [pr-size.yml](.github/workflows/pr-size.yml), and [rust.yml](.github/workflows/rust.yml).
> - In [android-release.yml](.github/workflows/android-release.yml), narrows the top-level permission to `contents: read` and moves `contents: write` to the `release` job only, following least-privilege principles.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fa281c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->