### PR TITLE
fix(map): wire up location permissions, iOS provider, user marker

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -114,6 +114,16 @@ fun EventsScreen(
         rememberLocationPermissionLauncher { granted ->
             if (granted) viewModel.retryNearby()
         }
+    var hasAutoRequestedLocation by remember { mutableStateOf(false) }
+    LaunchedEffect(state.activeFilter, state.isLocationPermissionDenied) {
+        if (state.activeFilter == TimeFilter.NEARBY &&
+            state.isLocationPermissionDenied &&
+            !hasAutoRequestedLocation
+        ) {
+            hasAutoRequestedLocation = true
+            requestLocationPermission()
+        }
+    }
 
     val timeFilterTabs =
         listOf(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
@@ -232,6 +232,22 @@ internal fun NearbyEventsContent(
                     )
                 }
 
+                // User location dot
+                if (userLat != null && userLng != null) {
+                    val userSource =
+                        rememberGeoJsonSource(
+                            data = pointGeoJson(userLat, userLng),
+                        )
+                    CircleLayer(
+                        id = "user-location",
+                        source = userSource,
+                        radius = const(8.dp),
+                        color = const(White),
+                        strokeColor = const(Primary),
+                        strokeWidth = const(3.dp),
+                    )
+                }
+
                 // Selected dot
                 val selEvent = geoEvents.find { it.id == selectedEventId }
                 if (selEvent != null) {

--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/PermissionRequest.ios.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/PermissionRequest.ios.kt
@@ -1,6 +1,62 @@
 package com.poziomki.app.ui.shared
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.CoreLocation.CLAuthorizationStatus
+import platform.CoreLocation.CLLocationManager
+import platform.CoreLocation.CLLocationManagerDelegateProtocol
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
+import platform.CoreLocation.kCLAuthorizationStatusNotDetermined
+import platform.darwin.NSObject
 
+@OptIn(ExperimentalForeignApi::class)
 @Composable
-actual fun rememberLocationPermissionLauncher(onResult: (Boolean) -> Unit): () -> Unit = {}
+actual fun rememberLocationPermissionLauncher(onResult: (Boolean) -> Unit): () -> Unit {
+    val state =
+        remember {
+            object {
+                val manager = CLLocationManager()
+                var delegate: CLLocationManagerDelegateProtocol? = null
+            }
+        }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            state.manager.delegate = null
+            state.delegate = null
+        }
+    }
+
+    return {
+        val status = CLLocationManager.authorizationStatus()
+        if (status == kCLAuthorizationStatusAuthorizedWhenInUse ||
+            status == kCLAuthorizationStatusAuthorizedAlways
+        ) {
+            onResult(true)
+        } else if (status != kCLAuthorizationStatusNotDetermined) {
+            onResult(false)
+        } else {
+            val delegate =
+                object : NSObject(), CLLocationManagerDelegateProtocol {
+                    override fun locationManager(
+                        manager: CLLocationManager,
+                        didChangeAuthorizationStatus: CLAuthorizationStatus,
+                    ) {
+                        if (didChangeAuthorizationStatus == kCLAuthorizationStatusNotDetermined) return
+                        val granted =
+                            didChangeAuthorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse ||
+                                didChangeAuthorizationStatus == kCLAuthorizationStatusAuthorizedAlways
+                        manager.delegate = null
+                        state.delegate = null
+                        onResult(granted)
+                    }
+                }
+            state.delegate = delegate
+            state.manager.delegate = delegate
+            state.manager.requestWhenInUseAuthorization()
+        }
+    }
+}

--- a/mobile/core/src/iosMain/kotlin/com/poziomki/app/location/LocationProvider.kt
+++ b/mobile/core/src/iosMain/kotlin/com/poziomki/app/location/LocationProvider.kt
@@ -1,7 +1,71 @@
 package com.poziomki.app.location
 
