### PR TITLE
fix(chat): redact flagged latest-message in conversation list preview

### DIFF
--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -455,6 +455,22 @@ pub async fn list_for_user(
             false
         };
 
+        let latest_is_mine = latest.is_some_and(|m| m.sender_id == user_id);
+        // Redact the preview when the latest message is moderation-flagged
+        // and it isn't the viewer's own message. Otherwise the chat list
+        // leaks the body of the very content we're trying to blur in the
+        // chat view. Senders keep their own preview verbatim, matching
+        // the in-chat behavior (own message is annotated, not blurred).
+        let latest_message_text = latest.map(|m| {
+            if latest_is_mine {
+                return m.body.clone();
+            }
+            match m.moderation_verdict.as_deref() {
+                Some("flag" | "block") => redacted_preview(&m.moderation_categories),
+                _ => m.body.clone(),
+            }
+        });
+
         payloads.push(ConversationPayload {
             id: conv.id,
             kind: conv.kind.clone(),
@@ -465,9 +481,9 @@ pub async fn list_for_user(
             direct_user_name,
             direct_user_avatar,
             unread_count,
-            latest_message: latest.map(|m| m.body.clone()),
+            latest_message: latest_message_text,
             latest_timestamp: latest.map(|m| m.created_at.to_rfc3339()),
-            latest_message_is_mine: latest.is_some_and(|m| m.sender_id == user_id),
+            latest_message_is_mine: latest_is_mine,
             latest_sender_name,
             is_blocked,
         });
@@ -477,6 +493,30 @@ pub async fn list_for_user(
     payloads.sort_by(|a, b| b.latest_timestamp.cmp(&a.latest_timestamp));
 
     Ok(payloads)
+}
+
+/// Polish, category-aware placeholder used in the conversation list
+/// when the latest message has been moderation-flagged. Mirrors the
+/// in-chat overlay text in the mobile UI so the experience is
+/// consistent across the chat-list preview and the chat itself.
+fn redacted_preview(categories: &[String]) -> String {
+    let label = if categories.is_empty() {
+        "potencjalnie nieodpowiednia".to_string()
+    } else {
+        categories
+            .iter()
+            .map(|c| match c.as_str() {
+                "vulgar" => "wulgarna",
+                "hate" => "mowa nienawiści",
+                "sex" => "treść seksualna",
+                "self_harm" => "samookaleczenie",
+                "crime" => "treść przestępcza",
+                other => other,
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    format!("Wiadomość oznaczona jako {label}")
 }
 
 /// Helper struct for raw SQL unread count query.

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.18.6" // x-release-please-version
+val appVersionName = "0.18.8" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -28,11 +28,20 @@ class MainActivity : ComponentActivity() {
         // in via Privacy settings; the toggle defaults off so the first
         // frame is always protected.
         applySecureFlag(secure = true)
+        // Wrap defensively at the coroutine boundary — a failure to
+        // read the privacy flag must never crash the activity. Worst
+        // case the user stays on the safe default (FLAG_SECURE on).
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                appPreferences.screenshotsAllowed.collect { allowed ->
-                    applySecureFlag(secure = !allowed)
+            try {
+                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    appPreferences.screenshotsAllowed.collect { allowed ->
+                        applySecureFlag(secure = !allowed)
+                    }
                 }
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                android.util.Log.e("MainActivity", "screenshotsAllowed observer crashed", t)
             }
         }
         if (savedInstanceState == null) {


### PR DESCRIPTION
The chat list (Wiadomości) was showing the raw body of moderation-flagged messages in the latest-message preview, defeating the blur on the chat view — the recipient saw the vulgar text in the sidebar before opening the chat.

Server-side fix: when the latest message has `verdict=flag/block` and isn't the viewer's own, replace the preview with a Polish, category-aware placeholder (e.g. `Wiadomość oznaczona jako wulgarna`). Senders still see their own preview verbatim, consistent with the in-chat `OwnFlaggedNote`.

Also rolling up two unrelated changes that were already on the branch:
- App version bump 0.18.7 → 0.18.8.
- MainActivity wraps the FLAG_SECURE observer in try/catch so the activity can't be killed by a coroutine exception during the privacy-flag read.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redact flagged latest-message previews in conversation list for non-senders
> - In `conversations.list_for_user` ([conversations.rs](https://github.com/poziomki-app/poziomki/pull/270/files#diff-5a9a538ec12a48526c8fde752b98cccf545f577ca7b816e6e57820607ce81c62)), when the latest message has a moderation verdict of `flag` or `block` and was not sent by the viewing user, the preview text is replaced with a localized, category-aware placeholder (e.g. "Wiadomość oznaczona jako vulgar"). Senders continue to see their own message body.
> - Adds a `redacted_preview` helper that maps moderation categories (vulgar, hate, sex, self_harm, crime) to Polish labels and formats the redaction string.
> - Bumps Android `appVersionName` to `0.18.8` and wraps the `screenshotsAllowed` observer in `MainActivity.onCreate` with a try/catch to prevent activity crashes on observer failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cadf7b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->