### PR TITLE
fix(deploy): stage libs under /usr to unbreak buildkit on trixie

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,6 +38,16 @@ RUN apt-get update \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL4006
+#
+# Canonicalise every staged path under /usr: on trixie (usrmerge) /lib
+# and /bin are symlinks to /usr/lib and /usr/bin, so `ldd` reports deps
+# via the short /lib/... form. Letting those land at /staging/lib/...
+# creates a real directory in the staging tarball that then collides
+# with the runtime image's /lib → /usr/lib symlink when buildkit tries
+# `COPY --from=runtime-deps /staging/ /` ("cannot copy to non-directory"
+# errors in Build + push CI). Copying everything under /staging/usr/*
+# sidesteps the collision while still reaching the real files via the
+# same symlinks.
 RUN set -eux; \
     mkdir -p /staging/usr/lib/x86_64-linux-gnu /staging/etc/ssl/certs; \
     cp -aL /etc/ssl/certs/ca-certificates.crt /staging/etc/ssl/certs/; \
@@ -47,11 +57,13 @@ RUN set -eux; \
     for root in /staging/usr/lib/x86_64-linux-gnu/libpq.so.5 \
                 /staging/usr/lib/x86_64-linux-gnu/libwebp.so.7; do \
         ldd "$root" | awk '/=>/ && $3 ~ /^\// { print $3 }'; \
-    done | sort -u | while read -r dep; do \
+    done | sort -u | sed -e 's#^/lib/#/usr/lib/#' -e 's#^/bin/#/usr/bin/#' | while read -r dep; do \
         dest="/staging${dep}"; \
         [ -e "$dest" ] && continue; \
         mkdir -p "$(dirname "$dest")"; \
-        cp -aL "$dep" "$dest"; \
+        src="$dep"; \
+        [ -e "$src" ] || src="$(echo "$dep" | sed -e 's#^/usr/lib/#/lib/#' -e 's#^/usr/bin/#/bin/#')"; \
+        cp -aL "$src" "$dest"; \
     done
 
 # gcr.io/distroless/cc-debian13:nonroot  (trixie-based — matches glibc 2.41)


### PR DESCRIPTION
**Unbreak Build + push CI after the trixie bump**

Main's Build + push workflow is failing at the runtime stage with:

\`\`\`
#19 [runtime 3/5] COPY --from=runtime-deps /staging/ /
ERROR: cannot copy to non-directory: /var/lib/buildkit/runc-overlayfs/cachemounts/.../lib
\`\`\`

Trixie uses usrmerge — \`/lib\` and \`/bin\` are symlinks to \`/usr/lib\` and \`/usr/bin\`. \`ldd\` on trixie reports libs via the short \`/lib/…\` form, which made the dep-copy loop in the runtime-deps stage create a real \`/staging/lib/x86_64-linux-gnu/\` directory. The distroless runtime also has \`/lib\` as a symlink, so \`COPY --from=runtime-deps /staging/ /\` collides (can't copy a directory onto a symlink target).

Normalise every staged dep path under \`/usr\` before writing; fall back to the \`/lib\` or \`/bin\` source at \`cp\` time (the files are reachable both ways via the symlink). Everything ends up under \`/staging/usr/lib/…\` in the tarball, and the runtime still resolves the libs through its own \`/lib → /usr/lib\` link.

Verified locally with \`podman build --no-cache --target runtime-deps\` on the backend Dockerfile — every dep now stages under \`/staging/usr/lib/x86_64-linux-gnu/\`, no more \`/staging/lib/\` dir.

- [ ] Build + push turns green on this PR
- [ ] prod deploy picks up the fixed image before the next release cut

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix lib/bin path staging in Dockerfile to restore BuildKit compatibility on Debian trixie
> On Debian trixie, `/lib` and `/bin` are symlinks to `/usr/lib` and `/usr/bin`, which breaks BuildKit when staging dependencies at their raw `ldd`-reported paths. The [Dockerfile](https://github.com/poziomki-app/poziomki/pull/258/files#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486) now rewrites absolute `/lib` and `/bin` paths to their `/usr`-prefixed equivalents before copying, with a fallback to the original path if the `/usr` variant does not exist. Behavioral Change: staged dependencies are now placed under `/staging/usr/lib` or `/staging/usr/bin` instead of potentially top-level `/staging/lib` or `/staging/bin`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52d9110.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->