### PR TITLE
fix(deploy): cosign-installer v4.1.1 to install cosign v3

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -49,12 +49,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
-        # v3.0+ reads signatures via the OCI 1.1 referrers API that our
-        # publish workflow uses. v2.x only looks at legacy `.sig` sibling
-        # tags and cannot see our signatures at all.
-        uses: sigstore/cosign-installer@v3
-        with:
-          cosign-release: v3.0.6
+        # cosign-installer@v4 is required to install cosign v3.x binaries;
+        # @v3 bootstraps via cosign v2.5 which can't verify v3.x signatures.
+        # cosign v3.0+ reads signatures via the OCI 1.1 referrers API that
+        # our publish workflow uses. v2.x only looks at legacy `.sig` tags.
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Resolve digest from GHCR
         id: d


### PR DESCRIPTION
The publish workflow uses `cosign-installer@v4.1.1` (which installs cosign v3.x). The deploy workflow pinned `@v3` + `cosign-release: v3.0.6` — @v3 bootstraps via cosign v2.5 and can't verify a v3 binary's detached sig, so install fails with exit 22. Match the publish workflow's pin.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cosign installation in deploy-prod workflow to use cosign-installer v4.1.1
> - Updates the 'Install cosign' step in [deploy-prod.yml](.github/workflows/deploy-prod.yml) to use `sigstore/cosign-installer@v4.1.1` (pinned commit) instead of v3, removing the explicit `cosign-release: v3.0.6` input.
> - Removes the jq-based digest extraction line from the 'Resolve digest from GHCR' step, changing what value is assigned to `DIGEST`.
> - Removes `docker compose pull` and `docker compose up` commands from the 'Rollback on failure' step, so failed deployments no longer pull or restart services.
> - Risk: the rollback step no longer restores services on failure, which changes failure recovery behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9be2f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->