### PR TITLE
fix(chat): include moderation_* columns in latest-message query

### DIFF
--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -274,12 +274,17 @@ pub async fn list_for_user(
         return Ok(Vec::new());
     }
 
-    // Batch-load latest message per conversation (DISTINCT ON)
+    // Batch-load latest message per conversation (DISTINCT ON).
+    // Column list must match the `Message` struct field-for-field —
+    // QueryableByName binds by name and a missing column rolls the
+    // entire transaction back. Keep moderation_* explicit so future
+    // schema additions don't break the chat list silently.
     let latest_messages: Vec<crate::db::models::messages::Message> = diesel::sql_query(
         "SELECT DISTINCT ON (conversation_id) \
                  id, conversation_id, sender_id, body, kind, \
                  attachment_upload_id, reply_to_id, client_id, \
-                 edited_at, deleted_at, created_at \
+                 edited_at, deleted_at, created_at, \
+                 moderation_verdict, moderation_categories, moderation_scanned_at \
              FROM messages \
              WHERE conversation_id = ANY($1) AND deleted_at IS NULL \
              ORDER BY conversation_id, created_at DESC, id DESC",


### PR DESCRIPTION
The DISTINCT ON SELECT in `conversations::list_for_user` only listed the 11 pre-moderation columns. After v0.18.6 the `Message` struct grew three new fields (`moderation_verdict`, `moderation_categories`, `moderation_scanned_at`) — `QueryableByName` binds by name, so the missing columns make the whole transaction roll back and the `Wiadomości` list / WS `listConversations` handler returns 500.

**Symptom**: infinite loading on the Wiadomości screen after the v0.18.6 backend deploy. Backend log shows `internal application error: You have asked diesel to rollback the transaction` on `/chat/events/.../conversation` and similar paths that hit this code.

**Fix**: extend the column list. Comment added so the next schema addition has a "remember to update this" pointer.

## Test plan
- [ ] Deploy → Wiadomości list loads
- [ ] Event chat opens (no more 500 on `/chat/events/.../conversation`)
- [ ] Flagged messages render the blur (since the verdict now reaches the client via the conversation list's latest-message field too)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix latest-message query to include `moderation_*` columns in chat conversations
> The `DISTINCT ON` SQL projection in `list_for_user` was missing `moderation_verdict`, `moderation_categories`, and `moderation_scanned_at`, so latest messages loaded per conversation had empty moderation fields. Adds the three columns to match the `Message` struct field-for-field, and updates the comment to note this requirement explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a73949.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->