### PR TITLE
Enable zstd/br/gzip compression on poziomki.app

### DIFF
--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -51,6 +51,7 @@
 
 poziomki.app, www.poziomki.app {
 	import secure_headers
+	encode zstd br gzip
 
 	handle_path /fdroid/repo/* {
 		root * /var/www/fdroid


### PR DESCRIPTION
**Turn on response compression for the landing site**

Siteone crawler audit showed the landing served ~21 KB HTML uncompressed — no `Content-Encoding` header. Adding `encode` lets Caddy negotiate Brotli / Zstd / gzip per request, which should drop HTML payload to ~5 KB and improve TTFB on mobile.

## Todos
- [ ] reload Caddy on the server after merge
- [ ] verify `content-encoding: br` on https://poziomki.app/
- [ ] re-run siteone crawler to confirm the Brotli warning is gone

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable zstd, brotli, and gzip compression on poziomki.app
> Adds an `encode zstd br gzip` directive to the [Caddyfile.prod](https://github.com/poziomki-app/poziomki/pull/243/files#diff-507ac62fa8220af2d08c3d8f2ef5aee0806600e1d1085fc4c641c643ea9f4e36) site block for `poziomki.app` and `www.poziomki.app`. Caddy will now compress HTTP responses when clients send a matching `Accept-Encoding` header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ee89c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->