### PR TITLE
feat(chat): polish flagged-message UX

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.18.9" // x-release-please-version
+val appVersionName = "0.18.10" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
@@ -101,6 +101,7 @@ fun ChatContent(
     onCancelComposerMode: () -> Unit,
     onRedactEvent: (String) -> Unit,
     onRevealModeration: (TimelineItem.Event) -> Unit,
+    onReportFlagged: (TimelineItem.Event) -> Unit,
     onClearError: () -> Unit,
     onNavigateToProfile: (String) -> Unit,
     resolveDisplayNames: suspend (List<String>) -> Map<String, String>,
@@ -220,6 +221,7 @@ fun ChatContent(
                                         onActionsLongPress = { selectedActionEvent = item },
                                         onSwipeReply = { onStartReply(item) },
                                         onRevealModeration = { onRevealModeration(item) },
+                                        onReportFlagged = { onReportFlagged(item) },
                                         compactTimestamp = showSenderMeta,
                                         avatarOverride =
                                             resolveAvatarOverride(item.senderId, avatarOverrides)

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -163,6 +163,7 @@ fun ChatScreen(
             onCancelComposerMode = viewModel::cancelComposerMode,
             onRedactEvent = viewModel::redactEvent,
             onRevealModeration = viewModel::revealModeration,
+            onReportFlagged = viewModel::reportFlaggedMessage,
             onClearError = viewModel::clearError,
             onNavigateToProfile = onNavigateToProfile,
             resolveDisplayNames = viewModel::resolveDisplayNames,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -333,6 +333,27 @@ class ChatViewModel(
         }
     }
 
+    fun reportFlaggedMessage(event: TimelineItem.Event) {
+        val roomId = boundRoomId ?: return
+        // Reuse the existing conversation-level report endpoint —
+        // we don't have per-message reporting yet but conversation
+        // reason="inappropriate" is the right shape for a model
+        // miss. Description carries the message id so the admin
+        // tooling can correlate.
+        val description = event.eventId?.let { "Flagged message: $it" }
+        viewModelScope.launch {
+            when (apiService.reportConversation(roomId, "inappropriate", description)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(error = "Zgłoszenie wysłane. Dzięki.") }
+                }
+
+                is ApiResult.Error -> {
+                    _uiState.update { it.copy(error = "Nie udało się wysłać zgłoszenia.") }
+                }
+            }
+        }
+    }
+
     fun clearError() {
         _uiState.update { it.copy(error = null) }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
@@ -56,6 +57,7 @@ import com.adamglin.phosphoricons.bold.ArrowBendUpLeft
 import com.adamglin.phosphoricons.bold.Check
 import com.adamglin.phosphoricons.bold.CheckCircle
 import com.adamglin.phosphoricons.bold.Clock
+import com.adamglin.phosphoricons.bold.Eye
 import com.adamglin.phosphoricons.bold.Flag
 import com.adamglin.phosphoricons.bold.WarningCircle
 import com.poziomki.app.chat.api.EventSendStatus
@@ -92,6 +94,7 @@ internal fun MessageEventRow(
     onActionsLongPress: () -> Unit,
     onSwipeReply: () -> Unit,
     onRevealModeration: () -> Unit,
+    onReportFlagged: () -> Unit,
     compactTimestamp: Boolean = false,
     avatarOverride: String? = null,
     isHighlighted: Boolean = false,
@@ -289,25 +292,39 @@ internal fun MessageEventRow(
                                                 .padding(top = 2.dp, bottom = 2.dp),
                                     )
                                 }
-                                Surface(
-                                    color = bubbleColor,
-                                    shape = bubbleShape,
-                                    modifier =
-                                        Modifier
-                                            .then(highlightBorderModifier)
-                                            .widthIn(
-                                                max = if (showSenderMeta) maxBubbleWidth - AvatarSize - AvatarSpacing else maxBubbleWidth,
-                                            ).combinedClickable(
-                                                onClick = {},
-                                                onLongClick = onActionsLongPress,
-                                            ),
-                                ) {
-                                    BubbleContent(
-                                        event = event,
-                                        onFocusOnReply = onFocusOnReply,
-                                        compactTimestamp = compactTimestamp,
-                                        onRevealModeration = onRevealModeration,
-                                    )
+                                val showReportFlag =
+                                    event.locallyRevealed &&
+                                        event.moderationVerdict in setOf("flag", "block")
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    val maxBubbleWidthForRow =
+                                        if (showSenderMeta) {
+                                            maxBubbleWidth - AvatarSize - AvatarSpacing
+                                        } else {
+                                            maxBubbleWidth
+                                        }
+                                    Surface(
+                                        color = bubbleColor,
+                                        shape = bubbleShape,
+                                        modifier =
+                                            Modifier
+                                                .then(highlightBorderModifier)
+                                                .widthIn(max = maxBubbleWidthForRow)
+                                                .combinedClickable(
+                                                    onClick = {},
+                                                    onLongClick = onActionsLongPress,
+                                                ),
+                                    ) {
+                                        BubbleContent(
+                                            event = event,
+                                            onFocusOnReply = onFocusOnReply,
+                                            compactTimestamp = compactTimestamp,
+                                            onRevealModeration = onRevealModeration,
+                                        )
+                                    }
+                                    if (showReportFlag) {
+                                        Spacer(modifier = Modifier.width(6.dp))
+                                        FloatingReportFlag(onClick = onReportFlagged)
+                                    }
                                 }
                                 if (event.reactions.isNotEmpty()) {
                                     Row(
@@ -402,12 +419,10 @@ private fun BubbleContent(
             if (event.isMine && event.moderationVerdict in setOf("flag", "block")) {
                 Spacer(modifier = Modifier.height(4.dp))
                 OwnFlaggedNote(categories = event.moderationCategories)
-            } else if (isFlaggedRecipient) {
-                // Revealed: still nudge toward reporting in case the
-                // moderation engine missed the mark or it's harassment.
-                Spacer(modifier = Modifier.height(6.dp))
-                ReportFlaggedChip()
             }
+            // Note: the floating flag lives outside the bubble (in
+            // MessageEventRow) so the bubble keeps its shape and the
+            // affordance reads as "this message" not "this paragraph".
         }
         Row(
             modifier = Modifier.align(Alignment.End).padding(top = 4.dp),
@@ -444,34 +459,30 @@ private fun BlurredFlaggedBody(
                 .clickable(onClick = onReveal),
         contentAlignment = Alignment.Center,
     ) {
-        // Blurred body — radius is high enough that no glyphs are
-        // legible, low enough that the bubble keeps roughly the
-        // same shape so the row doesn't reflow on reveal.
+        // Blurred body, dimmed slightly to soften residual letter-shape
+        // hints and let the overlay pill stand out cleanly. Italic adds
+        // texture so the row doesn't read as a loading skeleton.
         Text(
             text = body,
-            style = MaterialTheme.typography.bodyLarge,
-            color = TextPrimary,
-            modifier = Modifier.blur(radius = 14.dp),
+            style = MaterialTheme.typography.bodyLarge.copy(fontStyle = FontStyle.Italic),
+            color = TextPrimary.copy(alpha = 0.6f),
+            modifier = Modifier.blur(radius = 18.dp),
         )
-        // "Tap to show" pill on top, keeps the affordance visible.
+        // Centered glass pill — backdrop alpha keeps the blurred body
+        // visible behind it so the user sees there's content to reveal.
         Surface(
-            color = SurfaceColor.copy(alpha = 0.92f),
+            color = Background.copy(alpha = 0.55f),
             shape = RoundedCornerShape(999.dp),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 5.dp),
             ) {
-                Text(
-                    text = "Oznaczono jako $label",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = TextSecondary,
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-                Text(
-                    text = "·",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = TextSecondary,
+                Icon(
+                    imageVector = PhosphorIcons.Bold.Eye,
+                    contentDescription = null,
+                    tint = Primary,
+                    modifier = Modifier.size(13.dp),
                 )
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
@@ -480,32 +491,41 @@ private fun BlurredFlaggedBody(
                     color = Primary,
                     fontWeight = FontWeight.SemiBold,
                 )
+                Spacer(modifier = Modifier.width(8.dp))
+                Box(
+                    modifier =
+                        Modifier
+                            .size(width = 1.dp, height = 10.dp)
+                            .background(TextSecondary.copy(alpha = 0.4f)),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = TextSecondary,
+                )
             }
         }
     }
 }
 
 @Composable
-private fun ReportFlaggedChip() {
+private fun FloatingReportFlag(onClick: () -> Unit) {
+    // Floating circular flag beside the bubble. Single tap reports.
     Surface(
         color = MaterialTheme.colorScheme.errorContainer,
         contentColor = MaterialTheme.colorScheme.onErrorContainer,
-        shape = RoundedCornerShape(999.dp),
+        shape = CircleShape,
+        modifier =
+            Modifier
+                .size(28.dp)
+                .clickable(onClick = onClick),
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
-        ) {
+        Box(contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = PhosphorIcons.Bold.Flag,
-                contentDescription = null,
-                modifier = Modifier.size(11.dp),
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-            Text(
-                text = "Zgłoś",
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.SemiBold,
+                contentDescription = "Zgłoś",
+                modifier = Modifier.size(14.dp),
             )
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
@@ -144,6 +144,7 @@ fun EventChatScreen(
                         onCancelComposerMode = chatViewModel::cancelComposerMode,
                         onRedactEvent = chatViewModel::redactEvent,
                         onRevealModeration = chatViewModel::revealModeration,
+                        onReportFlagged = chatViewModel::reportFlaggedMessage,
                         onClearError = chatViewModel::clearError,
                         onNavigateToProfile = onNavigateToProfile,
                         resolveDisplayNames = chatViewModel::resolveDisplayNames,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -29,7 +28,6 @@ import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.bold.Check
 import com.adamglin.phosphoricons.bold.CheckCircle
 import com.adamglin.phosphoricons.bold.Clock
-import com.adamglin.phosphoricons.bold.Flag
 import com.adamglin.phosphoricons.bold.WarningCircle
 import com.poziomki.app.chat.api.EventSendStatus
 import com.poziomki.app.chat.api.RoomSummary
@@ -142,71 +140,19 @@ fun RoomRow(
                 val flagged =
                     !room.latestMessageIsMine &&
                         room.latestModerationVerdict in setOf("flag", "block")
-                if (flagged) {
-                    FlaggedRoomPreview(
-                        body = room.latestMessagePreview(),
-                        unread = room.unreadCount > 0,
-                        modifier = Modifier.weight(1f, fill = false),
-                    )
-                } else {
-                    Text(
-                        text = room.latestMessagePreview(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = if (room.unreadCount > 0) TextPrimary else TextSecondary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun FlaggedRoomPreview(
-    body: String,
-    unread: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    // Visual-only blur — body is on the wire so this is a UX hint, not
-    // an access control. The "Zgłoś" pill nudges the user toward
-    // reporting if the moderation hit was wrong-shaped or harassing.
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier,
-    ) {
-        Text(
-            text = body,
-            style = MaterialTheme.typography.bodyMedium,
-            color = if (unread) TextPrimary else TextSecondary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            fontStyle = FontStyle.Italic,
-            modifier =
-                Modifier
-                    .weight(1f, fill = false)
-                    .blur(radius = 6.dp),
-        )
-        Spacer(modifier = Modifier.width(6.dp))
-        Surface(
-            color = MaterialTheme.colorScheme.errorContainer,
-            contentColor = MaterialTheme.colorScheme.onErrorContainer,
-            shape = RoundedCornerShape(8.dp),
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-            ) {
-                Icon(
-                    imageVector = PhosphorIcons.Bold.Flag,
-                    contentDescription = null,
-                    modifier = Modifier.size(10.dp),
-                )
-                Spacer(modifier = Modifier.width(3.dp))
                 Text(
-                    text = "Zgłoś",
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.SemiBold,
+                    text = room.latestMessagePreview(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (room.unreadCount > 0) TextPrimary else TextSecondary,
+                    fontStyle = if (flagged) FontStyle.Italic else null,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier =
+                        if (flagged) {
+                            Modifier.blur(radius = 8.dp)
+                        } else {
+                            Modifier
+                        },
                 )
             }
         }


### PR DESCRIPTION
Three changes after user feedback on the prior PR:

1. **Wiadomości list**: dropped the Zgłoś chip — just blur the preview text (italic, 8 dp). Cleaner row layout.
2. **In-chat blur**: heavier blur (18 dp + reduced opacity), and a frosted-glass pill with eye icon + 'Pokaż' + category label as the reveal CTA.
3. **Reporting**: after tap-to-reveal, a floating circular flag icon appears next to the bubble. Tap calls the existing `POST /chat/conversations/:id/report` with `reason='inappropriate'` and the message id in the description so admin tooling can correlate to the specific message.

Bumps app version to 0.18.10.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish flagged-message UX in chat with floating report button and blurred previews
> - Replaces the in-bubble 'Zgłoś' chip with a circular floating flag icon button rendered beside the message bubble in [`MessageEventRow`](https://github.com/poziomki-app/poziomki/pull/273/files#diff-205e553f5f37749cbb095d7ebb6ef8fc7a522c33a70cef909b5d576b613450f3), visible only when a flagged/blocked message is locally revealed.
> - Adds `reportFlaggedMessage` to [`ChatViewModel`](https://github.com/poziomki-app/poziomki/pull/273/files#diff-016868bdd2fb23a6d4dc15c4e4202b05086c17c7c1400f9aa0c1c50c8a01f6ab), which calls the API with reason "inappropriate" and surfaces success/failure via the UI error state.
> - Updates the blurred flagged-message body with a higher blur radius, dimmed italic text, an eye icon, and a rearranged 'Pokaż' reveal pill.
> - Removes the dedicated `FlaggedRoomPreview` composable from [`RoomRow`](https://github.com/poziomki-app/poziomki/pull/273/files#diff-638303e155da802f51e452c8fad551f5d6f23cbe70f9b86990bf5cf49e95de0c); flagged message previews in the room list are now shown as blurred italic text without a report chip.
> - Bumps Android `appVersionName` to `0.18.10`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ef8a36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->