### PR TITLE
ci: adopt release-please for linked backend + android versioning

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,0 +1,4 @@
+{
+  "backend": "0.18.4",
+  "mobile/androidApp": "0.18.4"
+}

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "bootstrap-sha": "HEAD",
   "include-component-in-tag": false,
   "group-pull-request-title-pattern": "chore: release ${version}",
   "separate-pull-requests": false,

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "simple",
+  "bootstrap-sha": "HEAD",
+  "include-component-in-tag": false,
+  "group-pull-request-title-pattern": "chore: release ${version}",
+  "separate-pull-requests": false,
+  "packages": {
+    "backend": {
+      "release-type": "rust",
+      "package-name": "poziomki-backend",
+      "component": "backend",
+      "include-component-in-tag": false
+    },
+    "mobile/androidApp": {
+      "release-type": "simple",
+      "package-name": "poziomki-android",
+      "component": "android",
+      "include-component-in-tag": false,
+      "extra-files": ["build.gradle.kts"]
+    }
+  },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "components": ["backend", "android"],
+      "groupName": "poziomki",
+      "merge": true
+    }
+  ],
+  "changelog-sections": [
+    { "type": "feat",     "section": "Features" },
+    { "type": "fix",      "section": "Bug Fixes" },
+    { "type": "perf",     "section": "Performance" },
+    { "type": "revert",   "section": "Reverts" },
+    { "type": "deps",     "section": "Dependencies" },
+    { "type": "security", "section": "Security" },
+    { "type": "docs",     "section": "Documentation",      "hidden": true },
+    { "type": "chore",    "section": "Chores",             "hidden": true },
+    { "type": "style",    "section": "Style",              "hidden": true },
+    { "type": "refactor", "section": "Refactors",          "hidden": true },
+    { "type": "test",     "section": "Tests",              "hidden": true },
+    { "type": "build",    "section": "Build",              "hidden": true },
+    { "type": "ci",       "section": "CI",                 "hidden": true }
+  ]
+}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -43,9 +43,9 @@ jobs:
         env:
           INPUT_TAG_NAME: ${{ inputs.tag_name }}
         run: |
-          version_name="$(sed -n 's/.*versionName = "\(.*\)"/\1/p' mobile/androidApp/build.gradle.kts | head -n1)"
+          version_name="$(sed -n 's/.*appVersionName = "\(.*\)".*/\1/p' mobile/androidApp/build.gradle.kts | head -n1)"
           if [[ -z "$version_name" ]]; then
-            echo "Could not read versionName" >&2
+            echo "Could not read appVersionName" >&2
             exit 1
           fi
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,29 @@
+name: Release Please
+
+# On each main push, open/update a release PR that bumps backend/Cargo.toml
+# and mobile/androidApp/build.gradle.kts (versionName) based on conventional
+# commits. Merging that PR creates the tag `vX.Y.Z`, which triggers
+# android-release.yml (APK) and backend-image.yml (GHCR tag).
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # create release tags + branches
+      pull-requests: write  # open/update the release PR
+    steps:
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        with:
+          config-file: .github/release-please-config.json
+          manifest-file: .github/.release-please-manifest.json

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -30,7 +30,7 @@ multiple_crate_versions = "allow"
 
 [package]
 name = "poziomki-backend"
-version = "0.1.0"
+version = "0.18.4"
 edition = "2021"
 publish = false
 default-run = "poziomki_backend-cli"

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -10,6 +10,23 @@ composeCompiler {
     includeTraceMarkers.set(false)
 }
 
