### PR TITLE
fix(chat): close message-id enumeration in reveal handler

### DIFF
--- a/backend/src/api/chat/reveal_handler.rs
+++ b/backend/src/api/chat/reveal_handler.rs
@@ -51,21 +51,19 @@ pub(in crate::api) async fn message_reveal(
         async move {
             // RLS on chat_message_reveals enforces both that the
             // viewer is a member of the message's conversation and
-            // that they're inserting for themselves. So the only
-            // failure mode we need to surface is "message doesn't
-            // exist" — which RLS would surface as a CHECK violation
-            // we can't distinguish, hence the explicit pre-check.
-            let exists: bool = crate::db::schema::messages::table
-                .filter(crate::db::schema::messages::id.eq(message_id))
-                .count()
-                .get_result::<i64>(conn)
-                .await?
-                > 0;
-            if !exists {
-                return Ok::<_, diesel::result::Error>(RevealOutcome::NotFound);
-            }
-
-            diesel::insert_into(r::chat_message_reveals)
+            // that they're inserting for themselves. The FK on
+            // `message_id` enforces existence.
+            //
+            // We deliberately do NOT pre-check existence: an existence
+            // probe before the RLS-gated insert would let any caller
+            // distinguish "message doesn't exist" (404 from probe)
+            // from "exists but not in your conversation" (RLS reject)
+            // — i.e. enumerate every message UUID in the system. The
+            // insert itself is the source of truth: success means the
+            // viewer can see this message and it exists; any failure
+            // collapses to NOT_FOUND so the responses are
+            // indistinguishable from the outside.
+            let insert_result = diesel::insert_into(r::chat_message_reveals)
                 .values((
                     r::message_id.eq(message_id),
                     r::viewer_user_id.eq(viewer_user_id),
@@ -74,9 +72,24 @@ pub(in crate::api) async fn message_reveal(
                 .on_conflict((r::message_id, r::viewer_user_id))
                 .do_nothing()
                 .execute(conn)
-                .await?;
+                .await;
 
-            Ok(RevealOutcome::Inserted)
+            match insert_result {
+                Ok(_) => Ok::<_, diesel::result::Error>(RevealOutcome::Inserted),
+                Err(err) => {
+                    // FK violation (message gone) and RLS rejection
+                    // (not your conversation, or somebody else's
+                    // viewer_user_id) both surface here. Log so real
+                    // outages aren't silently 404'd, then collapse.
+                    tracing::debug!(
+                        message_id = %message_id,
+                        viewer_user_id,
+                        error = %err,
+                        "chat reveal rejected (treating as not-found for response uniformity)"
+                    );
+                    Ok(RevealOutcome::NotFound)
+                }
+            }
         }
         .scope_boxed()
     })


### PR DESCRIPTION
## Summary

The reveal handler did a raw existence probe on `messages` before the RLS-gated insert into `chat_message_reveals`. The probe returned a clean `NOT_FOUND` for "no such message"; the RLS reject for "exists but not in your conversation" surfaced as an `Err` from the insert. The two error paths produced **different** responses, letting any caller distinguish them and enumerate message UUIDs system-wide.

## Fix

Drop the pre-check. The FK on `message_id → messages(id)` enforces existence; the RLS `WITH CHECK` on the table enforces conversation membership and self-insertion (see `migrations/2026-04-27-180000_chat_moderation_blur/up.sql`). Run the insert directly and collapse **any** DB error to `NOT_FOUND` so the response is identical whether:

- the message id doesn't exist (FK violation, SQLSTATE 23503),
- it exists but the caller isn't a member of its conversation (RLS WITH CHECK, SQLSTATE 42501),
- the caller spoofed `viewer_user_id` (also blocked by RLS).

Real DB outages still get a `tracing::debug!` for ops visibility — they'll silently 404 to the client, but they're observable server-side. (I considered logging at `warn`, but the expected non-membership case would be too noisy; debug is the right level given that this endpoint is rare.)

Idempotency on repeat reveals is preserved by the existing `on_conflict.do_nothing()`.

## Repro (before fix)

```bash
# Authenticated as user A who is NOT a member of conversation X
M_REAL=<real message id from convo X>
M_FAKE=$(uuidgen)

# Real id, no membership: server returns 500 / DB error path
curl -X POST .../chat/messages/$M_REAL/reveal -H "Authorization: Bearer ..."

# Fake id: server returns 404 NOT_FOUND
curl -X POST .../chat/messages/$M_FAKE/reveal -H "Authorization: Bearer ..."
```

After fix: both responses are byte-identical 404 NOT_FOUND.

## Test plan

- [ ] `cargo clippy --all-targets` clean (locally verified)
- [ ] `cargo check --tests` clean (locally verified)
- [ ] Manual: send to a conversation you're a member of → 200; send a random UUID → 404; send a real id from a conversation you're not in → 404 (same response shape).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix message-id enumeration in chat `message_reveal` handler
> Removes the pre-insert existence check for messages, which could be used to enumerate valid message IDs via distinct error responses. Instead, the insert into `chat_message_reveals` is attempted directly, and any failure (FK violation, RLS rejection, or other DB error) is collapsed into a `NotFound` outcome with a debug log. This makes the response indistinguishable regardless of whether the message exists or access is denied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86d7b37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->