### PR TITLE
feat(staging): proper role isolation on slim parallel stack

### DIFF
--- a/backend/migrations/2026-04-18-010000_auth_security_definer/up.sql
+++ b/backend/migrations/2026-04-18-010000_auth_security_definer/up.sql
@@ -77,16 +77,27 @@ REVOKE EXECUTE ON FUNCTION app.resolve_session(text) FROM PUBLIC;
 -- setup-roles.sh is forward-compatible: re-running it after this migration
 -- applies catches up USAGE/EXECUTE on the app schema, so bootstrap ordering
 -- doesn't matter in either direction.
+--
+-- Role names come from the `app.api_role` GUC (per-database override) and
+-- default to `poziomki_api`. Default privileges are attributed to the actual
+-- database owner, not a hardcoded role, so staging/dev DBs owned by a
+-- different role still satisfy `ALTER DEFAULT PRIVILEGES FOR ROLE`.
 DO $$
+DECLARE
+    api_role text := COALESCE(current_setting('app.api_role', true), 'poziomki_api');
+    owner_role text;
 BEGIN
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
-        EXECUTE 'GRANT USAGE ON SCHEMA app TO poziomki_api';
-        EXECUTE 'GRANT EXECUTE ON FUNCTION app.find_user_for_login(text) TO poziomki_api';
-        EXECUTE 'GRANT EXECUTE ON FUNCTION app.resolve_session(text) TO poziomki_api';
+    SELECT pg_get_userbyid(datdba) INTO owner_role
+      FROM pg_database WHERE datname = current_database();
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = api_role) THEN
+        EXECUTE format('GRANT USAGE ON SCHEMA app TO %I', api_role);
+        EXECUTE format('GRANT EXECUTE ON FUNCTION app.find_user_for_login(text) TO %I', api_role);
+        EXECUTE format('GRANT EXECUTE ON FUNCTION app.resolve_session(text) TO %I', api_role);
         -- Any future function added to `app` by a later migration is
-        -- auto-granted EXECUTE to poziomki_api.
-        EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE poziomki IN SCHEMA app '
-             || 'GRANT EXECUTE ON FUNCTIONS TO poziomki_api';
+        -- auto-granted EXECUTE to the API role.
+        EXECUTE format(
+            'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA app GRANT EXECUTE ON FUNCTIONS TO %I',
+            owner_role, api_role);
     END IF;
 END
 $$;

--- a/backend/migrations/2026-04-19-040000_invariants_and_audit/down.sql
+++ b/backend/migrations/2026-04-19-040000_invariants_and_audit/down.sql
@@ -1,7 +1,13 @@
 DO $$
+DECLARE
+    api_role text := COALESCE(current_setting('app.api_role', true), 'poziomki_api');
 BEGIN
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
-        EXECUTE 'ALTER ROLE poziomki_api RESET statement_timeout';
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = api_role) THEN
+        BEGIN
+            EXECUTE format('ALTER ROLE %I RESET statement_timeout', api_role);
+        EXCEPTION WHEN insufficient_privilege THEN
+            RAISE NOTICE 'skipped ALTER ROLE % RESET statement_timeout: insufficient privilege', api_role;
+        END;
     END IF;
 END
 $$;

--- a/backend/migrations/2026-04-19-040000_invariants_and_audit/up.sql
+++ b/backend/migrations/2026-04-19-040000_invariants_and_audit/up.sql
@@ -217,10 +217,21 @@ CREATE TRIGGER user_settings_audit
 -- ---------------------------------------------------------------------------
 REVOKE ALL ON SCHEMA public FROM PUBLIC;
 
+-- Role name comes from the `app.api_role` GUC (per-database override) and
+-- defaults to `poziomki_api`. Swallow insufficient_privilege — on a shared
+-- cluster where the role exists but the migration connection is not its
+-- admin (e.g. staging pointing at a prod-owned role), we'd rather skip the
+-- timeout tweak than fail the migration.
 DO $$
+DECLARE
+    api_role text := COALESCE(current_setting('app.api_role', true), 'poziomki_api');
 BEGIN
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
-        EXECUTE 'ALTER ROLE poziomki_api SET statement_timeout = ''5s''';
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = api_role) THEN
+        BEGIN
+            EXECUTE format('ALTER ROLE %I SET statement_timeout = %L', api_role, '5s');
+        EXCEPTION WHEN insufficient_privilege THEN
+            RAISE NOTICE 'skipped ALTER ROLE % SET statement_timeout: insufficient privilege', api_role;
+        END;
     END IF;
 END
 $$;

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -134,11 +134,25 @@ impl PoolRole {
         }
     }
 