-actual class LocationProvider {
-    actual fun isPermissionGranted(): Boolean = false
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import platform.CoreLocation.CLAuthorizationStatus
+import platform.CoreLocation.CLLocation
+import platform.CoreLocation.CLLocationManager
+import platform.CoreLocation.CLLocationManagerDelegateProtocol
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
+import platform.CoreLocation.kCLLocationAccuracyHundredMeters
+import platform.Foundation.NSError
+import platform.darwin.NSObject
+import kotlin.coroutines.resume
 
-    actual suspend fun getCurrentLocation(): LocationResult? = null
+private const val LOCATION_TIMEOUT_MS = 5_000L
+
+@OptIn(ExperimentalForeignApi::class)
+actual class LocationProvider {
+    private val manager =
+        CLLocationManager().apply {
+            desiredAccuracy = kCLLocationAccuracyHundredMeters
+        }
+
+    actual fun isPermissionGranted(): Boolean {
+        val status: CLAuthorizationStatus = CLLocationManager.authorizationStatus()
+        return status == kCLAuthorizationStatusAuthorizedWhenInUse ||
+            status == kCLAuthorizationStatusAuthorizedAlways
+    }
+
+    actual suspend fun getCurrentLocation(): LocationResult? {
+        if (!isPermissionGranted()) return null
+        return withTimeoutOrNull(LOCATION_TIMEOUT_MS) {
+            suspendCancellableCoroutine { continuation ->
+                val delegate =
+                    object : NSObject(), CLLocationManagerDelegateProtocol {
+                        override fun locationManager(
+                            manager: CLLocationManager,
+                            didUpdateLocations: List<*>,
+                        ) {
+                            val location = didUpdateLocations.lastOrNull() as? CLLocation ?: return
+                            manager.stopUpdatingLocation()
+                            manager.delegate = null
+                            if (continuation.isActive) {
+                                location.coordinate.useContents {
+                                    continuation.resume(LocationResult(latitude, longitude))
+                                }
+                            }
+                        }
+
+                        override fun locationManager(
+                            manager: CLLocationManager,
+                            didFailWithError: NSError,
+                        ) {
+                            manager.stopUpdatingLocation()
+                            manager.delegate = null
+                            if (continuation.isActive) continuation.resume(null)
+                        }
+                    }
+                manager.delegate = delegate
+                continuation.invokeOnCancellation {
+                    manager.stopUpdatingLocation()
+                    manager.delegate = null
+                }
+                manager.startUpdatingLocation()
+            }
+        }
+    }
 }

--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Poziomki używa Twojej lokalizacji, aby pokazać wydarzenia w pobliżu na mapie.</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## Summary
- iOS: replace the stub \`LocationProvider\` with a CoreLocation implementation, replace the no-op \`rememberLocationPermissionLauncher\` with one that actually calls \`requestWhenInUseAuthorization\`, and add \`NSLocationWhenInUseUsageDescription\` to \`Info.plist\` so the system prompt is allowed to appear at all.
- Auto-trigger the location permission prompt the first time the user opens the *w pobliżu* (Nearby) tab, instead of presenting a 'permission denied' fallback before the OS prompt has ever been shown.
- Render the user's own location as a dot on the MapLibre map so 'find my location and display it on the map' actually works (the closest-event preselect was already wired up via \`/matching\`).

## Test plan
- [ ] iOS first launch → tap *w pobliżu* → system location prompt appears → grant → user dot + nearby events visible, closest event preselected.
- [ ] iOS denied path → falls back to 'brak dostępu do lokalizacji' UI.
- [ ] Android first launch → tap *w pobliżu* → system location prompt appears automatically → grant → user dot + nearby events.
- [ ] Android denied path → 'brak dostępu' UI with working *udostępnij lokalizację* button.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire up location permissions, iOS location provider, and user marker on map
> - Implements the iOS-specific `rememberLocationPermissionLauncher` in [PermissionRequest.ios.kt](https://github.com/poziomki-app/poziomki/pull/275/files#diff-e365bd8f13a5fc748f15b5bcfa1358a564d6bc1676c65e56a5f386ade4762442) using `CLLocationManager`, handling already-granted, denied, and not-determined states.
> - Implements the iOS `LocationProvider` in [LocationProvider.kt](https://github.com/poziomki-app/poziomki/pull/275/files#diff-b9badf078304ca57557524627b04db5bd5dadec568797809062540e03654e696) with 100m accuracy, a 5-second timeout, and null returned on timeout, error, or missing permission.
> - Adds a user location dot (white fill, primary-colored stroke) to the map in [NearbyEventsContent.kt](https://github.com/poziomki-app/poziomki/pull/275/files#diff-4b254621a5c67acf73fc8f3619229de35cfcffe5ed1d64536e7e98375cc84e98) when coordinates are available.
> - Auto-triggers a location permission request in [EventsScreen.kt](https://github.com/poziomki-app/poziomki/pull/275/files#diff-b1aad26129722f5aa103f55ac1d883a2b472203a3df536f251798d2ab83260dd) when the Nearby filter is selected and permission is denied, once per composition state.
> - Adds `NSLocationWhenInUseUsageDescription` to [Info.plist](https://github.com/poziomki-app/poziomki/pull/275/files#diff-5897280c2b4695102b6259401869cd43697b3f07b7a565b4fa44233b3ada6906) so the iOS permission dialog shows an explanation.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 73b6de2. 5 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->