### PR TITLE
ci: post debug APK link on PRs via trusted workflow_run

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -37,6 +37,17 @@ jobs:
 
       - run: ./gradlew :androidApp:assembleDebug
 
+      # Upload debug APK on PR runs so the trusted pr-apk-comment workflow
+      # can surface a download link back on the PR. Fork PRs run this step
+      # with a read-only token — no secrets exposed.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: github.event_name == 'pull_request'
+        with:
+          name: debug-apk-${{ github.run_id }}
+          path: mobile/androidApp/build/outputs/apk/debug/*.apk
+          retention-days: 14
+          if-no-files-found: error
+
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr-apk-comment.yml
+++ b/.github/workflows/pr-apk-comment.yml
@@ -1,0 +1,88 @@
+name: PR APK comment
+
+# Posts a download link for the debug APK built by Mobile CI back onto the PR.
+# Runs from `main` via workflow_run, so it has a write token — but it never
+# checks out PR code and never reads artifact CONTENTS for control flow.
+# PR number comes from the trusted event payload, not from inside the artifact.
+
+on:
+  workflow_run:
+    workflows: ["Mobile CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # Only run for PRs that built successfully. Fork PRs and in-repo PRs
+    # both satisfy this: event=pull_request is recorded in workflow_run.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Resolve PR number + artifact URL
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+        with:
+          script: |
+            const runId = Number(process.env.RUN_ID);
+            const headSha = process.env.HEAD_SHA;
+
+            // Trust only the event payload, never artifact contents.
+            const prs = context.payload.workflow_run.pull_requests || [];
+            let prNumber = prs.length ? prs[0].number : null;
+
+            // Fork PRs don't populate workflow_run.pull_requests — look it up by head SHA.
+            if (!prNumber) {
+              const { data } = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${process.env.REPO} is:pr sha:${headSha}`,
+              });
+              prNumber = data.items.length ? data.items[0].number : null;
+            }
+            if (!prNumber) {
+              core.info(`no PR found for head ${headSha}; skipping`);
+              return;
+            }
+
+            const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+              ...context.repo,
+              run_id: runId,
+            });
+            const apk = artifacts.artifacts.find(a => a.name.startsWith('debug-apk-'));
+            if (!apk) {
+              core.info('no debug-apk artifact on this run');
+              return;
+            }
+
+            const artifactUrl = `${process.env.SERVER_URL}/${process.env.REPO}/actions/runs/${runId}/artifacts/${apk.id}`;
+            const marker = '<!-- pr-apk-comment -->';
+            const body = [
+              marker,
+              '### Debug APK',
+              '',
+              `[Download](${artifactUrl}) — built from ${headSha.slice(0, 7)}, expires in 14 days.`,
+              '',
+              'You need to be signed in to GitHub to download workflow artifacts.',
+            ].join('\n');
+
+            const { data: existing } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const mine = existing.find(c => c.body && c.body.includes(marker));
+            if (mine) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: prNumber, body });
+            }


### PR DESCRIPTION
**ci: fork-safe PR APK download**

Contributors get a download link for the debug APK posted as a comment on every mobile PR.

- [ ] verify in-repo PR shows the bot comment after Mobile CI finishes
- [ ] open a fork PR touching \`mobile/**\` and confirm the link appears
- [ ] confirm artifact expires after 14 days

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Post debug APK download link on PRs via trusted `workflow_run` workflow
> - The [mobile.yml](https://github.com/poziomki-app/poziomki/pull/233/files#diff-fba277883616717b49f01e1fa603c38c85603327832ed325c0688d0ee75f1162) build job now uploads the debug APK as an artifact (`debug-apk-<run_id>`, 14-day retention) on `pull_request` events.
> - A new [pr-apk-comment.yml](https://github.com/poziomki-app/poziomki/pull/233/files#diff-f60afec680925c34bbdea095d5546a00eff0b2214c748f140f91e7558d1cb7f2) workflow triggers on `workflow_run` completion of "Mobile CI" and posts or updates a PR comment with the artifact download link and build SHA.
> - Using `workflow_run` keeps the comment step in a trusted context with `pull-requests: write` permission, which is not available in untrusted `pull_request` workflows from forks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3a5e11.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->