### PR TITLE
ci: clear remaining Scorecard & Hadolint alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,13 +9,16 @@ on:
     - cron: "0 6 * * 1"
 
 permissions:
-  security-events: write
   contents: read
-  actions: read
 
 jobs:
   analyze:
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
-      - run: pip install --upgrade semgrep
+      - run: pip install semgrep==1.159.0
       - name: Run Semgrep
         run: |
           set +e

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
+# hadolint ignore=DL4006
 RUN set -eux; \
     mkdir -p /staging/usr/lib/x86_64-linux-gnu /staging/etc/ssl/certs; \
     cp -aL /etc/ssl/certs/ca-certificates.crt /staging/etc/ssl/certs/; \


### PR DESCRIPTION
**Three narrow fixes to close the last code-scanning alerts.**

- Move `security-events: write` per-job on `codeql.yml` (match `security.yml`)
- Pin `semgrep` version instead of `pip install --upgrade`
- Inline `hadolint ignore=DL4006` on the runtime-deps staging `RUN` (SHELL pipefail is already set; hadolint re-flags anyway)

- [ ] CI green
- [ ] next Security run: confirm alerts #432, #430, #373 close

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear Scorecard and Hadolint CI alerts by scoping permissions and pinning dependencies
> - Moves `security-events: write` and `actions: read` permissions from workflow-level to the `analyze` job in [codeql.yml](.github/workflows/codeql.yml), following least-privilege best practices.
> - Pins Semgrep to version `1.159.0` in [security.yml](.github/workflows/security.yml) instead of installing the latest available version.
> - Adds a `hadolint` directive to suppress rule `DL4006` in the [backend Dockerfile](https://github.com/poziomki-app/poziomki/pull/226/files#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe45469.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->