### PR TITLE
fix(deploy): drop bogus explicit migrate step

### DIFF
--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -36,14 +36,11 @@ fi
 
 docker compose -p "$PROJECT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull api worker
 
-# Run migrations in a one-off container on the compose project's network
-# using the api service definition. This gives the migrator the full
-# composed DATABASE_URL + pgdog DNS that the service depends on, which a
-# plain `docker run` on the default bridge can't see. --no-deps avoids
-# starting postgres/pgdog as side effects (they're already running).
-docker compose -p "$PROJECT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" \
-  run --rm --no-deps --entrypoint /usr/local/bin/poziomki_backend-cli api migrate
-
+# Migrations run on api startup (backend/src/app.rs calls run_migrations()
+# before serving). There is no `migrate` subcommand in the CLI. `up -d`
+# below brings up the api container, which applies any pending migration
+# before binding the listener. Pre-deploy migration would need a real
+# one-shot subcommand — add it if we ever want an explicit gate.
 docker compose -p "$PROJECT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --no-build
 
 # Append to deploy history for audit.


### PR DESCRIPTION
**fix migrate step**

The CLI has no `migrate` subcommand, so the explicit migration step booted a second API server and hung compose until CI timed out. Migrations already apply on startup before the listener binds.

## Todos
- [ ] merge + re-dispatch deploy-prod
- [ ] add real `migrate` subcommand later if we want a pre-deploy gate

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove bogus explicit migrate step from deploy script
> The [deploy.sh](https://github.com/poziomki-app/poziomki/pull/247/files#diff-a2d7058c3782841a423fb0df88bd1184fb4e4dfc069e4ff70946c9c6b81716fd) script previously ran a one-off `docker compose run` to execute `poziomki_backend-cli api migrate` before bringing services up. This subcommand does not exist. Migrations are applied automatically by the API container on startup, so the explicit step is dropped and comments are added to clarify this behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 748568a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->