-    const fn expected_db_user(self) -> &'static str {
+    const fn role_env_var(self) -> &'static str {
+        match self {
+            Self::Api => "DB_ROLE_API",
+            Self::Worker => "DB_ROLE_WORKER",
+        }
+    }
+
+    const fn default_db_user(self) -> &'static str {
         match self {
             Self::Api => "poziomki_api",
             Self::Worker => "poziomki_worker",
         }
+    }
+
+    fn expected_db_user(self) -> String {
+        std::env::var(self.role_env_var())
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| self.default_db_user().to_string())
     }
 }
 
@@ -199,7 +213,7 @@ async fn assert_pool_role(role: PoolRole) -> crate::error::AppResult<()> {
         .await
         .map_err(|e| crate::error::AppError::Message(format!("pool role check: {e}")))?;
     let expected = role.expected_db_user();
-    if row.current_user != expected {
+    if row.current_user != expected.as_str() {
         return Err(crate::error::AppError::Message(format!(
             "pool connected as db user {actual:?}, expected {expected:?} — refusing to start \
              (RLS would be bypassed)",

--- a/infra/.env.staging.example
+++ b/infra/.env.staging.example
@@ -11,6 +11,15 @@
 BACKEND_DIGEST=ghcr.io/poziomki-app/poziomki-backend@sha256:0000000000000000000000000000000000000000000000000000000000000000
 
 # --- Postgres (shared prod cluster; separate DB + roles for staging) ---
+# Bootstrap the DB + the three login roles with:
+#   POSTGRES_STAGING_OWNER_PASSWORD=...  \
+#   POSTGRES_STAGING_API_PASSWORD=...    \
+#   POSTGRES_STAGING_WORKER_PASSWORD=... \
+#   ./infra/ops/postgres/setup-roles-staging.sh
+# The same passwords go into the variables below (same values, different
+# names: the script uses POSTGRES_STAGING_*_PASSWORD, the compose stack
+# uses POSTGRES_*_PASSWORD). Script also sets `app.api_role` per-database
+# so the role-aware migrations target the staging role on re-run.
 POSTGRES_USER=poziomki_staging
 POSTGRES_PASSWORD=
 POSTGRES_DB=poziomki_staging

--- a/infra/docker-compose.staging.yml
+++ b/infra/docker-compose.staging.yml
@@ -85,6 +85,9 @@ services:
       SERVER_HOST: ${SERVER_HOST:-https://staging-api.poziomki.app}
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki_staging}:${POSTGRES_PASSWORD}@pgdog_staging:6432/${POSTGRES_DB:-poziomki_staging}
       API_DATABASE_URL: ${API_DATABASE_URL:?API_DATABASE_URL must be set}
+      # Role the pool is expected to connect as. Staging uses its own role
+      # (a member of poziomki_api so RLS policies still apply).
+      DB_ROLE_API: ${POSTGRES_API_USER:-poziomki_staging_api}
       DB_POOL_MAX_SIZE: ${API_DB_POOL_MAX_SIZE:-8}
       DB_POOL_WAIT_TIMEOUT_MS: ${API_DB_POOL_WAIT_TIMEOUT_MS:-3000}
       DB_POOL_CREATE_TIMEOUT_MS: ${API_DB_POOL_CREATE_TIMEOUT_MS:-5000}
@@ -147,6 +150,9 @@ services:
       SERVER_HOST: ${SERVER_HOST:-https://staging-api.poziomki.app}
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki_staging}:${POSTGRES_PASSWORD}@pgdog_staging:6432/${POSTGRES_DB:-poziomki_staging}
       WORKER_DATABASE_URL: ${WORKER_DATABASE_URL:?WORKER_DATABASE_URL must be set}
+      # Role the pool is expected to connect as. Staging uses its own role
+      # (a member of poziomki_worker so BYPASSRLS still applies).
+      DB_ROLE_WORKER: ${POSTGRES_WORKER_USER:-poziomki_staging_worker}
       DB_POOL_MAX_SIZE: ${WORKER_DB_POOL_MAX_SIZE:-4}
       DB_POOL_WAIT_TIMEOUT_MS: ${WORKER_DB_POOL_WAIT_TIMEOUT_MS:-3000}
       DB_POOL_CREATE_TIMEOUT_MS: ${WORKER_DB_POOL_CREATE_TIMEOUT_MS:-5000}

--- a/infra/docker-compose.staging.yml
+++ b/infra/docker-compose.staging.yml
@@ -85,8 +85,10 @@ services:
       SERVER_HOST: ${SERVER_HOST:-https://staging-api.poziomki.app}
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki_staging}:${POSTGRES_PASSWORD}@pgdog_staging:6432/${POSTGRES_DB:-poziomki_staging}
       API_DATABASE_URL: ${API_DATABASE_URL:?API_DATABASE_URL must be set}
-      # Role the pool is expected to connect as. Staging uses its own role
-      # (a member of poziomki_api so RLS policies still apply).
+      # Role the pool is expected to connect as. The staging login role is
+      # GRANTed `poziomki_api` so RLS policies written `TO poziomki_api`
+      # match via role membership (CREATE POLICY is member-aware; role
+      # attributes like BYPASSRLS are not — see the worker role below).
       DB_ROLE_API: ${POSTGRES_API_USER:-poziomki_staging_api}
       DB_POOL_MAX_SIZE: ${API_DB_POOL_MAX_SIZE:-8}
       DB_POOL_WAIT_TIMEOUT_MS: ${API_DB_POOL_WAIT_TIMEOUT_MS:-3000}
@@ -150,8 +152,9 @@ services:
       SERVER_HOST: ${SERVER_HOST:-https://staging-api.poziomki.app}
       DATABASE_URL: postgres://${POSTGRES_USER:-poziomki_staging}:${POSTGRES_PASSWORD}@pgdog_staging:6432/${POSTGRES_DB:-poziomki_staging}
       WORKER_DATABASE_URL: ${WORKER_DATABASE_URL:?WORKER_DATABASE_URL must be set}
-      # Role the pool is expected to connect as. Staging uses its own role
-      # (a member of poziomki_worker so BYPASSRLS still applies).
+      # Role the pool is expected to connect as. BYPASSRLS is a role
+      # **attribute** and is not inherited through role membership, so
+      # setup-roles-staging.sql applies it directly to this login role.
       DB_ROLE_WORKER: ${POSTGRES_WORKER_USER:-poziomki_staging_worker}
       DB_POOL_MAX_SIZE: ${WORKER_DB_POOL_MAX_SIZE:-4}
       DB_POOL_WAIT_TIMEOUT_MS: ${WORKER_DB_POOL_WAIT_TIMEOUT_MS:-3000}

--- a/infra/ops/postgres/setup-roles-staging.sh
+++ b/infra/ops/postgres/setup-roles-staging.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# One-time bootstrap for the staging slim parallel stack: creates the staging
+# DB and the owner / api / worker roles on the shared prod Postgres cluster.
+#
+# Idempotent; re-running rotates passwords to whatever is in the env vars.
+# After roles exist, installs extensions the consolidated migration needs
+# (cube, earthdistance, pg_trgm) because the staging owner is intentionally
+# NOT a superuser and can't CREATE EXTENSION itself.
+#
+# Required env vars:
+#   POSTGRES_STAGING_OWNER_PASSWORD   Password for poziomki_staging (DB owner).
+#   POSTGRES_STAGING_API_PASSWORD     Password for poziomki_staging_api.
+#   POSTGRES_STAGING_WORKER_PASSWORD  Password for poziomki_staging_worker.
+#
+# Optional:
+#   POSTGRES_CONTAINER  (default: poziomki-rs-postgres-1)
+#   CLUSTER_SUPERUSER   (default: poziomki — the prod superuser)
+#
+# Example (prod VPS):
+#   ssh poziomki 'cd ~/poziomki-rs-staging && \
+#     POSTGRES_STAGING_OWNER_PASSWORD=... \
+#     POSTGRES_STAGING_API_PASSWORD=... \
+#     POSTGRES_STAGING_WORKER_PASSWORD=... \
+#     ./infra/ops/postgres/setup-roles-staging.sh'
+
+set -eu
+
+: "${POSTGRES_STAGING_OWNER_PASSWORD:?Set POSTGRES_STAGING_OWNER_PASSWORD}"
+: "${POSTGRES_STAGING_API_PASSWORD:?Set POSTGRES_STAGING_API_PASSWORD}"
+: "${POSTGRES_STAGING_WORKER_PASSWORD:?Set POSTGRES_STAGING_WORKER_PASSWORD}"
+
+CONTAINER="${POSTGRES_CONTAINER:-poziomki-rs-postgres-1}"
+SUPERUSER="${CLUSTER_SUPERUSER:-poziomki}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SQL_FILE="${SCRIPT_DIR}/setup-roles-staging.sql"
+
+if [ ! -f "${SQL_FILE}" ]; then
+  echo "Missing ${SQL_FILE}" >&2
+  exit 1
+fi
+
+echo "Bootstrapping staging roles + DB in ${CONTAINER} as ${SUPERUSER}..."
+
+docker exec -i "${CONTAINER}" \
+  psql -v ON_ERROR_STOP=1 \
+       -v "owner_password=${POSTGRES_STAGING_OWNER_PASSWORD}" \
+       -v "api_password=${POSTGRES_STAGING_API_PASSWORD}" \
+       -v "worker_password=${POSTGRES_STAGING_WORKER_PASSWORD}" \
+       -U "${SUPERUSER}" \
+       -d postgres \
+  < "${SQL_FILE}"
+
+# Extensions are required by the consolidated migration and must be created
+# as a superuser — the staging DB owner deliberately isn't one.
+echo "Installing extensions into poziomki_staging..."
+docker exec -i "${CONTAINER}" \
+  psql -v ON_ERROR_STOP=1 -U "${SUPERUSER}" -d poziomki_staging <<'SQL'
+CREATE EXTENSION IF NOT EXISTS cube;
+CREATE EXTENSION IF NOT EXISTS earthdistance;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+SQL
+
+echo "Done. Verify with:"
+echo "  docker exec ${CONTAINER} psql -U ${SUPERUSER} -d postgres -c '\\du poziomki_staging*'"
+echo "  docker exec ${CONTAINER} psql -U ${SUPERUSER} -d poziomki_staging -c '\\dx'"

--- a/infra/ops/postgres/setup-roles-staging.sql
+++ b/infra/ops/postgres/setup-roles-staging.sql
@@ -1,0 +1,86 @@
+-- Staging role + database bootstrap for Poziomki's slim parallel stack.
+--
+-- Staging shares the prod Postgres cluster; this script carves out a fresh
+-- database and a distinct triplet of login roles. Safe to re-run.
+--
+-- Run as the cluster superuser (`poziomki`) against the `postgres` maintenance
+-- database. The wrapper `setup-roles-staging.sh` invokes this with the right
+-- -v variables.
+--
+-- Variables (passed via `psql -v`):
+--   owner_password     -- password for poziomki_staging (DB owner, runs migrations)
+--   api_password       -- password for poziomki_staging_api (app connections)
+--   worker_password    -- password for poziomki_staging_worker (background jobs)
+--
+-- Role model:
+--   * poziomki_staging       — owns the staging DB. NOT a cluster superuser;
+--     migrations run as this role. Members: the staging api/worker roles
+--     (so the owner can administer them without being superuser).
+--   * poziomki_staging_api   — NOBYPASSRLS; the running staging API.
+--     GRANTed `poziomki_api` so every RLS policy written `TO poziomki_api`
+--     applies via membership (PostgreSQL CREATE POLICY matches members).
+--   * poziomki_staging_worker — BYPASSRLS **attribute** set directly.
+--     Role *attributes* (BYPASSRLS, SUPERUSER, …) are non-inheritable even
+--     when the role is granted poziomki_worker — the attribute must be set
+--     on the login role itself.
+--
+-- Extensions (cube, earthdistance, pg_trgm) are installed into the staging
+-- DB by this script because the migration's `CREATE EXTENSION` requires
+-- superuser and the staging owner deliberately isn't one.
+
+\set ON_ERROR_STOP on
+
+-- ---------------------------------------------------------------------------
+-- Roles
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_staging') THEN
+    CREATE ROLE poziomki_staging LOGIN NOSUPERUSER CREATEDB NOCREATEROLE NOBYPASSRLS;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_staging_api') THEN
+    CREATE ROLE poziomki_staging_api LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_staging_worker') THEN
+    CREATE ROLE poziomki_staging_worker LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE BYPASSRLS;
+  END IF;
+END
+$$;
+
+ALTER ROLE poziomki_staging        WITH PASSWORD :'owner_password';
+ALTER ROLE poziomki_staging_api    WITH PASSWORD :'api_password';
+ALTER ROLE poziomki_staging_worker WITH PASSWORD :'worker_password';
+
+-- Re-assert attributes on every run — role creation above is guarded by
+-- existence, so a pre-existing role without BYPASSRLS (the original bug this
+-- script fixes) gets the attribute applied here.
+ALTER ROLE poziomki_staging_api    WITH NOBYPASSRLS;
+ALTER ROLE poziomki_staging_worker WITH BYPASSRLS;
+
+-- RLS policies across migrations target the prod role names literally.
+-- Granting them to the staging login roles makes CREATE POLICY ... TO role
+-- match via role membership, so the policies apply to staging sessions too.
+GRANT poziomki_api    TO poziomki_staging_api;
+GRANT poziomki_worker TO poziomki_staging_worker;
+
+-- Lets the staging DB owner administer the two staging login roles (set
+-- passwords, ALTER ROLE SET guc) without being a cluster superuser.
+GRANT poziomki_staging_api    TO poziomki_staging;
+GRANT poziomki_staging_worker TO poziomki_staging;
+
+-- ---------------------------------------------------------------------------
+-- Database
+-- ---------------------------------------------------------------------------
+
+SELECT 'CREATE DATABASE poziomki_staging OWNER poziomki_staging'
+WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'poziomki_staging')
+\gexec
+
+GRANT CONNECT ON DATABASE poziomki_staging TO
+  poziomki_staging, poziomki_staging_api, poziomki_staging_worker;
+
+-- Per-database override read by migrations 2026-04-18-010000 and
+-- 2026-04-19-040000 — targets staging roles for the ALTER statements that
+-- otherwise default to `poziomki_api` (which is prod's role).
+ALTER DATABASE poziomki_staging SET app.api_role = 'poziomki_staging_api';

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -31,6 +31,17 @@ esac
 
 [[ -f "$ENV_FILE" ]] || { echo "missing $ENV_FILE" >&2; exit 1; }
 
+# Staging imgproxy has no published image tag — the service is built on the
+# host from ../imgproxy. `up -d --no-build` below would fail on first run if
+# the image isn't cached, so build it lazily here. Prod imgproxy pulls a
+# published tag and is unaffected.
+if [[ "$ENV" == "staging" ]]; then
+  if ! docker image inspect poziomki-rs-staging-imgproxy_staging >/dev/null 2>&1; then
+    echo "building imgproxy_staging (first run on this host)…"
+    docker compose -p "$PROJECT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" build imgproxy_staging
+  fi
+fi
+
 # Snapshot current digest for rollback before any mutation.
 cp "$ENV_FILE" "${ENV_FILE}.prev"
 


### PR DESCRIPTION
**Proper staging isolation**

Three hardcoded prod-role assumptions made the slim staging stack fall back onto prod credentials. This unblocks staging using its own least-privilege roles while the shared postgres cluster still enforces RLS through role inheritance.

- [ ] backend tests green in CI
- [ ] after merge: redeploy staging and verify API comes up as `poziomki_staging_api`
- [ ] swap `/etc/caddy/Caddyfile.staging` on the VPS back to the repo version once Caddy is rebuilt with the brotli module

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add role isolation support for staging parallel stack via configurable DB role names
> - Adds `DB_ROLE_API` and `DB_ROLE_WORKER` env vars to override the expected DB role names in `PoolRole.expected_db_user`, falling back to hardcoded defaults (`poziomki_api`, `poziomki_worker`).
> - Introduces staging-specific roles (`poziomki_staging_api`, `poziomki_staging_worker`) in [setup-roles-staging.sql](https://github.com/poziomki-app/poziomki/pull/253/files#diff-39afb433a0c25c4cfb2db808b917ffb71b3ac9682bd687f2fd7b9138d2af4e00) with production-aligned policy role membership and `BYPASSRLS` on the worker.
> - Reworks migrations in [2026-04-18-010000_auth_security_definer/up.sql](https://github.com/poziomki-app/poziomki/pull/253/files#diff-e47aa49766a4c3bc76824ca27689c2a82d1281100b6cbf694dd87daad3287dbb) and [2026-04-19-040000_invariants_and_audit/up.sql](https://github.com/poziomki-app/poziomki/pull/253/files#diff-1dcce8be274d9a383a2cb1022366d4b035e7cca43dfd8edb07d6620e0b56edd1) to read the target role from `app.api_role` GUC instead of hardcoding `poziomki_api`.
> - Staging deployments now auto-build `imgproxy_staging` if the image is missing before running `up -d --no-build`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1723058.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->