### PR TITLE
ci: add concurrency groups + fork-safe pr-size labelling

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pr-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -14,6 +18,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR by size
+        # Fork PRs run under a read-only token, so label add/remove will 403.
+        # Keep the job green so size labels are best-effort, not gating.
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Trivy (fs + config). Installs the CLI directly — the Marketplace action
   # has had broken tag-to-SHA resolutions lately (tarball 404s).


### PR DESCRIPTION
**ci: concurrency + fork-safe labelling**

Small hardening pass on three workflows.

- [ ] verify pr-size labels still appear on main-branch PRs
- [ ] verify a fork PR doesn't fail the pr-size check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add concurrency groups to CI workflows and make PR size labelling fork-safe
> - Adds concurrency groups to [codeql.yml](https://github.com/poziomki-app/poziomki/pull/229/files#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27) and [security.yml](https://github.com/poziomki-app/poziomki/pull/229/files#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dc), canceling in-progress runs on the same ref for pull request events.
> - Adds a concurrency group to [pr-size.yml](https://github.com/poziomki-app/poziomki/pull/229/files#diff-ba5ea00fc62a25fa64bd3e53e7b367bce2efbd29f3be946269f8a7bb2277eaa6) scoped per PR number, so only the latest run proceeds.
> - Sets `continue-on-error: true` on the label step in `pr-size.yml` so 403 errors from fork PRs (which run under read-only tokens) no longer fail the job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6b6665.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->