### PR TITLE
fix(deploy): pin cosign to v3.0.6

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -49,7 +49,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
+        # v3.0+ reads signatures via the OCI 1.1 referrers API that our
+        # publish workflow uses. v2.x only looks at legacy `.sig` sibling
+        # tags and cannot see our signatures at all.
         uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v3.0.6
 
       - name: Resolve digest from GHCR
         id: d


### PR DESCRIPTION
CI installer defaulted to cosign v2.5.2 which only reads legacy `.sig` sibling tags. Our publish workflow pushes signatures via the OCI 1.1 referrers API, which v3+ is needed to see — hence the "no signatures found" error. Pin to v3.0.6.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin cosign to v3.0.6 in the production deploy workflow
> Updates [deploy-prod.yml](.github/workflows/deploy-prod.yml) to pin the cosign installer action to `v3.0.6` instead of using the action's default version, ensuring reproducible builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b96be7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->