### PR TITLE
feat(deploy): restore cosign verify gate

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -48,6 +48,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
       - name: Resolve digest from GHCR
         id: d
         run: |
@@ -56,6 +59,16 @@ jobs:
             --format '{{json .Manifest}}' | jq -r .digest)
           test -n "$DIGEST"
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Verify signature (gate)
+        env:
+          DIGEST: ${{ steps.d.outputs.digest }}
+        run: |
+          cosign verify \
+            --certificate-identity-regexp "https://github.com/poziomki-app/poziomki/.github/workflows/backend-image.yml@.*" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${IMAGE}@${DIGEST}" > /dev/null
+          echo "Signature verified for ${IMAGE}@${DIGEST}"
 
       - name: Apply on VPS
         env:


### PR DESCRIPTION
Restore the verify step dropped in #246. Local verify against the same digest succeeds, so the earlier CI failure was most likely a flake during initial setup.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore cosign signature verification gate in prod deploy workflow
> Adds two steps to [deploy-prod.yml](.github/workflows/deploy-prod.yml): one to install cosign via `sigstore/cosign-installer@v3`, and one to run `cosign verify` against the resolved image digest before deployment proceeds. Verification checks the certificate identity against the `backend-image.yml` workflow and the GitHub OIDC issuer. Risk: the deploy job will now fail if the target image is not signed correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72a6909.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->