### PR TITLE
fix(release): skip metadata tar when paths are gone

### DIFF
--- a/scripts/prepare_android_release.sh
+++ b/scripts/prepare_android_release.sh
@@ -61,10 +61,20 @@ done
   sha256sum ./*.apk > "poziomki-${version_name}-sha256.txt"
 )
 
-tar -C "$ROOT_DIR" -czf "$OUTPUT_DIR/poziomki-${version_name}-metadata.tar.gz" \
-  .fdroid.yml \
-  docs/android-distribution.txt \
-  fastlane \
-  fdroid
+# Bundle any distribution metadata that still lives in the repo (historical
+# set: .fdroid.yml, fastlane/, fdroid/, docs/android-distribution.txt — most
+# of which was removed in the 2026-02 cleanup). Skip the tar entirely when
+# none are present so the workflow doesn't fail for a baseline release.
+metadata_paths=()
+for candidate in .fdroid.yml docs/android-distribution.txt fastlane fdroid; do
+  if [[ -e "$ROOT_DIR/$candidate" ]]; then
+    metadata_paths+=("$candidate")
+  fi
+done
+
+if (( ${#metadata_paths[@]} > 0 )); then
+  tar -C "$ROOT_DIR" -czf "$OUTPUT_DIR/poziomki-${version_name}-metadata.tar.gz" \
+    "${metadata_paths[@]}"
+fi
 
 printf 'Prepared Android release assets for version %s (%s) in %s\n' "$version_name" "$version_code" "$OUTPUT_DIR"


### PR DESCRIPTION
**fix: android-release metadata tar**

Caught while cutting v0.18.4. The .fdroid/fastlane/docs paths were all removed in the Feb cleanup; the tar step still referenced them.

- [ ] after merge + re-running android-release for v0.18.4, Release lands in the tab with the signed APKs

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip metadata tar in `prepare_android_release.sh` when no metadata paths exist
> The script previously ran `tar` unconditionally over `.fdroid.yml`, `docs/android-distribution.txt`, `fastlane`, and `fdroid`, which would error if those paths were absent. It now checks each path for existence first and only runs `tar` when at least one is found, skipping archive creation entirely if none exist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccabecd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->