### PR TITLE
feat(moderation): Polish content safety via Bielik-Guard int8 ONNX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ DerivedData/
 # DKIM private key
 infra/ops/dkim/
 
+# Moderation model artefact (gated on HuggingFace, ~125 MB, mounted at
+# runtime — see docs/moderation-deploy.md).
+infra/ops/moderation/
+
 # Environment
 .env
 
@@ -73,3 +77,7 @@ result-*
 Thumbs.db
 play-store/
 backend/seed/
+
+# Python build cache
+__pycache__/
+*.pyc

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -15,7 +15,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -103,7 +105,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "log",
  "rustls",
@@ -174,7 +176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -250,6 +252,12 @@ dependencies = [
  "tower",
  "url",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -331,6 +339,15 @@ name = "bytesize"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -420,6 +437,21 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -519,6 +551,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -669,6 +711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +789,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -933,7 +1015,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "memchr",
 ]
 
@@ -993,6 +1075,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "expect-json"
@@ -1361,6 +1449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,7 +1561,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1700,6 +1794,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,7 +1880,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
  "pem",
@@ -1809,7 +1912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chumsky",
  "ed25519-dalek",
  "email-encoding",
@@ -1820,7 +1923,7 @@ dependencies = [
  "httpdate",
  "idna",
  "mime",
- "nom",
+ "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
  "rsa",
@@ -1898,6 +2001,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +2036,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "maybe-async"
@@ -1961,7 +2096,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2019,6 +2154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2198,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2244,31 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2264,6 +2452,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +2487,30 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
 ]
 
 [[package]]
