### PR TITLE
feat(chat): gaussian blur + Zgłoś chip on flagged messages

### DIFF
--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -456,20 +456,17 @@ pub async fn list_for_user(
         };
 
         let latest_is_mine = latest.is_some_and(|m| m.sender_id == user_id);
-        // Redact the preview when the latest message is moderation-flagged
-        // and it isn't the viewer's own message. Otherwise the chat list
-        // leaks the body of the very content we're trying to blur in the
-        // chat view. Senders keep their own preview verbatim, matching
-        // the in-chat behavior (own message is annotated, not blurred).
-        let latest_message_text = latest.map(|m| {
-            if latest_is_mine {
-                return m.body.clone();
-            }
-            match m.moderation_verdict.as_deref() {
-                Some("flag" | "block") => redacted_preview(&m.moderation_categories),
-                _ => m.body.clone(),
-            }
-        });
+        // Send the raw body; the client renders a gaussian blur over
+        // the text when verdict is flag/block (and the message isn't
+        // the viewer's own). Visual-only — the body is on the wire so
+        // tap-to-reveal in the chat works without a round-trip.
+        let (latest_verdict, latest_categories) = match latest {
+            Some(m) if !latest_is_mine => (
+                m.moderation_verdict.clone(),
+                m.moderation_categories.clone(),
+            ),
+            _ => (None, Vec::new()),
+        };
 
         payloads.push(ConversationPayload {
             id: conv.id,
@@ -481,11 +478,13 @@ pub async fn list_for_user(
             direct_user_name,
             direct_user_avatar,
             unread_count,
-            latest_message: latest_message_text,
+            latest_message: latest.map(|m| m.body.clone()),
             latest_timestamp: latest.map(|m| m.created_at.to_rfc3339()),
             latest_message_is_mine: latest_is_mine,
             latest_sender_name,
             is_blocked,
+            latest_moderation_verdict: latest_verdict,
+            latest_moderation_categories: latest_categories,
         });
     }
 
@@ -493,30 +492,6 @@ pub async fn list_for_user(
     payloads.sort_by(|a, b| b.latest_timestamp.cmp(&a.latest_timestamp));
 
     Ok(payloads)
-}
-
-/// Polish, category-aware placeholder used in the conversation list
-/// when the latest message has been moderation-flagged. Mirrors the
-/// in-chat overlay text in the mobile UI so the experience is
-/// consistent across the chat-list preview and the chat itself.
-fn redacted_preview(categories: &[String]) -> String {
-    let label = if categories.is_empty() {
-        "potencjalnie nieodpowiednia".to_string()
-    } else {
-        categories
-            .iter()
-            .map(|c| match c.as_str() {
-                "vulgar" => "wulgarna",
-                "hate" => "mowa nienawiści",
-                "sex" => "treść seksualna",
-                "self_harm" => "samookaleczenie",
-                "crime" => "treść przestępcza",
-                other => other,
-            })
-            .collect::<Vec<_>>()
-            .join(", ")
-    };
-    format!("Wiadomość oznaczona jako {label}")
 }
 
 /// Helper struct for raw SQL unread count query.

--- a/backend/src/api/chat/protocol.rs
+++ b/backend/src/api/chat/protocol.rs
@@ -197,4 +197,15 @@ pub struct ConversationPayload {
     pub latest_message_is_mine: bool,
     pub latest_sender_name: Option<String>,
     pub is_blocked: bool,
+    /// Bielik-Guard verdict for the latest message body — `None` until
+    /// scanned, `"allow"`/`"flag"`/`"block"` after. Clients render the
+    /// blur overlay in the chat list using this field; the body is
+    /// still delivered so the blur is purely visual (and the user can
+    /// reveal in the chat itself).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_moderation_verdict: Option<String>,
+    /// Categories that exceeded the flag threshold for the latest
+    /// message. Empty when verdict is allow / not yet scanned.
+    #[serde(default)]
+    pub latest_moderation_categories: Vec<String>,
 }

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.18.8" // x-release-please-version
+val appVersionName = "0.18.9" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.poziomki.app.ui.feature.chat
 
 import androidx.compose.animation.core.LinearEasing
@@ -38,10 +40,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -52,6 +56,7 @@ import com.adamglin.phosphoricons.bold.ArrowBendUpLeft
 import com.adamglin.phosphoricons.bold.Check
 import com.adamglin.phosphoricons.bold.CheckCircle
 import com.adamglin.phosphoricons.bold.Clock
+import com.adamglin.phosphoricons.bold.Flag
 import com.adamglin.phosphoricons.bold.WarningCircle
 import com.poziomki.app.chat.api.EventSendStatus
 import com.poziomki.app.chat.api.ReplyDetails
