### PR TITLE
fix(mobile): preserve chat timeline cache across cold starts

### DIFF
--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -210,7 +210,10 @@ class WsChatClient(
             }
 
         return if (connected == true) {
-            roomTimelineCacheStore.clearAll()
+            // Don't clear the persistent timeline cache here — server
+            // snapshots overwrite stale entries as they arrive, and
+            // wiping on every cold start defeats the offline-open path
+            // (UI reads the cache first in ChatViewModel.openRoom).
             Result.success(Unit)
         } else {
             _state.value = ChatClientState.Error("Connection timeout")


### PR DESCRIPTION
## Summary

`WsChatClient.ensureStarted()` called `roomTimelineCacheStore.clearAll()` on every successful WS connect. Since `App.kt` warms up the chat client at launch for any logged-in user, the persistent SqlDelight timeline cache was wiped before the UI could ever read it.

## Symptom

- Visible blank-then-fill flash on every cold open of any room.
- Offline launch: zero history shown even though the cache exists on disk.
- `ChatViewModel.openRoom` reads `getRoomTimelineCache` first (line 508) — by the time we get there, the cache has already been emptied by warmup.

## Fix

Drop the `clearAll()` call. Server snapshots already overwrite stale rows as they arrive via the normal WS message path. If schema-driven invalidation is ever needed (e.g. a SqlDelight migration), do it once at install/migration time, not on every reconnect.

## Test plan

- [ ] Open the app fresh while logged in, navigate to a room — messages render immediately, no blank-flash.
- [ ] Force-quit, then open offline. The cached messages should still be visible.
- [ ] Send a new message; older cached messages aren't duplicated.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve chat timeline cache on WebSocket reconnection in mobile
> Previously, `WsChatClient` called `roomTimelineCacheStore.clearAll()` on every successful connection, discarding cached messages on cold starts. The cache is now left intact and relies on incoming server snapshots to overwrite stale entries, preserving offline-open behavior.
>
> Behavioral Change: cached timeline entries now persist across reconnects until replaced by server data, rather than being wiped on each connection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08f92b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->