### PR TITLE
fix: close auth and client token security gaps

### DIFF
--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -9,7 +9,7 @@ use super::conversations;
 use super::hub::ChatHub;
 use super::messages as chat_messages;
 use super::protocol::{ClientMessage, ServerMessage};
-use crate::api::state::hash_session_token;
+use crate::api::state::{require_auth_token, AuthFailure};
 use crate::db;
 use crate::db::schema::{conversations as conversations_table, profile_blocks, profiles};
 
@@ -201,8 +201,8 @@ fn into_diesel(e: crate::error::AppError) -> diesel::result::Error {
 }
 
 /// Authenticate the first message. Returns a `SocketViewer` + user pid, or
-/// None on failure. Routes through `app.resolve_session` so it works once
-/// Tier-A RLS lands on the sessions table.
+/// None on failure. Uses the same token auth path as REST so expiry caps,
+/// bans, session renewal, and RLS-ready user loading stay consistent.
 async fn authenticate(
     ws_tx: &mut futures_util::stream::SplitSink<WebSocket, Message>,
     ws_rx: &mut futures_util::stream::SplitStream<WebSocket>,
@@ -237,58 +237,35 @@ async fn authenticate(
         return None;
     };
 
-    let hashed = hash_session_token(&token);
-
-    let Ok(mut conn) = crate::db::conn().await else {
-        let _ = send_json(
-            ws_tx,
-            &ServerMessage::AuthError {
-                message: "internal error".to_string(),
-            },
-        )
-        .await;
-        return None;
+    let auth = match require_auth_token(&token).await {
+        Ok(auth) => auth,
+        Err(AuthFailure::Banned) => {
+            tracing::warn!("WS auth failed: account suspended");
+            let _ = send_json(
+                ws_tx,
+                &ServerMessage::AuthError {
+                    message: "account suspended".to_string(),
+                },
+            )
+            .await;
+            return None;
+        }
+        Err(AuthFailure::Unauthorized) => {
+            tracing::warn!("WS auth failed: invalid token");
+            let _ = send_json(
+                ws_tx,
+                &ServerMessage::AuthError {
+                    message: "invalid token".to_string(),
+                },
+            )
+            .await;
+            return None;
+        }
     };
-
-    let Ok(session) = db::resolve_session(&mut conn, &hashed).await else {
-        tracing::warn!("WS auth failed: database query error");
-        let _ = send_json(
-            ws_tx,
-            &ServerMessage::AuthError {
-                message: "internal error".to_string(),
-            },
-        )
-        .await;
-        return None;
-    };
-
-    let Some(session) = session else {
-        tracing::warn!("WS auth failed: invalid token");
-        let _ = send_json(
-            ws_tx,
-            &ServerMessage::AuthError {
-                message: "invalid token".to_string(),
-            },
-        )
-        .await;
-        return None;
-    };
-
-    if session.expires_at <= chrono::Utc::now() {
-        tracing::warn!("WS auth failed: session expired");
-        let _ = send_json(
-            ws_tx,
-            &ServerMessage::AuthError {
-                message: "invalid token".to_string(),
-            },
-        )
-        .await;
-        return None;
-    }
 
     let viewer = SocketViewer {
-        user_id: session.user_id,
-        is_review_stub: session.is_review_stub,
+        user_id: auth.user.id,
+        is_review_stub: auth.user.is_review_stub,
     };
 
     let _ = send_json(
@@ -298,7 +275,7 @@ async fn authenticate(
         },
     )
     .await;
-    Some((viewer, session.user_pid))
+    Some((viewer, auth.user.pid))
 }
 
 /// Process a single client message.

--- a/backend/src/api/search.rs
+++ b/backend/src/api/search.rs
@@ -169,7 +169,11 @@ pub(super) async fn search(
 
     let geo = build_geo_params(&query);
 
-    let mut results = crate::search::search_all(&q, limit, geo.as_ref(), user.id)
+    let viewer = crate::db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let mut results = crate::search::search_all(&q, limit, geo.as_ref(), viewer)
         .await
         .map_err(|e| {
             tracing::error!("Search query failed: {e}");

--- a/backend/src/api/state/auth.rs
+++ b/backend/src/api/state/auth.rs
@@ -62,6 +62,12 @@ pub(in crate::api) struct AuthContext {
     pub(in crate::api) user: User,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::api) enum AuthFailure {
+    Unauthorized,
+    Banned,
+}
+
 #[derive(Clone)]
 struct CachedAuthEntry {
     session: Session,
@@ -162,12 +168,23 @@ pub(in crate::api) async fn require_auth_context(
 ) -> std::result::Result<AuthContext, Box<axum::response::Response>> {
     let token =
         extract_bearer_token(headers).ok_or_else(|| Box::new(unauthorized_response(headers)))?;
-    let hashed = session_token_hash(&token);
+    require_auth_token(&token)
+        .await
+        .map_err(|failure| match failure {
+            AuthFailure::Unauthorized => Box::new(unauthorized_response(headers)),
+            AuthFailure::Banned => Box::new(banned_response(headers)),
+        })
+}
+
+pub(in crate::api) async fn require_auth_token(
+    token: &str,
+) -> std::result::Result<AuthContext, AuthFailure> {
+    let hashed = session_token_hash(token);
 
     if let Some((session, user)) = cache_auth_get(&hashed).await {
         if user.banned_at.is_some() {
             invalidate_auth_cache_for_user_id(user.id).await;
-            return Err(Box::new(banned_response(headers)));
+            return Err(AuthFailure::Banned);
         }
         let elapsed = Utc::now() - session.updated_at;
         if elapsed >= Duration::seconds(SESSION_UPDATE_AGE_SECS) {
@@ -184,7 +201,7 @@ pub(in crate::api) async fn require_auth_context(
     // the correct RLS scope.
     let mut conn = crate::db::conn()
         .await
-        .map_err(|_| Box::new(unauthorized_response(headers)))?;
+        .map_err(|_| AuthFailure::Unauthorized)?;
     let now = Utc::now();
 
     let hashed_for_tx = hashed.clone();
@@ -220,14 +237,14 @@ pub(in crate::api) async fn require_auth_context(
             .scope_boxed()
         })
         .await
-        .map_err(|_| Box::new(unauthorized_response(headers)))?;
+        .map_err(|_| AuthFailure::Unauthorized)?;
 
-    let (session, user) = result.ok_or_else(|| Box::new(unauthorized_response(headers)))?;
+    let (session, user) = result.ok_or(AuthFailure::Unauthorized)?;
     if user.banned_at.is_some() {
         // Don't cache a banned user — they'd be a fast-path back in.
         // The admin-ban path also purges sessions, so a banned user
         // should normally not reach this branch.
-        return Err(Box::new(banned_response(headers)));
+        return Err(AuthFailure::Banned);
     }
     cache_auth_put(hashed, &session, &user).await;
     tracing::Span::current().record("user_id", user.id);

--- a/backend/src/search.rs
+++ b/backend/src/search.rs
@@ -1,6 +1,7 @@
 use diesel::deserialize::QueryableByName;
 use diesel::sql_types::{Array, BigInt, Float8, Integer, Nullable, Text, Uuid as DieselUuid};
-use diesel_async::RunQueryDsl;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 
 // --- Geo types ---
@@ -64,7 +65,7 @@ pub async fn search_all(
     query: &str,
     limit: usize,
     geo: Option<&GeoSearchParams>,
-    viewer_user_id: i32,
+    viewer: crate::db::DbViewer,
 ) -> crate::error::AppResult<SearchResults> {
     let normalized_query = query.trim().to_ascii_lowercase();
 
@@ -78,28 +79,46 @@ pub async fn search_all(
 
     let pattern = format!("%{normalized_query}%");
     let limit_i64 = i64::try_from(limit).unwrap_or(50);
+    let geo_owned = geo.map(|g| GeoSearchParams {
+        lat: g.lat,
+        lng: g.lng,
+        radius_m: g.radius_m,
+    });
 
-    let profiles_fut = search_profiles(&normalized_query, &pattern, limit_i64, viewer_user_id);
-    let events_fut = search_events(&normalized_query, &pattern, limit_i64, geo);
-    let tags_fut = search_tags(&normalized_query, &pattern, limit_i64);
+    crate::db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let profiles =
+                search_profiles(conn, &normalized_query, &pattern, limit_i64, viewer.user_id)
+                    .await?;
+            let events = search_events(
+                conn,
+                &normalized_query,
+                &pattern,
+                limit_i64,
+                geo_owned.as_ref(),
+            )
+            .await?;
+            let tags = search_tags(conn, &normalized_query, &pattern, limit_i64).await?;
 
-    let (profiles, events, tags) = tokio::try_join!(profiles_fut, events_fut, tags_fut)?;
-
-    Ok(SearchResults {
-        profiles,
-        events,
-        tags,
+            Ok(SearchResults {
+                profiles,
+                events,
+                tags,
+            })
+        }
+        .scope_boxed()
     })
+    .await
+    .map_err(Into::into)
 }
 
 async fn search_profiles(
+    conn: &mut AsyncPgConnection,
     query: &str,
     pattern: &str,
     limit_i64: i64,
     viewer_user_id: i32,
-) -> crate::error::AppResult<Vec<ProfileDocument>> {
-    let mut conn = crate::db::conn().await?;
-
+) -> Result<Vec<ProfileDocument>, diesel::result::Error> {
     let profile_rows = diesel::sql_query(
         r"
         SELECT
@@ -157,7 +176,7 @@ async fn search_profiles(
     .bind::<Text, _>(pattern)
     .bind::<BigInt, _>(limit_i64)
     .bind::<diesel::sql_types::Integer, _>(viewer_user_id)
-    .load::<ProfileSearchRow>(&mut conn)
+    .load::<ProfileSearchRow>(conn)
     .await?;
 
     Ok(profile_rows
@@ -174,13 +193,12 @@ async fn search_profiles(
 }
 
 async fn search_events(
+    conn: &mut AsyncPgConnection,
     query: &str,
     pattern: &str,
     limit_i64: i64,
     geo: Option<&GeoSearchParams>,
-) -> crate::error::AppResult<Vec<EventDocument>> {
-    let mut conn = crate::db::conn().await?;
-
+) -> Result<Vec<EventDocument>, diesel::result::Error> {
     let (geo_filter, order_by, has_geo) = match geo {
         Some(_) => (
             "AND e.latitude IS NOT NULL AND e.longitude IS NOT NULL \
@@ -224,14 +242,14 @@ async fn search_events(
             .bind::<Float8, _>(g.lng)
             .bind::<BigInt, _>(i64::from(g.radius_m))
             .bind::<BigInt, _>(limit_i64)
-            .load::<EventSearchRow>(&mut conn)
+            .load::<EventSearchRow>(conn)
             .await?
     } else {
         diesel::sql_query(&sql)
             .bind::<Text, _>(query)
             .bind::<Text, _>(pattern)
             .bind::<BigInt, _>(limit_i64)
-            .load::<EventSearchRow>(&mut conn)
+            .load::<EventSearchRow>(conn)
             .await?
     };
 
@@ -255,12 +273,11 @@ fn event_row_to_doc(row: EventSearchRow) -> EventDocument {
 }
 
 async fn search_tags(
+    conn: &mut AsyncPgConnection,
     query: &str,
     pattern: &str,
     limit_i64: i64,
-) -> crate::error::AppResult<Vec<TagDocument>> {
-    let mut conn = crate::db::conn().await?;
-
+) -> Result<Vec<TagDocument>, diesel::result::Error> {
     let rows = diesel::sql_query(
         r"
         SELECT
@@ -283,7 +300,7 @@ async fn search_tags(
     .bind::<Text, _>(query)
     .bind::<Text, _>(pattern)
     .bind::<BigInt, _>(limit_i64)
-    .load::<TagSearchRow>(&mut conn)
+    .load::<TagSearchRow>(conn)
     .await?;
 
     Ok(rows

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
+import kotlin.concurrent.Volatile
 
 class EventRepository(
     private val db: PoziomkiDatabase,

--- a/mobile/core/src/iosMain/kotlin/com/poziomki/app/network/ImageFormat.ios.kt
+++ b/mobile/core/src/iosMain/kotlin/com/poziomki/app/network/ImageFormat.ios.kt
@@ -1,6 +1,9 @@
 package com.poziomki.app.network
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
 import platform.Foundation.NSProcessInfo
 
+@OptIn(ExperimentalForeignApi::class)
 actual fun preferredImageFormat(): String =
     if (NSProcessInfo.processInfo.operatingSystemVersion.useContents { majorVersion } >= 16L) "avif" else "webp"

--- a/mobile/core/src/iosMain/kotlin/com/poziomki/app/session/DataStore.ios.kt
+++ b/mobile/core/src/iosMain/kotlin/com/poziomki/app/session/DataStore.ios.kt
@@ -2,11 +2,13 @@ package com.poziomki.app.session
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSUserDomainMask
 
+@OptIn(ExperimentalForeignApi::class)
 fun createDataStoreIos(): DataStore<Preferences> =
     createDataStore {
         val directoryUrl =

--- a/mobile/core/src/iosMain/kotlin/com/poziomki/app/session/IosSecureSessionTokenStore.kt
+++ b/mobile/core/src/iosMain/kotlin/com/poziomki/app/session/IosSecureSessionTokenStore.kt
@@ -1,19 +1,31 @@
 package com.poziomki.app.session
 
-import kotlinx.cinterop.CFTypeRefVar
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
+import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.toCValues
+import kotlinx.cinterop.value
+import platform.CoreFoundation.CFDataCreate
+import platform.CoreFoundation.CFDataGetBytePtr
+import platform.CoreFoundation.CFDataGetLength
+import platform.CoreFoundation.CFDictionaryCreateMutable
 import platform.CoreFoundation.CFDictionaryRef
-import platform.Foundation.NSData
-import platform.Foundation.NSString
-import platform.Foundation.NSUTF8StringEncoding
-import platform.Foundation.create
-import platform.Foundation.dataUsingEncoding
-import platform.Foundation.stringWithUTF8String
+import platform.CoreFoundation.CFDictionarySetValue
+import platform.CoreFoundation.CFRelease
+import platform.CoreFoundation.CFStringCreateWithCString
+import platform.CoreFoundation.CFTypeRefVar
+import platform.CoreFoundation.kCFAllocatorDefault
+import platform.CoreFoundation.kCFBooleanTrue
+import platform.CoreFoundation.kCFStringEncodingUTF8
 import platform.Security.SecItemAdd
 import platform.Security.SecItemCopyMatching
 import platform.Security.SecItemDelete
 import platform.Security.errSecSuccess
+import platform.Security.kSecAttrAccessible
+import platform.Security.kSecAttrAccessibleWhenUnlockedThisDeviceOnly
 import platform.Security.kSecAttrAccount
 import platform.Security.kSecAttrService
 import platform.Security.kSecClass
@@ -23,41 +35,91 @@ import platform.Security.kSecMatchLimitOne
 import platform.Security.kSecReturnData
 import platform.Security.kSecValueData
 
+@OptIn(ExperimentalForeignApi::class)
 class IosSecureSessionTokenStore : SessionTokenStore {
     override suspend fun getToken(): String? =
-        memScoped {
-            val query =
-                baseQuery().apply { put(kSecReturnData, true) }.apply {
-                    put(kSecMatchLimit, kSecMatchLimitOne)
+        withBaseQuery(includeAccessible = false) { query ->
+            memScoped {
+                CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue)
+                CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne)
+
+                val result = alloc<CFTypeRefVar>()
+                val status = SecItemCopyMatching(query, result.ptr)
+                if (status != errSecSuccess) {
+                    return@memScoped null
                 }
-            val result = alloc<CFTypeRefVar>()
-            val status = SecItemCopyMatching(query as CFDictionaryRef, result.ptr)
-            if (status != errSecSuccess) {
-                return@memScoped null
+
+                val dataRef = result.value?.reinterpret<cnames.structs.__CFData>() ?: return@memScoped null
+                try {
+                    dataRef.toUtf8String()
+                } finally {
+                    CFRelease(dataRef)
+                }
             }
-            val data = result.value as? NSData ?: return@memScoped null
-            NSString.create(data, NSUTF8StringEncoding)?.toString()
         }
 
     override suspend fun saveToken(token: String) {
         clearToken()
-        val data = token.toNSData() ?: return
-        val query = baseQuery().apply { put(kSecValueData, data) }
-        SecItemAdd(query as CFDictionaryRef, null)
+        val data = token.toCFData() ?: return
+        try {
+            withBaseQuery(includeAccessible = true) { query ->
+                CFDictionarySetValue(query, kSecValueData, data)
+                SecItemAdd(query, null)
+            }
+        } finally {
+            CFRelease(data)
+        }
     }
 
     override suspend fun clearToken() {
-        SecItemDelete(baseQuery() as CFDictionaryRef)
+        withBaseQuery(includeAccessible = false) { query ->
+            SecItemDelete(query)
+        }
     }
 
-    private fun baseQuery(): MutableMap<Any?, Any?> =
-        mutableMapOf(
-            kSecClass to kSecClassGenericPassword,
-            kSecAttrService to SERVICE,
-            kSecAttrAccount to ACCOUNT,
-        )
+    private inline fun <T> withBaseQuery(
+        includeAccessible: Boolean,
+        block: (CFDictionaryRef) -> T,
+    ): T? {
+        val query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, null, null) ?: return null
+        val service = CFStringCreateWithCString(kCFAllocatorDefault, SERVICE, kCFStringEncodingUTF8)
+        val account = CFStringCreateWithCString(kCFAllocatorDefault, ACCOUNT, kCFStringEncodingUTF8)
+        if (service == null || account == null) {
+            service?.let(::CFRelease)
+            account?.let(::CFRelease)
+            CFRelease(query)
+            return null
+        }
 
-    private fun String.toNSData(): NSData? = (NSString.stringWithUTF8String(this) as NSString?)?.dataUsingEncoding(NSUTF8StringEncoding)
+        return try {
+            CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword)
+            CFDictionarySetValue(query, kSecAttrService, service)
+            CFDictionarySetValue(query, kSecAttrAccount, account)
+            if (includeAccessible) {
+                CFDictionarySetValue(
+                    query,
+                    kSecAttrAccessible,
+                    kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                )
+            }
+            block(query)
+        } finally {
+            CFRelease(account)
+            CFRelease(service)
+            CFRelease(query)
+        }
+    }
+
+    private fun String.toCFData(): platform.CoreFoundation.CFDataRef? {
+        val bytes = encodeToByteArray().toUByteArray()
+        return CFDataCreate(kCFAllocatorDefault, bytes.toCValues(), bytes.size.toLong())
+    }
+
+    private fun platform.CoreFoundation.CFDataRef.toUtf8String(): String? {
+        val length = CFDataGetLength(this).toInt()
+        val bytes = CFDataGetBytePtr(this) ?: return null
+        return ByteArray(length) { index -> bytes[index].toByte() }.decodeToString()
+    }
 
     private companion object {
         const val SERVICE = "com.poziomki.app.session"


### PR DESCRIPTION
## Summary
- run general search through a viewer-scoped transaction so profile/event/tag queries execute with RLS context
- route chat websocket token auth through the same REST session validation path, including banned users and session expiry/renewal handling
- store iOS session tokens as ThisDeviceOnly keychain items and fix Kotlin/Native keychain interop

## Verification
- cd backend && cargo fmt --check
- cd backend && cargo check
- cd backend && cargo clippy --all-targets --all-features -- -D warnings
- cd backend && cargo test --lib
- cd backend && cargo deny check advisories
- cd backend && cargo audit
- cd mobile && ./gradlew :core:ktlintCheck
- cd mobile && ./gradlew :core:compileKotlinIosSimulatorArm64
- cd mobile && ./gradlew :androidApp:assembleDebug
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix auth and client token security gaps in WebSocket, HTTP search, and iOS Keychain
> - Extracts token validation into a shared `require_auth_token` function in [`auth.rs`](https://github.com/poziomki-app/poziomki/pull/266/files#diff-a95455a48400299e8e3618ecf6c66b8d7f3468741a4249921a2e088a64dec42b) that handles banned users, session renewal, and RLS-aware user loading; WebSocket auth and HTTP middleware both delegate to it
> - WebSocket auth in [`ws.rs`](https://github.com/poziomki-app/poziomki/pull/266/files#diff-11aeaf422f7bb7b849d4b2cbc4c07341e6461eb8c18f9032f4f8594cfc1f0839) now emits distinct `AuthError` messages for banned vs. invalid token cases
> - Search in [`search.rs`](https://github.com/poziomki-app/poziomki/pull/266/files#diff-f157aaca4d578281c5d617b3970ba00ee9a8915ac4d1d1251a5744e61ff62fe1) now runs all queries inside a single transaction with a `DbViewer` context so RLS applies consistently, replacing three parallel independent-connection queries
> - iOS session token storage in [`IosSecureSessionTokenStore.kt`](https://github.com/poziomki-app/poziomki/pull/266/files#diff-11d91f0929d5560b695742e182a17ff945659ca3030de53e63025d3b186fcd66) is rewritten to use CoreFoundation Keychain APIs with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` and proper CF object lifetime management
> - Behavioral Change: search results are now fetched sequentially within one transaction rather than in parallel, which may affect latency under load
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7571eab. 7 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->