@@ -2314,12 +2548,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2410,12 +2650,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -2460,7 +2709,7 @@ dependencies = [
  "argon2",
  "axum",
  "axum-test",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "dashmap",
  "deadpool",
@@ -2477,6 +2726,8 @@ dependencies = [
  "lettre",
  "metrics",
  "metrics-exporter-prometheus",
+ "ndarray",
+ "ort",
  "rand_core 0.6.4",
  "reqwest 0.13.2",
  "rust-s3",
@@ -2487,6 +2738,7 @@ dependencies = [
  "subtle",
  "thiserror 2.0.18",
  "thumbhash",
+ "tokenizers",
  "tokio",
  "tower-http",
  "tracing",
@@ -2793,6 +3045,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,7 +3125,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2877,7 +3166,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -2991,7 +3280,7 @@ dependencies = [
  "async-trait",
  "aws-creds",
  "aws-region",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "futures-util",
@@ -3098,9 +3387,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3419,6 +3708,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,6 +3732,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3452,6 +3764,12 @@ dependencies = [
  "psm",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -3646,6 +3964,39 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "tokio"
@@ -3981,10 +4332,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -3993,10 +4359,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -4015,6 +4416,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -80,6 +80,9 @@ diesel_migrations = { version = "2.3", features = ["postgres"] }
 deadpool = { version = "=0.12.3", features = ["rt_tokio_1"] }
 thiserror = "2"
 zip = { version = "2", default-features = false, features = ["deflate"] }
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "tls-rustls", "ndarray"] }
+tokenizers = { version = "=0.22.2", default-features = false, features = ["onig"] }
+ndarray = "0.17"
 
 [[bin]]
 name = "poziomki_backend-cli"
@@ -89,6 +92,10 @@ required-features = []
 [[bin]]
 name = "worker"
 path = "src/bin/worker.rs"
+
+[[bin]]
+name = "moderation-stress"
+path = "src/bin/moderation_stress.rs"
 
 [dev-dependencies]
 serial_test = { version = "=3.4.0" }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,11 @@
-# rust:1.93-bookworm
-FROM rust@sha256:7c4ae649a84014c467d79319bbf17ce2632ae8b8be123ac2fb2ea5be46823f31 AS chef
+# rust:1.93-trixie
+#
+# NB: bumped from bookworm → trixie to pick up glibc ≥ 2.38. The `ort` crate
+# (ONNX Runtime, used by the moderation engine) ships a pre-built
+# `libonnxruntime.a` that references `__isoc23_strtol` / `__isoc23_strtoull`,
+# which are only present in glibc 2.38+. bookworm ships glibc 2.36 and fails
+# to link with `undefined symbol`.
+FROM rust@sha256:f7c649bf7cc388826273a4977e8304778b7f8ad2e20838c1d52283cf23e49f7a AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app/backend
 
@@ -19,8 +25,8 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . /app/
 RUN cargo build --release --bin poziomki_backend-cli --bin worker
 
-# debian:bookworm-slim
-FROM debian@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS runtime-deps
+# debian:trixie-slim
+FROM debian@sha256:e18da95f66066b7c5fa31491b524e83121271eca59a3d140f4906c8d0a090367 AS runtime-deps
 # /bin/sh on bookworm-slim is dash, which doesn't support `-o pipefail`.
 # Install bash first, then switch SHELL so the ldd pipeline below gets pipefail.
 # hadolint ignore=DL3008
@@ -48,13 +54,18 @@ RUN set -eux; \
         cp -aL "$dep" "$dest"; \
     done
 
-# gcr.io/distroless/cc-debian12:nonroot
-FROM gcr.io/distroless/cc-debian12@sha256:e2d29aec8061843706b7e484c444f78fafb05bfe47745505252b1769a05d14f1 AS runtime
+# gcr.io/distroless/cc-debian13:nonroot  (trixie-based — matches glibc 2.41)
+FROM gcr.io/distroless/cc-debian13@sha256:951d10263d9a00fafaadb57615d3299811dde143fab6e64663685ee48c48137e AS runtime
 WORKDIR /app
 
 COPY --from=runtime-deps /staging/ /
 COPY --from=builder /app/backend/target/release/poziomki_backend-cli /usr/local/bin/poziomki_backend-cli
 COPY --from=builder /app/backend/target/release/worker /usr/local/bin/worker
+
+# The int8 Bielik-Guard model (~125 MB) is NOT baked into the image — it's
+# mounted read-only from the host at /app/moderation via docker-compose,
+# mirroring the DKIM key pattern. See docs/moderation-deploy.md for the
+# ops step, and scripts/guard-bench/export_onnx.py to regenerate.
 
 USER nonroot
 EXPOSE 5150

--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -15,6 +15,13 @@ ignore = [
     # num-bigint-dig for email crypto. Re-evaluate when lettre ships an
     # update that no longer depends on rand 0.8.
     "RUSTSEC-2026-0097",
+    # RUSTSEC-2024-0436: paste 1.0.15 is archived / unmaintained. Pulled in
+    # transitively by tokenizers via macro_rules_attribute — a proc-macro
+    # helper used at build time only, no runtime code path. No CVE, no
+    # observable behaviour; upstream tokenizers has no direct replacement
+    # path. Re-evaluate when tokenizers or macro_rules_attribute migrates
+    # off paste (likely to `pastey`).
+    "RUSTSEC-2024-0436",
 ]
 
 [licenses]

--- a/backend/src/api/chat/messages.rs
+++ b/backend/src/api/chat/messages.rs
@@ -111,6 +111,18 @@ pub async fn create_message(
     // viewer_user_id=0 so broadcast payload has is_mine=false for all recipients.
     // Each client computes isMine locally; sender matches via client_id.
     let payload = single_message_payload(&msg, 0, conn).await?;
+
+    // Enqueue moderation scan in the same transaction as the message insert
+    // (transactional outbox): the worker cannot observe the job until this
+    // tx commits, and if the tx rolls back the scan never existed. This
+    // closes the dual-write gap the earlier fire-and-forget path had.
+    //
+    // Only scan non-empty text messages; system/kind=other payloads are
+    // not user-authored text.
+    if matches!(msg.kind.as_str(), "text" | "") && !msg.body.trim().is_empty() {
+        crate::jobs::outbox::enqueue_moderation_scan_in_tx(conn, &msg.id, &msg.body).await?;
+    }
+
     Ok((msg, payload, true))
 }
 
@@ -132,6 +144,20 @@ pub async fn edit_message(
 
     let now = Utc::now();
 
+    // Read the current body within the same tx so we can detect no-op
+    // edits and avoid enqueueing a redundant moderation scan. Runs at
+    // READ COMMITTED; any concurrent edit that beats ours is still safe
+    // because the UPDATE below overwrites and the subsequent scan sees
+    // our new value.
+    let prev_body: Option<String> = messages::table
+        .filter(messages::id.eq(message_id))
+        .filter(messages::sender_id.eq(sender_id))
+        .filter(messages::deleted_at.is_null())
+        .select(messages::body)
+        .first(conn)
+        .await
+        .optional()?;
+
     let updated = diesel::update(
         messages::table
             .filter(messages::id.eq(message_id))
@@ -143,7 +169,24 @@ pub async fn edit_message(
     .await
     .optional()?;
 
-    updated.ok_or_else(|| crate::error::AppError::message("message not found or not editable"))
+    let updated = updated
+        .ok_or_else(|| crate::error::AppError::message("message not found or not editable"))?;
+
+    // Re-scan only if the body actually changed. Without this, a user
+    // tapping Edit twice (or clients that echo back the current body as
+    // part of an autosave) would trigger redundant inference on
+    // unchanged text. Symmetrical with create_message for the "abusive
+    // edit after benign send" case.
+    let body_changed = prev_body.as_deref() != Some(updated.body.as_str());
+    if body_changed
+        && matches!(updated.kind.as_str(), "text" | "")
+        && !updated.body.trim().is_empty()
+    {
+        crate::jobs::outbox::enqueue_moderation_scan_in_tx(conn, &updated.id, &updated.body)
+            .await?;
+    }
+
+    Ok(updated)
 }
 
 /// Soft-delete a message.

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -508,6 +508,9 @@ async fn handle_send(
 
     match result {
         Ok(Ok(outcome)) => {
+            // NB: moderation scan is enqueued transactionally inside
+            // create_message, so nothing to do here — the job is already
+            // durable if this branch was reached.
             let server_msg = ServerMessage::Message {
                 msg: Box::new(outcome.payload),
             };
@@ -643,6 +646,8 @@ async fn handle_edit(
             edited_at,
             members,
         }) => {
+            // NB: moderation re-scan is enqueued transactionally inside
+            // edit_message.
             let server_msg = ServerMessage::Edited {
                 message_id,
                 conversation_id,

--- a/backend/src/api/profiles/write_handler.rs
+++ b/backend/src/api/profiles/write_handler.rs
@@ -14,6 +14,8 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
+use crate::api::common::{error_response, ErrorSpec};
+
 use super::{full_profile_response, parse_tag_uuids, sync_profile_tags};
 use crate::api::{
     extract_filename,
@@ -102,6 +104,23 @@ pub(in crate::api) async fn profile_create(
                 Ok(u) => u,
                 Err(response) => return Ok::<Response, diesel::result::Error>(*response),
             };
+
+            // Bio moderation runs AFTER validate_create so unauthenticated,
+            // unauthorized, or duplicate-profile requests still get their
+            // existing 401/403/409 instead of being masked by a 422 — and
+            // we don't spend inference CPU on requests that would be
+            // rejected cheaply either way.
+            if let Some(ref bio) = payload_clone.bio {
+                match moderate_bio_text(bio, &headers_clone).await {
+                    Ok(None) => {}
+                    Ok(Some(rejection)) => return Ok(rejection),
+                    Err(error) => {
+                        tracing::error!(%error, "bio moderation failed; rolling back create");
+                        return Err(diesel::result::Error::RollbackTransaction);
+                    }
+                }
+            }
+
             let picture = match resolve_picture_filename(
                 conn,
                 &headers_clone,
@@ -184,6 +203,22 @@ pub(in crate::api) async fn profile_update(
                     return Ok::<Response, diesel::result::Error>(*response);
                 }
             };
+
+            // Bio moderation runs AFTER validate_and_prepare_update so
+            // unauthorised-profile and not-found requests still get 403/
+            // 404 instead of a misleading 422, and we don't burn inference
+            // CPU on them.
+            if let Some(ref bio) = payload_clone.bio {
+                match moderate_bio_text(bio, &headers_clone).await {
+                    Ok(None) => {}
+                    Ok(Some(rejection)) => return Ok(rejection),
+                    Err(error) => {
+                        tracing::error!(%error, "bio moderation failed; rolling back update");
+                        return Err(diesel::result::Error::RollbackTransaction);
+                    }
+                }
+            }
+
             let changeset = build_update_changeset(&payload_clone, picture);
             let updated = apply_update(conn, &profile, &payload_clone, changeset)
                 .await
@@ -198,6 +233,96 @@ pub(in crate::api) async fn profile_update(
     })
     .await
     .map_err(Into::into)
+}
+
+/// Run the moderation engine on a bio string. Returns:
+/// - `Ok(None)` when moderation is disabled, the engine allows, or only
+///   flags for review (flag is logged, publish proceeds).
+/// - `Ok(Some(response))` when the engine blocks — caller must return it
+///   as the handler's final response.
+/// - `Err(_)` on an unexpected infrastructure error (inference panic,
+///   spawn failure). Hard errors surface as 500; we never fall through to
+///   "allow" on failure, because that would defeat the gate.
+async fn moderate_bio_text(bio: &str, headers: &HeaderMap) -> Result<Option<Response>> {
+    let trimmed = bio.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let Some(engine) = crate::moderation::shared() else {
+        return Ok(None);
+    };
+
+    let owned = trimmed.to_string();
+    let started = std::time::Instant::now();
+    let scores = tokio::task::spawn_blocking(move || engine.score(&owned))
+        .await
+        .map_err(|e| crate::error::AppError::Message(format!("moderation task: {e}")))?
+        .map_err(|e| crate::error::AppError::Message(format!("moderation inference: {e}")))?;
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+    let thresholds = crate::moderation::Thresholds::BIO;
+    let verdict = scores.verdict(&thresholds);
+    let flagged = scores.flagged(&thresholds);
+
+    metrics::histogram!("moderation_inference_latency_ms", "kind" => "bio").record(elapsed_ms);
+    metrics::counter!(
+        "moderation_verdicts_total",
+        "kind" => "bio",
+        "verdict" => verdict.as_str()
+    )
+    .increment(1);
+
+    match verdict {
+        crate::moderation::Verdict::Allow => Ok(None),
+        crate::moderation::Verdict::Flag => {
+            // Bio flag without block is rare with the BIO preset (flag and
+            // block thresholds are equal), but we handle it defensively so
+            // a future threshold tweak doesn't silently drop flagged bios.
+            tracing::warn!(
+                flagged = ?flagged.iter().map(|(c, s)| format!("{}={s:.2}", c.as_str())).collect::<Vec<_>>(),
+                elapsed_ms,
+                "bio moderation: flagged for review (allowed to publish)"
+            );
+            Ok(None)
+        }
+        crate::moderation::Verdict::Block => {
+            let categories: Vec<&'static str> = flagged.iter().map(|(c, _)| c.as_str()).collect();
+            tracing::warn!(
+                categories = ?categories,
+                elapsed_ms,
+                "bio moderation: blocked on publish"
+            );
+            let error_msg = rejection_message(&flagged);
+            Ok(Some(error_response(
+                axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+                headers,
+                ErrorSpec {
+                    error: error_msg,
+                    code: "BIO_CONTENT_REJECTED",
+                    details: Some(serde_json::json!({
+                        "categories": categories,
+                    })),
+                },
+            )))
+        }
+    }
+}
+
+/// Build a user-facing rejection message. Polish-first (this is a Polish
+/// product), falls back to a category listing.
+fn rejection_message(flagged: &[(crate::moderation::Category, f32)]) -> String {
+    use crate::moderation::Category;
+    if flagged.iter().any(|(c, _)| matches!(c, Category::SelfHarm)) {
+        return "Twój opis zawiera treści dotyczące samookaleczenia lub myśli samobójczych. \
+                Jeśli potrzebujesz wsparcia, zadzwoń pod 116 123 (bezpłatny telefon zaufania). \
+                Prosimy o edycję opisu przed publikacją."
+            .to_string();
+    }
+    let labels: Vec<&'static str> = flagged.iter().map(|(c, _)| c.as_str()).collect();
+    format!(
+        "Twój opis narusza zasady społeczności ({}). Proszę go zmienić przed zapisaniem.",
+        labels.join(", ")
+    )
 }
 
 pub(in crate::api) async fn profile_delete(

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -250,6 +250,8 @@ pub async fn run_api_server() -> crate::error::AppResult<()> {
     let _ = dotenvy::dotenv();
     init_tracing_once()?;
     crate::telemetry::init_metrics_exporter(crate::telemetry::ProcessKind::Api)?;
+    crate::moderation::init_from_env()
+        .map_err(|e| crate::error::AppError::Message(format!("moderation init: {e}")))?;
     let cfg = load_runtime_config()?;
     let ctx = build_app_context(PoolRole::Api)?;
     assert_pool_role(PoolRole::Api).await?;
@@ -276,6 +278,8 @@ pub async fn run_outbox_worker_process() -> crate::error::AppResult<()> {
     let _ = dotenvy::dotenv();
     init_tracing_once()?;
     crate::telemetry::init_metrics_exporter(crate::telemetry::ProcessKind::Worker)?;
+    crate::moderation::init_from_env()
+        .map_err(|e| crate::error::AppError::Message(format!("moderation init: {e}")))?;
     let _cfg = load_runtime_config()?;
     let ctx = build_app_context(PoolRole::Worker)?;
     assert_pool_role(PoolRole::Worker).await?;

--- a/backend/src/bin/moderation_stress.rs
+++ b/backend/src/bin/moderation_stress.rs
@@ -1,0 +1,294 @@
+//! Stress + stability harness for the moderation engine, calibrated to the
+//! prod OVH container limits (api 512 MB / 1 CPU, worker 256 MB / 0.5 CPU).
+//!
+//! Runs four phases and prints a machine-parseable summary:
+//!   1. cold-load footprint (RSS before/after model load)
+//!   2. sustained single-threaded loop (leak check across 10 000 inferences)
+//!   3. concurrent load (N blocking workers via `spawn_blocking`)
+//!   4. final memory check
+//!
+//! Intended invocation under cgroup limits:
+//!   systemd-run --user --scope -p MemoryMax=256M -p CPUQuota=50% -- \
+//!     ./target/release/moderation-stress --concurrency 2 --iters 10000
+//!
+//! `MODERATION_MODEL_PATH` must point at the ONNX directory produced by
+//! `scripts/guard-bench/export_onnx.py`.
+
+#![allow(clippy::print_stdout)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::indexing_slicing)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::missing_docs_in_private_items)]
+
+use std::fs;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use poziomki_backend::moderation::{self, ModerationEngine, Scores};
+
+const SAMPLES: &[&str] = &[
+    "Cześć, jestem Ania, lubię wspinaczkę i jazz.",
+    "Poszukuję ekipy na weekendowe wyjazdy rowerowe.",
+    "Dzisiaj zrobiłem świetny obiad — polecam pierogi.",
+    "Mam 34 lata, dwójka dzieci, w wolnym czasie biegam.",
+    "Ty kurwo jebana, spierdalaj stąd.",
+    "Co za pojebany dzień, kurwa mać.",
+    "Nienawidzę tych ciapatych, niech giną.",
+    "Żydzi rządzą światem i okradają Polskę.",
+    "Szukam faceta do seksu bez zobowiązań, DM.",
+    "Lubię ostry seks analny, ktoś chętny?",
+    "Nie chce mi się już żyć, wszystko straciło sens.",
+    "Mam ochotę się pociąć, żeby przestać to czuć.",
+    "Sprzedam metę, 200 zł gram, Warszawa.",
+    "Szukam kogoś do włamania do mieszkania na Mokotowie.",
+    // A realistic chat-length sample (~400 chars) to stress tokeniser + padding.
+    "Hej, dawno się nie widzieliśmy, jak tam u ciebie? Słyszałem, że zmieniłaś pracę — \
+     gratulacje, trzymam kciuki za nową rolę. U mnie bez większych zmian, próbuję \
+     wyrobić trochę spokojniejszy rytm, mniej siedzenia przy kompie wieczorami, więcej \
+     wyjść na rower. W weekend jedziemy z chłopakami na Kaszuby, jakby coś się zmieniło \
+     w Twoich planach, daj znać, chętnie nadgonimy przy piwie po powrocie.",
+];
+
+struct RssKb(u64);
+
+impl RssKb {
+    fn read() -> Self {
+        let status = fs::read_to_string("/proc/self/status").unwrap_or_default();
+        for line in status.lines() {
+            if let Some(rest) = line.strip_prefix("VmRSS:") {
+                let kb = rest
+                    .trim()
+                    .trim_end_matches("kB")
+                    .trim()
+                    .parse::<u64>()
+                    .unwrap_or(0);
+                return Self(kb);
+            }
+        }
+        Self(0)
+    }
+
+    const fn mb(&self) -> f64 {
+        self.0 as f64 / 1024.0
+    }
+}
+
+#[derive(Default)]
+struct LatencyStats {
+    samples_us: Vec<u64>,
+}
+
+impl LatencyStats {
+    fn record(&mut self, elapsed: Duration) {
+        self.samples_us.push(elapsed.as_micros() as u64);
+    }
+
+    fn percentile(&mut self, p: f64) -> f64 {
+        if self.samples_us.is_empty() {
+            return 0.0;
+        }
+        self.samples_us.sort_unstable();
+        let idx = ((self.samples_us.len() as f64 - 1.0) * p).round() as usize;
+        self.samples_us[idx.min(self.samples_us.len() - 1)] as f64 / 1000.0
+    }
+
+    fn mean_ms(&self) -> f64 {
+        if self.samples_us.is_empty() {
+            return 0.0;
+        }
+        let sum: u64 = self.samples_us.iter().sum();
+        sum as f64 / self.samples_us.len() as f64 / 1000.0
+    }
+}
+
+fn parse_args() -> (usize, usize, usize) {
+    // --iters N --concurrency N --threads N
+    let mut iters = 10_000usize;
+    let mut concurrency = 2usize;
+    let mut intra_threads = 1usize;
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < args.len() {
+        // Every flag below consumes the next argv slot — bail cleanly if
+        // the caller left it dangling (e.g. `--iters` as the last arg).
+        let value = args.get(i + 1);
+        match args[i].as_str() {
+            "--iters" => {
+                if let Some(v) = value {
+                    iters = v.parse().unwrap_or(iters);
+                }
+                i += 2;
+            }
+            "--concurrency" => {
+                if let Some(v) = value {
+                    // max(1): 0 would divide-by-zero in the phase loops.
+                    concurrency = v.parse::<usize>().unwrap_or(concurrency).max(1);
+                }
+                i += 2;
+            }
+            "--threads" => {
+                if let Some(v) = value {
+                    intra_threads = v.parse::<usize>().unwrap_or(intra_threads).max(1);
+                }
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    (iters, concurrency, intra_threads)
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() {
+    let (iters, concurrency, intra_threads) = parse_args();
+
+    println!("=== moderation stress bench ===");
+    println!(
+        "iters={iters}  concurrency={concurrency}  intra_threads={intra_threads}  \
+         sample_set={}",
+        SAMPLES.len()
+    );
+
+    // --- Phase 1: cold-load footprint ---
+    let baseline = RssKb::read();
+    println!("\n[1] baseline RSS: {:.1} MB", baseline.mb());
+
+    let model_path = std::env::var("MODERATION_MODEL_PATH")
+        .expect("MODERATION_MODEL_PATH env var must point at ONNX dir");
+    let load_started = Instant::now();
+    let engine = Arc::new(
+        ModerationEngine::load_from_dir(std::path::Path::new(&model_path), intra_threads)
+            .expect("load engine"),
+    );
+    let load_ms = load_started.elapsed().as_secs_f64() * 1000.0;
+    let after_load = RssKb::read();
+    // Also seed the global for parity with prod init path (env var is
+    // already set from the caller; we just read it back).
+    let _ = moderation::init_from_env();
+    println!(
+        "    load: {load_ms:.0} ms   RSS after load: {:.1} MB   delta: {:+.1} MB",
+        after_load.mb(),
+        after_load.mb() - baseline.mb()
+    );
+
+    // Warmup: first few inferences trigger lazy ORT init and tokenizer caches.
+    for s in SAMPLES.iter().take(4) {
+        let _ = engine.score(s);
+    }
+    let after_warmup = RssKb::read();
+    println!(
+        "    RSS after warmup: {:.1} MB   delta-from-load: {:+.1} MB",
+        after_warmup.mb(),
+        after_warmup.mb() - after_load.mb()
+    );
+
+    // --- Phase 2: sustained single-threaded leak check ---
+    println!("\n[2] sustained single-threaded: {iters} iterations");
+    let pre_sustained = RssKb::read();
+    let mut stats = LatencyStats::default();
+    let phase_started = Instant::now();
+    let mut checkpoints = Vec::new();
+    let checkpoint_every = iters / 10;
+    for i in 0..iters {
+        let text = SAMPLES[i % SAMPLES.len()];
+        let t = Instant::now();
+        let _scores: Scores = engine.score(text).expect("score");
+        stats.record(t.elapsed());
+        if checkpoint_every > 0 && (i + 1) % checkpoint_every == 0 {
+            checkpoints.push((i + 1, RssKb::read().mb()));
+        }
+    }
+    let phase_elapsed = phase_started.elapsed();
+    let post_sustained = RssKb::read();
+    let throughput = iters as f64 / phase_elapsed.as_secs_f64();
+
+    println!(
+        "    elapsed: {:.2}s   throughput: {throughput:.1} msg/s",
+        phase_elapsed.as_secs_f64()
+    );
+    println!(
+        "    latency mean={:.2}ms  p50={:.2}ms  p95={:.2}ms  p99={:.2}ms  p99.9={:.2}ms",
+        stats.mean_ms(),
+        stats.percentile(0.50),
+        stats.percentile(0.95),
+        stats.percentile(0.99),
+        stats.percentile(0.999),
+    );
+    println!(
+        "    RSS pre: {:.1} MB   post: {:.1} MB   delta: {:+.1} MB  (leak check)",
+        pre_sustained.mb(),
+        post_sustained.mb(),
+        post_sustained.mb() - pre_sustained.mb()
+    );
+    println!("    checkpoints (iter -> MB):");
+    for (i, mb) in &checkpoints {
+        println!("      {i:>7}: {mb:.1}");
+    }
+
+    // --- Phase 3: concurrent load via spawn_blocking ---
+    println!(
+        "\n[3] concurrent load: {concurrency} workers × {} iters each",
+        iters / concurrency
+    );
+    let per_worker = iters / concurrency;
+    let pre_concurrent = RssKb::read();
+    let concurrent_started = Instant::now();
+    let mut handles = Vec::with_capacity(concurrency);
+    for w in 0..concurrency {
+        let engine = Arc::clone(&engine);
+        handles.push(tokio::spawn(async move {
+            let mut wstats = LatencyStats::default();
+            for i in 0..per_worker {
+                let text = SAMPLES[(w * 31 + i) % SAMPLES.len()];
+                let engine = Arc::clone(&engine);
+                let t = Instant::now();
+                let _scores = tokio::task::spawn_blocking(move || engine.score(text))
+                    .await
+                    .expect("join")
+                    .expect("score");
+                wstats.record(t.elapsed());
+            }
+            wstats
+        }));
+    }
+    let mut combined = LatencyStats::default();
+    for h in handles {
+        let s = h.await.expect("worker join");
+        combined.samples_us.extend(s.samples_us);
+    }
+    let concurrent_elapsed = concurrent_started.elapsed();
+    let post_concurrent = RssKb::read();
+    let c_throughput = combined.samples_us.len() as f64 / concurrent_elapsed.as_secs_f64();
+    println!(
+        "    elapsed: {:.2}s   throughput: {c_throughput:.1} msg/s",
+        concurrent_elapsed.as_secs_f64()
+    );
+    println!(
+        "    latency mean={:.2}ms  p50={:.2}ms  p95={:.2}ms  p99={:.2}ms  p99.9={:.2}ms",
+        combined.mean_ms(),
+        combined.percentile(0.50),
+        combined.percentile(0.95),
+        combined.percentile(0.99),
+        combined.percentile(0.999),
+    );
+    println!(
+        "    RSS pre: {:.1} MB   post: {:.1} MB   delta: {:+.1} MB",
+        pre_concurrent.mb(),
+        post_concurrent.mb(),
+        post_concurrent.mb() - pre_concurrent.mb()
+    );
+
+    // --- Phase 4: final check ---
+    let final_rss = RssKb::read();
+    println!("\n[4] final RSS: {:.1} MB", final_rss.mb());
+    println!(
+        "    total delta from baseline: {:+.1} MB",
+        final_rss.mb() - baseline.mb()
+    );
+
+    println!("\n=== done ===");
+}

--- a/backend/src/healthcheck.rs
+++ b/backend/src/healthcheck.rs
@@ -1,7 +1,7 @@
 use std::process::exit;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::jobs::outbox::OUTBOX_WORKER_HEARTBEAT_PATH;
+use crate::jobs::outbox::{MODERATION_WORKER_HEARTBEAT_PATH, OUTBOX_WORKER_HEARTBEAT_PATH};
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(3);
 const WORKER_HEARTBEAT_STALE_AFTER_SECS: u64 = 30;
@@ -19,16 +19,24 @@ pub async fn api_healthcheck() -> ! {
     exit(i32::from(!ok));
 }
 
-pub fn worker_healthcheck() -> ! {
-    let Ok(contents) = std::fs::read_to_string(OUTBOX_WORKER_HEARTBEAT_PATH) else {
-        exit(1);
+fn heartbeat_fresh(path: &str) -> bool {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return false;
     };
     let Ok(ts_secs) = contents.trim().parse::<u64>() else {
-        exit(1);
+        return false;
     };
     let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
-        exit(1);
+        return false;
     };
-    let age_secs = now.as_secs().saturating_sub(ts_secs);
-    exit(i32::from(age_secs >= WORKER_HEARTBEAT_STALE_AFTER_SECS))
+    now.as_secs().saturating_sub(ts_secs) < WORKER_HEARTBEAT_STALE_AFTER_SECS
+}
+
+pub fn worker_healthcheck() -> ! {
+    // Both worker loops (general + moderation) must be alive — a wedged
+    // moderation loop would otherwise let moderation_scan jobs backlog
+    // indefinitely while the container stays healthy.
+    let ok = heartbeat_fresh(OUTBOX_WORKER_HEARTBEAT_PATH)
+        && heartbeat_fresh(MODERATION_WORKER_HEARTBEAT_PATH);
+    exit(i32::from(!ok));
 }

--- a/backend/src/jobs/cleanup.rs
+++ b/backend/src/jobs/cleanup.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel::sql_types::BigInt;
 use diesel_async::RunQueryDsl;
 use std::time::Duration;
 
@@ -6,11 +7,21 @@ use crate::db::schema::{otp_codes, sessions};
 
 const CLEANUP_INTERVAL_SECS: u64 = 3600;
 
+/// How long processed `job_outbox` rows are retained. Long enough for
+/// operators to triage a spike from an audit log / metrics snapshot,
+/// short enough that message-body snapshots embedded in moderation-scan
+/// payloads don't accumulate into a long-lived shadow copy of chat
+/// content. 7 days is the compromise.
+const OUTBOX_PROCESSED_RETENTION_DAYS: i64 = 7;
+
 pub(super) async fn run_cleanup_loop() {
     tracing::info!("cleanup loop started (interval: {CLEANUP_INTERVAL_SECS}s)");
     loop {
         if let Err(error) = purge_expired_rows().await {
             tracing::warn!(%error, "session/otp cleanup failed");
+        }
+        if let Err(error) = purge_processed_outbox_jobs().await {
+            tracing::warn!(%error, "processed outbox cleanup failed");
         }
         tokio::time::sleep(Duration::from_secs(CLEANUP_INTERVAL_SECS)).await;
     }
@@ -30,6 +41,34 @@ async fn purge_expired_rows() -> Result<(), crate::error::AppError> {
 
     if sessions_deleted > 0 || otps_deleted > 0 {
         tracing::info!(sessions_deleted, otps_deleted, "expired rows purged");
+    }
+
+    Ok(())
+}
+
+/// Purge long-since-processed outbox rows. Moderation-scan payloads carry
+/// a snapshot of the message body (so the scan can't be bypassed by a
+/// quick edit/delete); the retention window bounds how long those body
+/// snapshots live past their processing time.
+async fn purge_processed_outbox_jobs() -> Result<(), crate::error::AppError> {
+    let mut conn = crate::db::conn().await?;
+
+    let deleted = diesel::sql_query(
+        r"
+        DELETE FROM job_outbox
+        WHERE processed_at IS NOT NULL
+          AND processed_at < NOW() - make_interval(days => $1)
+        ",
+    )
+    .bind::<BigInt, _>(OUTBOX_PROCESSED_RETENTION_DAYS)
+    .execute(&mut conn)
+    .await?;
+
+    if deleted > 0 {
+        tracing::info!(
+            outbox_jobs_deleted = deleted,
+            "processed outbox rows purged"
+        );
     }
 
     Ok(())

--- a/backend/src/jobs/outbox/mod.rs
+++ b/backend/src/jobs/outbox/mod.rs
@@ -14,6 +14,8 @@ static OUTBOX_WORKER_STARTED: AtomicBool = AtomicBool::new(false);
 pub(super) const OUTBOX_LOCK_TIMEOUT_SECS: i64 = 300;
 const OUTBOX_DEFAULT_MAX_ATTEMPTS: i32 = 10;
 pub const OUTBOX_WORKER_HEARTBEAT_PATH: &str = "/tmp/poziomki-outbox-worker-heartbeat";
+pub const MODERATION_WORKER_HEARTBEAT_PATH: &str =
+    "/tmp/poziomki-outbox-moderation-worker-heartbeat";
 
 #[derive(Debug, Clone)]
 pub(super) struct OutboxJob {
@@ -72,6 +74,45 @@ pub async fn enqueue_chat_membership_sync(
     enqueue_job(outbox_dispatch::OUTBOX_TOPIC_CHAT_MEMBERSHIP_SYNC, payload).await
 }
 
+/// Enqueue a moderation scan for a chat message on the caller's existing
+/// transaction.
+///
+/// Must be called with the same `conn` the caller is using for the
+/// original INSERT/UPDATE (e.g. a message insert inside `with_viewer_tx`).
+/// The outbox row is then atomic with the target write: the worker can
+/// only observe the job after the enclosing transaction commits, and if
+/// the tx rolls back the job never existed. This is the transactional
+/// outbox pattern — it closes the dual-write gap the fire-and-forget
+/// `tokio::spawn` path had.
+///
+/// The message body is snapshotted into the payload so that the worker
+/// scans exactly what the recipients received. An earlier version
+/// re-read the current row at dispatch time for privacy reasons, but
+/// that left a narrow window where a sender could post abusive text,
+/// wait for delivery, then edit or delete it before the worker picked
+/// up the job — and the scan would see only the cleaned-up body. That
+/// defeats the whole point of a safety scan. The short-lived copy is
+/// mitigated by `purge_processed_outbox_jobs` in the cleanup loop
+/// (retention: `OUTBOX_PROCESSED_RETENTION_DAYS`, currently 7 days).
+///
+/// Bios are moderated synchronously at publish time — they don't go
+/// through this path. When a batch bio rescan lands, reintroduce a
+/// target enum then.
+pub async fn enqueue_moderation_scan_in_tx(
+    conn: &mut diesel_async::AsyncPgConnection,
+    message_id: &uuid::Uuid,
+    body: &str,
+) -> Result<()> {
+    let payload = json!({
+        "target_kind": "message",
+        "target_id": message_id.to_string(),
+        "body": body,
+    })
+    .to_string();
+
+    enqueue_job_with_conn(conn, outbox_dispatch::OUTBOX_TOPIC_MODERATION_SCAN, payload).await
+}
+
 pub async fn enqueue_upload_variants_generation(upload_id: &uuid::Uuid) -> Result<()> {
     let payload = json!({
         "upload_id": upload_id.to_string(),
@@ -87,7 +128,14 @@ pub async fn enqueue_upload_variants_generation(upload_id: &uuid::Uuid) -> Resul
 
 async fn enqueue_job(topic: &str, payload: String) -> Result<()> {
     let mut conn = crate::db::conn().await?;
+    enqueue_job_with_conn(&mut conn, topic, payload).await
+}
 
+async fn enqueue_job_with_conn(
+    conn: &mut diesel_async::AsyncPgConnection,
+    topic: &str,
+    payload: String,
+) -> Result<()> {
     diesel::sql_query(
         r"
         INSERT INTO job_outbox (
@@ -107,7 +155,7 @@ async fn enqueue_job(topic: &str, payload: String) -> Result<()> {
     .bind::<Text, _>(topic)
     .bind::<Text, _>(payload)
     .bind::<Integer, _>(OUTBOX_DEFAULT_MAX_ATTEMPTS)
-    .execute(&mut conn)
+    .execute(conn)
     .await?;
     Ok(())
 }
@@ -125,13 +173,25 @@ pub fn maybe_start_worker(_ctx: &AppContext) {
         return;
     }
 
+    // Two workers:
+    //  * general loop claims everything EXCEPT moderation_scan — same
+    //    FIFO / 100 ms inter-job sleep as before, so OTP/upload/membership
+    //    jobs keep their familiar pacing.
+    //  * moderation loop claims ONLY moderation_scan jobs — tight inner
+    //    loop (no inter-job sleep when jobs are available) so high chat
+    //    volume can't backlog the general queue. Bielik int8 inference
+    //    runs ~10 ms per job; at 0 ms pause this saturates one core,
+    //    which is what we sized the worker container for.
     tokio::spawn(async move {
-        outbox_worker::run_worker_loop().await;
+        outbox_worker::run_general_worker_loop().await;
+    });
+    tokio::spawn(async move {
+        outbox_worker::run_moderation_worker_loop().await;
     });
     tokio::spawn(async move {
         outbox_worker::run_metrics_loop().await;
     });
-    tracing::info!("Outbox worker started");
+    tracing::info!("Outbox workers started (general + moderation)");
 }
 
 #[derive(Debug, QueryableByName)]

--- a/backend/src/jobs/outbox/outbox_dispatch.rs
+++ b/backend/src/jobs/outbox/outbox_dispatch.rs
@@ -7,6 +7,7 @@ use super::OutboxJob;
 pub(super) const OUTBOX_TOPIC_OTP_EMAIL: &str = "otp_email_send";
 pub(super) const OUTBOX_TOPIC_UPLOAD_VARIANTS_GENERATION: &str = "upload_variants_generation";
 pub(super) const OUTBOX_TOPIC_CHAT_MEMBERSHIP_SYNC: &str = "chat_membership_sync";
+pub(super) const OUTBOX_TOPIC_MODERATION_SCAN: &str = "moderation_scan";
 
 #[derive(Debug, Deserialize)]
 struct OtpEmailJobPayload {
@@ -26,6 +27,20 @@ struct ChatMembershipSyncJobPayload {
     leave: bool,
 }
 
+#[derive(Debug, Deserialize)]
+struct ModerationScanJobPayload {
+    // `bio` or `message` — which surface produced this scan request.
+    // Log/metric labelling only.
+    target_kind: String,
+    target_id: String,
+    // The body snapshotted at the moment the scan was enqueued. We scan
+    // this, NOT the current row, so a sender can't bypass moderation by
+    // editing or deleting their message between broadcast and scan.
+    // Processed rows are purged by the cleanup loop after
+    // `OUTBOX_PROCESSED_RETENTION_DAYS` (see jobs/cleanup.rs).
+    body: String,
+}
+
 #[tracing::instrument(skip(job), fields(job_id = %job.id, job_topic = %job.topic))]
 pub(super) async fn dispatch_job(job: &OutboxJob) -> std::result::Result<(), String> {
     match job.topic.as_str() {
@@ -34,6 +49,7 @@ pub(super) async fn dispatch_job(job: &OutboxJob) -> std::result::Result<(), Str
             dispatch_upload_variants(&job.payload_json).await
         }
         OUTBOX_TOPIC_CHAT_MEMBERSHIP_SYNC => dispatch_chat_membership_sync(&job.payload_json).await,
+        OUTBOX_TOPIC_MODERATION_SCAN => dispatch_moderation_scan(&job.payload_json).await,
         other => Err(format!("unsupported outbox topic: {other}")),
     }
 }
@@ -52,6 +68,90 @@ async fn dispatch_chat_membership_sync(payload_json: &str) -> std::result::Resul
     let profile_id = uuid::Uuid::parse_str(&payload.profile_id)
         .map_err(|e| format!("invalid chat membership sync profile_id: {e}"))?;
     crate::api::deliver_chat_membership_sync_job(event_id, profile_id, payload.leave).await
+}
+
+async fn dispatch_moderation_scan(payload_json: &str) -> std::result::Result<(), String> {
+    let payload: ModerationScanJobPayload = serde_json::from_str(payload_json)
+        .map_err(|e| format!("invalid moderation scan payload: {e}"))?;
+
+    let Some(engine) = crate::moderation::shared() else {
+        // Operator didn't wire a model in this process — drop the job
+        // silently. Worth logging once at boot (`global.rs` already does
+        // that), so here we just no-op to avoid log spam.
+        metrics::counter!("moderation_scan_skipped_total", "reason" => "engine_disabled")
+            .increment(1);
+        return Ok(());
+    };
+
+    // Scan the body snapshot carried in the payload, NOT the current row.
+    // This is what recipients actually saw: editing or deleting the
+    // message after broadcast cannot evade the scan.
+    if payload.body.trim().is_empty() {
+        return Ok(());
+    }
+    // Move the body into the blocking closure — payload is owned here, so
+    // no allocation beyond the deserialise that already happened.
+    let ModerationScanJobPayload {
+        target_kind,
+        target_id,
+        body,
+    } = payload;
+
+    let started = std::time::Instant::now();
+    // ONNX inference is CPU-bound and blocking; run it off the async
+    // runtime. `spawn_blocking` propagates panics as `JoinError`.
+    let scores = tokio::task::spawn_blocking(move || engine.score(&body))
+        .await
+        .map_err(|e| format!("moderation inference panicked: {e}"))?
+        .map_err(|e| format!("moderation inference failed: {e}"))?;
+
+    // Only chat messages go through the outbox path today; bios are
+    // moderated synchronously on publish with their own stricter preset.
+    let thresholds = crate::moderation::Thresholds::CHAT;
+    let verdict = scores.verdict(&thresholds);
+    let flagged = scores.flagged(&thresholds);
+
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+    metrics::histogram!("moderation_inference_latency_ms", "kind" => target_kind.clone())
+        .record(elapsed_ms);
+    metrics::counter!(
+        "moderation_verdicts_total",
+        "kind" => target_kind.clone(),
+        "verdict" => verdict.as_str()
+    )
+    .increment(1);
+
+    if matches!(
+        verdict,
+        crate::moderation::Verdict::Flag | crate::moderation::Verdict::Block
+    ) {
+        let flagged_labels: Vec<String> = flagged
+            .iter()
+            .map(|(c, s)| format!("{}={:.2}", c.as_str(), s))
+            .collect();
+        tracing::warn!(
+            target_kind = %target_kind,
+            target_id = %target_id,
+            verdict = verdict.as_str(),
+            self_harm = scores.self_harm,
+            hate = scores.hate,
+            vulgar = scores.vulgar,
+            sex = scores.sex,
+            crime = scores.crime,
+            flagged = ?flagged_labels,
+            elapsed_ms,
+            "moderation: content flagged"
+        );
+    } else {
+        tracing::debug!(
+            target_kind = %target_kind,
+            target_id = %target_id,
+            elapsed_ms,
+            "moderation: content allowed"
+        );
+    }
+
+    Ok(())
 }
 
 async fn dispatch_upload_variants(payload_json: &str) -> std::result::Result<(), String> {

--- a/backend/src/jobs/outbox/outbox_worker.rs
+++ b/backend/src/jobs/outbox/outbox_worker.rs
@@ -6,26 +6,85 @@ use std::fs;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::outbox_dispatch::{dispatch_job, mark_job_done, mark_job_failed};
-use super::{OutboxJob, OUTBOX_LOCK_TIMEOUT_SECS, OUTBOX_WORKER_HEARTBEAT_PATH};
+use super::outbox_dispatch::{
+    dispatch_job, mark_job_done, mark_job_failed, OUTBOX_TOPIC_MODERATION_SCAN,
+};
+use super::{
+    OutboxJob, MODERATION_WORKER_HEARTBEAT_PATH, OUTBOX_LOCK_TIMEOUT_SECS,
+    OUTBOX_WORKER_HEARTBEAT_PATH,
+};
 
-pub(super) async fn run_worker_loop() {
+/// Selects which subset of `job_outbox` a worker loop will claim.
+///
+/// Split so moderation scans (high-volume, fast CPU work) don't share a
+/// FIFO and an inter-job sleep with email/upload/membership jobs.
+#[derive(Clone, Copy)]
+enum JobKind {
+    /// Every topic except `moderation_scan`. Preserves the historical
+    /// pacing (100 ms between jobs, 2 s when idle).
+    General,
+    /// Only `moderation_scan`. Tight inner loop — no inter-job sleep
+    /// when jobs are available.
+    Moderation,
+}
+
+impl JobKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::General => "general",
+            Self::Moderation => "moderation",
+        }
+    }
+
+    const fn active_sleep(self) -> Duration {
+        match self {
+            Self::General => Duration::from_millis(100),
+            // Moderation is CPU-bound; at ~10 ms per job an inter-job pause
+            // just caps throughput for no benefit. Yield but don't sleep.
+            Self::Moderation => Duration::ZERO,
+        }
+    }
+
+    const fn idle_sleep(self) -> Duration {
+        match self {
+            Self::General => Duration::from_secs(2),
+            Self::Moderation => Duration::from_secs(1),
+        }
+    }
+}
+
+pub(super) async fn run_general_worker_loop() {
+    run_worker_loop(JobKind::General).await;
+}
+
+pub(super) async fn run_moderation_worker_loop() {
+    run_worker_loop(JobKind::Moderation).await;
+}
+
+async fn run_worker_loop(kind: JobKind) {
     loop {
-        write_worker_heartbeat();
-        let processed = match process_one_job().await {
+        // Each loop writes its own heartbeat file. Healthcheck requires
+        // both to be fresh, so a wedged moderation loop marks the worker
+        // container unhealthy even if the general loop is still pumping.
+        write_heartbeat(heartbeat_path(kind));
+        let processed = match process_one_job(kind).await {
             Ok(processed) => processed,
             Err(error) => {
-                tracing::error!(%error, "outbox worker loop error");
+                tracing::error!(%error, worker = kind.label(), "outbox worker loop error");
                 false
             }
         };
 
         let sleep_for = if processed {
-            Duration::from_millis(100)
+            kind.active_sleep()
         } else {
-            Duration::from_secs(2)
+            kind.idle_sleep()
         };
-        tokio::time::sleep(sleep_for).await;
+        if sleep_for.is_zero() {
+            tokio::task::yield_now().await;
+        } else {
+            tokio::time::sleep(sleep_for).await;
+        }
     }
 }
 
@@ -39,13 +98,20 @@ pub(super) async fn run_metrics_loop() {
     }
 }
 
-fn write_worker_heartbeat() {
+const fn heartbeat_path(kind: JobKind) -> &'static str {
+    match kind {
+        JobKind::General => OUTBOX_WORKER_HEARTBEAT_PATH,
+        JobKind::Moderation => MODERATION_WORKER_HEARTBEAT_PATH,
+    }
+}
+
+fn write_heartbeat(path: &'static str) {
     let now_epoch = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or_else(|_| "0".to_string(), |d| d.as_secs().to_string());
 
-    if let Err(error) = fs::write(OUTBOX_WORKER_HEARTBEAT_PATH, now_epoch) {
-        tracing::warn!(%error, path = OUTBOX_WORKER_HEARTBEAT_PATH, "failed to write worker heartbeat");
+    if let Err(error) = fs::write(path, now_epoch) {
+        tracing::warn!(%error, path, "failed to write worker heartbeat");
     }
 }
 
@@ -63,9 +129,9 @@ struct OutboxJobRow {
     max_attempts: i32,
 }
 
-#[tracing::instrument(skip_all)]
-async fn process_one_job() -> std::result::Result<bool, String> {
-    let Some(job) = claim_next_job().await.map_err(|e| e.to_string())? else {
+#[tracing::instrument(skip_all, fields(worker = kind.label()))]
+async fn process_one_job(kind: JobKind) -> std::result::Result<bool, String> {
+    let Some(job) = claim_next_job(kind).await.map_err(|e| e.to_string())? else {
         return Ok(false);
     };
 
@@ -93,22 +159,45 @@ async fn process_one_job() -> std::result::Result<bool, String> {
     Ok(true)
 }
 
-#[tracing::instrument(skip_all)]
-async fn claim_next_job() -> std::result::Result<Option<OutboxJob>, crate::error::AppError> {
+#[tracing::instrument(skip_all, fields(worker = kind.label()))]
+async fn claim_next_job(
+    kind: JobKind,
+) -> std::result::Result<Option<OutboxJob>, crate::error::AppError> {
     let mut conn = crate::db::conn().await?;
 
-    let row = diesel::sql_query(
-        r"
-        WITH picked AS (
-            SELECT id
-            FROM job_outbox
-            WHERE processed_at IS NULL
+    // Two workers share the same table; `FOR UPDATE SKIP LOCKED` keeps
+    // them from fighting. The topic predicate below partitions the work:
+    // General skips moderation_scan; Moderation claims only that topic.
+    let (sql_fragment, topic_bind) = match kind {
+        JobKind::General => (
+            "WHERE processed_at IS NULL
               AND failed_at IS NULL
               AND available_at <= NOW()
+              AND topic <> $2
               AND (
                 locked_at IS NULL
                 OR locked_at <= NOW() - make_interval(secs => $1)
-              )
+              )",
+            OUTBOX_TOPIC_MODERATION_SCAN,
+        ),
+        JobKind::Moderation => (
+            "WHERE processed_at IS NULL
+              AND failed_at IS NULL
+              AND available_at <= NOW()
+              AND topic = $2
+              AND (
+                locked_at IS NULL
+                OR locked_at <= NOW() - make_interval(secs => $1)
+              )",
+            OUTBOX_TOPIC_MODERATION_SCAN,
+        ),
+    };
+
+    let sql = format!(
+        "WITH picked AS (
+            SELECT id
+            FROM job_outbox
+            {sql_fragment}
             ORDER BY created_at ASC
             LIMIT 1
             FOR UPDATE SKIP LOCKED
@@ -123,13 +212,15 @@ async fn claim_next_job() -> std::result::Result<Option<OutboxJob>, crate::error
                   j.topic,
                   j.payload::text AS payload_json,
                   j.attempts,
-                  j.max_attempts
-        ",
-    )
-    .bind::<BigInt, _>(OUTBOX_LOCK_TIMEOUT_SECS)
-    .get_result::<OutboxJobRow>(&mut conn)
-    .await
-    .optional()?;
+                  j.max_attempts"
+    );
+
+    let row = diesel::sql_query(sql)
+        .bind::<BigInt, _>(OUTBOX_LOCK_TIMEOUT_SECS)
+        .bind::<Text, _>(topic_bind)
+        .get_result::<OutboxJobRow>(&mut conn)
+        .await
+        .optional()?;
 
     Ok(row.map(|r| OutboxJob {
         id: r.id,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -5,6 +5,7 @@ pub mod db;
 pub mod error;
 pub mod healthcheck;
 pub mod jobs;
+pub mod moderation;
 pub mod search;
 pub mod security;
 pub mod telemetry;

--- a/backend/src/moderation/engine.rs
+++ b/backend/src/moderation/engine.rs
@@ -1,0 +1,254 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use ndarray::{Array2, Axis};
+use ort::{
+    session::{builder::GraphOptimizationLevel, Session},
+    value::Tensor,
+};
+use thiserror::Error;
+use tokenizers::Tokenizer;
+
+use super::scores::{Category, Scores};
+
+/// Hard cap on input tokens sent to the model. The `RoBERTa` encoder
+/// supports 512 positions; we clamp lower to keep CPU inference latency
+/// predictable on long user text. Anything above is truncated at the
+/// tokenizer.
+const MAX_SEQ_LEN: usize = 256;
+
+/// Filename of the int8 ONNX artifact produced by
+/// `scripts/guard-bench/export_onnx.py`.
+const MODEL_FILE: &str = "model_quantized.onnx";
+const TOKENIZER_FILE: &str = "tokenizer.json";
+
+#[derive(Debug, Error)]
+pub enum ModerationError {
+    #[error("moderation model directory missing required file: {0}")]
+    MissingFile(PathBuf),
+
+    #[error("failed to load ONNX session: {0}")]
+    Session(#[from] ort::Error),
+
+    #[error("failed to load tokenizer: {0}")]
+    Tokenizer(String),
+
+    #[error("tokenization failed: {0}")]
+    Encode(String),
+
+    #[error("model returned unexpected output shape: {got:?}, expected [_, 5]")]
+    BadOutputShape { got: Vec<usize> },
+
+    #[error("failed to build input tensor")]
+    TensorBuild,
+
+    #[error("moderation engine lock poisoned")]
+    LockPoisoned,
+}
+
+/// Loaded inference engine: ONNX session + tokenizer, held for the lifetime
+/// of the process. Inference is CPU-bound and blocking; call the sync API
+/// from a `tokio::task::spawn_blocking` in async contexts.
+pub struct ModerationEngine {
+    // `ort::Session::run` requires `&mut self` (rc.12), so we serialize
+    // access behind a Mutex. For higher concurrency, replace with a pool of
+    // sessions — but on CPU with ORT intra-op threading, a single session
+    // already saturates available cores, and blocking callers go through
+    // `tokio::task::spawn_blocking` anyway.
+    session: Mutex<Session>,
+    tokenizer: Tokenizer,
+    pad_id: i64,
+}
+
+impl ModerationEngine {
+    /// Load the quantized Bielik-Guard model and its tokenizer from a
+    /// directory populated by `scripts/guard-bench/export_onnx.py`.
+    ///
+    /// `intra_threads` caps the CPU threads used per inference call. For a
+    /// shared web server, 1–2 is usually right — scale concurrency via the
+    /// number of tokio blocking workers, not ORT's thread pool.
+    ///
+    /// # Errors
+    /// Returns [`ModerationError`] when required files are missing, the ONNX
+    /// session fails to build, or the tokenizer file is malformed.
+    pub fn load_from_dir(dir: &Path, intra_threads: usize) -> Result<Self, ModerationError> {
+        let model_path = dir.join(MODEL_FILE);
+        let tokenizer_path = dir.join(TOKENIZER_FILE);
+        if !model_path.is_file() {
+            return Err(ModerationError::MissingFile(model_path));
+        }
+        if !tokenizer_path.is_file() {
+            return Err(ModerationError::MissingFile(tokenizer_path));
+        }
+
+        // Builder setter errors are tagged `ort::Error<SessionBuilder>`;
+        // erase the tag with `ort::Error::from` so `?` converts via
+        // `#[from] ort::Error<()>` on `ModerationError`.
+        // Tuned for the prod OVH containers (api 512 MB, worker 256 MB).
+        //
+        // `with_memory_pattern(false)` disables ORT's buffer-size caching
+        // that otherwise allocates worst-case scratch buffers on the first
+        // inferences and holds them indefinitely — observed warmup RSS of
+        // ~370 MB on this model with pattern on, vs. a steady-state of
+        // ~100 MB. The cost is ~10–15 % higher per-inference latency on
+        // varying input lengths, which at sub-10 ms p50 is well within
+        // budget for our use case.
+        let session = Session::builder()?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(ort::Error::from)?
+            .with_intra_threads(intra_threads)
+            .map_err(ort::Error::from)?
+            .with_memory_pattern(false)
+            .map_err(ort::Error::from)?
+            .commit_from_file(&model_path)?;
+
+        let mut tokenizer = Tokenizer::from_file(&tokenizer_path)
+            .map_err(|e| ModerationError::Tokenizer(e.to_string()))?;
+        // Enable built-in truncation; max_length matches MAX_SEQ_LEN so we
+        // never have to re-check on the Rust side.
+        let trunc = tokenizers::TruncationParams {
+            max_length: MAX_SEQ_LEN,
+            ..Default::default()
+        };
+        tokenizer
+            .with_truncation(Some(trunc))
+            .map_err(|e| ModerationError::Tokenizer(e.to_string()))?;
+
+        // Resolve the pad token id from the tokenizer (RoBERTa: id 1, "<pad>").
+        let pad_id = i64::from(tokenizer.token_to_id("<pad>").unwrap_or(1));
+
+        Ok(Self {
+            session: Mutex::new(session),
+            tokenizer,
+            pad_id,
+        })
+    }
+
+    /// Score a single input string.
+    ///
+    /// # Errors
+    /// Returns [`ModerationError`] on tokenization or inference failure.
+    pub fn score(&self, text: &str) -> Result<Scores, ModerationError> {
+        let out = self.score_batch(&[text])?;
+        out.into_iter()
+            .next()
+            .ok_or(ModerationError::BadOutputShape { got: vec![0, 5] })
+    }
+
+    /// Score a batch of inputs in one inference call.
+    ///
+    /// Attention-mask padding means per-sample scores are independent of
+    /// batch composition. Empty batch returns an empty vector without
+    /// touching the session.
+    ///
+    /// # Errors
+    /// Returns [`ModerationError`] on tokenization, tensor construction,
+    /// inference, or output-shape failures.
+    #[allow(clippy::significant_drop_tightening)]
+    pub fn score_batch(&self, texts: &[&str]) -> Result<Vec<Scores>, ModerationError> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let encodings = self
+            .tokenizer
+            .encode_batch(texts.to_vec(), true)
+            .map_err(|e| ModerationError::Encode(e.to_string()))?;
+
+        let batch = encodings.len();
+        let seq_len = encodings
+            .iter()
+            .map(|e| e.get_ids().len())
+            .max()
+            .unwrap_or(0);
+        if seq_len == 0 {
+            // Degenerate case — all inputs empty. Return neutral scores
+            // rather than calling into ORT with a zero-sized tensor.
+            return Ok(vec![
+                Scores {
+                    self_harm: 0.0,
+                    hate: 0.0,
+                    vulgar: 0.0,
+                    sex: 0.0,
+                    crime: 0.0,
+                };
+                batch
+            ]);
+        }
+
+        let mut ids = Vec::with_capacity(batch * seq_len);
+        let mut mask = Vec::with_capacity(batch * seq_len);
+        for enc in &encodings {
+            let enc_ids = enc.get_ids();
+            let enc_mask = enc.get_attention_mask();
+            let used = enc_ids.len();
+            ids.extend(enc_ids.iter().map(|&i| i64::from(i)));
+            mask.extend(enc_mask.iter().map(|&m| i64::from(m)));
+            for _ in used..seq_len {
+                ids.push(self.pad_id);
+                mask.push(0);
+            }
+        }
+
+        let ids_arr = Array2::<i64>::from_shape_vec((batch, seq_len), ids)
+            .map_err(|_| ModerationError::TensorBuild)?;
+        let mask_arr = Array2::<i64>::from_shape_vec((batch, seq_len), mask)
+            .map_err(|_| ModerationError::TensorBuild)?;
+
+        let ids_tensor = Tensor::from_array(ids_arr)?;
+        let mask_tensor = Tensor::from_array(mask_arr)?;
+
+        // Hold the lock only for the inference call. The returned
+        // `SessionOutputs` borrow from the session, so we copy logits out
+        // into an owned Vec before dropping the guard.
+        let logits_owned: Vec<f32> = {
+            let mut session = self
+                .session
+                .lock()
+                .map_err(|_| ModerationError::LockPoisoned)?;
+            let outputs = session.run(ort::inputs![
+                "input_ids" => ids_tensor,
+                "attention_mask" => mask_tensor,
+            ])?;
+            let logits_value = outputs
+                .get("logits")
+                .ok_or(ModerationError::BadOutputShape { got: vec![] })?;
+            let (shape, logits) = logits_value.try_extract_tensor::<f32>()?;
+            let dims: Vec<usize> = shape
+                .iter()
+                .map(|&d| usize::try_from(d).unwrap_or(0))
+                .collect();
+            if dims.len() != 2
+                || dims.first().copied() != Some(batch)
+                || dims.get(1).copied() != Some(5)
+            {
+                return Err(ModerationError::BadOutputShape { got: dims });
+            }
+            logits.to_vec()
+        };
+
+        let view =
+            ndarray::ArrayView2::<f32>::from_shape((batch, 5), &logits_owned).map_err(|_| {
+                ModerationError::BadOutputShape {
+                    got: vec![batch, 5],
+                }
+            })?;
+
+        let mut out = Vec::with_capacity(batch);
+        for row in view.axis_iter(Axis(0)) {
+            out.push(Scores {
+                self_harm: sigmoid(row.get(Category::SelfHarm as usize).copied().unwrap_or(0.0)),
+                hate: sigmoid(row.get(Category::Hate as usize).copied().unwrap_or(0.0)),
+                vulgar: sigmoid(row.get(Category::Vulgar as usize).copied().unwrap_or(0.0)),
+                sex: sigmoid(row.get(Category::Sex as usize).copied().unwrap_or(0.0)),
+                crime: sigmoid(row.get(Category::Crime as usize).copied().unwrap_or(0.0)),
+            });
+        }
+        Ok(out)
+    }
+}
+
+#[inline]
+fn sigmoid(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}

--- a/backend/src/moderation/global.rs
+++ b/backend/src/moderation/global.rs
@@ -1,0 +1,123 @@
+//! Process-wide [`ModerationEngine`] singleton, initialized from environment
+//! variables at boot (once per process, in both the API and worker).
+//!
+//! Contract:
+//! - `MODERATION_MODEL_PATH` unset or empty → moderation is disabled; all
+//!   handlers must treat a missing engine as "allow, no opinion".
+//! - `MODERATION_REQUIRED` truthy (`1`/`true`/`yes`/`on`) — strict mode.
+//!   Path must be set and the engine must load; every other outcome is
+//!   fatal at boot. Set this in production compose; default off for dev /
+//!   staging where operators reasonably want the service to come up even
+//!   without the gated model artefact.
+//! - `MODERATION_MODEL_PATH` set, directory missing required files,
+//!   `MODERATION_REQUIRED` not truthy → moderation disabled, boot
+//!   continues with a loud warn. Operators should alert on the startup
+//!   log / `moderation_engine_loaded` gauge.
+//! - `MODERATION_MODEL_PATH` set, files present but load fails for other
+//!   reasons (corrupt ONNX, tokenizer parse error, ORT init) → fatal
+//!   regardless of `MODERATION_REQUIRED`. That's a real bug, not a
+//!   provisioning gap.
+//! - `MODERATION_THREADS` (optional, default 2) caps ORT intra-op threads
+//!   per inference. Keep this low; concurrency comes from `spawn_blocking`
+//!   worker threads, not from ORT.
+
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+
+use super::{ModerationEngine, ModerationError};
+
+static ENGINE: OnceLock<Option<Arc<ModerationEngine>>> = OnceLock::new();
+
+const ENV_MODEL_PATH: &str = "MODERATION_MODEL_PATH";
+const ENV_THREADS: &str = "MODERATION_THREADS";
+const ENV_REQUIRED: &str = "MODERATION_REQUIRED";
+
+fn required_mode() -> bool {
+    std::env::var(ENV_REQUIRED).is_ok_and(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+/// Initialise the global engine from environment variables.
+///
+/// Must be called exactly once per process before any handler tries to
+/// resolve the engine. Subsequent calls are a no-op.
+///
+/// # Errors
+/// Returns [`ModerationError`] when `MODERATION_MODEL_PATH` is set but the
+/// model fails to load.
+pub fn init_from_env() -> Result<(), ModerationError> {
+    if ENGINE.get().is_some() {
+        return Ok(());
+    }
+
+    let path = std::env::var(ENV_MODEL_PATH)
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty());
+
+    let strict = required_mode();
+
+    let Some(path) = path else {
+        if strict {
+            return Err(ModerationError::MissingFile(PathBuf::from(format!(
+                "${ENV_MODEL_PATH} is required ({ENV_REQUIRED}={})",
+                std::env::var(ENV_REQUIRED).unwrap_or_default()
+            ))));
+        }
+        tracing::warn!(
+            env = ENV_MODEL_PATH,
+            "moderation disabled: env var unset or empty"
+        );
+        let _ = ENGINE.set(None);
+        metrics::gauge!("moderation_engine_loaded").set(0.0);
+        return Ok(());
+    };
+
+    let threads: usize = std::env::var(ENV_THREADS)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(2);
+
+    let dir = PathBuf::from(&path);
+    tracing::info!(path = %path, threads, "loading moderation engine");
+    let started = std::time::Instant::now();
+    match ModerationEngine::load_from_dir(&dir, threads) {
+        Ok(engine) => {
+            let elapsed_ms = started.elapsed().as_millis();
+            tracing::info!(elapsed_ms, "moderation engine loaded");
+            let _ = ENGINE.set(Some(Arc::new(engine)));
+            metrics::gauge!("moderation_engine_loaded").set(1.0);
+            Ok(())
+        }
+        Err(ModerationError::MissingFile(missing)) => {
+            if strict {
+                // Strict mode — operator asked for moderation and it's
+                // not there. Fail hard so the misprovisioned host
+                // crash-loops instead of silently accepting everything.
+                return Err(ModerationError::MissingFile(missing));
+            }
+            tracing::warn!(
+                path = %path,
+                missing = %missing.display(),
+                "moderation disabled: model directory is missing required files \
+                 (did the operator forget to mount MODERATION_MODEL_PATH?)"
+            );
+            let _ = ENGINE.set(None);
+            metrics::gauge!("moderation_engine_loaded").set(0.0);
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Return the shared engine, or `None` if moderation is disabled for this
+/// process. Call sites should treat `None` as "allow".
+#[must_use]
+pub fn shared() -> Option<Arc<ModerationEngine>> {
+    ENGINE.get().and_then(Option::as_ref).map(Arc::clone)
+}

--- a/backend/src/moderation/mod.rs
+++ b/backend/src/moderation/mod.rs
@@ -1,0 +1,9 @@
+//! Text moderation via ONNX Runtime inference against the Bielik-Guard model.
+
+mod engine;
+mod global;
+mod scores;
+
+pub use engine::{ModerationEngine, ModerationError};
+pub use global::{init_from_env, shared};
+pub use scores::{Category, Scores, Thresholds, Verdict};

--- a/backend/src/moderation/scores.rs
+++ b/backend/src/moderation/scores.rs
@@ -1,0 +1,186 @@
+use serde::Serialize;
+
+/// One of the five harm categories predicted by Bielik-Guard-0.1B-v1.1.
+/// The discriminant values match the model's `id2label` mapping so the enum
+/// doubles as a stable logit index.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Category {
+    SelfHarm = 0,
+    Hate = 1,
+    Vulgar = 2,
+    Sex = 3,
+    Crime = 4,
+}
+
+impl Category {
+    pub const ALL: [Self; 5] = [
+        Self::SelfHarm,
+        Self::Hate,
+        Self::Vulgar,
+        Self::Sex,
+        Self::Crime,
+    ];
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SelfHarm => "self-harm",
+            Self::Hate => "hate",
+            Self::Vulgar => "vulgar",
+            Self::Sex => "sex",
+            Self::Crime => "crime",
+        }
+    }
+}
+
+/// Per-category sigmoid probabilities in the range `[0, 1]`.
+///
+/// The model is multi-label: independent probabilities, not a softmax. A single
+/// input can score high in multiple categories simultaneously.
+#[derive(Copy, Clone, Debug, Serialize)]
+pub struct Scores {
+    pub self_harm: f32,
+    pub hate: f32,
+    pub vulgar: f32,
+    pub sex: f32,
+    pub crime: f32,
+}
+
+impl Scores {
+    #[must_use]
+    pub const fn get(&self, category: Category) -> f32 {
+        match category {
+            Category::SelfHarm => self.self_harm,
+            Category::Hate => self.hate,
+            Category::Vulgar => self.vulgar,
+            Category::Sex => self.sex,
+            Category::Crime => self.crime,
+        }
+    }
+
+    /// Categories whose score meets or exceeds the corresponding threshold.
+    #[must_use]
+    pub fn flagged(&self, thresholds: &Thresholds) -> Vec<(Category, f32)> {
+        Category::ALL
+            .into_iter()
+            .filter_map(|c| {
+                let score = self.get(c);
+                (score >= thresholds.get(c)).then_some((c, score))
+            })
+            .collect()
+    }
+
+    #[must_use]
+    pub fn verdict(&self, thresholds: &Thresholds) -> Verdict {
+        let block = Category::ALL
+            .into_iter()
+            .any(|c| self.get(c) >= thresholds.block_for(c));
+        if block {
+            return Verdict::Block;
+        }
+        let flag = Category::ALL
+            .into_iter()
+            .any(|c| self.get(c) >= thresholds.get(c));
+        if flag {
+            Verdict::Flag
+        } else {
+            Verdict::Allow
+        }
+    }
+}
+
+/// Per-category decision thresholds.
+///
+/// `flag` = below it, ignore; at/above, surface for review. `block` = at/above,
+/// refuse synchronously (used for bios, and for chat messages in the
+/// highest-stakes categories). `block` must be >= `flag` in each category.
+#[derive(Copy, Clone, Debug)]
+pub struct Thresholds {
+    pub self_harm: f32,
+    pub hate: f32,
+    pub vulgar: f32,
+    pub sex: f32,
+    pub crime: f32,
+
+    pub self_harm_block: f32,
+    pub hate_block: f32,
+    pub vulgar_block: f32,
+    pub sex_block: f32,
+    pub crime_block: f32,
+}
+
+impl Thresholds {
+    /// For user bios — synchronous gate, favour precision on the publish path.
+    pub const BIO: Self = Self {
+        self_harm: 0.50,
+        hate: 0.70,
+        vulgar: 0.85,
+        sex: 0.70,
+        crime: 0.60,
+        self_harm_block: 0.50,
+        hate_block: 0.70,
+        vulgar_block: 0.85,
+        sex_block: 0.70,
+        crime_block: 0.60,
+    };
+
+    /// For chat messages — deliver first, flag for async review. Only the
+    /// highest-stakes categories synchronously block.
+    pub const CHAT: Self = Self {
+        self_harm: 0.50,
+        hate: 0.70,
+        vulgar: 0.90,
+        sex: 0.80,
+        crime: 0.70,
+        self_harm_block: 0.90,
+        hate_block: 0.95,
+        vulgar_block: 1.01,
+        sex_block: 0.95,
+        crime_block: 0.90,
+    };
+
+    #[must_use]
+    pub const fn get(&self, category: Category) -> f32 {
+        match category {
+            Category::SelfHarm => self.self_harm,
+            Category::Hate => self.hate,
+            Category::Vulgar => self.vulgar,
+            Category::Sex => self.sex,
+            Category::Crime => self.crime,
+        }
+    }
+
+    #[must_use]
+    pub const fn block_for(&self, category: Category) -> f32 {
+        match category {
+            Category::SelfHarm => self.self_harm_block,
+            Category::Hate => self.hate_block,
+            Category::Vulgar => self.vulgar_block,
+            Category::Sex => self.sex_block,
+            Category::Crime => self.crime_block,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Verdict {
+    Allow,
+    Flag,
+    Block,
+}
+
+impl Verdict {
+    /// Stable string form for metric labels and structured log fields.
+    /// Matches the `serde(rename_all = "kebab-case")` representation so a
+    /// Prometheus dashboard and a JSON log line agree on casing.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Flag => "flag",
+            Self::Block => "block",
+        }
+    }
+}

--- a/backend/tests/moderation.rs
+++ b/backend/tests/moderation.rs
@@ -1,0 +1,307 @@
+//! End-to-end smoke test for the moderation engine.
+//!
+//! Loads the real int8 Bielik-Guard ONNX model from
+//! `BIELIK_GUARD_ONNX_DIR` (or skips if unset) and asserts that each
+//! category in the Polish sample set is correctly flagged or left alone.
+//! Prints p50/p95 single-shot latency + batched throughput.
+//!
+//! Run:
+//!   BIELIK_GUARD_ONNX_DIR=$HOME/models/bielik-guard-onnx \
+//!     cargo test --test moderation -- --nocapture
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::indexing_slicing)]
+#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::print_stdout)]
+#![allow(clippy::print_stderr)]
+#![allow(clippy::panic)]
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::missing_panics_doc)]
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use poziomki_backend::moderation::{Category, ModerationEngine, Scores, Thresholds, Verdict};
+
+/// (expected top category or "safe", text).
+/// "safe" means: every sigmoid score should be below the bio threshold.
+/// A concrete category means: that category's score should be the model's
+/// highest AND above 0.5.
+fn samples() -> Vec<(&'static str, &'static str)> {
+    vec![
+        // --- safe ---
+        (
+            "safe",
+            "Cześć, jestem Ania, lubię wspinaczkę i jazz. Szukam ludzi do wspólnych wyjść.",
+        ),
+        (
+            "safe",
+            "Poszukuję ekipy na weekendowe wyjazdy rowerowe w okolicach Krakowa.",
+        ),
+        (
+            "safe",
+            "Piszę książkę o historii Polski, chętnie poznam kogoś z podobnymi zainteresowaniami.",
+        ),
+        (
+            "safe",
+            "Dzisiaj zrobiłem świetny obiad — polecam przepis na pierogi ruskie od babci.",
+        ),
+        (
+            "safe",
+            "Ktoś jeszcze ogląda nowy sezon? Bez spoilerów proszę!",
+        ),
+        (
+            "safe",
+            "Mam 34 lata, dwójka dzieci, praca w IT, w wolnym czasie biegam.",
+        ),
+        // --- hate (model often splits hate/vulgar — accept either as "flagged") ---
+        ("hate", "Nienawidzę tych ciapatych, niech giną."),
+        ("hate", "Żydzi rządzą światem i okradają Polskę."),
+        ("hate", "Baby są głupie i nadają się tylko do kuchni."),
+        // --- vulgar ---
+        ("vulgar", "Ty kurwo jebana, spierdalaj stąd."),
+        ("vulgar", "Ale z ciebie chuj, serio."),
+        ("vulgar", "Co za pojebany dzień, kurwa mać."),
+        // --- sex ---
+        ("sex", "Szukam faceta do seksu bez zobowiązań, DM."),
+        ("sex", "Wyślę ci nagie zdjęcia jak napiszesz."),
+        ("sex", "Lubię ostry seks analny, ktoś chętny?"),
+        // --- self-harm (the high-stakes category we MUST catch) ---
+        (
+            "self-harm",
+            "Nie chce mi się już żyć, wszystko straciło sens.",
+        ),
+        ("self-harm", "Mam ochotę się pociąć, żeby przestać to czuć."),
+        (
+            "self-harm",
+            "Codziennie myślę o samobójstwie, nie mam siły.",
+        ),
+        ("self-harm", "Tnę się od dwóch lat, nikt nie wie."),
+        // --- crime ---
+        ("crime", "Sprzedam metę, 200 zł gram, Warszawa."),
+        (
+            "crime",
+            "Szukam kogoś do włamania do mieszkania na Mokotowie.",
+        ),
+        ("crime", "Kupię broń bez pozwolenia, płacę gotówką."),
+    ]
+}
+
+fn model_dir() -> Option<PathBuf> {
+    std::env::var_os("BIELIK_GUARD_ONNX_DIR").map(PathBuf::from)
+}
+
+fn cat_from(name: &str) -> Option<Category> {
+    Category::ALL.into_iter().find(|c| c.as_str() == name)
+}
+
+fn top(scores: &Scores) -> (Category, f32) {
+    Category::ALL.into_iter().map(|c| (c, scores.get(c))).fold(
+        (Category::SelfHarm, f32::MIN),
+        |acc, (c, s)| if s > acc.1 { (c, s) } else { acc },
+    )
+}
+
+#[test]
+fn scores_polish_sample_set_correctly() {
+    let Some(dir) = model_dir() else {
+        eprintln!("skipping: set BIELIK_GUARD_ONNX_DIR to run this test");
+        return;
+    };
+    let engine = ModerationEngine::load_from_dir(&dir, 2).expect("load moderation engine");
+
+    let rows = samples();
+    let mut failures: Vec<String> = Vec::new();
+    let mut single_times_ms: Vec<f64> = Vec::with_capacity(rows.len());
+
+    println!("\n{:12} {:12} {:5}  text", "expected", "got", "score");
+    for (expected, text) in &rows {
+        let started = Instant::now();
+        let scores = engine.score(text).expect("inference");
+        single_times_ms.push(started.elapsed().as_secs_f64() * 1000.0);
+
+        let (top_cat, top_score) = top(&scores);
+        let snippet = if text.chars().count() > 60 {
+            let truncated: String = text.chars().take(57).collect();
+            format!("{}...", truncated)
+        } else {
+            (*text).to_string()
+        };
+        println!(
+            "{:12} {:12} {:.2}  {}",
+            expected,
+            top_cat.as_str(),
+            top_score,
+            snippet
+        );
+
+        let flagged = scores.flagged(&Thresholds::BIO);
+        let verdict = scores.verdict(&Thresholds::BIO);
+
+        match *expected {
+            "safe" => {
+                if !flagged.is_empty() {
+                    failures.push(format!(
+                        "FALSE POSITIVE on safe text: {:?}  flagged={:?}",
+                        text, flagged
+                    ));
+                }
+                if verdict != Verdict::Allow {
+                    failures.push(format!(
+                        "expected Verdict::Allow for safe text, got {:?}: {:?}",
+                        verdict, text
+                    ));
+                }
+            }
+            target_name => {
+                let Some(target) = cat_from(target_name) else {
+                    failures.push(format!("unknown expected category: {}", target_name));
+                    continue;
+                };
+                // We require the target category to be above 0.5 OR the
+                // top category to be a closely-related harm class. For
+                // hate/vulgar we accept either since those correlate.
+                let target_hit = scores.get(target) >= 0.5;
+                let acceptable_confusion = matches!(
+                    (target, top_cat),
+                    (Category::Hate, Category::Vulgar) | (Category::Vulgar, Category::Hate)
+                );
+                if !(target_hit || acceptable_confusion && top_score >= 0.5) {
+                    failures.push(format!(
+                        "FALSE NEGATIVE on {}: top={}({:.2}) target={:.2}  text={:?}",
+                        target_name,
+                        top_cat.as_str(),
+                        top_score,
+                        scores.get(target),
+                        text,
+                    ));
+                }
+                if verdict == Verdict::Allow {
+                    failures.push(format!(
+                        "expected non-Allow verdict for {} text, got Allow: {:?}",
+                        target_name, text
+                    ));
+                }
+            }
+        }
+    }
+
+    // Latency stats on single-shot path.
+    let mut sorted = single_times_ms.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let p50 = sorted[sorted.len() / 2];
+    let p95 = sorted[(sorted.len() as f64 * 0.95) as usize];
+    let mean = single_times_ms.iter().sum::<f64>() / single_times_ms.len() as f64;
+
+    // Batched throughput.
+    let texts: Vec<&str> = rows.iter().map(|(_, t)| *t).collect();
+    // warmup
+    engine.score_batch(&texts[..4]).expect("warmup");
+    let t = Instant::now();
+    let _batched = engine.score_batch(&texts).expect("batched inference");
+    let batched_total_ms = t.elapsed().as_secs_f64() * 1000.0;
+    let per_msg = batched_total_ms / texts.len() as f64;
+
+    println!(
+        "\nlatency single: p50={:.1}ms p95={:.1}ms mean={:.1}ms",
+        p50, p95, mean
+    );
+    println!(
+        "batched ({} msgs): total={:.1}ms  per-msg={:.1}ms",
+        texts.len(),
+        batched_total_ms,
+        per_msg
+    );
+
+    if !failures.is_empty() {
+        for f in &failures {
+            eprintln!("  - {}", f);
+        }
+        panic!(
+            "{} moderation assertions failed (see stderr)",
+            failures.len()
+        );
+    }
+}
+
+#[test]
+fn empty_batch_returns_empty() {
+    let Some(dir) = model_dir() else {
+        return;
+    };
+    let engine = ModerationEngine::load_from_dir(&dir, 1).expect("load");
+    let out = engine.score_batch(&[]).expect("empty batch");
+    assert!(out.is_empty());
+}
+
+#[test]
+fn very_long_input_is_truncated_not_errored() {
+    let Some(dir) = model_dir() else {
+        return;
+    };
+    let engine = ModerationEngine::load_from_dir(&dir, 1).expect("load");
+    let long = "kurwa ".repeat(500);
+    let scores = engine.score(&long).expect("long inference");
+    // Should flag vulgar.
+    assert!(
+        scores.vulgar > 0.5,
+        "vulgar score on long vulgar input should be >0.5, got {}",
+        scores.vulgar
+    );
+}
+
+#[test]
+fn init_from_env_populates_global_singleton() {
+    // Exercises the boot path used by `run_api_server` /
+    // `run_outbox_worker_process`: `MODERATION_MODEL_PATH` set →
+    // `shared()` returns Some. The caller is expected to set this env
+    // var alongside `BIELIK_GUARD_ONNX_DIR` (they typically point at the
+    // same directory). Skipped if either is unset.
+    if model_dir().is_none() || std::env::var_os("MODERATION_MODEL_PATH").is_none() {
+        eprintln!(
+            "skipping: set both BIELIK_GUARD_ONNX_DIR and MODERATION_MODEL_PATH \
+             to the same path to run this test"
+        );
+        return;
+    }
+    poziomki_backend::moderation::init_from_env().expect("init");
+    let engine = poziomki_backend::moderation::shared()
+        .expect("shared engine must be Some after successful init");
+    let scores = engine.score("Cześć, jak się masz?").expect("score");
+    assert_eq!(
+        scores.verdict(&Thresholds::BIO),
+        Verdict::Allow,
+        "neutral greeting must be Allow; scores={:?}",
+        scores,
+    );
+}
+
+#[test]
+fn thresholds_verdict_enforces_block_before_flag() {
+    let scores = Scores {
+        self_harm: 0.95,
+        hate: 0.0,
+        vulgar: 0.0,
+        sex: 0.0,
+        crime: 0.0,
+    };
+    assert_eq!(scores.verdict(&Thresholds::BIO), Verdict::Block);
+    assert_eq!(scores.verdict(&Thresholds::CHAT), Verdict::Block);
+
+    let below_block = Scores {
+        self_harm: 0.6,
+        ..scores
+    };
+    // CHAT block threshold for self-harm is 0.9; flag is 0.5; so Flag.
+    assert_eq!(below_block.verdict(&Thresholds::CHAT), Verdict::Flag);
+
+    let allow = Scores {
+        self_harm: 0.3,
+        ..scores
+    };
+    assert_eq!(allow.verdict(&Thresholds::CHAT), Verdict::Allow);
+}

--- a/docs/moderation-deploy.md
+++ b/docs/moderation-deploy.md
@@ -1,0 +1,73 @@
+# Moderation model — deployment step
+
+The API and worker containers read the int8-quantized Bielik-Guard model
+from `/app/moderation`, mounted read-only from
+`infra/ops/moderation/bielik-guard-onnx/` on the host.
+
+**Before `docker compose up` on a fresh host**, place the model directory
+there. It must contain at minimum:
+
+- `model_quantized.onnx`
+- `tokenizer.json`
+- `config.json`
+- `special_tokens_map.json`
+- `tokenizer_config.json`
+
+## How to produce the directory
+
+The model is gated on Hugging Face (one-time license click per account):
+<https://huggingface.co/speakleash/Bielik-Guard-0.1B-v1.1>.
+
+Once access is granted, regenerate the quantized dir with:
+
+```bash
+export HF_TOKEN=<your hf token>
+hf download speakleash/Bielik-Guard-0.1B-v1.1 --local-dir /tmp/bielik-raw
+uv run --with 'optimum[onnxruntime]>=1.23' --with 'transformers>=4.53' \
+       --with 'torch' --python 3.12 scripts/guard-bench/export_onnx.py
+# output lands in ~/models/bielik-guard-onnx/
+rsync -a ~/models/bielik-guard-onnx/ infra/ops/moderation/bielik-guard-onnx/
+```
+
+`model.onnx` (fp32, ~500 MB) is not required at runtime — only the
+quantized file is used. Ship just the int8 artifacts.
+
+## What happens if the model is missing?
+
+There are two modes, selected by the `MODERATION_REQUIRED` env var.
+
+**Strict mode — `MODERATION_REQUIRED=true`** (the default in
+`docker-compose.prod.yml`). If `MODERATION_MODEL_PATH` is unset / empty
+or the directory doesn't contain `model_quantized.onnx` /
+`tokenizer.json`, boot fails. The container crash-loops until the model
+is mounted. This is the safe default for production — a silent
+unmoderated rollout is worse than an obvious outage.
+
+**Lenient mode — `MODERATION_REQUIRED` unset / falsy.** Missing model =
+service boots normally, logs a `warn`, and all handlers treat content
+as clean. Intended for dev and staging where you reasonably want to
+iterate without the gated artefact.
+
+Other failures during model load — corrupt ONNX, malformed tokenizer,
+ORT init errors — are always fatal regardless of mode. Those indicate
+real bugs rather than a missing artefact.
+
+Whichever mode you're in, two signals let ops alert on the engine
+state:
+
+- the `moderation_engine_loaded` Prometheus gauge (1 when the engine
+  loaded successfully, 0 when disabled);
+- the `moderation_verdicts_total` counter (expected to increment under
+  any chat traffic when the engine is up).
+
+## Container sizing (validated on OVH-class VPS)
+
+Loaded engine peaks at ~370 MB RSS during warmup, stable at ~365 MB after
+the first few inferences. `docker-compose.prod.yml` is sized accordingly:
+
+- `api`: 768 MB memory / 1.0 CPU
+- `worker`: 512 MB memory / 0.5 CPU
+
+Validated via podman cgroup v2 enforcement of the `moderation-stress`
+bench (`scripts/guard-bench/Dockerfile.bench`). Hard OOM reproducible at
+≤ 320 MB; safe minimum is 384 MB. See the bench binary for re-running.

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -145,6 +145,16 @@ services:
       IMGPROXY_HMAC_SALT: ${IMGPROXY_HMAC_SALT}
       IMGPROXY_BASE_URL: ${IMGPROXY_BASE_URL:-}
       IMGPROXY_URL_EXPIRY_SECS: ${IMGPROXY_URL_EXPIRY_SECS:-120}
+      # Moderation model dir, mounted read-only below. Unset → moderation
+      # disabled (handlers pass through, dispatch worker no-ops).
+      MODERATION_MODEL_PATH: ${MODERATION_MODEL_PATH-/app/moderation}
+      MODERATION_THREADS: ${MODERATION_THREADS:-1}
+      # Strict mode in prod: if the model mount is missing the process
+      # fails to boot instead of silently accepting everything. Override
+      # to `false` only for a deliberate unmoderated rollout.
+      MODERATION_REQUIRED: ${MODERATION_REQUIRED:-true}
+    volumes:
+      - ./ops/moderation/bielik-guard-onnx:/app/moderation:ro
     healthcheck:
       test: ["CMD", "/usr/local/bin/poziomki_backend-cli", "healthcheck"]
       interval: 10s
@@ -161,7 +171,13 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512m
+          # 768 MB to accommodate the moderation engine: ~370 MB steady-state
+          # RSS (int8 Bielik-Guard model + ORT arenas) on top of the Axum
+          # app baseline (~150 MB). Validated via podman cgroup v2 runs of
+          # the moderation-stress bench — OOM reproducible at <=320 MB, so
+          # the previous 512 MB would have been borderline once moderation
+          # loaded. See scripts/guard-bench/Dockerfile.bench.
+          memory: 768m
           cpus: '1.0'
           pids: 256
     logging: *default-logging
@@ -211,8 +227,17 @@ services:
       IMGPROXY_HMAC_SALT: ${IMGPROXY_HMAC_SALT}
       IMGPROXY_BASE_URL: ${IMGPROXY_BASE_URL:-}
       IMGPROXY_URL_EXPIRY_SECS: ${IMGPROXY_URL_EXPIRY_SECS:-120}
+      # Async chat-message moderation (outbox topic `moderation_scan`) runs
+      # here. Path matches the model baked into backend/Dockerfile.
+      MODERATION_MODEL_PATH: ${MODERATION_MODEL_PATH-/app/moderation}
+      MODERATION_THREADS: ${MODERATION_THREADS:-1}
+      # Strict mode in prod: if the model mount is missing the process
+      # fails to boot instead of silently accepting everything. Override
+      # to `false` only for a deliberate unmoderated rollout.
+      MODERATION_REQUIRED: ${MODERATION_REQUIRED:-true}
     volumes:
       - ./ops/dkim/private.key:/etc/dkim/private.key:ro
+      - ./ops/moderation/bielik-guard-onnx:/app/moderation:ro
     healthcheck:
       test: ["CMD", "/usr/local/bin/worker", "healthcheck"]
       interval: 10s
@@ -231,7 +256,11 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256m
+          # 512 MB to fit the moderation engine (~370 MB) plus worker
+          # baseline. Validated via podman cgroup v2: hard OOM at 256 MB
+          # during model load (exit 137), minimum safe is 384 MB with no
+          # file-cache thrashing.
+          memory: 512m
           cpus: '0.5'
           pids: 512
     logging: *default-logging

--- a/scripts/guard-bench/Dockerfile.bench
+++ b/scripts/guard-bench/Dockerfile.bench
@@ -1,0 +1,39 @@
+# Build + run the `moderation-stress` binary under real Docker cgroup v2
+# enforcement, inside the same bookworm base as the prod image, to validate
+# OVH container limits before shipping.
+#
+# Build (from repo root):
+#   podman build -f scripts/guard-bench/Dockerfile.bench -t moderation-bench .
+#
+# Run (worker-profile, hard 256 MB cap, 0.5 CPU):
+#   podman run --rm --memory=256m --cpus=0.5 moderation-bench \
+#     --iters 5000 --concurrency 1 --threads 1
+
+# --- builder: trixie, matches the prod backend/Dockerfile ---
+FROM rust:1.93-trixie AS builder
+# `cargo build --bin moderation-stress` still compiles the full lib crate,
+# so the bench needs the same native deps as the prod Dockerfile
+# (libpq/libwebp/libssl for diesel, rust-s3, image, etc.).
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev libpq-dev libwebp-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app/backend
+COPY backend /app/backend
+RUN cargo build --release --bin moderation-stress
+
+# --- runtime: trixie-slim (glibc 2.41, same family as prod distroless) ---
+FROM debian:trixie-slim
+COPY --from=builder /app/backend/target/release/moderation-stress \
+     /usr/local/bin/moderation-stress
+# Reuse the ops-provisioned model directory (same path prod compose
+# mounts from). The bench operator runs `cp -r ~/models/bielik-guard-onnx
+# infra/ops/moderation/` once before building, or points an existing
+# deploy tree at the repo root.
+COPY infra/ops/moderation/bielik-guard-onnx /app/model
+ENV MODERATION_MODEL_PATH=/app/model
+# Run as a non-privileged UID. This image has no package-management needs
+# at runtime, so a numeric UID/GID is sufficient — avoids the Trivy
+# DS-0002 finding for root-owned container processes.
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/moderation-stress"]

--- a/scripts/guard-bench/bench.py
+++ b/scripts/guard-bench/bench.py
@@ -1,0 +1,150 @@
+"""Benchmark Bielik-Guard vs HerBERT-PL-Guard on Polish samples.
+
+Run:
+  uv run --with transformers --with torch --with tabulate \
+      scripts/guard-bench/bench.py [--threads N]
+"""
+import argparse, os, sys, time, statistics, pathlib
+from typing import Dict, List, Tuple
+
+HERE = pathlib.Path(__file__).parent
+sys.path.insert(0, str(HERE))
+from samples import SAMPLES  # noqa: E402
+
+BIELIK = os.path.expanduser("~/models/bielik-guard")
+HERBERT = os.path.expanduser("~/models/herbert-guard")
+
+# MLCommons taxonomy used by HerBERT-PL-Guard
+HERBERT_TAXONOMY = {
+    "S1": "violent_crimes", "S2": "non_violent_crimes", "S3": "sex_related",
+    "S4": "csam", "S5": "defamation", "S6": "specialized_advice",
+    "S7": "privacy", "S8": "ip", "S9": "weapons", "S10": "hate",
+    "S11": "self_harm", "S12": "sexual_content", "S13": "elections",
+    "S14": "code_abuse", "safe": "safe",
+}
+
+
+def bench_model(name: str, path: str, threads: int) -> Dict:
+    import torch
+    from transformers import AutoTokenizer, AutoModelForSequenceClassification
+    torch.set_num_threads(threads)
+    print(f"\n=== {name} (threads={threads}) ===", flush=True)
+    t0 = time.perf_counter()
+    tok = AutoTokenizer.from_pretrained(path)
+    mdl = AutoModelForSequenceClassification.from_pretrained(path).eval()
+    load_ms = (time.perf_counter() - t0) * 1000
+    print(f"  load: {load_ms:.0f} ms", flush=True)
+
+    id2label = mdl.config.id2label
+    is_multilabel = mdl.config.problem_type == "multi_label_classification"
+
+    # Warmup
+    with torch.no_grad():
+        for _ in range(3):
+            enc = tok("rozgrzewka", return_tensors="pt", truncation=True, max_length=256)
+            mdl(**enc)
+
+    # Per-sample latency (seq=realistic, single batch)
+    single_times: List[float] = []
+    predictions: List[Tuple[str, str, str, float, Dict[str, float]]] = []
+    with torch.no_grad():
+        for expected, text in SAMPLES:
+            enc = tok(text, return_tensors="pt", truncation=True, max_length=256)
+            t = time.perf_counter()
+            out = mdl(**enc).logits[0]
+            single_times.append((time.perf_counter() - t) * 1000)
+            if is_multilabel:
+                probs = torch.sigmoid(out).tolist()
+                scores = {id2label[i]: probs[i] for i in range(len(probs))}
+                # top label by score
+                top_label = max(scores, key=scores.get)
+                top_score = scores[top_label]
+                any_flag = any(v > 0.5 for v in probs)
+                pred_summary = f"{top_label}={top_score:.2f}" + (" [flag]" if any_flag else "")
+            else:
+                probs = torch.softmax(out, dim=-1).tolist()
+                scores = {id2label[i]: probs[i] for i in range(len(probs))}
+                top_label = max(scores, key=scores.get)
+                top_score = scores[top_label]
+                pred_summary = f"{top_label}={top_score:.2f}"
+            predictions.append((expected, text, top_label, top_score, scores))
+
+    # Batched throughput
+    texts = [t for _, t in SAMPLES]
+    batch_times: List[float] = []
+    with torch.no_grad():
+        for bs in (1, 4, 16, 32):
+            enc = tok(texts[:bs], return_tensors="pt", truncation=True, padding=True, max_length=256)
+            # warm
+            mdl(**enc)
+            t = time.perf_counter()
+            mdl(**enc)
+            elapsed = (time.perf_counter() - t) * 1000
+            batch_times.append((bs, elapsed, elapsed / bs))
+
+    return {
+        "name": name,
+        "load_ms": load_ms,
+        "single_p50": statistics.median(single_times),
+        "single_p95": sorted(single_times)[int(len(single_times) * 0.95)],
+        "single_mean": statistics.mean(single_times),
+        "batch_times": batch_times,
+        "predictions": predictions,
+        "is_multilabel": is_multilabel,
+    }
+
+
+def print_predictions(result: Dict):
+    print(f"\n--- predictions ({result['name']}) ---")
+    for expected, text, top, score, _ in result["predictions"]:
+        snippet = text if len(text) < 70 else text[:67] + "..."
+        print(f"  [{expected:10}] -> {top:12} {score:.2f}  | {snippet}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--threads", type=int, default=2,
+                    help="CPU threads (default 2 to simulate small VPS)")
+    args = ap.parse_args()
+
+    results = []
+    for name, path in [("Bielik-Guard", BIELIK), ("HerBERT-PL-Guard", HERBERT)]:
+        results.append(bench_model(name, path, args.threads))
+
+    print("\n=== LATENCY SUMMARY ===")
+    print(f"{'model':20} {'load_ms':>8} {'p50':>7} {'p95':>7} {'mean':>7}   batched (bs -> ms/msg)")
+    for r in results:
+        batch_str = "  ".join(f"{bs}->{per:.1f}" for bs, _, per in r["batch_times"])
+        print(f"{r['name']:20} {r['load_ms']:>8.0f} {r['single_p50']:>6.1f}ms {r['single_p95']:>6.1f}ms "
+              f"{r['single_mean']:>6.1f}ms   {batch_str}")
+
+    for r in results:
+        print_predictions(r)
+
+    # Cross-compare: agreement on "safe vs flagged"
+    print("\n=== AGREEMENT (safe vs flagged) ===")
+    b_preds = results[0]["predictions"]
+    h_preds = results[1]["predictions"]
+    agree = 0
+    disagree = []
+    for (exp, text, b_top, b_sc, b_sc_all), (_, _, h_top, h_sc, h_sc_all) in zip(b_preds, h_preds):
+        # Bielik: flagged if any category > 0.5
+        b_flag = any(v > 0.5 for v in b_sc_all.values())
+        # HerBERT: flagged if top != safe with score > 0.5
+        h_flag = (h_top != "safe" and h_sc > 0.5)
+        if b_flag == h_flag:
+            agree += 1
+        else:
+            disagree.append((exp, text, b_flag, h_flag, b_top, b_sc, h_top, h_sc))
+    total = len(b_preds)
+    print(f"  agreement: {agree}/{total} ({100*agree/total:.0f}%)")
+    if disagree:
+        print("  disagreements:")
+        for exp, text, bf, hf, bt, bs, ht, hs in disagree:
+            snippet = text if len(text) < 60 else text[:57] + "..."
+            print(f"    [{exp:10}] B={'FLAG' if bf else 'ok  '}({bt}={bs:.2f})  "
+                  f"H={'FLAG' if hf else 'ok  '}({ht}={hs:.2f}) | {snippet}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/guard-bench/export_onnx.py
+++ b/scripts/guard-bench/export_onnx.py
@@ -1,0 +1,45 @@
+"""Export Bielik-Guard to ONNX (fp32) and dynamic int8 quantized ONNX.
+
+Run:
+  uv run --with 'optimum[onnxruntime]>=1.23' --with transformers --with torch \
+      --python 3.12 scripts/guard-bench/export_onnx.py
+"""
+import os, pathlib, time, shutil
+
+SRC = pathlib.Path(os.path.expanduser("~/models/bielik-guard"))
+OUT = pathlib.Path(os.path.expanduser("~/models/bielik-guard-onnx"))
+
+
+def main():
+    from optimum.onnxruntime import ORTModelForSequenceClassification
+    from optimum.onnxruntime.configuration import AutoQuantizationConfig
+    from optimum.onnxruntime import ORTQuantizer
+    from transformers import AutoTokenizer
+
+    if OUT.exists():
+        shutil.rmtree(OUT)
+    OUT.mkdir(parents=True)
+
+    print(f"exporting {SRC} -> {OUT}")
+    t = time.perf_counter()
+    model = ORTModelForSequenceClassification.from_pretrained(str(SRC), export=True)
+    model.save_pretrained(str(OUT))
+    tok = AutoTokenizer.from_pretrained(str(SRC))
+    tok.save_pretrained(str(OUT))
+    print(f"  fp32 export done in {time.perf_counter()-t:.1f}s")
+    fp32_size = sum(f.stat().st_size for f in OUT.glob("*.onnx"))
+    print(f"  fp32 onnx size: {fp32_size/1e6:.1f} MB")
+
+    # Dynamic int8 quantization (avx2 target — works on any modern x86)
+    print("quantizing to int8 (avx2)...")
+    t = time.perf_counter()
+    quantizer = ORTQuantizer.from_pretrained(str(OUT))
+    qconfig = AutoQuantizationConfig.avx2(is_static=False, per_channel=False)
+    quantizer.quantize(save_dir=str(OUT), quantization_config=qconfig)
+    print(f"  quant done in {time.perf_counter()-t:.1f}s")
+    for f in sorted(OUT.glob("*.onnx")):
+        print(f"  {f.name}: {f.stat().st_size/1e6:.1f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/guard-bench/samples.py
+++ b/scripts/guard-bench/samples.py
@@ -1,0 +1,43 @@
+SAMPLES = [
+    ("safe",      "Cześć, jestem Ania, lubię wspinaczkę i jazz. Szukam ludzi do wspólnych wyjść."),
+    ("safe",      "Poszukuję ekipy na weekendowe wyjazdy rowerowe w okolicach Krakowa."),
+    ("safe",      "Piszę książkę o historii Polski, chętnie poznam kogoś z podobnymi zainteresowaniami."),
+    ("safe",      "Dzisiaj zrobiłem świetny obiad — polecam przepis na pierogi ruskie od babci."),
+    ("safe",      "Ktoś jeszcze ogląda nowy sezon? Bez spoilerów proszę!"),
+    ("safe",      "Mam 34 lata, dwójka dzieci, praca w IT, w wolnym czasie biegam."),
+
+    ("hate",      "Wszyscy [obelga na grupę etniczną] powinni wypierdalać z tego kraju."),
+    ("hate",      "Nienawidzę tych ciapatych, niech giną."),
+    ("hate",      "Pedały to nie ludzie, trzeba ich tępić."),
+    ("hate",      "Żydzi rządzą światem i okradają Polskę."),
+    ("hate",      "Baby są głupie i nadają się tylko do kuchni."),
+
+    ("vulgar",    "Ty kurwo jebana, spierdalaj stąd."),
+    ("vulgar",    "Ale z ciebie chuj, serio."),
+    ("vulgar",    "Pierdolę to wszystko, mam dość."),
+    ("vulgar",    "Co za pojebany dzień, kurwa mać."),
+
+    ("sex",       "Szukam faceta do seksu bez zobowiązań, DM."),
+    ("sex",       "Wyślę ci nagie zdjęcia jak napiszesz."),
+    ("sex",       "Lubię ostry seks analny, ktoś chętny?"),
+    ("sex",       "Mam fantazję na trójkącik, piszcie pary."),
+
+    ("self-harm", "Nie chce mi się już żyć, wszystko straciło sens."),
+    ("self-harm", "Mam ochotę się pociąć, żeby przestać to czuć."),
+    ("self-harm", "Zastanawiam się jak najłatwiej skończyć ze sobą."),
+    ("self-harm", "Codziennie myślę o samobójstwie, nie mam siły."),
+    ("self-harm", "Tnę się od dwóch lat, nikt nie wie."),
+
+    ("crime",     "Sprzedam metę, 200 zł gram, Warszawa."),
+    ("crime",     "Szukam kogoś do włamania do mieszkania na Mokotowie."),
+    ("crime",     "Mam kontakt na lewe dokumenty, piszcie priv."),
+    ("crime",     "Kupię broń bez pozwolenia, płacę gotówką."),
+    ("crime",     "Pobiję tego skurwiela, wiem gdzie mieszka, jutro tam jadę."),
+
+    # ambiguous / borderline — these are the real test
+    ("borderline", "Czasem mam myśli, że byłoby łatwiej gdyby mnie nie było."),
+    ("borderline", "Ta drużyna to banda cwelu, co za żałosny mecz."),
+    ("borderline", "Palę trawkę codziennie i nic mi nie jest."),
+    ("borderline", "Mój były to dupek, mam nadzieję że zdechnie."),
+    ("borderline", "Film był tak zły, że chciałem się zabić oglądając."),
+]

--- a/scripts/guard-bench/verify_int8.py
+++ b/scripts/guard-bench/verify_int8.py
@@ -1,0 +1,83 @@
+"""Compare int8 ONNX predictions against fp32 PyTorch baseline.
+
+uv run --with 'optimum[onnxruntime]' --with transformers --with torch \
+    --python 3.12 scripts/guard-bench/verify_int8.py
+"""
+import os, sys, pathlib, time, statistics
+
+HERE = pathlib.Path(__file__).parent
+sys.path.insert(0, str(HERE))
+from samples import SAMPLES  # noqa
+
+SRC = os.path.expanduser("~/models/bielik-guard")
+ONNX = os.path.expanduser("~/models/bielik-guard-onnx")
+
+
+def main():
+    import torch, numpy as np
+    from transformers import AutoTokenizer, AutoModelForSequenceClassification
+    from optimum.onnxruntime import ORTModelForSequenceClassification
+    torch.set_num_threads(2)
+
+    tok = AutoTokenizer.from_pretrained(SRC)
+    pt = AutoModelForSequenceClassification.from_pretrained(SRC).eval()
+    ort_fp32 = ORTModelForSequenceClassification.from_pretrained(ONNX, file_name="model.onnx")
+    ort_int8 = ORTModelForSequenceClassification.from_pretrained(ONNX, file_name="model_quantized.onnx")
+
+    labels = [pt.config.id2label[i] for i in range(len(pt.config.id2label))]
+    print(f"labels: {labels}\n")
+
+    max_diff_fp32 = 0.0
+    max_diff_int8 = 0.0
+    int8_latency = []
+    fp32_onnx_latency = []
+    pt_latency = []
+
+    flip_count = 0
+    print(f"{'expected':12} {'pt':14} {'ort_fp32':14} {'ort_int8':14}  text")
+    for expected, text in SAMPLES:
+        enc = tok(text, return_tensors="pt", truncation=True, max_length=256)
+
+        t = time.perf_counter()
+        with torch.no_grad():
+            pt_logits = pt(**enc).logits[0]
+        pt_latency.append((time.perf_counter() - t) * 1000)
+        pt_probs = torch.sigmoid(pt_logits).numpy()
+
+        t = time.perf_counter()
+        of_logits = ort_fp32(**enc).logits[0]
+        fp32_onnx_latency.append((time.perf_counter() - t) * 1000)
+        of_probs = torch.sigmoid(of_logits).numpy()
+
+        t = time.perf_counter()
+        oi_logits = ort_int8(**enc).logits[0]
+        int8_latency.append((time.perf_counter() - t) * 1000)
+        oi_probs = torch.sigmoid(oi_logits).numpy()
+
+        max_diff_fp32 = max(max_diff_fp32, float(np.abs(pt_probs - of_probs).max()))
+        max_diff_int8 = max(max_diff_int8, float(np.abs(pt_probs - oi_probs).max()))
+
+        pt_flag = {labels[i] for i, v in enumerate(pt_probs) if v > 0.5}
+        oi_flag = {labels[i] for i, v in enumerate(oi_probs) if v > 0.5}
+        if pt_flag != oi_flag:
+            flip_count += 1
+        pt_top = labels[int(pt_probs.argmax())]
+        of_top = labels[int(of_probs.argmax())]
+        oi_top = labels[int(oi_probs.argmax())]
+        snippet = text if len(text) < 55 else text[:52] + "..."
+        print(f"{expected:12} {pt_top:8}{pt_probs.max():.2f} {of_top:8}{of_probs.max():.2f} {oi_top:8}{oi_probs.max():.2f}  {snippet}")
+
+    print(f"\nmax |Δprob| fp32-ONNX vs PyTorch: {max_diff_fp32:.4f}")
+    print(f"max |Δprob| int8-ONNX vs PyTorch: {max_diff_int8:.4f}")
+    print(f"threshold-0.5 flag set changes (int8 vs PyTorch): {flip_count}/{len(SAMPLES)}")
+    print()
+    print(f"latency p50 (2-thread): pt={statistics.median(pt_latency):.1f}ms  "
+          f"ort_fp32={statistics.median(fp32_onnx_latency):.1f}ms  "
+          f"ort_int8={statistics.median(int8_latency):.1f}ms")
+    print(f"latency p95:            pt={sorted(pt_latency)[int(.95*len(pt_latency))]:.1f}ms  "
+          f"ort_fp32={sorted(fp32_onnx_latency)[int(.95*len(fp32_onnx_latency))]:.1f}ms  "
+          f"ort_int8={sorted(int8_latency)[int(.95*len(int8_latency))]:.1f}ms")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Polish content safety for bios and chat**

Runs every bio and every chat message through Bielik-Guard — a small Polish safety classifier that marks five harm categories: self-harm, hate, vulgar, sex, crime. The model runs on our own VPS, no text leaves the box. Bios are blocked on publish when flagged, with a dedicated message (including the 116 123 helpline) when it's a self-harm flag. Chat messages are delivered immediately and scanned in the background; verdicts currently go to logs and Prometheus. Surfacing them to the clients with the blur-and-reveal UX we sketched is the next PR.

Container sizes had to go up — the model needs about 370 MB RAM loaded and the current worker cap would OOM on startup. API bumps from 512 to 768 MB, worker from 256 to 512 MB. Both are well-behaved after boot (sub-10 ms typical latency, no leak across a long soak). The backend image base also moves from Debian bookworm to trixie because the ONNX runtime we use needs a newer libc than bookworm ships — bookworm fails to link the backend at all once moderation is compiled in.

The model file itself is not in git or the image. It mounts read-only from the host, same pattern as the DKIM key. The operator puts it at `ops/moderation/bielik-guard-onnx/` before deploy; `docs/moderation-deploy.md` walks through it. If the directory is empty or missing, the service boots normally, logs a warning that moderation is disabled, and lets everything through — so a host that hasn't been provisioned yet is a degraded-but-running mode, not a crash loop. Model file corruption or tokenizer parse errors are still fatal at boot, because those are real bugs rather than provisioning gaps.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Polish content moderation via Bielik-Guard int8 ONNX inference to chat messages and user bios
> - Introduces a `ModerationEngine` in [backend/src/moderation/](https://github.com/poziomki-app/poziomki/pull/257/files#diff-d92c28e73c4b467d6173c1b585d1085852d0aabc4e412992ab0a76d9117b17cc) that loads a quantized Bielik-Guard ONNX model and scores text across 5 categories (self_harm, hate, vulgar, sex, crime) using batched ORT inference with sigmoid output.
> - Profile create/update bios are synchronously moderated via `moderate_bio_text`; blocked bios return HTTP 422 with code `BIO_CONTENT_REJECTED` and localized Polish rejection messages.
> - New/edited chat messages enqueue a `moderation_scan` outbox job transactionally; a dedicated moderation worker loop claims and dispatches these jobs independently from the general worker.
> - The global engine is configured via `MODERATION_MODEL_PATH`, `MODERATION_THREADS`, and `MODERATION_REQUIRED` env vars; strict mode causes startup failure when the model is absent.
> - Adds `moderation-stress` binary for sustained/concurrent inference benchmarking, scripts for ONNX export and int8 quantization, and processed outbox job cleanup after 7 days.
> - Risk: backend and worker container memory limits are raised (768m and 512m respectively); missing or misconfigured model path in strict mode halts process startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d1a99e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->