### PR TITLE
chore(infra): bump pgdog to v0.1.37

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -50,7 +50,7 @@ services:
     networks: [db]
 
   pgdog:
-    image: ghcr.io/pgdogdev/pgdog:v0.1.30
+    image: ghcr.io/pgdogdev/pgdog:v0.1.37
     entrypoint: ["/bin/sh", "/opt/pgdog/entrypoint.sh"]
     restart: unless-stopped
     depends_on:

--- a/infra/docker-compose.staging.yml
+++ b/infra/docker-compose.staging.yml
@@ -19,7 +19,7 @@ x-logging: &default-logging
 
 services:
   pgdog_staging:
-    image: ghcr.io/pgdogdev/pgdog:v0.1.30
+    image: ghcr.io/pgdogdev/pgdog:v0.1.37
     entrypoint: ["/bin/sh", "/opt/pgdog/entrypoint.sh"]
     restart: unless-stopped
     ports:


### PR DESCRIPTION
**pgdog v0.1.37**

Bumps pgdog across prod + staging. On v0.1.30 we hit a pooled-backend state issue that blocked the staging-role cutover from PR #253; upgrading clears it. v0.1.37 also picks up the v0.1.34 in-transaction deadlock fix and smaller stability fixes through v0.1.36.

- [ ] deploy prod pgdog (expect no behaviour change)
- [ ] watch staging `pg_stat_activity` for the first day