### PR TITLE
chore(security): fix open GitHub security alerts

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -34,15 +34,15 @@ jobs:
       VPS_HOST: ${{ secrets.VPS_HOSTNAME }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: tailscale/github-action@v3
+      - uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret:    ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci-deployer
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -35,15 +35,15 @@ jobs:
       VPS_HOST: ${{ secrets.VPS_HOSTNAME }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: tailscale/github-action@v3
+      - uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret:    ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci-deployer
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: tailscale/github-action@v3
+      - uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret:    ${{ secrets.TS_OAUTH_SECRET }}


### PR DESCRIPTION
**Security alert triage (9 open)**

Pins three workflows' actions to commit SHAs to close the Scorecard Pinned-Dependencies findings (alerts 452–459). Matches the SHAs already used across the rest of the workflow suite.

The remaining two alerts are upstream-stuck and already suppressed in `backend/deny.toml` + `backend/.cargo/audit.toml` with rationale:
- `RUSTSEC-2023-0071` — rsa Marvin timing side-channel (no upstream fix; rsa 0.10 still RC)
- `GHSA-cq8v-f236-94qc` — rand 0.8 unsoundness (pulled transitively via rsa → num-bigint-dig)

Neither is actionable with a code change in this repo today — they need dismissal in the UI with a comment pointing at the ignore rationale. I'd leave those two to you since dismissal is a per-alert UI action.

- [ ] Scorecard re-runs on next main push and auto-resolves alerts 452–459
- [ ] dismiss alert 451 (Vulnerabilities) + the rand Dependabot alert as "tolerated risk"

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin GitHub Actions to specific commits in CI/CD workflows to fix security alerts
> Replaces floating version tags (`v3`, `v4`) with pinned commit SHAs for `actions/checkout`, `tailscale/github-action`, and `docker/login-action` in the production deploy, staging deploy, and drift-check workflows. This prevents supply chain attacks where a mutable tag could be silently updated to point to malicious code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 002db7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->