### PR TITLE
fix(deploy): correct binary path + health endpoint

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Health check
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS https://api.poziomki.app/healthz; then exit 0; fi
+            if curl -fsS https://api.poziomki.app/health; then exit 0; fi
             sleep 2
           done
           exit 1

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Health check
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS https://staging.poziomki.app/healthz; then exit 0; fi
+            if curl -fsS https://staging.poziomki.app/health; then exit 0; fi
             sleep 2
           done
           exit 1

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -42,7 +42,7 @@ docker compose -p "$PROJECT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull api 
 # plain `docker run` on the default bridge can't see. --no-deps avoids
 # starting postgres/pgdog as side effects (they're already running).
 docker compose -p "$PROJECT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" \
-  run --rm --no-deps --entrypoint /app/poziomki_backend-cli api migrate
+  run --rm --no-deps --entrypoint /usr/local/bin/poziomki_backend-cli api migrate
 
 docker compose -p "$PROJECT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --no-build
 


### PR DESCRIPTION
**fix: deploy paths**

Caught during first real cutover — migration path was \`/app/\` (should be \`/usr/local/bin/\`), health check was \`/healthz\` (should be \`/health\`).

Workflows are still dormant (Environments + Tailscale not wired yet), but the script runs live on the VPS too — next manual deploy needs this fix.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix binary path and health check endpoint in deploy scripts
> - Corrects the CLI binary path in [deploy.sh](https://github.com/poziomki-app/poziomki/pull/245/files#diff-a2d7058c3782841a423fb0df88bd1184fb4e4dfc069e4ff70946c9c6b81716fd) from `/app/poziomki_backend-cli` to `/usr/local/bin/poziomki_backend-cli` so migrations run correctly.
> - Updates health check URLs in [deploy-prod.yml](https://github.com/poziomki-app/poziomki/pull/245/files#diff-4ce342fb97e7d7feb8a578c91ba89fe4c27ddf16b4306909fe6d90220141913d) and [deploy-staging.yml](https://github.com/poziomki-app/poziomki/pull/245/files#diff-98b468326a86981405fb6e13c66ea8cd0032c4c7e4f2816fbc42a1fa9b32e991) from `/healthz` to `/health`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c6d002.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->