### PR TITLE
ci(codeql): run on push+schedule only, drop PR trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,17 +3,20 @@ name: CodeQL
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
     - cron: "0 6 * * 1"
+
+# CodeQL only runs on main pushes and the weekly schedule — PRs don't
+# wait on it. Findings still surface in the Security tab within ~1 day
+# of landing on main, which is the right tradeoff for a small team:
+# cuts PR wall time by ~4 minutes without losing coverage on shipped code.
 
 permissions:
   contents: read
 
 concurrency:
   group: codeql-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   analyze:


### PR DESCRIPTION
**Removes CodeQL from PR critical path (~4 min faster merges).**

CodeQL still scans every push to main and the Monday 06:00 UTC schedule. Findings appear in the Security tab within a day of landing, which is the right tradeoff for a small-team, merge-straight-to-main workflow.

- [ ] verify CodeQL still runs on the post-merge push

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove pull_request trigger from CodeQL workflow
> The [codeql.yml](.github/workflows/codeql.yml) workflow now runs only on pushes to `main` and on the scheduled cron, not on pull requests. `concurrency.cancel-in-progress` is changed from a conditional expression to a hard `false`, so concurrent runs are never cancelled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2ea89f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->