### PR TITLE
fix(backend): install bash before SHELL pipefail directive

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,12 +21,15 @@ RUN cargo build --release --bin poziomki_backend-cli --bin worker
 
 # debian:bookworm-slim
 FROM debian@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS runtime-deps
-SHELL ["/bin/sh", "-o", "pipefail", "-c"]
+# /bin/sh on bookworm-slim is dash, which doesn't support `-o pipefail`.
+# Install bash first, then switch SHELL so the ldd pipeline below gets pipefail.
 # hadolint ignore=DL3008
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libpq5 libwebp7 ca-certificates \
+    && apt-get install -y --no-install-recommends libpq5 libwebp7 ca-certificates bash \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL4006
 RUN set -eux; \


### PR DESCRIPTION
**fix: Dockerfile bookworm-slim pipefail**

Caught when the new GHCR workflow built from a clean cache — dash doesn't grok \`-o pipefail\`.

- [ ] confirm backend-image workflow goes green on main after merge

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `SHELL` pipefail directive in backend Dockerfile by installing bash first
> The `runtime-deps` stage in [Dockerfile](https://github.com/poziomki-app/poziomki/pull/231/files#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486) previously set `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` before bash was installed, causing the directive to fail since the default shell (`dash`) does not support `-o pipefail`. Bash is now installed via `apt-get` before the `SHELL` directive, so the library-staging pipeline runs under bash with pipefail enabled and fails fast on errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d4bf35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->