### PR TITLE
ci(release-please): set bootstrap-sha to cut off historical commits

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "bootstrap-sha": "920c949a424aff60814de62c079b3d88c26fe4cb",
   "include-component-in-tag": false,
   "group-pull-request-title-pattern": "chore: release ${version}",
   "separate-pull-requests": false,


### PR DESCRIPTION
**ci: release-please bootstrap-sha**

Fixes #239 aftermath: release-please was generating a changelog from the entire git history. Pin bootstrap-sha to the current main HEAD so only commits after it get considered.

- [ ] confirm next release-please run does NOT open a release PR (no new feat/fix since bootstrap-sha)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `bootstrap-sha` in release-please config to cut off historical commits
> Adds `bootstrap-sha` set to `920c949` in [release-please-config.json](.github/release-please-config.json) to tell release-please where to start scanning commit history, ignoring all commits before that SHA.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3789b35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->