### PR TITLE
feat(moderation): blur flagged chat messages, sync-block events + bios

### DIFF
--- a/backend/migrations/2026-04-27-180000_chat_moderation_blur/down.sql
+++ b/backend/migrations/2026-04-27-180000_chat_moderation_blur/down.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS public.chat_message_reveals;
+
+ALTER TABLE public.messages
+    DROP COLUMN IF EXISTS moderation_verdict,
+    DROP COLUMN IF EXISTS moderation_categories,
+    DROP COLUMN IF EXISTS moderation_scanned_at;

--- a/backend/migrations/2026-04-27-180000_chat_moderation_blur/up.sql
+++ b/backend/migrations/2026-04-27-180000_chat_moderation_blur/up.sql
@@ -1,0 +1,78 @@
+-- Chat-message moderation blur + reveal audit.
+--
+-- Today the moderation_scan outbox dispatcher only logs a verdict. To
+-- let clients render flagged messages with a tap-to-reveal blur, the
+-- verdict has to be persisted on the row and broadcast over WS.
+--
+-- `moderation_verdict` is NULL until the async scan completes (clients
+-- treat NULL as "allow" so unscanned messages render normally during
+-- the scan window). After scanning, it's one of `allow` / `flag` /
+-- `block`. We don't enforce a CHECK constraint to keep adding new
+-- verdicts cheap; the worker writes a closed set.
+--
+-- `moderation_categories` carries the flagged subset (e.g.
+-- {"vulgar","hate"}) so the client can render a category-aware
+-- explanation without round-tripping. Empty array when verdict=allow.
+
+ALTER TABLE public.messages
+    ADD COLUMN IF NOT EXISTS moderation_verdict TEXT,
+    ADD COLUMN IF NOT EXISTS moderation_categories TEXT[] NOT NULL DEFAULT '{}'::text[],
+    ADD COLUMN IF NOT EXISTS moderation_scanned_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.messages.moderation_verdict IS
+    'Bielik-Guard verdict: NULL=not yet scanned, ''allow''/''flag''/''block''. Clients render NULL as allow.';
+COMMENT ON COLUMN public.messages.moderation_categories IS
+    'Categories above their flag threshold (vulgar, hate, sex, self_harm, crime). Empty for allow.';
+COMMENT ON COLUMN public.messages.moderation_scanned_at IS
+    'When the moderation_scan dispatcher last wrote a verdict. NULL until first scan.';
+
+-- Append-only audit of who tapped to reveal a flagged/blocked message.
+-- We need this for misuse detection: a viewer who repeatedly unhides
+-- vulgar/hate content is the same signal as a sender who repeatedly
+-- posts it. Admin can query this table directly until a UI exists.
+--
+-- (message_id, viewer_user_id) is the natural PK — revealing twice
+-- is idempotent. `revealed_at` reflects the first reveal.
+CREATE TABLE IF NOT EXISTS public.chat_message_reveals (
+    message_id UUID NOT NULL REFERENCES public.messages(id) ON DELETE CASCADE,
+    viewer_user_id INT4 NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    revealed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (message_id, viewer_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_message_reveals_viewer
+    ON public.chat_message_reveals (viewer_user_id, revealed_at DESC);
+
+COMMENT ON TABLE public.chat_message_reveals IS
+    'Audit of tap-to-reveal actions on flagged chat messages. Append-only; misuse detection.';
+
+-- RLS: a viewer may insert a reveal only for a message they can see
+-- (they're a member of the conversation). They may read their own
+-- reveals (UI cache). Admin role bypasses via BYPASSRLS.
+ALTER TABLE public.chat_message_reveals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chat_message_reveals FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS chat_message_reveals_insert ON public.chat_message_reveals;
+CREATE POLICY chat_message_reveals_insert ON public.chat_message_reveals
+    FOR INSERT
+    WITH CHECK (
+        viewer_user_id = app.current_user_id()
+        AND app.viewer_can_see_message(message_id)
+    );
+
+DROP POLICY IF EXISTS chat_message_reveals_select_self ON public.chat_message_reveals;
+CREATE POLICY chat_message_reveals_select_self ON public.chat_message_reveals
+    FOR SELECT
+    USING (viewer_user_id = app.current_user_id());
+
+-- Grants. The api role inserts/selects for the user; worker doesn't
+-- touch this table. Wrapped in a role-existence guard so dev DBs
+-- (which may not have the least-privilege role created yet) still
+-- migrate cleanly.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT INSERT, SELECT ON public.chat_message_reveals TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/api/chat/messages.rs
+++ b/backend/src/api/chat/messages.rs
@@ -543,6 +543,8 @@ async fn batch_messages_to_payloads(
             is_mine: msg.sender_id == viewer_user_id,
             is_edited: msg.edited_at.is_some(),
             created_at: msg.created_at.to_rfc3339(),
+            moderation_verdict: msg.moderation_verdict.clone(),
+            moderation_categories: msg.moderation_categories.clone(),
         });
     }
 

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -5,6 +5,7 @@ pub mod protocol;
 pub mod push;
 pub mod report_handler;
 pub mod report_repo;
+pub mod reveal_handler;
 pub mod ws;
 
 use axum::{

--- a/backend/src/api/chat/protocol.rs
+++ b/backend/src/api/chat/protocol.rs
@@ -152,6 +152,14 @@ pub struct MessagePayload {
     pub is_mine: bool,
     pub is_edited: bool,
     pub created_at: String,
+    /// Bielik-Guard verdict: `None` = not yet scanned (clients render
+    /// as allow), `"allow"` / `"flag"` / `"block"` once scanned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub moderation_verdict: Option<String>,
+    /// Categories above the flag threshold. Always present (possibly
+    /// empty) so clients don't need to default-construct.
+    #[serde(default)]
+    pub moderation_categories: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/backend/src/api/chat/reveal_handler.rs
+++ b/backend/src/api/chat/reveal_handler.rs
@@ -1,0 +1,97 @@
+//! Tap-to-reveal audit endpoint for flagged chat messages.
+//!
+//! When a viewer chooses to unblur a message that the moderation
+//! engine flagged or blocked, the client posts here. We insert one
+//! audit row per (message, viewer) so abuse of the reveal action
+//! (e.g. someone repeatedly unhiding hate-speech) is greppable.
+//! The PK makes repeat reveals idempotent — a 200 always means
+//! "your reveal is recorded", regardless of whether it was the
+//! first or fifth tap.
+
+use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::RunQueryDsl;
+
+use crate::api::common::{auth_or_respond, error_response, parse_uuid_response, ErrorSpec};
+use crate::api::state::SuccessResponse;
+use crate::app::AppContext;
+use crate::db;
+use crate::db::schema::chat_message_reveals::dsl as r;
+
+type Result<T> = crate::error::AppResult<T>;
+
+enum RevealOutcome {
+    NotFound,
+    Inserted,
+}
+
+pub(in crate::api) async fn message_reveal(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Response> {
+    let (_session, user) = auth_or_respond!(headers);
+
+    let message_id = match parse_uuid_response(&id, "message", &headers) {
+        Ok(id) => id,
+        Err(response) => return Ok(*response),
+    };
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let viewer_user_id = user.id;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            // RLS on chat_message_reveals enforces both that the
+            // viewer is a member of the message's conversation and
+            // that they're inserting for themselves. So the only
+            // failure mode we need to surface is "message doesn't
+            // exist" — which RLS would surface as a CHECK violation
+            // we can't distinguish, hence the explicit pre-check.
+            let exists: bool = crate::db::schema::messages::table
+                .filter(crate::db::schema::messages::id.eq(message_id))
+                .count()
+                .get_result::<i64>(conn)
+                .await?
+                > 0;
+            if !exists {
+                return Ok::<_, diesel::result::Error>(RevealOutcome::NotFound);
+            }
+
+            diesel::insert_into(r::chat_message_reveals)
+                .values((
+                    r::message_id.eq(message_id),
+                    r::viewer_user_id.eq(viewer_user_id),
+                    r::revealed_at.eq(chrono::Utc::now()),
+                ))
+                .on_conflict((r::message_id, r::viewer_user_id))
+                .do_nothing()
+                .execute(conn)
+                .await?;
+
+            Ok(RevealOutcome::Inserted)
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    match outcome {
+        RevealOutcome::NotFound => Ok(error_response(
+            axum::http::StatusCode::NOT_FOUND,
+            &headers,
+            ErrorSpec {
+                error: "Message not found".to_string(),
+                code: "NOT_FOUND",
+                details: None,
+            },
+        )),
+        RevealOutcome::Inserted => Ok(Json(SuccessResponse { success: true }).into_response()),
+    }
+}

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -14,6 +14,7 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
+use crate::api::common::{error_response, ErrorSpec};
 use crate::api::state::{
     AttendEventBody, AttendeeStatus, CreateEventBody, DataResponse, EventResponse, SuccessResponse,
     UpdateEventBody,
@@ -37,6 +38,90 @@ use super::events_tags_service::{
 use super::events_view::{build_event_response_raw, created_event_response, resolve_event_images};
 use super::events_write_repo::{self, is_serialization_failure};
 use super::events_write_service::prepare_update_changeset;
+
+/// Run Bielik-Guard against the supplied event text. Returns
+/// `Ok(None)` when moderation passes (allow / flag) or is disabled,
+/// `Ok(Some(response))` when the engine blocks — caller must return
+/// it as the handler's final response. Mirrors `moderate_bio_text`
+/// with the same `BIO` preset (conservative for sync gates) and a
+/// distinct error code so the client can decide which form field
+/// to highlight.
+async fn moderate_event_text(
+    text: &str,
+    field: &'static str,
+    headers: &HeaderMap,
+) -> Result<Option<Response>> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let Some(engine) = crate::moderation::shared() else {
+        return Ok(None);
+    };
+
+    let owned = trimmed.to_string();
+    let started = std::time::Instant::now();
+    let scores = tokio::task::spawn_blocking(move || engine.score(&owned))
+        .await
+        .map_err(|e| crate::error::AppError::Message(format!("moderation task: {e}")))?
+        .map_err(|e| crate::error::AppError::Message(format!("moderation inference: {e}")))?;
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+    let thresholds = crate::moderation::Thresholds::BIO;
+    let verdict = scores.verdict(&thresholds);
+    let flagged = scores.flagged(&thresholds);
+
+    metrics::histogram!("moderation_inference_latency_ms", "kind" => "event").record(elapsed_ms);
+    metrics::counter!(
+        "moderation_verdicts_total",
+        "kind" => "event",
+        "verdict" => verdict.as_str()
+    )
+    .increment(1);
+
+    match verdict {
+        crate::moderation::Verdict::Allow => Ok(None),
+        crate::moderation::Verdict::Flag => {
+            tracing::warn!(
+                field = field,
+                flagged = ?flagged.iter().map(|(c, s)| format!("{}={s:.2}", c.as_str())).collect::<Vec<_>>(),
+                elapsed_ms,
+                "event moderation: flagged for review (allowed to publish)"
+            );
+            Ok(None)
+        }
+        crate::moderation::Verdict::Block => {
+            let categories: Vec<&'static str> = flagged.iter().map(|(c, _)| c.as_str()).collect();
+            tracing::warn!(
+                field = field,
+                categories = ?categories,
+                elapsed_ms,
+                "event moderation: blocked on publish"
+            );
+            let label = match field {
+                "title" => "Tytuł",
+                "description" => "Opis",
+                _ => "Treść",
+            };
+            let error_msg = format!(
+                "{label} wydarzenia narusza zasady społeczności ({}). Proszę go zmienić przed zapisaniem.",
+                categories.join(", ")
+            );
+            Ok(Some(error_response(
+                axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+                headers,
+                ErrorSpec {
+                    error: error_msg,
+                    code: "EVENT_CONTENT_REJECTED",
+                    details: Some(serde_json::json!({
+                        "field": field,
+                        "categories": categories,
+                    })),
+                },
+            )))
+        }
+    }
+}
 
 /// Wrap an `AppError` into a diesel-level error so it can propagate through
 /// transaction boundaries. `Message` / `Validation` preserve their text for
@@ -138,6 +223,19 @@ pub(in crate::api) async fn event_create(
         Ok(v) => v,
         Err(response) => return Ok(*response),
     };
+
+    // Sync moderation gate for user-supplied free-text fields, mirroring
+    // the bio path. Title runs first because it's required; description
+    // only runs if present + non-empty.
+    if let Some(response) = moderate_event_text(&validated.title, "title", &headers).await? {
+        return Ok(response);
+    }
+    if let Some(desc) = payload.description.as_deref() {
+        if let Some(response) = moderate_event_text(desc, "description", &headers).await? {
+            return Ok(response);
+        }
+    }
+
     let tag_names = payload.tags.clone();
     let user_id = viewer.user_id;
 
@@ -269,6 +367,19 @@ pub(in crate::api) async fn event_update(
         },
         None => None,
     };
+
+    // Sync moderation gate. Only run on fields the caller is actually
+    // changing — partial updates omit unchanged fields.
+    if let Some(ref new_title) = payload.title {
+        if let Some(response) = moderate_event_text(new_title, "title", &headers).await? {
+            return Ok(response);
+        }
+    }
+    if let Some(Some(ref new_desc)) = payload.description {
+        if let Some(response) = moderate_event_text(new_desc, "description", &headers).await? {
+            return Ok(response);
+        }
+    }
 
     let mut conn = crate::db::conn().await?;
     let user_id = viewer.user_id;

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -195,6 +195,10 @@ fn chat_routes() -> Router<AppContext> {
             "/conversations/{id}/report",
             post(chat::report_handler::conversation_report),
         )
+        .route(
+            "/messages/{id}/reveal",
+            post(chat::reveal_handler::message_reveal),
+        )
         .route("/push/register", post(chat::push_register))
         .route("/push/unregister", post(chat::push_unregister))
         .layer(cache_layer("no-store"))

--- a/backend/src/db/models/messages.rs
+++ b/backend/src/db/models/messages.rs
@@ -18,6 +18,9 @@ pub struct Message {
     pub edited_at: Option<DateTime<Utc>>,
     pub deleted_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
+    pub moderation_verdict: Option<String>,
+    pub moderation_categories: Vec<String>,
+    pub moderation_scanned_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Insertable)]

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -36,6 +36,17 @@ diesel::table! {
         edited_at -> Nullable<Timestamptz>,
         deleted_at -> Nullable<Timestamptz>,
         created_at -> Timestamptz,
+        moderation_verdict -> Nullable<Text>,
+        moderation_categories -> Array<Text>,
+        moderation_scanned_at -> Nullable<Timestamptz>,
+    }
+}
+
+diesel::table! {
+    chat_message_reveals (message_id, viewer_user_id) {
+        message_id -> Uuid,
+        viewer_user_id -> Int4,
+        revealed_at -> Timestamptz,
     }
 }
 
@@ -327,6 +338,8 @@ diesel::joinable!(conversations -> events (event_id));
 diesel::joinable!(messages -> conversations (conversation_id));
 diesel::joinable!(messages -> uploads (attachment_upload_id));
 diesel::joinable!(message_reactions -> messages (message_id));
+diesel::joinable!(chat_message_reveals -> messages (message_id));
+diesel::joinable!(chat_message_reveals -> users (viewer_user_id));
 diesel::joinable!(recommendation_feedback -> events (event_id));
 diesel::joinable!(recommendation_feedback -> profiles (profile_id));
 diesel::joinable!(event_attendees -> events (event_id));
@@ -347,6 +360,7 @@ diesel::joinable!(task_completions -> profiles (profile_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     auth_rate_limits,
+    chat_message_reveals,
     conversation_members,
     conversations,
     degrees,

--- a/backend/src/jobs/outbox/outbox_dispatch.rs
+++ b/backend/src/jobs/outbox/outbox_dispatch.rs
@@ -1,6 +1,9 @@
+use diesel::prelude::*;
 use diesel::sql_types::{BigInt, Text};
 use diesel_async::RunQueryDsl;
 use serde::Deserialize;
+
+use crate::db::schema::messages::dsl as m;
 
 use super::OutboxJob;
 
@@ -149,6 +152,41 @@ async fn dispatch_moderation_scan(payload_json: &str) -> std::result::Result<(),
             elapsed_ms,
             "moderation: content allowed"
         );
+    }
+
+    // Persist the verdict on the message row so clients can render a
+    // blur overlay on next history fetch / conversation reload. Worker
+    // connects with BYPASSRLS, so a direct UPDATE bypasses the chat
+    // membership policies that gate normal callers.
+    //
+    // Live WS broadcast of the verdict change is intentionally not
+    // wired in this PR — would require LISTEN/NOTIFY plumbing between
+    // worker and api processes. Eventual consistency on next read is
+    // acceptable for v1 (typical user opens the chat and sees the
+    // blur immediately on history load).
+    if target_kind == "message" {
+        let message_uuid = match uuid::Uuid::parse_str(&target_id) {
+            Ok(u) => u,
+            Err(e) => return Err(format!("invalid message target_id {target_id}: {e}")),
+        };
+        let verdict_str = verdict.as_str().to_string();
+        let categories: Vec<String> = flagged
+            .iter()
+            .map(|(c, _)| c.as_str().to_string())
+            .collect();
+        let mut conn = crate::db::conn()
+            .await
+            .map_err(|e| format!("moderation write-back: pool: {e}"))?;
+        let now = chrono::Utc::now();
+        diesel::update(m::messages.filter(m::id.eq(message_uuid)))
+            .set((
+                m::moderation_verdict.eq(verdict_str),
+                m::moderation_categories.eq(categories),
+                m::moderation_scanned_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .map_err(|e| format!("moderation write-back: update: {e}"))?;
     }
 
     Ok(())

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.18.4" // x-release-please-version
+val appVersionName = "0.18.6" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -7,21 +7,34 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.poziomki.app.chat.push.NotificationChatTarget
+import com.poziomki.app.session.AppPreferences
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
+    private val appPreferences: AppPreferences by inject()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Block screenshots + recent-apps previews of the whole app.
-        // Chat messages, profile edit, and password-reset flows all
-        // surface PII that shouldn't leak to a device's recents
-        // carousel, screen-record apps, or untrusted projections.
-        // Set once on MainActivity because the app is single-activity;
-        // every screen inherits the window flag.
-        window.setFlags(
-            WindowManager.LayoutParams.FLAG_SECURE,
-            WindowManager.LayoutParams.FLAG_SECURE,
-        )
+        // Block screenshots + recent-apps previews by default. Chat
+        // messages, profile edit, and password-reset flows all surface
+        // PII that shouldn't leak to a device's recents carousel,
+        // screen-record apps, or untrusted projections. Users can opt
+        // in via Privacy settings; the toggle defaults off so the first
+        // frame is always protected.
+        applySecureFlag(secure = true)
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                appPreferences.screenshotsAllowed.collect { allowed ->
+                    applySecureFlag(secure = !allowed)
+                }
+            }
+        }
         if (savedInstanceState == null) {
             handleIntent(intent)
         }
@@ -43,5 +56,13 @@ class MainActivity : ComponentActivity() {
 
     private fun handleIntent(intent: Intent?) {
         NotificationChatTarget.open(intent?.getStringExtra(NotificationChatTarget.EXTRA_OPEN_CHAT_ROOM_ID))
+    }
+
+    private fun applySecureFlag(secure: Boolean) {
+        if (secure) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
@@ -85,6 +85,7 @@ import kotlinx.datetime.toLocalDateTime
 import com.poziomki.app.ui.designsystem.theme.Surface as SurfaceColor
 
 @OptIn(ExperimentalMaterial3Api::class)
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @Composable
 fun ChatContent(
     state: ChatUiState,
@@ -99,6 +100,7 @@ fun ChatContent(
     onStartEdit: (TimelineItem.Event) -> Unit,
     onCancelComposerMode: () -> Unit,
     onRedactEvent: (String) -> Unit,
+    onRevealModeration: (TimelineItem.Event) -> Unit,
     onClearError: () -> Unit,
     onNavigateToProfile: (String) -> Unit,
     resolveDisplayNames: suspend (List<String>) -> Map<String, String>,
@@ -217,6 +219,7 @@ fun ChatContent(
                                         onSenderClick = { item.senderPid?.let { onNavigateToProfile(it) } },
                                         onActionsLongPress = { selectedActionEvent = item },
                                         onSwipeReply = { onStartReply(item) },
+                                        onRevealModeration = { onRevealModeration(item) },
                                         compactTimestamp = showSenderMeta,
                                         avatarOverride =
                                             resolveAvatarOverride(item.senderId, avatarOverrides)

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -162,6 +162,7 @@ fun ChatScreen(
             onStartEdit = viewModel::startEdit,
             onCancelComposerMode = viewModel::cancelComposerMode,
             onRedactEvent = viewModel::redactEvent,
+            onRevealModeration = viewModel::revealModeration,
             onClearError = viewModel::clearError,
             onNavigateToProfile = onNavigateToProfile,
             resolveDisplayNames = viewModel::resolveDisplayNames,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -318,6 +318,21 @@ class ChatViewModel(
         }
     }
 
+    fun revealModeration(event: TimelineItem.Event) {
+        // Local unblur is fire-and-forget — no point blocking the UI
+        // on the audit POST. The server-side audit row is best-effort;
+        // if the network drops we still let the user see what they
+        // asked for. The server-side row is for misuse detection,
+        // not access control.
+        viewModelScope.launch {
+            val timeline = activeTimeline ?: return@launch
+            timeline.markModerationRevealed(event.eventOrTransactionId)
+            event.eventId?.let { messageId ->
+                apiService.revealChatMessage(messageId)
+            }
+        }
+    }
+
     fun clearError() {
         _uiState.update { it.copy(error = null) }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -74,6 +74,7 @@ import com.poziomki.app.ui.designsystem.theme.Surface as SurfaceColor
 private val AvatarSize = 28.dp
 private val AvatarSpacing = 6.dp
 
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @Composable
 internal fun MessageEventRow(
     event: TimelineItem.Event,
@@ -85,6 +86,7 @@ internal fun MessageEventRow(
     onSenderClick: () -> Unit,
     onActionsLongPress: () -> Unit,
     onSwipeReply: () -> Unit,
+    onRevealModeration: () -> Unit,
     compactTimestamp: Boolean = false,
     avatarOverride: String? = null,
     isHighlighted: Boolean = false,
@@ -210,6 +212,7 @@ internal fun MessageEventRow(
                                     event = event,
                                     onFocusOnReply = onFocusOnReply,
                                     compactTimestamp = compactTimestamp,
+                                    onRevealModeration = onRevealModeration,
                                 )
                             }
                             if (event.reactions.isNotEmpty()) {
@@ -298,6 +301,7 @@ internal fun MessageEventRow(
                                         event = event,
                                         onFocusOnReply = onFocusOnReply,
                                         compactTimestamp = compactTimestamp,
+                                        onRevealModeration = onRevealModeration,
                                     )
                                 }
                                 if (event.reactions.isNotEmpty()) {
@@ -354,6 +358,7 @@ private fun BubbleContent(
     event: TimelineItem.Event,
     onFocusOnReply: () -> Unit,
     compactTimestamp: Boolean,
+    onRevealModeration: () -> Unit,
 ) {
     Column(
         modifier =
@@ -369,11 +374,31 @@ private fun BubbleContent(
             )
             Spacer(modifier = Modifier.height(6.dp))
         }
-        Text(
-            text = event.body,
-            style = MaterialTheme.typography.bodyLarge,
-            color = TextPrimary,
-        )
+        // Hide flagged/blocked content from recipients until they tap
+        // to reveal. Senders see their own message normally with a
+        // subtle warning chip — they wrote it, so blurring it would
+        // be patronising; instead we surface that the message was
+        // flagged so they don't repeat the pattern.
+        val isFlagged =
+            !event.isMine &&
+                !event.locallyRevealed &&
+                event.moderationVerdict in setOf("flag", "block")
+        if (isFlagged) {
+            FlaggedMessagePlaceholder(
+                categories = event.moderationCategories,
+                onReveal = onRevealModeration,
+            )
+        } else {
+            Text(
+                text = event.body,
+                style = MaterialTheme.typography.bodyLarge,
+                color = TextPrimary,
+            )
+            if (event.isMine && event.moderationVerdict in setOf("flag", "block")) {
+                Spacer(modifier = Modifier.height(4.dp))
+                OwnFlaggedNote(categories = event.moderationCategories)
+            }
+        }
         Row(
             modifier = Modifier.align(Alignment.End).padding(top = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -395,6 +420,61 @@ private fun BubbleContent(
         }
     }
 }
+
+@Composable
+private fun FlaggedMessagePlaceholder(
+    categories: List<String>,
+    onReveal: () -> Unit,
+) {
+    val label = polishCategoryList(categories)
+    Surface(
+        color = SurfaceColor,
+        shape = RoundedCornerShape(8.dp),
+        modifier =
+            Modifier
+                .clickable(onClick = onReveal),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+        ) {
+            Text(
+                text = "Wiadomość oznaczona jako $label",
+                style = MaterialTheme.typography.bodyMedium,
+                color = TextSecondary,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = "Stuknij, aby pokazać",
+                style = MaterialTheme.typography.labelSmall,
+                color = Primary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun OwnFlaggedNote(categories: List<String>) {
+    Text(
+        text = "Twoja wiadomość została oznaczona jako ${polishCategoryList(categories)}.",
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.error,
+    )
+}
+
+private fun polishCategoryList(categories: List<String>): String {
+    if (categories.isEmpty()) return "potencjalnie nieodpowiednia"
+    return categories.joinToString(", ") { translateCategory(it) }
+}
+
+private fun translateCategory(category: String): String =
+    when (category) {
+        "vulgar" -> "wulgarna"
+        "hate" -> "mowa nienawiści"
+        "sex" -> "treść seksualna"
+        "self_harm" -> "samookaleczenie"
+        "crime" -> "treść przestępcza"
+        else -> category
+    }
 
 @Composable
 private fun OutgoingMessageStatusIcon(event: TimelineItem.Event) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
@@ -143,6 +143,7 @@ fun EventChatScreen(
                         onStartEdit = chatViewModel::startEdit,
                         onCancelComposerMode = chatViewModel::cancelComposerMode,
                         onRedactEvent = chatViewModel::redactEvent,
+                        onRevealModeration = chatViewModel::revealModeration,
                         onClearError = chatViewModel::clearError,
                         onNavigateToProfile = onNavigateToProfile,
                         resolveDisplayNames = chatViewModel::resolveDisplayNames,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateViewModel.kt
@@ -241,7 +241,7 @@ class EventCreateViewModel(
                 tagIds = s.selectedTags.map { it.id },
                 requiresApproval = s.requiresApproval,
             )
-        when (eventRepository.updateEvent(eventId, request)) {
+        when (val result = eventRepository.updateEvent(eventId, request)) {
             is ApiResult.Success -> {
                 onSaved()
             }
@@ -250,7 +250,7 @@ class EventCreateViewModel(
                 _state.value =
                     _state.value.copy(
                         isLoading = false,
-                        error = "Nie udało się zaktualizować wydarzenia",
+                        error = moderationAwareError(result, "Nie udało się zaktualizować wydarzenia"),
                     )
             }
         }
@@ -275,7 +275,7 @@ class EventCreateViewModel(
                 tagIds = s.selectedTags.map { it.id },
                 requiresApproval = if (s.requiresApproval) true else null,
             )
-        when (eventRepository.createEvent(request)) {
+        when (val result = eventRepository.createEvent(request)) {
             is ApiResult.Success -> {
                 onSaved()
             }
@@ -284,11 +284,24 @@ class EventCreateViewModel(
                 _state.value =
                     _state.value.copy(
                         isLoading = false,
-                        error = "Nie udało się utworzyć wydarzenia",
+                        error = moderationAwareError(result, "Nie udało się utworzyć wydarzenia"),
                     )
             }
         }
     }
+
+    private fun moderationAwareError(
+        result: ApiResult.Error,
+        fallback: String,
+    ): String =
+        if (result.code == "EVENT_CONTENT_REJECTED" || result.code == "BIO_CONTENT_REJECTED") {
+            // Server-side moderation rejection — its `message` is
+            // already a user-facing Polish sentence with the
+            // categories listed. Surface it verbatim.
+            result.message
+        } else {
+            fallback
+        }
 
     companion object {
         private const val MAX_EVENT_TAGS = 15

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
@@ -97,6 +97,7 @@ fun PrivacyScreen(
             onDelete = { showDeleteDialog = true },
             onToggleDiscoverable = viewModel::toggleDiscoverable,
             onToggleShowProgram = viewModel::toggleShowProgram,
+            onToggleScreenshots = viewModel::toggleScreenshotsAllowed,
         )
     }
 
@@ -138,6 +139,7 @@ private fun PrivacyContent(
     onDelete: () -> Unit,
     onToggleDiscoverable: (Boolean) -> Unit,
     onToggleShowProgram: (Boolean) -> Unit,
+    onToggleScreenshots: (Boolean) -> Unit,
 ) {
     Column(
         modifier =
@@ -164,6 +166,17 @@ private fun PrivacyContent(
             description = "Inni widzą Twój kierunek na profilu",
             checked = state.showProgram,
             onCheckedChange = onToggleShowProgram,
+            nunito = nunito,
+        )
+
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
+        SectionLabel("ZRZUTY EKRANU", color = TextMuted)
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
+        PrivacyToggleRow(
+            label = "zezwalaj na zrzuty ekranu",
+            description = "Pozwala robić screenshoty i pokazuje aplikację w podglądzie ostatnich aplikacji",
+            checked = state.screenshotsAllowed,
+            onCheckedChange = onToggleScreenshots,
             nunito = nunito,
         )
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
@@ -6,11 +6,14 @@ import com.poziomki.app.data.CacheManager
 import com.poziomki.app.data.repository.SettingsRepository
 import com.poziomki.app.network.ApiResult
 import com.poziomki.app.network.ApiService
+import com.poziomki.app.session.AppPreferences
 import com.poziomki.app.session.SessionManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 data class PrivacyState(
@@ -23,6 +26,7 @@ data class PrivacyState(
     val error: String? = null,
     val discoverable: Boolean = true,
     val showProgram: Boolean = true,
+    val screenshotsAllowed: Boolean = false,
 )
 
 class PrivacyViewModel(
@@ -30,6 +34,7 @@ class PrivacyViewModel(
     private val sessionManager: SessionManager,
     private val cacheManager: CacheManager,
     private val settingsRepository: SettingsRepository,
+    private val appPreferences: AppPreferences,
 ) : ViewModel() {
     private val _state = MutableStateFlow(PrivacyState())
     val state: StateFlow<PrivacyState> = _state.asStateFlow()
@@ -46,6 +51,17 @@ class PrivacyViewModel(
                         showProgram = settings.privacy_show_program != 0L,
                     )
             }
+        }
+        appPreferences.screenshotsAllowed
+            .onEach { allowed ->
+                _state.value = _state.value.copy(screenshotsAllowed = allowed)
+            }.launchIn(viewModelScope)
+    }
+
+    fun toggleScreenshotsAllowed(enabled: Boolean) {
+        _state.value = _state.value.copy(screenshotsAllowed = enabled)
+        viewModelScope.launch {
+            appPreferences.setScreenshotsAllowed(enabled)
         }
     }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditViewModel.kt
@@ -297,7 +297,7 @@ class ProfileEditViewModel(
                     gradientStart = s.gradientStart ?: "",
                     gradientEnd = s.gradientEnd ?: "",
                 )
-            when (profileRepository.updateProfile(s.profileId, request)) {
+            when (val result = profileRepository.updateProfile(s.profileId, request)) {
                 is ApiResult.Success -> {
                     for (imageUrl in removedImages) {
                         val filename = imageUrl.substringAfterLast("/").substringBefore("?")
@@ -310,9 +310,18 @@ class ProfileEditViewModel(
                 }
 
                 is ApiResult.Error -> {
+                    val message =
+                        if (result.code == "BIO_CONTENT_REJECTED") {
+                            // Server returns a Polish, category-aware
+                            // sentence \u2014 surface it verbatim instead
+                            // of the generic save-failed snackbar.
+                            result.message
+                        } else {
+                            "nie uda\u0142o si\u0119 zapisa\u0107 profilu"
+                        }
                     _state.value =
                         _state.value.copy(
-                            snackbarMessage = "nie uda\u0142o si\u0119 zapisa\u0107 profilu",
+                            snackbarMessage = message,
                             snackbarType = SnackbarType.ERROR,
                         )
                 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/Timeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/Timeline.kt
@@ -57,6 +57,21 @@ sealed interface TimelineItem {
         val sendStatus: EventSendStatus?,
         val readByCount: Int,
         val canReply: Boolean,
+        /**
+         * Bielik-Guard verdict for this message body. `null` until the
+         * async scan completes (clients render as allow). `"allow"` /
+         * `"flag"` / `"block"` once scanned.
+         */
+        val moderationVerdict: String? = null,
+        /** Categories that exceeded the flag threshold, e.g. `["vulgar"]`. */
+        val moderationCategories: List<String> = emptyList(),
+        /**
+         * `true` once the local viewer has tapped to reveal a
+         * flagged/blocked message. Not persisted server-side per
+         * device — re-blurs on app restart unless the cache layer
+         * later carries the reveal state.
+         */
+        val locallyRevealed: Boolean = false,
     ) : TimelineItem
 
     data class DateDivider(
@@ -117,6 +132,15 @@ interface Timeline : AutoCloseable {
     suspend fun markAsRead(): Result<Unit>
 
     suspend fun sendReadReceipt(eventId: String): Result<Unit>
+
+    /**
+     * Locally unblur a moderation-flagged message. The audit-trail
+     * POST to `/chat/messages/:id/reveal` is the caller's
+     * responsibility — keeping it out of the timeline lets a
+     * higher-level view-model fail loudly on network errors without
+     * blocking the UI from updating. Idempotent.
+     */
+    suspend fun markModerationRevealed(eventId: String): Result<Unit>
 
     override fun close()
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt
@@ -132,6 +132,9 @@ private sealed interface CachedTimelineItem {
         val sendStatus: CachedEventSendStatus?,
         val readByCount: Int,
         val canReply: Boolean,
+        val moderationVerdict: String? = null,
+        val moderationCategories: List<String> = emptyList(),
+        val locallyRevealed: Boolean = false,
     ) : CachedTimelineItem {
         override fun toDomain(): TimelineItem =
             TimelineItem.Event(
@@ -150,6 +153,9 @@ private sealed interface CachedTimelineItem {
                 sendStatus = sendStatus?.toDomain(),
                 readByCount = readByCount,
                 canReply = canReply,
+                moderationVerdict = moderationVerdict,
+                moderationCategories = moderationCategories,
+                locallyRevealed = locallyRevealed,
             )
     }
 
@@ -190,6 +196,9 @@ private sealed interface CachedTimelineItem {
                         sendStatus = item.sendStatus?.toCached(),
                         readByCount = item.readByCount,
                         canReply = item.canReply,
+                        moderationVerdict = item.moderationVerdict,
+                        moderationCategories = item.moderationCategories,
+                        locallyRevealed = item.locallyRevealed,
                     )
                 }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
@@ -115,6 +115,8 @@ sealed interface WsServerMessage {
         val isMine: Boolean = false,
         val isEdited: Boolean = false,
         val createdAt: String,
+        val moderationVerdict: String? = null,
+        val moderationCategories: List<String> = emptyList(),
     ) : WsServerMessage
 
     @Serializable
@@ -202,6 +204,8 @@ data class WsMessagePayload(
     val isMine: Boolean = false,
     val isEdited: Boolean = false,
     val createdAt: String,
+    val moderationVerdict: String? = null,
+    val moderationCategories: List<String> = emptyList(),
 )
 
 @Serializable

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -425,6 +425,24 @@ class WsTimeline(
     override suspend fun sendReadReceipt(eventId: String): Result<Unit> =
         sendOrFail(WsClientMessage.Read(conversationId = conversationId, messageId = eventId), Unit)
 
+    override suspend fun markModerationRevealed(eventId: String): Result<Unit> {
+        itemsMutex.withLock {
+            val current = _items.value.toMutableList()
+            val idx =
+                current.indexOfFirst {
+                    it is TimelineItem.Event && it.eventId == eventId
+                }
+            if (idx >= 0) {
+                val event = current[idx] as TimelineItem.Event
+                if (!event.locallyRevealed) {
+                    current[idx] = event.copy(locallyRevealed = true)
+                    emitAndPersist(current)
+                }
+            }
+        }
+        return Result.success(Unit)
+    }
+
     private suspend fun <T> sendOrFail(
         msg: WsClientMessage,
         value: T,
@@ -501,6 +519,8 @@ private fun toTimelineEvent(
     createdAt: String,
     replyTo: WsReplyPayload?,
     reactions: List<WsReactionPayload>,
+    moderationVerdict: String? = null,
+    moderationCategories: List<String> = emptyList(),
 ): TimelineItem.Event {
     val replyDetails =
         replyTo?.let {
@@ -526,12 +546,27 @@ private fun toTimelineEvent(
         sendStatus = EventSendStatus.Sent,
         readByCount = 0,
         canReply = true,
+        moderationVerdict = moderationVerdict,
+        moderationCategories = moderationCategories,
     )
 }
 
 private fun WsServerMessage.Message.toTimelineItem(currentUserId: String?): TimelineItem.Event {
     val mine = currentUserId != null && senderId.toString() == currentUserId
-    return toTimelineEvent(id, senderId, senderPid, senderName, senderAvatar, mine, body, createdAt, replyTo, reactions)
+    return toTimelineEvent(
+        id,
+        senderId,
+        senderPid,
+        senderName,
+        senderAvatar,
+        mine,
+        body,
+        createdAt,
+        replyTo,
+        reactions,
+        moderationVerdict,
+        moderationCategories,
+    )
 }
 
 private fun WsReactionPayload.toReaction(): Reaction {
@@ -549,5 +584,18 @@ private fun WsReactionPayload.toReaction(): Reaction {
 
 internal fun WsMessagePayload.toTimelineItem(currentUserId: String? = null): TimelineItem.Event {
     val mine = if (currentUserId != null) senderId.toString() == currentUserId else isMine
-    return toTimelineEvent(id, senderId, senderPid, senderName, senderAvatar, mine, body, createdAt, replyTo, reactions)
+    return toTimelineEvent(
+        id,
+        senderId,
+        senderPid,
+        senderName,
+        senderAvatar,
+        mine,
+        body,
+        createdAt,
+        replyTo,
+        reactions,
+        moderationVerdict,
+        moderationCategories,
+    )
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
@@ -20,6 +20,7 @@ import com.poziomki.app.db.PoziomkiDatabase
 import com.poziomki.app.network.ApiClient
 import com.poziomki.app.network.ApiService
 import com.poziomki.app.network.GeocodingService
+import com.poziomki.app.session.AppPreferences
 import com.poziomki.app.session.SessionManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -30,6 +31,7 @@ import org.koin.dsl.module
 val sharedModule =
     module {
         single { SessionManager(get(), get()) }
+        single { AppPreferences(get()) }
         single<RoomComposerDraftStore> { SqlDelightRoomComposerDraftStore(get()) }
         single<RoomTimelineCacheStore> { SqlDelightRoomTimelineCacheStore(get()) }
         single {

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
@@ -266,4 +266,9 @@ class ApiService(
             "/api/v1/chat/conversations/$conversationId/report",
             ReportConversationRequest(reason = reason, description = description),
         )
+
+    // Audit a tap-to-reveal of a moderation-flagged chat message.
+    @Suppress("ktlint:standard:function-signature")
+    suspend fun revealChatMessage(messageId: String): ApiResult<SuccessResponse> =
+        client.post("/api/v1/chat/messages/$messageId/reveal")
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/AppPreferences.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/AppPreferences.kt
@@ -1,0 +1,23 @@
+package com.poziomki.app.session
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class AppPreferences(
+    private val dataStore: DataStore<Preferences>,
+) {
+    private companion object {
+        val SCREENSHOTS_ALLOWED = booleanPreferencesKey("screenshots_allowed")
+    }
+
+    val screenshotsAllowed: Flow<Boolean> =
+        dataStore.data.map { prefs -> prefs[SCREENSHOTS_ALLOWED] ?: false }
+
+    suspend fun setScreenshotsAllowed(allowed: Boolean) {
+        dataStore.edit { it[SCREENSHOTS_ALLOWED] = allowed }
+    }
+}


### PR DESCRIPTION
## Summary
- **Chat**: async-flagged messages now persist their verdict on the row and clients render a tap-to-reveal blur. Tapping to unblur posts to a new `/chat/messages/:id/reveal` audit endpoint so admin can grep for misuse of the reveal action.
- **Events**: `event_create` and `event_update` now run the same sync moderation gate as bios — flagged title or description returns 422 with `EVENT_CONTENT_REJECTED` and a Polish, category-aware message that the mobile app surfaces verbatim.
- **Mobile (v0.18.6)**: `BubbleContent` shows `FlaggedMessagePlaceholder` for recipient-side flagged messages; senders see `OwnFlaggedNote` instead of a blur (they wrote it). `EventCreateViewModel` and `ProfileEditViewModel` surface the server's user-facing rejection text instead of a generic "save failed".

This PR also includes the screenshot privacy toggle work that shipped to users as v0.18.5 (`AppPreferences.screenshotsAllowed`, default off, drives `FLAG_SECURE` dynamically).

## Architecture notes
- **Live broadcast deferred.** The worker writes `moderation_verdict` back to the row, but the api process is not yet notified, so blur appears on next history fetch / conversation reload — not the moment the verdict lands. Wiring `LISTEN/NOTIFY` between worker and api is the obvious follow-up; intentionally out of scope here.
- **Reveal audit, not a gate.** The reveal endpoint records who unblurred what and when. It is *not* an access-control mechanism — the body is already in the row and a determined client could ignore the verdict. It's there so a pattern of "user X repeatedly reveals hate-speech" is greppable.
- **No separate per-message report endpoint.** The existing `/conversations/:id/report` covers the "user wants to escalate" case at conversation granularity. We can split message-level reporting into its own endpoint if reveal-audit data shows it's worth it.

## Test plan
- [ ] Run backend tests: `cargo test --workspace`
- [ ] Apply migration on staging, post a vulgar chat message, confirm `messages.moderation_verdict='flag'` and `moderation_categories @> '{vulgar}'` after the worker scan
- [ ] Open the chat on a second device — message renders blurred; tap reveals + inserts a row in `chat_message_reveals`
- [ ] Try to create an event with title `"ty pojebie"` — backend returns 422 `EVENT_CONTENT_REJECTED`; mobile shows the Polish message inline
- [ ] Same for editing an existing event's description
- [ ] Bio: existing `BIO_CONTENT_REJECTED` flow now shows the server message verbatim instead of "nie udało się zapisać profilu"
- [ ] Privacy → "zezwalaj na zrzuty ekranu" toggles `FLAG_SECURE` on the live activity (verify via screenshot attempt + recent-apps preview)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add blur UI for flagged chat messages, tap-to-reveal audit, and sync moderation blocking for events and bios
> - Flagged or blocked chat messages are hidden behind a blurred placeholder for recipients; tapping reveals the content locally and posts an audit record to the new `POST /api/v1/chat/messages/{id}/reveal` endpoint. Senders see their own flagged messages with a warning note instead.
> - Adds `moderation_verdict`, `moderation_categories`, and `moderation_scanned_at` columns to the `messages` table and a new `chat_message_reveals` table (with RLS) to track reveals.
> - Moderation scan jobs now write verdict and categories back to the message row; websocket payloads and the timeline cache carry this metadata through to the UI.
> - Event create and update endpoints now run synchronous Bielik-Guard checks on title and description, returning 422 with code `EVENT_CONTENT_REJECTED` if content is blocked; the mobile event and profile-edit UIs surface the server's error message verbatim.
> - Adds a user-controlled screenshots/recents-preview toggle (Privacy settings), backed by `AppPreferences` (DataStore), defaulting to blocked.
> - Behavioral Change: event creation and update requests may now be rejected with 422 where they previously succeeded; `FLAG_SECURE` on Android is now reactive to a preference rather than always-on.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd46dc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
