### PR TITLE
fix(search,events): filter blocked users from search results and attendee list

### DIFF
--- a/backend/src/api/events/mod.rs
+++ b/backend/src/api/events/mod.rs
@@ -265,7 +265,7 @@ pub(super) async fn event_attendees(
             else {
                 return Ok(AttendeesOutcome::NotFound);
             };
-            let list = events_view::attendee_info(conn, event_uuid, event.creator_id)
+            let list = events_view::attendee_info(conn, event_uuid, event.creator_id, user.id)
                 .await
                 .map_err(into_diesel)?;
             Ok(AttendeesOutcome::Listed(list))

--- a/backend/src/api/events/view_attendees.rs
+++ b/backend/src/api/events/view_attendees.rs
@@ -1,12 +1,14 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use diesel_async::AsyncPgConnection;
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use super::events_view_images::resolve_image_map;
 use super::events_view_repo::{load_attendee_rows, AttendeeRow};
 use crate::api::state::AttendeeFullInfo;
 use crate::db;
+use crate::db::schema::{profile_blocks, profiles};
 
 /// Resolve `profile.user_id -> user.pid` for a set of attendee profiles via
 /// the narrow `app.user_pids_for_ids` SECURITY DEFINER helper. The API role
@@ -53,14 +55,66 @@ fn build_attendee_info(
     }
 }
 
+/// Resolve the set of profile ids that are on either side of a block with the
+/// viewer. Mirrors `api::matching::repo::load_candidate_profiles` so that
+/// attendee listings hide blocked users in both directions.
+async fn load_blocked_profile_ids(
+    conn: &mut AsyncPgConnection,
+    viewer_user_id: i32,
+) -> std::result::Result<HashSet<Uuid>, crate::error::AppError> {
+    let viewer_profile_ids: Vec<Uuid> = profiles::table
+        .filter(profiles::user_id.eq(viewer_user_id))
+        .select(profiles::id)
+        .load(conn)
+        .await?;
+
+    if viewer_profile_ids.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let rows: Vec<(Uuid, Uuid)> = profile_blocks::table
+        .filter(
+            profile_blocks::blocker_id
+                .eq_any(&viewer_profile_ids)
+                .or(profile_blocks::blocked_id.eq_any(&viewer_profile_ids)),
+        )
+        .select((profile_blocks::blocker_id, profile_blocks::blocked_id))
+        .load(conn)
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .flat_map(|(a, b)| {
+            let mut out = Vec::with_capacity(2);
+            if !viewer_profile_ids.contains(&a) {
+                out.push(a);
+            }
+            if !viewer_profile_ids.contains(&b) {
+                out.push(b);
+            }
+            out
+        })
+        .collect())
+}
+
 /// Collect attendee rows + the viewer-facing pid/name/picture tuples required
 /// to render them. Must run inside an existing viewer-scoped transaction.
+///
+/// Filters out attendees on either side of a block with `viewer_user_id`. The
+/// raw `event_attendees` table has no block awareness, and RLS on profiles is
+/// bucket-only, so without this filter blocked users leak through the
+/// attendee list (matching/search/chat already filter — this closes the gap).
 pub(in crate::api) async fn attendee_info(
     conn: &mut AsyncPgConnection,
     event_id: Uuid,
     creator_id: Uuid,
+    viewer_user_id: i32,
 ) -> std::result::Result<Vec<AttendeeFullInfo>, crate::error::AppError> {
-    let rows = load_attendee_rows(conn, event_id).await?;
+    let mut rows = load_attendee_rows(conn, event_id).await?;
+    let blocked = load_blocked_profile_ids(conn, viewer_user_id).await?;
+    if !blocked.is_empty() {
+        rows.retain(|row| !blocked.contains(&row.profile.id));
+    }
     let user_pids = load_user_pids(conn, &rows).await?;
 
     let filenames = rows

--- a/backend/src/search.rs
+++ b/backend/src/search.rs
@@ -141,6 +141,12 @@ async fn search_profiles(
         LEFT JOIN tags t_agg ON t_agg.id = pt_agg.tag_id
         WHERE
             (COALESCE(us.privacy_discoverable, true) = true OR p.user_id = $4)
+            AND NOT EXISTS (
+                SELECT 1 FROM profile_blocks pb
+                JOIN profiles vp ON vp.user_id = $4
+                WHERE (pb.blocker_id = vp.id AND pb.blocked_id = p.id)
+                   OR (pb.blocked_id = vp.id AND pb.blocker_id = p.id)
+            )
             AND (
                 p.public_search_vector @@ websearch_to_tsquery('simple', $1)
                 OR (


### PR DESCRIPTION
## Summary

Two leaks where `profile_blocks` was not enforced:

- **`search_profiles`** (`backend/src/search.rs`) only filtered `privacy_discoverable`. A blocked user re-appears in search.
- **`attendee_info`** (`backend/src/api/events/view_attendees.rs`) loads `event_attendees` straight from the table; both sides of a block see each other in any shared event's attendee list.

Both bugs are narrow gaps — matching, chat conversations, and bookmarks already filter `profile_blocks` (see `api/matching/repo.rs:209-234` and the chat-conversations comment referenced from there).

## Changes

- `search.rs`: add `NOT EXISTS (... profile_blocks ... blocker_id/blocked_id)` (either direction) to the search WHERE, joining through `profiles` so it works for users with multiple profile rows.
- `view_attendees.rs`: thread `viewer_user_id` into `attendee_info`, batch-load symmetric block set, `retain` rows before the rest of the pipeline.
- `events/mod.rs`: pass `user.id` through the existing viewer-tx caller.

Both new queries run inside the existing viewer-scoped tx, so RLS still applies; the `profile_blocks` policy already lets viewers see blocks in both directions (covered by `tests/requests/rls_tier_a.rs::profile_blocks_viewer_sees_both_directions`).

## Repro (before fix)

1. Sign in as A. `POST /profiles/{B_id}/block`.
2. `GET /api/v1/search?q=<B's name>` → B in `profiles`.
3. With both A and B attending event E, `GET /api/v1/events/{E_id}/attendees` → B listed.

After fix: B absent in both responses.

## Test plan

- [ ] `cargo clippy --all-targets` clean (locally verified)
- [ ] `cargo check --tests` clean (locally verified)
- [ ] CI integration tests (`rls_tier_a` etc.) green
- [ ] Manual: run repro above against a staging instance

## Notes

- DM/event-chat search (`search_dm_room_ids` / `search_event_room_ids`) goes through `conversation_members`, which is membership-gated. A blocked user cannot newly DM you, but a pre-existing DM could still surface in search by name. That's a separate cleanup if desired — out of scope here.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter blocked users from profile search results and event attendee lists
> - Adds block-relationship filtering to `search_profiles` via an `AND NOT EXISTS` subquery that excludes profiles blocking or blocked by the viewer.
> - Adds a `load_blocked_profile_ids` helper in [view_attendees.rs](https://github.com/poziomki-app/poziomki/pull/276/files#diff-3b130c129d9575942be13492a12fa5629adbeff431fc7a40c8416fd98e0c727f) that queries `profile_blocks` for both directions of a block relationship, returning a `HashSet` of excluded profile IDs.
> - Passes the authenticated viewer's user ID into `attendee_info` to filter blocked profiles from event attendee responses.
> - Behavioral Change: users who block or are blocked by the viewer no longer appear in search results or event attendee lists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7c88d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->