### PR TITLE
ci: add CODEOWNERS for CI + auth + release-sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# CODEOWNERS — protects paths that materially affect security or supply chain.
+# A PR touching any of these paths requires review from the listed owner(s)
+# before it can merge. Solo-dev shape: @dpiotrkowski owns everything that
+# matters to CI/release/auth.
+
+# CI, workflows, and repo security posture.
+/.github/                 @dpiotrkowski
+/.gitattributes           @dpiotrkowski
+/.gitignore               @dpiotrkowski
+
+# Build + release tooling — anything here can silently change what gets
+# shipped as a signed APK or GHCR image.
+/backend/Dockerfile       @dpiotrkowski
+/backend/Cargo.toml       @dpiotrkowski
+/backend/Cargo.lock       @dpiotrkowski
+/scripts/                 @dpiotrkowski
+
+# Version source of truth for release-please.
+/mobile/androidApp/build.gradle.kts  @dpiotrkowski
+/mobile/androidApp/version.txt       @dpiotrkowski
+
+# Auth-sensitive backend paths. Extend as the auth module grows.
+/backend/src/auth/        @dpiotrkowski
+
+# Security policy + governance docs.
+/SECURITY.md              @dpiotrkowski
+/CODEOWNERS               @dpiotrkowski
+/.github/CODEOWNERS       @dpiotrkowski


### PR DESCRIPTION
**ci: CODEOWNERS**

Protects paths that materially affect what gets shipped or what runs in CI. Enforcement kicks in once branch protection on main turns on "Require review from Code Owners" (separate step).

- [ ] after merge, configure branch protection with CODEOWNERS requirement

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CODEOWNERS for CI, auth, and release-sensitive paths
> Adds [.github/CODEOWNERS](https://github.com/poziomki-app/poziomki/pull/242/files#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7) to enforce review requirements on high-risk paths. @dpiotrkowski is designated as owner for CI/workflow configs, backend Dockerfile and Cargo files, release scripts, mobile versioning files, backend auth paths, and security/governance docs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d941513.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->