### PR TITLE
fix(mobile): make Android session writes durable and ordered

### DIFF
--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/session/AndroidSecureSessionTokenStore.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/session/AndroidSecureSessionTokenStore.kt
@@ -5,6 +5,8 @@ package com.poziomki.app.session
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class AndroidSecureSessionTokenStore(
     context: Context,
@@ -21,20 +23,33 @@ class AndroidSecureSessionTokenStore(
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
         )
 
-    override suspend fun getToken(): String? = sharedPreferences.getString(KEY_TOKEN, null)
+    override suspend fun getToken(): String? =
+        withContext(Dispatchers.IO) {
+            sharedPreferences.getString(KEY_TOKEN, null)
+        }
 
+    // Use commit() (synchronous) rather than apply() so the caller's
+    // suspend boundary is the disk-flush boundary. With apply(), the
+    // SessionManager.saveSession sequence "saveToken → dataStore.edit"
+    // would let the DataStore commit beat the token to disk; a crash
+    // between the two leaves USER_ID set with no token, and the app
+    // boots into a logged-in-no-token state with no recovery path.
     override suspend fun saveToken(token: String) {
-        sharedPreferences
-            .edit()
-            .putString(KEY_TOKEN, token)
-            .apply()
+        withContext(Dispatchers.IO) {
+            sharedPreferences
+                .edit()
+                .putString(KEY_TOKEN, token)
+                .commit()
+        }
     }
 
     override suspend fun clearToken() {
-        sharedPreferences
-            .edit()
-            .remove(KEY_TOKEN)
-            .apply()
+        withContext(Dispatchers.IO) {
+            sharedPreferences
+                .edit()
+                .remove(KEY_TOKEN)
+                .commit()
+        }
     }
 
     private companion object {

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/SessionManager.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/SessionManager.kt
@@ -52,6 +52,12 @@ class SessionManager(
         email: String,
         name: String,
     ) {
+        // Order matters: token first (durably flushed by tokenStore),
+        // then DataStore. USER_ID is the gate that `isLoggedIn` reads,
+        // so committing it last guarantees we never observe
+        // logged-in-without-token. If the second write fails, USER_ID
+        // stays unset, the app shows the login screen, and the next
+        // sign-in overwrites the orphaned token cleanly.
         tokenStore.saveToken(token)
         dataStore.edit { prefs ->
             prefs[USER_ID] = userId
@@ -100,12 +106,18 @@ class SessionManager(
     }
 
     suspend fun clearSession() {
-        tokenStore.clearToken()
-        // Preserve device_id across logouts
+        // Order matters (mirrors saveSession): clear USER_ID first so
+        // `isLoggedIn` immediately observes false, *then* drop the
+        // token. If we crash between the two, we'd have an orphaned
+        // token but no USER_ID — the app shows the login screen, the
+        // next sign-in overwrites the token, and there's no stuck
+        // logged-in-without-token state.
+        // Preserve device_id across logouts.
         val deviceId = dataStore.data.first()[DEVICE_ID]
         dataStore.edit {
             it.clear()
             if (deviceId != null) it[DEVICE_ID] = deviceId
         }
+        tokenStore.clearToken()
     }
 }


### PR DESCRIPTION
## Summary

Two coupled bugs in the Android session-persistence path that, together, leave the app stuck in an unrecoverable logged-in-without-token state after a process death.

### Bug 1 — non-durable token writes

`AndroidSecureSessionTokenStore.saveToken` used `EncryptedSharedPreferences.edit().apply()`. `.apply()` returns immediately and queues the disk flush on a background thread. The suspending function therefore resolved *before* the token was actually on disk.

`SessionManager.saveSession` does:

```kotlin
tokenStore.saveToken(token)        // returns before flush (under .apply)
dataStore.edit { prefs[USER_ID] = ... }  // DataStore is durable on return
```

So the DataStore commit could win the race. A crash in that window leaves `USER_ID` persisted but no token. On next launch:

- `isLoggedIn` reads `prefs[USER_ID] != null` → **true**
- `tokenProvider()` → **null**
- every API call returns 401, the existing 401 handler clears session, but the user-visible wedge is real until that round-trip happens

### Bug 2 — wrong clear order

`SessionManager.clearSession` cleared the token first, then DataStore. After fix #1 (durable token writes), a crash between the two flips the failure mode: token gone, `USER_ID` still set → same logged-in-without-token wedge.

## Fix

- `AndroidSecureSessionTokenStore`: switch `.apply()` → `.commit()` on `Dispatchers.IO`. The suspend boundary is now the disk-flush boundary, so `saveSession`'s ordering becomes meaningful.
- `SessionManager.saveSession`: ordering preserved (token first, then DataStore-with-`USER_ID`), now with a comment documenting the invariant.
- `SessionManager.clearSession`: reordered — clear `USER_ID` first, then the token. A crash between the two leaves an orphaned token; the next sign-in overwrites it cleanly. No stuck state.

`getToken` also dispatches on `Dispatchers.IO` now — EncryptedSharedPreferences reads are crypto-bound and shouldn't run on whatever thread happens to call `tokenProvider()`. Minor, but consistent.

## Repro (before fix)

1. Sign in successfully on Android.
2. Mid-`saveSession` (or right after), force-stop the app from adb (`adb shell am force-stop ...`).
3. Relaunch. Observe: app shows authed UI, but every request 401s.

After fix: either both writes are durable (clean state) or only the token is — which leaves `USER_ID` unset, the app shows login, and re-auth overwrites the orphaned token.

## Test plan

- [x] `./gradlew :core:compileCommonMainKotlinMetadata` clean
- [x] `./gradlew :core:compileAndroidMain` clean
- [ ] Manual: force-stop app mid-sign-in (multiple times) and verify next launch never shows authed UI without a token
- [ ] Manual: force-stop app mid-logout and verify next launch goes to login screen

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Android session token reads and writes durable and ordered
> - Switches `SharedPreferences.Editor.apply()` to `commit()` in `AndroidSecureSessionTokenStore` so `saveToken` and `clearToken` block until data is written to disk, preventing token loss on process death.
> - Wraps all `SharedPreferences` operations in `withContext(Dispatchers.IO)` to move disk I/O off the calling coroutine dispatcher.
> - Reorders `SessionManager.clearSession` to clear `USER_ID` via DataStore before calling `tokenStore.clearToken`, so `isLoggedIn` becomes false immediately rather than after token removal.
> - Behavioral Change: `saveToken` and `clearToken` now suspend until disk commit completes; callers that expected fire-and-forget semantics will now wait.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c3e4a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->