### PR TITLE
fix(map,events): sort nearby by distance, drop finished events in filter

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
@@ -12,6 +12,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
 
 data class EventsState(
     val allEvents: List<Event> = emptyList(),
@@ -212,15 +219,18 @@ class EventsViewModel(
         viewModelScope.launch {
             when (val result = apiService.getMatchingEvents(lat = lat, lng = lng, radiusM = radiusM)) {
                 is ApiResult.Success -> {
-                    val nearby = result.data
-                    val closest =
-                        nearby
+                    val sortedNearby =
+                        result.data
                             .filter { it.latitude != null && it.longitude != null }
-                            .minByOrNull { distanceDeg(lat, lng, it.latitude!!, it.longitude!!) }
+                            .map { it to distanceMeters(lat, lng, it.latitude!!, it.longitude!!) }
+                            .filter { (_, d) -> d <= radiusM }
+                            .sortedBy { (_, d) -> d }
+                            .map { (event, _) -> event }
                     _state.value =
                         _state.value.copy(
-                            nearbyEvents = nearby,
-                            selectedNearbyEventId = closest?.id ?: _state.value.selectedNearbyEventId,
+                            nearbyEvents = sortedNearby,
+                            selectedNearbyEventId =
+                                sortedNearby.firstOrNull()?.id ?: _state.value.selectedNearbyEventId,
                         )
                     filterEvents()
                 }
@@ -230,16 +240,24 @@ class EventsViewModel(
         }
     }
 
-    private fun distanceDeg(
+    private fun distanceMeters(
         lat1: Double,
         lng1: Double,
         lat2: Double,
         lng2: Double,
     ): Double {
-        val dLat = lat1 - lat2
-        val dLng = lng1 - lng2
-        return dLat * dLat + dLng * dLng
+        val earthRadiusM = 6_371_000.0
+        val dLat = (lat2 - lat1).toRadians()
+        val dLng = (lng2 - lng1).toRadians()
+        val a =
+            sin(dLat / 2) * sin(dLat / 2) +
+                cos(lat1.toRadians()) * cos(lat2.toRadians()) *
+                sin(dLng / 2) * sin(dLng / 2)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return earthRadiusM * c
     }
+
+    private fun Double.toRadians(): Double = this * PI / 180.0
 
     fun onSwipeFeedback(
         eventId: String,
@@ -306,8 +324,10 @@ class EventsViewModel(
                 TimeFilter.NEARBY -> current.nearbyEvents
                 else -> current.allEvents
             }
+        val now = Clock.System.now()
         val filtered =
             source.filter { event ->
+                val notFinished = !event.hasFinished(now)
                 val notDismissed =
                     current.activeFilter != TimeFilter.ALL || event.id !in current.dismissedEventIds
                 val matchesSearch =
@@ -320,8 +340,14 @@ class EventsViewModel(
                 val matchesTags =
                     current.selectedCategories.isEmpty() ||
                         event.tags.any { it.category in current.selectedCategories }
-                notDismissed && matchesSearch && matchesTime && matchesTags
+                notFinished && notDismissed && matchesSearch && matchesTime && matchesTags
             }
         _state.value = current.copy(events = filtered)
+    }
+
+    private fun Event.hasFinished(now: Instant): Boolean {
+        val end = endsAt ?: startsAt
+        val endInstant = runCatching { Instant.parse(end) }.getOrNull() ?: return false
+        return endInstant < now
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #275 and #274. Two fixes that hit the same screen:

1. **Nearby tab now actually surfaces the closest events.** `loadNearbyEvents` previously kept the backend response in arbitrary order and only used distance to pick a single \"selected\" pin. Now we compute haversine distance in meters, drop anything outside `radiusM`, and sort nearest-first — so the list itself is ordered by proximity.
2. **Defense-in-depth finish filter in the view layer.** `EventsViewModel.filterEvents` now also drops events whose end is in the past, so a stale cache row or an unfiltered API path can't render a finished event in any tab.

Stacked on top of #275 — merge that first.

## Test plan
- [ ] \`./gradlew :androidApp:compileDebugKotlin\` (passes locally; pre-commit ran detekt + ktlint)
- [ ] Manual: open Nearby tab — events appear sorted by distance and far-away events are filtered out
- [ ] Manual: insert a finished event into local cache and confirm it doesn't render in any tab

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort nearby events by distance and exclude finished events from map filter
> - Replaces a squared-degree distance approximation with a haversine calculation in `distanceMeters`, yielding accurate geodesic distances in meters.
> - Nearby events are now filtered to within the given radius, sorted by distance ascending, and the default selected event is the nearest one in range.
> - Finished events (past `endsAt` or `startsAt`) are excluded from the filtered events list via a new `Event.hasFinished` helper in [`EventsViewModel.kt`](https://github.com/poziomki-app/poziomki/pull/283/files#diff-b2c66bd651d1d73d57ae5d3393ac44ada5336f26f262f8dd4be4eaaa7601334c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33f032c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->