### PR TITLE
ci(android-release): move ${{ inputs/secrets }} into env vars

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Validate tag matches versionName
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
         run: |
           version_name="$(sed -n 's/.*versionName = "\(.*\)"/\1/p' mobile/androidApp/build.gradle.kts | head -n1)"
           if [[ -z "$version_name" ]]; then
@@ -44,7 +46,7 @@ jobs:
             exit 1
           fi
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            release_tag="${{ github.event.inputs.tag_name }}"
+            release_tag="${INPUT_TAG_NAME}"
             if [[ -z "$release_tag" ]]; then
               release_tag="v${version_name}"
             fi
@@ -70,13 +72,17 @@ jobs:
 
       - name: Build signed Android release
         working-directory: mobile
+        env:
+          RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
         run: |
           ./gradlew \
             :androidApp:assembleRelease \
             -PreleaseStoreFile="$RUNNER_TEMP/android-release.jks" \
-            -PreleaseStorePassword="${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}" \
-            -PreleaseKeyAlias="${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}" \
-            -PreleaseKeyPassword="${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}"
+            -PreleaseStorePassword="$RELEASE_STORE_PASSWORD" \
+            -PreleaseKeyAlias="$RELEASE_KEY_ALIAS" \
+            -PreleaseKeyPassword="$RELEASE_KEY_PASSWORD"
 
       - name: Prepare release assets
         run: bash scripts/prepare_android_release.sh


### PR DESCRIPTION
**Close the Semgrep run-shell-injection finding on android-release.yml:40.**

Moves `inputs.tag_name` and the three signing-secret expressions into step-level `env:` blocks so the `run:` scripts consume them as shell variables rather than template-interpolated source.

- [ ] next tag push: confirm release still builds and signs correctly

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move inputs and secrets into env vars in the Android release workflow
> Replaces inline `${{ github.event.inputs.* }}` and `${{ secrets.* }}` expressions in the [android-release.yml](.github/workflows/android-release.yml) workflow with env block variables. The tag validation step reads `INPUT_TAG_NAME` from the environment, and the Gradle build step reads signing credentials (`releaseStorePassword`, `releaseKeyAlias`, `releaseKeyPassword`) from env vars instead of embedding secrets directly in the command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d599ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->