### PR TITLE
fix(events): hide finished events from listings and cache

### DIFF
--- a/backend/src/api/events/repo.rs
+++ b/backend/src/api/events/repo.rs
@@ -12,7 +12,12 @@ pub(in crate::api) async fn list_upcoming_events(
     limit: i64,
 ) -> std::result::Result<Vec<Event>, crate::error::AppError> {
     let models = events::table
-        .filter(events::starts_at.ge(now))
+        .filter(
+            events::ends_at
+                .is_null()
+                .and(events::starts_at.ge(now))
+                .or(events::ends_at.ge(now)),
+        )
         .order(events::starts_at.asc())
         .limit(limit)
         .load::<Event>(conn)

--- a/backend/src/api/matching/repo.rs
+++ b/backend/src/api/matching/repo.rs
@@ -265,7 +265,12 @@ impl MatchingRepository {
         conn: &mut diesel_async::AsyncPgConnection,
     ) -> std::result::Result<Vec<Event>, crate::error::AppError> {
         events::table
-            .filter(events::starts_at.ge(now))
+            .filter(
+                events::ends_at
+                    .is_null()
+                    .and(events::starts_at.ge(now))
+                    .or(events::ends_at.ge(now)),
+            )
             .order(events::starts_at.asc())
             .limit(limit)
             .load::<Event>(conn)

--- a/backend/src/search.rs
+++ b/backend/src/search.rs
@@ -229,6 +229,7 @@ async fn search_events(
          WHERE (e.search_vector @@ websearch_to_tsquery('simple', $1) \
                 OR LOWER(e.title) LIKE $2 \
                 OR LOWER(COALESCE(p.name, '')) LIKE $2) \
+         AND COALESCE(e.ends_at, e.starts_at) >= NOW() \
          {geo_filter} \
          ORDER BY {order_by} \
          LIMIT {limit_param}"

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
@@ -22,7 +22,19 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.concurrent.Volatile
+
+private fun Event.hasFinished(now: Instant): Boolean {
+    val end = endsAt ?: startsAt
+    val endInstant = runCatching { Instant.parse(end) }.getOrNull() ?: return false
+    return endInstant < now
+}
+
+private fun List<Event>.dropFinished(): List<Event> {
+    val now = Clock.System.now()
+    return filterNot { it.hasFinished(now) }
+}
 
 class EventRepository(
     private val db: PoziomkiDatabase,
@@ -75,21 +87,21 @@ class EventRepository(
             .selectAll()
             .asFlow()
             .mapToList(Dispatchers.IO)
-            .map { rows -> rows.map { it.toApiModel() } }
+            .map { rows -> rows.map { it.toApiModel() }.dropFinished() }
 
     fun observeRecommendedEvents(): Flow<List<Event>> =
         db.eventQueries
             .selectRecommended()
             .asFlow()
             .mapToList(Dispatchers.IO)
-            .map { rows -> rows.map { it.toApiModel() } }
+            .map { rows -> rows.map { it.toApiModel() }.dropFinished() }
 
     fun observeSavedEvents(): Flow<List<Event>> =
         db.eventQueries
             .selectSaved()
             .asFlow()
             .mapToList(Dispatchers.IO)
-            .map { rows -> rows.map { it.toApiModel() } }
+            .map { rows -> rows.map { it.toApiModel() }.dropFinished() }
 
     fun observeEvent(id: String): Flow<Event?> =
         db.eventQueries
@@ -134,6 +146,7 @@ class EventRepository(
                         .selectRecommended()
                         .executeAsList()
                         .map { it.toApiModel() }
+                        .dropFinished()
                 }
             }
 
@@ -155,7 +168,7 @@ class EventRepository(
                     lastLat = lat
                     lastLng = lng
                     lastRadius = radiusM
-                    result.data
+                    result.data.dropFinished()
                 }
 
                 is ApiResult.Error -> {
@@ -163,6 +176,7 @@ class EventRepository(
                         .selectRecommended()
                         .executeAsList()
                         .map { it.toApiModel() }
+                        .dropFinished()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Backend: filter out events whose end time has passed in upcoming, matching, and search queries (events with no \`ends_at\` use \`starts_at\` as the cutoff).
- Mobile: drop finished events in the \`EventRepository\` observe layer so cached SQLDelight rows stop reappearing in the list/recommended/saved/nearby views after the event has finished.

## Test plan
- [ ] Insert a finished event (\`ends_at\` in the past) and verify it no longer appears in \`/events\`, recommended/matching, or search.
- [ ] Insert an ongoing event (\`starts_at\` past, \`ends_at\` future) and verify it still appears.
- [ ] Open the app with cached events whose end time has passed and verify they disappear from the events list, recommended feed, saved list, and map.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter finished events from listings and cached results
> - Updates SQL queries in [`list_upcoming_events`](https://github.com/poziomki-app/poziomki/pull/274/files#diff-c8fefb2a843f2ea25954f0b78583b65bcc2d77f5c092e7718a2d651b13d7ee6c), [`load_future_events`](https://github.com/poziomki-app/poziomki/pull/274/files#diff-fe2cacd26eb8e974a5e780381831fead540ac7b253e064e48b07dd2ceef85ba9), and [`search_events`](https://github.com/poziomki-app/poziomki/pull/274/files#diff-f157aaca4d578281c5d617b3970ba00ee9a8915ac4d1d1251a5744e61ff62fe1) to exclude events where `ends_at` (or `starts_at` when `ends_at` is null) is in the past.
> - Adds client-side `hasFinished` and `dropFinished` helpers in [`EventRepository.kt`](https://github.com/poziomki-app/poziomki/pull/274/files#diff-ba799a61c5df483672ec816ebfe3e3afc3f9407eb57b4c6ad827c4576f78043e) to filter finished events from all observe and load methods, covering both network results and local DB fallbacks.
> - Behavioral Change: Events that have already ended no longer appear in any listing, search, or cached result — including saved and recommended events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 501232a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->