### PR TITLE
fix(events): hide finished events from mine and saved listings

### DIFF
--- a/backend/src/api/events/mod.rs
+++ b/backend/src/api/events/mod.rs
@@ -142,8 +142,9 @@ pub(super) async fn events_mine(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    list_events_with_viewer(&headers, |conn, profile_id| {
-        Box::pin(async move { events_repo::list_events_by_creator(conn, profile_id).await })
+    let now = Utc::now();
+    list_events_with_viewer(&headers, move |conn, profile_id| {
+        Box::pin(async move { events_repo::list_events_by_creator(conn, profile_id, now).await })
     })
     .await
 }
@@ -152,8 +153,9 @@ pub(super) async fn events_saved(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    list_events_with_viewer(&headers, |conn, profile_id| {
-        Box::pin(async move { events_repo::list_saved_events(conn, profile_id).await })
+    let now = Utc::now();
+    list_events_with_viewer(&headers, move |conn, profile_id| {
+        Box::pin(async move { events_repo::list_saved_events(conn, profile_id, now).await })
     })
     .await
 }

--- a/backend/src/api/events/repo.rs
+++ b/backend/src/api/events/repo.rs
@@ -28,10 +28,17 @@ pub(in crate::api) async fn list_upcoming_events(
 pub(in crate::api) async fn list_events_by_creator(
     conn: &mut AsyncPgConnection,
     creator_id: Uuid,
+    now: DateTime<Utc>,
 ) -> std::result::Result<Vec<Event>, crate::error::AppError> {
     let models = events::table
         .filter(events::creator_id.eq(creator_id))
-        .order(events::starts_at.desc())
+        .filter(
+            events::ends_at
+                .is_null()
+                .and(events::starts_at.ge(now))
+                .or(events::ends_at.ge(now)),
+        )
+        .order(events::starts_at.asc())
         .load::<Event>(conn)
         .await?;
     Ok(models)
@@ -40,6 +47,7 @@ pub(in crate::api) async fn list_events_by_creator(
 pub(in crate::api) async fn list_saved_events(
     conn: &mut AsyncPgConnection,
     profile_id: Uuid,
+    now: DateTime<Utc>,
 ) -> std::result::Result<Vec<Event>, crate::error::AppError> {
     let models = events::table
         .inner_join(
@@ -47,6 +55,12 @@ pub(in crate::api) async fn list_saved_events(
                 .eq(events::id)
                 .and(event_interactions::profile_id.eq(profile_id))
                 .and(event_interactions::kind.eq(super::EVENT_INTERACTION_SAVED))),
+        )
+        .filter(
+            events::ends_at
+                .is_null()
+                .and(events::starts_at.ge(now))
+                .or(events::ends_at.ge(now)),
         )
         .order(event_interactions::created_at.desc())
         .select(events::all_columns)


### PR DESCRIPTION
## Summary

Follow-up to #274. The same finished-event filter is now applied to:

- `GET /events/mine` (`list_events_by_creator`)
- `GET /events/saved` (`list_saved_events`)

Both endpoints previously returned every event the user created/saved regardless of whether it had already ended.

GDPR export (`load_created_events` / `load_attended_events`) is intentionally **not** changed — exports should remain a complete record of the user's data.

Stacked on top of #274 — merge that first.

## Test plan
- [ ] \`cargo clippy --all-targets\` (passes via pre-commit hook)
- [ ] Manual: create an event with \`ends_at\` in the past, confirm it disappears from \"My Events\" and \"Saved\"
- [ ] Manual: confirm GDPR export still lists past events

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide finished events from 'mine' and 'saved' event listings
> - `list_events_by_creator` and `list_saved_events` in [`repo.rs`](https://github.com/poziomki-app/poziomki/pull/281/files#diff-c8fefb2a843f2ea25954f0b78583b65bcc2d77f5c092e7718a2d651b13d7ee6c) now accept a `now: DateTime<Utc>` parameter and filter out events where `ends_at < now` (or where `ends_at IS NULL` and `starts_at < now`).
> - `events_mine` and `events_saved` handlers in [`mod.rs`](https://github.com/poziomki-app/poziomki/pull/281/files#diff-03f46e1a6cf81812831dade3f069b7a9b0ae706786ce26a9e16cdbc5012af821) capture `Utc::now()` and pass it through to the repository.
> - Behavioral Change: `events_mine` results are now ordered by `starts_at` ascending instead of descending, and both endpoints no longer return past events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 311d2a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->