### PR TITLE
fix(mobile): install HttpTimeout on Ktor clients

### DIFF
--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiClient.kt
@@ -2,6 +2,7 @@ package com.poziomki.app.network
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.plugins.defaultRequest
@@ -47,6 +48,16 @@ class ApiClient(
                 json(json)
             }
             install(HttpCookies)
+            install(HttpTimeout) {
+                // Total budget for a request including TLS, redirects, body
+                // streaming. 60s accommodates uploads on slow mobile networks
+                // without leaving spinners pinned forever on dead connections.
+                requestTimeoutMillis = REQUEST_TIMEOUT_MS
+                connectTimeoutMillis = CONNECT_TIMEOUT_MS
+                // Per-read inactivity. A stalled stream gets killed after 30s
+                // even if the overall request budget hasn't expired.
+                socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            }
             if (enableHttpLogging) {
                 install(Logging) {
                     level = LogLevel.INFO
@@ -62,8 +73,19 @@ class ApiClient(
     private val rawClient =
         HttpClient(engine) {
             install(HttpCookies)
+            install(HttpTimeout) {
+                requestTimeoutMillis = REQUEST_TIMEOUT_MS
+                connectTimeoutMillis = CONNECT_TIMEOUT_MS
+                socketTimeoutMillis = SOCKET_TIMEOUT_MS
+            }
             defaultRequest { url(baseUrl) }
         }
+
+    private companion object {
+        const val REQUEST_TIMEOUT_MS = 60_000L
+        const val CONNECT_TIMEOUT_MS = 15_000L
+        const val SOCKET_TIMEOUT_MS = 30_000L
+    }
 
     suspend inline fun <reified T> get(path: String): ApiResult<T> =
         request {


### PR DESCRIPTION
## Summary

Both Ktor `HttpClient` instances in `ApiClient.kt` (`httpClient` for JSON API, `rawClient` for binary downloads/exports) were created with **no `HttpTimeout` plugin**. Ktor's default is unbounded — a request against a stalled connection suspends the calling coroutine forever.

This is a real UX bug, not a hypothetical: on a poor connection a `viewModelScope` request can outlive the screen (Compose disposes the UI but the coroutine still holds the bearer token, the spinner stays pinned in any consumer of the parent flow, and navigation away doesn't cancel the in-flight call until the OS kills the socket many minutes later).

## Fix

Install `HttpTimeout` on both clients with shared constants:

| Setting | Value | Why |
| --- | --- | --- |
| `requestTimeoutMillis` | 60 s | Total budget. 60 s accommodates `uploadFile()` over slow mobile networks; smaller call sites benefit because the bound is finite. |
| `connectTimeoutMillis` | 15 s | TLS + DNS + handshake. |
| `socketTimeoutMillis` | 30 s | Per-read inactivity — kills stalled streams even when the overall budget hasn't expired. |

Timeouts surface as exceptions, which fall into the existing `catch (e: Exception)` in `request()`, `uploadFile()`, and `downloadBytes()`, producing `ApiResult.Error(..., "NETWORK_ERROR", 0)` — the same shape callers already handle for connectivity failures, so no caller-side changes needed.

## Repro (before fix)

1. On a device, throttle the upstream to ~10 KB/s with a network conditioner (or pull the SIM mid-request).
2. Tap login (or any API-backed action).
3. Spinner spins past 2 minutes; navigating away doesn't cancel.

After fix: at 60 s the request errors out with `NETWORK_ERROR`, the UI surfaces the standard offline message, and the coroutine completes.

## Test plan

- [x] `./gradlew :core:compileCommonMainKotlinMetadata` clean
- [x] `./gradlew :core:compileAndroidMain` clean
- [ ] Manual: throttle network on device → confirm requests error within ~60 s
- [ ] Manual: large upload over Wi-Fi still completes within budget

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install `HttpTimeout` on Ktor clients in `ApiClient`
> Adds the `HttpTimeout` plugin to both `httpClient` and `rawClient` in [ApiClient.kt](https://github.com/poziomki-app/poziomki/pull/279/files#diff-5804553f6989e4d5b72621c9fc0771a56307f80a681f0a707b89b28d0b82b5b2). Timeouts are defined as companion object constants: 60s request, 15s connect, and 30s socket. Risk: requests that previously hung indefinitely will now fail with a Ktor timeout exception after the configured limits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71b73eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->