+// Single source of truth for the app version. release-please bumps this line
+// (see .github/.release-please-manifest.json); versionCode is derived so it
+// never drifts out of monotonic order.
+val appVersionName = "0.18.4" // x-release-please-version
+
+fun computeVersionCode(name: String): Int {
+    val parts = name.split(".").map { it.toInt() }
+    require(parts.size == 3) { "appVersionName must be major.minor.patch, got '$name'" }
+    val (major, minor, patch) = parts
+    require(minor in 0..999 && patch in 0..999) {
+        "minor/patch must each be < 1000 in the m*1_000_000 + m*1_000 + p scheme (got '$name')"
+    }
+    return major * 1_000_000 + minor * 1_000 + patch
+}
+
+val appVersionCode = computeVersionCode(appVersionName)
+
 android {
     namespace = "com.poziomki.app"
     compileSdk = 36
@@ -23,8 +40,8 @@ android {
         applicationId = "app.poziomki"
         minSdk = 24
         targetSdk = 36
-        versionCode = 46
-        versionName = "0.18.4"
+        versionCode = appVersionCode
+        versionName = appVersionName
 
         val apiUrl = project.findProperty("apiBaseUrl")?.toString() ?: "http://localhost:5150"
         buildConfigField("String", "API_BASE_URL", "\"$apiUrl\"")

--- a/scripts/prepare_android_release.sh
+++ b/scripts/prepare_android_release.sh
@@ -8,13 +8,21 @@ OUTPUT_DIR="${1:-$ROOT_DIR/dist/android-release}"
 mkdir -p "$OUTPUT_DIR"
 rm -f "$OUTPUT_DIR"/*.apk "$OUTPUT_DIR"/*.txt "$OUTPUT_DIR"/*.tar.gz
 
-version_name="$(sed -n 's/.*versionName = "\(.*\)"/\1/p' "$BUILD_FILE" | head -n1)"
-version_code="$(sed -n 's/.*versionCode = \([0-9][0-9]*\).*/\1/p' "$BUILD_FILE" | head -n1)"
+# Read appVersionName (source of truth, bumped by release-please) and derive
+# versionCode from it using the same formula as build.gradle.kts.
+version_name="$(sed -n 's/.*appVersionName = "\(.*\)".*/\1/p' "$BUILD_FILE" | head -n1)"
 
-if [[ -z "$version_name" || -z "$version_code" ]]; then
-  echo "Could not read versionName/versionCode from $BUILD_FILE" >&2
+if [[ -z "$version_name" ]]; then
+  echo "Could not read appVersionName from $BUILD_FILE" >&2
   exit 1
 fi
+
+IFS=. read -r v_major v_minor v_patch <<<"$version_name"
+if [[ -z "$v_major" || -z "$v_minor" || -z "$v_patch" ]]; then
+  echo "appVersionName '$version_name' is not major.minor.patch" >&2
+  exit 1
+fi
+version_code=$(( v_major * 1000000 + v_minor * 1000 + v_patch ))
 
 apk_dir="$ROOT_DIR/mobile/androidApp/build/outputs/apk/release"
 shopt -s nullglob


### PR DESCRIPTION
**ci: release-please**

Conventional commits → automatic release PRs. Backend and android versions are linked so they bump together.

- [ ] verify a release-please PR opens after merge on the next \`feat:\`/\`fix:\` commit
- [ ] verify merging it tags \`v0.19.0\` (no component prefix) and kicks off android-release + backend-image
- [ ] verify appVersionCode computes correctly on a clean release build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adopt release-please for linked backend and Android versioning
> - Adds a [release-please workflow](.github/workflows/release-please.yml) that runs on every push to `main` to open/update release PRs and create tags, using a linked-versions plugin to keep `backend` and `android` versions in sync.
> - Introduces a single source of truth `appVersionName` in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/234/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be) and a `computeVersionCode` function that derives `versionCode` from the semver string (e.g. `0.18.4` → `18004`), replacing hardcoded values.
> - Updates [prepare_android_release.sh](https://github.com/poziomki-app/poziomki/pull/234/files#diff-32d885ad73cd52e27155f2e07e482b6df600aae07c25baeb53a521b83b43be92) and the [android-release workflow](.github/workflows/android-release.yml) to read `appVersionName` instead of separate `versionName`/`versionCode` fields.
> - Bumps both `backend/Cargo.toml` and the Android build to version `0.18.4` as the starting point for release-please tracking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac1e519.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->