### PR TITLE
fix(deploy): add positive pathspec to git checkout

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=accept-new "ubuntu@${VPS_HOST}" \
             "set -e; cd ~/poziomki-rs && git fetch --quiet && \
-             git checkout '$COMMIT_SHA' -- ':!infra/.env*' && \
+             git checkout '$COMMIT_SHA' -- . ':!infra/.env*' ':!infra/garage/garage.toml' && \
              ./infra/scripts/deploy.sh prod '$IMAGE@$DIGEST'"
 
       - name: Health check

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=accept-new "ubuntu@${VPS_HOST}" \
             "set -e; cd ~/poziomki-rs && git fetch --quiet && \
-             git checkout '$COMMIT_SHA' -- ':!infra/.env*' && \
+             git checkout '$COMMIT_SHA' -- . ':!infra/.env*' ':!infra/garage/garage.toml' && \
              ./infra/scripts/deploy.sh staging '$IMAGE@$DIGEST'"
 
       - name: Health check


### PR DESCRIPTION
**fix VPS tree sync**

Deploy's `git checkout $COMMIT_SHA -- ':!infra/.env*'` had only an exclusion pathspec, matching zero files — so the VPS never synced to the deployed commit. Add `.` as the positive pathspec.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add positive pathspec to `git checkout` in deploy workflows
> The `git checkout` command in the remote Apply step of both prod and staging deploy workflows was missing an explicit positive pathspec, which could cause the checkout to behave unexpectedly. Adding `.` ensures all files from the target commit are checked out, while `':!infra/garage/garage.toml'` is added alongside the existing `':!infra/.env*'` exclusion to protect that config file from being overwritten on the remote host.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f3fb1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->