### PR TITLE
feat(chat): per-message report endpoint + nicer blur

### DIFF
--- a/backend/migrations/2026-04-27-200000_chat_message_reports/down.sql
+++ b/backend/migrations/2026-04-27-200000_chat_message_reports/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.chat_message_reports;

--- a/backend/migrations/2026-04-27-200000_chat_message_reports/up.sql
+++ b/backend/migrations/2026-04-27-200000_chat_message_reports/up.sql
@@ -1,0 +1,66 @@
+-- Per-message report queue.
+--
+-- Conversation-level reports already exist (chat.report_handler →
+-- conversations_reports). Message-level reports are different:
+-- they're typically driven by a moderation flag (Bielik-Guard hit
+-- the message, the user revealed it, then chose to escalate). The
+-- row snapshots the moderation context at report time so admin
+-- can tell the difference between "model false positive" and
+-- "model caught it but it's still harassment".
+--
+-- (message_id, reporter_user_id) is the natural PK — a viewer
+-- reporting twice is idempotent.
+
+CREATE TABLE IF NOT EXISTS public.chat_message_reports (
+    message_id UUID NOT NULL REFERENCES public.messages(id) ON DELETE CASCADE,
+    reporter_user_id INT4 NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    reason TEXT NOT NULL,
+    description TEXT,
+    -- Snapshot of the moderation verdict + categories at the moment
+    -- the user filed the report, so admin sees what the auto-mod
+    -- engine thought regardless of whether the row changes later.
+    automoderation_verdict TEXT,
+    automoderation_categories TEXT[] NOT NULL DEFAULT '{}'::text[],
+    status TEXT NOT NULL DEFAULT 'open',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (message_id, reporter_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_message_reports_status_created
+    ON public.chat_message_reports (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_chat_message_reports_reporter
+    ON public.chat_message_reports (reporter_user_id, created_at DESC);
+
+COMMENT ON TABLE public.chat_message_reports IS
+    'Per-message moderation reports. Snapshots the auto-mod verdict at file time so admin can see model-vs-human disagreement.';
+
+-- RLS: a viewer can insert a report only for a message they can
+-- actually see (same gate as chat_message_reveals); they can read
+-- their own reports for UI cache. Admin role bypasses via BYPASSRLS.
+ALTER TABLE public.chat_message_reports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chat_message_reports FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS chat_message_reports_insert ON public.chat_message_reports;
+CREATE POLICY chat_message_reports_insert ON public.chat_message_reports
+    FOR INSERT
+    WITH CHECK (
+        reporter_user_id = app.current_user_id()
+        AND app.viewer_can_see_message(message_id)
+    );
+
+DROP POLICY IF EXISTS chat_message_reports_select_self ON public.chat_message_reports;
+CREATE POLICY chat_message_reports_select_self ON public.chat_message_reports
+    FOR SELECT
+    USING (reporter_user_id = app.current_user_id());
+
+-- Grants. The api role inserts/selects on the user's behalf;
+-- worker doesn't write here. Admin role is BYPASSRLS so doesn't
+-- need an explicit grant.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT INSERT, SELECT ON public.chat_message_reports TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/api/chat/message_report_handler.rs
+++ b/backend/src/api/chat/message_report_handler.rs
@@ -1,0 +1,157 @@
+//! Per-message moderation report endpoint.
+//!
+//! Conversation-level reports already exist; this is the message-
+//! granular variant. Typical flow: Bielik-Guard flags a chat message,
+//! the recipient blurs it, taps to reveal, then taps the floating
+//! flag → this endpoint. We snapshot the auto-mod verdict +
+//! categories at file time so admin tooling can correlate the report
+//! to the model's opinion (false positive vs. true positive that the
+//! model also caught).
+//!
+//! `(message_id, reporter_user_id)` is the natural PK; reporting twice
+//! is idempotent.
+
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::RunQueryDsl;
+use serde::Deserialize;
+
+use crate::api::common::{auth_or_respond, error_response, parse_uuid_response, ErrorSpec};
+use crate::api::state::SuccessResponse;
+use crate::app::AppContext;
+use crate::db;
+use crate::db::schema::{chat_message_reports::dsl as r, messages::dsl as m};
+
+type Result<T> = crate::error::AppResult<T>;
+
+/// Mirrors the conversation-report reasons so the same picker UI
+/// in the mobile app can drive both endpoints.
+const VALID_REASONS: &[&str] = &[
+    "spam",
+    "inappropriate",
+    "misleading",
+    "harassment",
+    "hate_speech",
+    "violence",
+    "scam",
+    "other",
+];
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ReportMessageBody {
+    pub reason: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+enum ReportOutcome {
+    NotFound,
+    Inserted,
+}
+
+pub(in crate::api) async fn message_report(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<ReportMessageBody>,
+) -> Result<Response> {
+    let (_session, user) = auth_or_respond!(headers);
+
+    let message_id = match parse_uuid_response(&id, "message", &headers) {
+        Ok(id) => id,
+        Err(response) => return Ok(*response),
+    };
+
+    let reason = body.reason.trim().to_lowercase();
+    if !VALID_REASONS.contains(&reason.as_str()) {
+        return Ok(error_response(
+            StatusCode::BAD_REQUEST,
+            &headers,
+            ErrorSpec {
+                error: "Nieprawidłowy powód zgłoszenia".to_string(),
+                code: "VALIDATION_ERROR",
+                details: None,
+            },
+        ));
+    }
+
+    let description = body
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+    if let Some(ref desc) = description {
+        if desc.chars().count() > 2000 {
+            return Ok(error_response(
+                StatusCode::BAD_REQUEST,
+                &headers,
+                ErrorSpec {
+                    error: "Opis może mieć maksymalnie 2000 znaków".to_string(),
+                    code: "VALIDATION_ERROR",
+                    details: None,
+                },
+            ));
+        }
+    }
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let reporter_user_id = user.id;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            // Snapshot the moderation context as it stands now. Even
+            // if the worker rescans later (it won't today), the
+            // report row keeps what the user saw at file time.
+            let snapshot: Option<(Option<String>, Vec<String>)> = m::messages
+                .filter(m::id.eq(message_id))
+                .select((m::moderation_verdict, m::moderation_categories))
+                .first::<(Option<String>, Vec<String>)>(conn)
+                .await
+                .optional()?;
+            let Some((automod_verdict, automod_categories)) = snapshot else {
+                return Ok::<_, diesel::result::Error>(ReportOutcome::NotFound);
+            };
+
+            diesel::insert_into(r::chat_message_reports)
+                .values((
+                    r::message_id.eq(message_id),
+                    r::reporter_user_id.eq(reporter_user_id),
+                    r::reason.eq(&reason),
+                    r::description.eq(description.as_deref()),
+                    r::automoderation_verdict.eq(automod_verdict.as_deref()),
+                    r::automoderation_categories.eq(&automod_categories),
+                    r::status.eq("open"),
+                    r::created_at.eq(chrono::Utc::now()),
+                ))
+                .on_conflict((r::message_id, r::reporter_user_id))
+                .do_nothing()
+                .execute(conn)
+                .await?;
+
+            Ok(ReportOutcome::Inserted)
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    match outcome {
+        ReportOutcome::NotFound => Ok(error_response(
+            StatusCode::NOT_FOUND,
+            &headers,
+            ErrorSpec {
+                error: "Message not found".to_string(),
+                code: "NOT_FOUND",
+                details: None,
+            },
+        )),
+        ReportOutcome::Inserted => Ok(Json(SuccessResponse { success: true }).into_response()),
+    }
+}

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -1,5 +1,6 @@
 pub mod conversations;
 pub mod hub;
+pub mod message_report_handler;
 pub mod messages;
 pub mod protocol;
 pub mod push;

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -199,6 +199,10 @@ fn chat_routes() -> Router<AppContext> {
             "/messages/{id}/reveal",
             post(chat::reveal_handler::message_reveal),
         )
+        .route(
+            "/messages/{id}/report",
+            post(chat::message_report_handler::message_report),
+        )
         .route("/push/register", post(chat::push_register))
         .route("/push/unregister", post(chat::push_unregister))
         .layer(cache_layer("no-store"))

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -51,6 +51,19 @@ diesel::table! {
 }
 
 diesel::table! {
+    chat_message_reports (message_id, reporter_user_id) {
+        message_id -> Uuid,
+        reporter_user_id -> Int4,
+        reason -> Text,
+        description -> Nullable<Text>,
+        automoderation_verdict -> Nullable<Text>,
+        automoderation_categories -> Array<Text>,
+        status -> Text,
+        created_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     message_reactions (id) {
         id -> Uuid,
         message_id -> Uuid,
@@ -340,6 +353,8 @@ diesel::joinable!(messages -> uploads (attachment_upload_id));
 diesel::joinable!(message_reactions -> messages (message_id));
 diesel::joinable!(chat_message_reveals -> messages (message_id));
 diesel::joinable!(chat_message_reveals -> users (viewer_user_id));
+diesel::joinable!(chat_message_reports -> messages (message_id));
+diesel::joinable!(chat_message_reports -> users (reporter_user_id));
 diesel::joinable!(recommendation_feedback -> events (event_id));
 diesel::joinable!(recommendation_feedback -> profiles (profile_id));
 diesel::joinable!(event_attendees -> events (event_id));
@@ -360,6 +375,7 @@ diesel::joinable!(task_completions -> profiles (profile_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     auth_rate_limits,
+    chat_message_reports,
     chat_message_reveals,
     conversation_members,
     conversations,

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.18.10" // x-release-please-version
+val appVersionName = "0.18.11" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -205,6 +205,15 @@ fun ChatScreen(
             onDismiss = { showReportDialog = false },
         )
     }
+
+    if (state.pendingMessageReport != null) {
+        ReportDialog(
+            onConfirm = { reason, description ->
+                viewModel.submitMessageReport(reason, description)
+            },
+            onDismiss = viewModel::dismissMessageReport,
+        )
+    }
 }
 
 @Composable

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -333,16 +333,25 @@ class ChatViewModel(
         }
     }
 
+    /** Open the existing ReportDialog targeted at this message. */
     fun reportFlaggedMessage(event: TimelineItem.Event) {
-        val roomId = boundRoomId ?: return
-        // Reuse the existing conversation-level report endpoint —
-        // we don't have per-message reporting yet but conversation
-        // reason="inappropriate" is the right shape for a model
-        // miss. Description carries the message id so the admin
-        // tooling can correlate.
-        val description = event.eventId?.let { "Flagged message: $it" }
+        if (event.eventId == null) return
+        _uiState.update { it.copy(pendingMessageReport = event) }
+    }
+
+    fun dismissMessageReport() {
+        _uiState.update { it.copy(pendingMessageReport = null) }
+    }
+
+    fun submitMessageReport(
+        reason: String,
+        description: String?,
+    ) {
+        val target = _uiState.value.pendingMessageReport ?: return
+        val messageId = target.eventId ?: return
+        _uiState.update { it.copy(pendingMessageReport = null) }
         viewModelScope.launch {
-            when (apiService.reportConversation(roomId, "inappropriate", description)) {
+            when (apiService.reportChatMessage(messageId, reason, description)) {
                 is ApiResult.Success -> {
                     _uiState.update { it.copy(error = "Zgłoszenie wysłane. Dzięki.") }
                 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
@@ -220,7 +219,6 @@ internal fun MessageEventRow(
                                     event = event,
                                     onFocusOnReply = onFocusOnReply,
                                     compactTimestamp = compactTimestamp,
-                                    onRevealModeration = onRevealModeration,
                                 )
                             }
                             if (event.reactions.isNotEmpty()) {
@@ -292,9 +290,10 @@ internal fun MessageEventRow(
                                                 .padding(top = 2.dp, bottom = 2.dp),
                                     )
                                 }
-                                val showReportFlag =
-                                    event.locallyRevealed &&
-                                        event.moderationVerdict in setOf("flag", "block")
+                                val isFlagged =
+                                    event.moderationVerdict in setOf("flag", "block")
+                                val isBlurred = isFlagged && !event.locallyRevealed
+                                val showReportFlag = isFlagged && event.locallyRevealed
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     val maxBubbleWidthForRow =
                                         if (showSenderMeta) {
@@ -302,27 +301,42 @@ internal fun MessageEventRow(
                                         } else {
                                             maxBubbleWidth
                                         }
-                                    Surface(
-                                        color = bubbleColor,
-                                        shape = bubbleShape,
-                                        modifier =
-                                            Modifier
-                                                .then(highlightBorderModifier)
-                                                .widthIn(max = maxBubbleWidthForRow)
-                                                .combinedClickable(
-                                                    onClick = {},
-                                                    onLongClick = onActionsLongPress,
-                                                ),
-                                    ) {
-                                        BubbleContent(
-                                            event = event,
-                                            onFocusOnReply = onFocusOnReply,
-                                            compactTimestamp = compactTimestamp,
-                                            onRevealModeration = onRevealModeration,
-                                        )
+                                    Box {
+                                        Surface(
+                                            color = bubbleColor,
+                                            shape = bubbleShape,
+                                            modifier =
+                                                Modifier
+                                                    .then(highlightBorderModifier)
+                                                    .widthIn(max = maxBubbleWidthForRow)
+                                                    .then(
+                                                        if (isBlurred) {
+                                                            Modifier.blur(radius = 22.dp)
+                                                        } else {
+                                                            Modifier
+                                                        },
+                                                    ).combinedClickable(
+                                                        onClick = {
+                                                            if (isBlurred) onRevealModeration()
+                                                        },
+                                                        onLongClick = onActionsLongPress,
+                                                    ),
+                                        ) {
+                                            BubbleContent(
+                                                event = event,
+                                                onFocusOnReply = onFocusOnReply,
+                                                compactTimestamp = compactTimestamp,
+                                            )
+                                        }
+                                        if (isBlurred) {
+                                            FlaggedRevealOverlay(
+                                                categories = event.moderationCategories,
+                                                modifier = Modifier.align(Alignment.Center),
+                                            )
+                                        }
                                     }
                                     if (showReportFlag) {
-                                        Spacer(modifier = Modifier.width(6.dp))
+                                        Spacer(modifier = Modifier.width(8.dp))
                                         FloatingReportFlag(onClick = onReportFlagged)
                                     }
                                 }
@@ -380,7 +394,6 @@ private fun BubbleContent(
     event: TimelineItem.Event,
     onFocusOnReply: () -> Unit,
     compactTimestamp: Boolean,
-    onRevealModeration: () -> Unit,
 ) {
     Column(
         modifier =
@@ -396,33 +409,14 @@ private fun BubbleContent(
             )
             Spacer(modifier = Modifier.height(6.dp))
         }
-        // Recipient-side flagged messages: render the body with a
-        // gaussian blur until tap-to-reveal. Visual-only — body is
-        // already on the wire so the tap is local.
-        // Senders see their own message normally with a subtle
-        // warning note (they wrote it; blurring is patronising).
-        val isFlaggedRecipient =
-            !event.isMine &&
-                event.moderationVerdict in setOf("flag", "block")
-        if (isFlaggedRecipient && !event.locallyRevealed) {
-            BlurredFlaggedBody(
-                body = event.body,
-                categories = event.moderationCategories,
-                onReveal = onRevealModeration,
-            )
-        } else {
-            Text(
-                text = event.body,
-                style = MaterialTheme.typography.bodyLarge,
-                color = TextPrimary,
-            )
-            if (event.isMine && event.moderationVerdict in setOf("flag", "block")) {
-                Spacer(modifier = Modifier.height(4.dp))
-                OwnFlaggedNote(categories = event.moderationCategories)
-            }
-            // Note: the floating flag lives outside the bubble (in
-            // MessageEventRow) so the bubble keeps its shape and the
-            // affordance reads as "this message" not "this paragraph".
+        Text(
+            text = event.body,
+            style = MaterialTheme.typography.bodyLarge,
+            color = TextPrimary,
+        )
+        if (event.isMine && event.moderationVerdict in setOf("flag", "block")) {
+            Spacer(modifier = Modifier.height(4.dp))
+            OwnFlaggedNote(categories = event.moderationCategories)
         }
         Row(
             modifier = Modifier.align(Alignment.End).padding(top = 4.dp),
@@ -447,85 +441,70 @@ private fun BubbleContent(
 }
 
 @Composable
-private fun BlurredFlaggedBody(
-    body: String,
+private fun FlaggedRevealOverlay(
     categories: List<String>,
-    onReveal: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val label = polishCategoryList(categories)
-    Box(
-        modifier =
-            Modifier
-                .clickable(onClick = onReveal),
-        contentAlignment = Alignment.Center,
+    Surface(
+        color = Background.copy(alpha = 0.78f),
+        shape = RoundedCornerShape(999.dp),
+        modifier = modifier,
     ) {
-        // Blurred body, dimmed slightly to soften residual letter-shape
-        // hints and let the overlay pill stand out cleanly. Italic adds
-        // texture so the row doesn't read as a loading skeleton.
-        Text(
-            text = body,
-            style = MaterialTheme.typography.bodyLarge.copy(fontStyle = FontStyle.Italic),
-            color = TextPrimary.copy(alpha = 0.6f),
-            modifier = Modifier.blur(radius = 18.dp),
-        )
-        // Centered glass pill — backdrop alpha keeps the blurred body
-        // visible behind it so the user sees there's content to reveal.
-        Surface(
-            color = Background.copy(alpha = 0.55f),
-            shape = RoundedCornerShape(999.dp),
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 5.dp),
-            ) {
-                Icon(
-                    imageVector = PhosphorIcons.Bold.Eye,
-                    contentDescription = null,
-                    tint = Primary,
-                    modifier = Modifier.size(13.dp),
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-                Text(
-                    text = "Pokaż",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = Primary,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Box(
-                    modifier =
-                        Modifier
-                            .size(width = 1.dp, height = 10.dp)
-                            .background(TextSecondary.copy(alpha = 0.4f)),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = label,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = TextSecondary,
-                )
-            }
+            Icon(
+                imageVector = PhosphorIcons.Bold.Eye,
+                contentDescription = null,
+                tint = Primary,
+                modifier = Modifier.size(14.dp),
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = "Pokaż",
+                style = MaterialTheme.typography.labelSmall,
+                color = Primary,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(
+                modifier =
+                    Modifier
+                        .size(width = 1.dp, height = 10.dp)
+                        .background(TextSecondary.copy(alpha = 0.4f)),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = TextSecondary,
+            )
         }
     }
 }
 
 @Composable
 private fun FloatingReportFlag(onClick: () -> Unit) {
-    // Floating circular flag beside the bubble. Single tap reports.
+    // Floating circular flag beside the bubble. Single tap opens the
+    // report dialog; bigger than a typical chat-icon hit-target so it
+    // reads as the primary affordance after reveal.
     Surface(
         color = MaterialTheme.colorScheme.errorContainer,
         contentColor = MaterialTheme.colorScheme.onErrorContainer,
         shape = CircleShape,
+        shadowElevation = 2.dp,
         modifier =
             Modifier
-                .size(28.dp)
+                .size(36.dp)
                 .clickable(onClick = onClick),
     ) {
         Box(contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = PhosphorIcons.Bold.Flag,
                 contentDescription = "Zgłoś",
-                modifier = Modifier.size(14.dp),
+                modifier = Modifier.size(20.dp),
             )
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/model/ChatUiModels.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/model/ChatUiModels.kt
@@ -43,6 +43,11 @@ data class ChatUiState(
     val searchMatchIndices: List<Int> = emptyList(),
     val currentSearchMatchIndex: Int = -1,
     val isBlocked: Boolean = false,
+    /**
+     * Set when the user taps the floating flag on a flagged message
+     * — drives the report dialog. Cleared on submit/dismiss.
+     */
+    val pendingMessageReport: TimelineItem.Event? = null,
 )
 
 data class NewChatUiState(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
@@ -167,6 +167,15 @@ fun EventChatScreen(
             )
         }
 
+        if (chatState.pendingMessageReport != null) {
+            ReportDialog(
+                onConfirm = { reason, description ->
+                    chatViewModel.submitMessageReport(reason, description)
+                },
+                onDismiss = chatViewModel::dismissMessageReport,
+            )
+        }
+
         // Snackbar overlay
         eventState.snackbarMessage?.let { message ->
             AppSnackbar(

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
@@ -271,4 +271,15 @@ class ApiService(
     @Suppress("ktlint:standard:function-signature")
     suspend fun revealChatMessage(messageId: String): ApiResult<SuccessResponse> =
         client.post("/api/v1/chat/messages/$messageId/reveal")
+
+    /** File a per-message moderation report. */
+    suspend fun reportChatMessage(
+        messageId: String,
+        reason: String,
+        description: String? = null,
+    ): ApiResult<SuccessResponse> =
+        client.post(
+            "/api/v1/chat/messages/$messageId/report",
+            ReportConversationRequest(reason = reason, description = description),
+        )
 }


### PR DESCRIPTION
Adds proper per-message moderation reporting + nicer visuals.

**Backend**: new chat_message_reports table that snapshots the auto-mod verdict + categories at file time; POST /chat/messages/:id/report accepts the same reason set as the conversation-level endpoint and is idempotent on (message_id, reporter_user_id). RLS gates inserts to messages the viewer can actually see.

**Mobile**: tap the floating flag → opens the existing ReportDialog (reason chips). Submit calls the new endpoint. Per-message reports now land in the new table with the user, message, and the auto-mod context properly recorded.

**Visuals**: blur is now applied to the entire bubble surface (22 dp), not just the body text. Centered glass pill (eye + Pokaż + category) on top. Floating flag bumped to 36 dp with shadow elevation so it reads as the primary post-reveal affordance.

App version 0.18.11.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-message report endpoint and improve flagged message blur UI in chat
> - Adds a `POST /api/v1/chat/messages/{id}/report` endpoint backed by a new `chat_message_reports` table with RLS; valid reasons are `spam`, `inappropriate`, `misleading`, `harassment`, `hate_speech`, `violence`, `scam`, `other`; duplicate reports are silently ignored.
> - Tapping the floating flag on a flagged message now opens a `ReportDialog` (with reason + optional description) instead of filing a conversation-level report directly.
> - Flagged message bubbles are now blurred at the bubble level with a centered `FlaggedRevealOverlay` pill; tapping the bubble reveals the content.
> - The floating report flag is larger (36dp surface, 20dp icon) and more visually prominent.
> - Behavioral Change: `reportFlaggedMessage` no longer calls the conversation report API; it sets `pendingMessageReport` in UI state, which drives the new dialog flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5f92534. 10 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->