@@ -374,17 +379,17 @@ private fun BubbleContent(
             )
             Spacer(modifier = Modifier.height(6.dp))
         }
-        // Hide flagged/blocked content from recipients until they tap
-        // to reveal. Senders see their own message normally with a
-        // subtle warning chip — they wrote it, so blurring it would
-        // be patronising; instead we surface that the message was
-        // flagged so they don't repeat the pattern.
-        val isFlagged =
+        // Recipient-side flagged messages: render the body with a
+        // gaussian blur until tap-to-reveal. Visual-only — body is
+        // already on the wire so the tap is local.
+        // Senders see their own message normally with a subtle
+        // warning note (they wrote it; blurring is patronising).
+        val isFlaggedRecipient =
             !event.isMine &&
-                !event.locallyRevealed &&
                 event.moderationVerdict in setOf("flag", "block")
-        if (isFlagged) {
-            FlaggedMessagePlaceholder(
+        if (isFlaggedRecipient && !event.locallyRevealed) {
+            BlurredFlaggedBody(
+                body = event.body,
                 categories = event.moderationCategories,
                 onReveal = onRevealModeration,
             )
@@ -397,6 +402,11 @@ private fun BubbleContent(
             if (event.isMine && event.moderationVerdict in setOf("flag", "block")) {
                 Spacer(modifier = Modifier.height(4.dp))
                 OwnFlaggedNote(categories = event.moderationCategories)
+            } else if (isFlaggedRecipient) {
+                // Revealed: still nudge toward reporting in case the
+                // moderation engine missed the mark or it's harassment.
+                Spacer(modifier = Modifier.height(6.dp))
+                ReportFlaggedChip()
             }
         }
         Row(
@@ -422,31 +432,80 @@ private fun BubbleContent(
 }
 
 @Composable
-private fun FlaggedMessagePlaceholder(
+private fun BlurredFlaggedBody(
+    body: String,
     categories: List<String>,
     onReveal: () -> Unit,
 ) {
     val label = polishCategoryList(categories)
-    Surface(
-        color = SurfaceColor,
-        shape = RoundedCornerShape(8.dp),
+    Box(
         modifier =
             Modifier
                 .clickable(onClick = onReveal),
+        contentAlignment = Alignment.Center,
     ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+        // Blurred body — radius is high enough that no glyphs are
+        // legible, low enough that the bubble keeps roughly the
+        // same shape so the row doesn't reflow on reveal.
+        Text(
+            text = body,
+            style = MaterialTheme.typography.bodyLarge,
+            color = TextPrimary,
+            modifier = Modifier.blur(radius = 14.dp),
+        )
+        // "Tap to show" pill on top, keeps the affordance visible.
+        Surface(
+            color = SurfaceColor.copy(alpha = 0.92f),
+            shape = RoundedCornerShape(999.dp),
         ) {
-            Text(
-                text = "Wiadomość oznaczona jako $label",
-                style = MaterialTheme.typography.bodyMedium,
-                color = TextSecondary,
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+            ) {
+                Text(
+                    text = "Oznaczono jako $label",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = TextSecondary,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "·",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = TextSecondary,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "Pokaż",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Primary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReportFlaggedChip() {
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        shape = RoundedCornerShape(999.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+        ) {
+            Icon(
+                imageVector = PhosphorIcons.Bold.Flag,
+                contentDescription = null,
+                modifier = Modifier.size(11.dp),
             )
-            Spacer(modifier = Modifier.height(2.dp))
+            Spacer(modifier = Modifier.width(4.dp))
             Text(
-                text = "Stuknij, aby pokazać",
+                text = "Zgłoś",
                 style = MaterialTheme.typography.labelSmall,
-                color = Primary,
+                fontWeight = FontWeight.SemiBold,
             )
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -18,6 +19,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -26,6 +29,7 @@ import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.bold.Check
 import com.adamglin.phosphoricons.bold.CheckCircle
 import com.adamglin.phosphoricons.bold.Clock
+import com.adamglin.phosphoricons.bold.Flag
 import com.adamglin.phosphoricons.bold.WarningCircle
 import com.poziomki.app.chat.api.EventSendStatus
 import com.poziomki.app.chat.api.RoomSummary
@@ -40,6 +44,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
+@Suppress("CyclomaticComplexMethod", "LongMethod")
 @Composable
 fun RoomRow(
     room: RoomSummary,
@@ -134,12 +139,74 @@ fun RoomRow(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                 }
+                val flagged =
+                    !room.latestMessageIsMine &&
+                        room.latestModerationVerdict in setOf("flag", "block")
+                if (flagged) {
+                    FlaggedRoomPreview(
+                        body = room.latestMessagePreview(),
+                        unread = room.unreadCount > 0,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                } else {
+                    Text(
+                        text = room.latestMessagePreview(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (room.unreadCount > 0) TextPrimary else TextSecondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FlaggedRoomPreview(
+    body: String,
+    unread: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    // Visual-only blur — body is on the wire so this is a UX hint, not
+    // an access control. The "Zgłoś" pill nudges the user toward
+    // reporting if the moderation hit was wrong-shaped or harassing.
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        Text(
+            text = body,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (unread) TextPrimary else TextSecondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            fontStyle = FontStyle.Italic,
+            modifier =
+                Modifier
+                    .weight(1f, fill = false)
+                    .blur(radius = 6.dp),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Surface(
+            color = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+            shape = RoundedCornerShape(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+            ) {
+                Icon(
+                    imageVector = PhosphorIcons.Bold.Flag,
+                    contentDescription = null,
+                    modifier = Modifier.size(10.dp),
+                )
+                Spacer(modifier = Modifier.width(3.dp))
                 Text(
-                    text = room.latestMessagePreview(),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (room.unreadCount > 0) TextPrimary else TextSecondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
+                    text = "Zgłoś",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
                 )
             }
         }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
@@ -36,6 +36,10 @@ data class RoomSummary(
     val latestMessageSendStatus: EventSendStatus? = null,
     val latestMessageReadByCount: Int = 0,
     val isBlocked: Boolean = false,
+    /** Bielik-Guard verdict for the latest message body, or null when unscanned / mine. */
+    val latestModerationVerdict: String? = null,
+    /** Categories that exceeded the flag threshold for the latest message. */
+    val latestModerationCategories: List<String> = emptyList(),
 )
 
 data class RoomTimelineCacheSnapshot(

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -144,6 +144,13 @@ class WsChatClient(
                     latestMessageSendStatus = EventSendStatus.Sent,
                     unreadCount = if (isMine) current[idx].unreadCount else current[idx].unreadCount + 1,
                     latestMessageReadByCount = 0,
+                    // Live broadcasts pre-date the worker scan (verdict
+                    // is null at this point). Carry whatever the WS
+                    // payload says — typically null until the next
+                    // refreshRooms cycle, when the server returns the
+                    // verdict that the worker has since written.
+                    latestModerationVerdict = if (isMine) null else msg.moderationVerdict,
+                    latestModerationCategories = if (isMine) emptyList() else msg.moderationCategories,
                 )
             current.sortByDescending { it.latestTimestampMillis ?: 0L }
             _rooms.value = current
@@ -334,6 +341,8 @@ private fun WsConversationPayload.toRoomSummary(): RoomSummary =
         latestMessageIsMine = latestMessageIsMine,
         latestMessageSendStatus = if (latestMessage != null) EventSendStatus.Sent else null,
         isBlocked = isBlocked,
+        latestModerationVerdict = latestModerationVerdict,
+        latestModerationCategories = latestModerationCategories,
     )
 
 internal fun parseTimestamp(iso8601: String): Long =

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
@@ -240,4 +240,6 @@ data class WsConversationPayload(
     val latestMessageIsMine: Boolean = false,
     val latestSenderName: String? = null,
     val isBlocked: Boolean = false,
+    val latestModerationVerdict: String? = null,
+    val latestModerationCategories: List<String> = emptyList(),
 )


### PR DESCRIPTION
Replaces the placeholder-text overlay with a real `Modifier.blur` over the body — the bubble keeps its shape, glyphs are unreadable, and a 'Pokaż' pill sits on top with the category label. After tap-to-reveal, a 'Zgłoś' chip appears under the body so the user can report harassment or model misfires.

The conversation list (Wiadomości) gets the same treatment: the preview text is rendered with blur + a 'Zgłoś' pill when the latest message is flag/block and not theirs.

Backend: revert the placeholder-text redaction (PR #270), expose `latestModerationVerdict` + `latestModerationCategories` on `ConversationPayload` so the client decides how to render. Visual-only — body is on the wire, tap-to-reveal is local.

Bumps app version to 0.18.9.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show flagged chat messages as gaussian-blurred with a 'Zgłoś' report chip
> - Flagged/blocked messages from others are now shown blurred in both the chat thread and room list preview, with a 'Pokaż' tap-to-reveal affordance instead of a text placeholder.
> - After revealing a flagged message, a 'Zgłoś' report chip appears below the bubble to nudge recipients to report it.
> - The backend no longer redacts latest message bodies server-side; instead it returns raw body text plus `latestModerationVerdict` and `latestModerationCategories` fields in `ConversationPayload` and `RoomSummary`.
> - WebSocket room updates also propagate moderation verdict and categories for incoming non-self messages.
> - Behavioral Change: server-side redaction of conversation previews is removed; clients are now responsible for blurring flagged content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 183b3e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->