### PR TITLE
fix(chat): report envelope + hidden-message UI + auto-picked reason

### DIFF
--- a/backend/src/api/chat/message_report_handler.rs
+++ b/backend/src/api/chat/message_report_handler.rs
@@ -21,7 +21,7 @@ use diesel_async::RunQueryDsl;
 use serde::Deserialize;
 
 use crate::api::common::{auth_or_respond, error_response, parse_uuid_response, ErrorSpec};
-use crate::api::state::SuccessResponse;
+use crate::api::state::{DataResponse, SuccessResponse};
 use crate::app::AppContext;
 use crate::db;
 use crate::db::schema::{chat_message_reports::dsl as r, messages::dsl as m};
@@ -152,6 +152,9 @@ pub(in crate::api) async fn message_report(
                 details: None,
             },
         )),
-        ReportOutcome::Inserted => Ok(Json(SuccessResponse { success: true }).into_response()),
+        ReportOutcome::Inserted => Ok(Json(DataResponse {
+            data: SuccessResponse { success: true },
+        })
+        .into_response()),
     }
 }

--- a/backend/src/api/chat/reveal_handler.rs
+++ b/backend/src/api/chat/reveal_handler.rs
@@ -17,7 +17,7 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::RunQueryDsl;
 
 use crate::api::common::{auth_or_respond, error_response, parse_uuid_response, ErrorSpec};
-use crate::api::state::SuccessResponse;
+use crate::api::state::{DataResponse, SuccessResponse};
 use crate::app::AppContext;
 use crate::db;
 use crate::db::schema::chat_message_reveals::dsl as r;
@@ -92,6 +92,9 @@ pub(in crate::api) async fn message_reveal(
                 details: None,
             },
         )),
-        RevealOutcome::Inserted => Ok(Json(SuccessResponse { success: true }).into_response()),
+        RevealOutcome::Inserted => Ok(Json(DataResponse {
+            data: SuccessResponse { success: true },
+        })
+        .into_response()),
     }
 }

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.18.11" // x-release-please-version
+val appVersionName = "0.18.12" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -205,15 +205,6 @@ fun ChatScreen(
             onDismiss = { showReportDialog = false },
         )
     }
-
-    if (state.pendingMessageReport != null) {
-        ReportDialog(
-            onConfirm = { reason, description ->
-                viewModel.submitMessageReport(reason, description)
-            },
-            onDismiss = viewModel::dismissMessageReport,
-        )
-    }
 }
 
 @Composable

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -333,25 +333,17 @@ class ChatViewModel(
         }
     }
 
-    /** Open the existing ReportDialog targeted at this message. */
+    /**
+     * One-tap report: auto-picks a reason from the moderation
+     * categories so the user doesn't have to re-select something
+     * the engine already determined. Categories that don't have a
+     * matching report reason fall through to "inappropriate".
+     */
     fun reportFlaggedMessage(event: TimelineItem.Event) {
-        if (event.eventId == null) return
-        _uiState.update { it.copy(pendingMessageReport = event) }
-    }
-
-    fun dismissMessageReport() {
-        _uiState.update { it.copy(pendingMessageReport = null) }
-    }
-
-    fun submitMessageReport(
-        reason: String,
-        description: String?,
-    ) {
-        val target = _uiState.value.pendingMessageReport ?: return
-        val messageId = target.eventId ?: return
-        _uiState.update { it.copy(pendingMessageReport = null) }
+        val messageId = event.eventId ?: return
+        val reason = autoPickReportReason(event.moderationCategories)
         viewModelScope.launch {
-            when (apiService.reportChatMessage(messageId, reason, description)) {
+            when (apiService.reportChatMessage(messageId, reason, null)) {
                 is ApiResult.Success -> {
                     _uiState.update { it.copy(error = "Zgłoszenie wysłane. Dzięki.") }
                 }
@@ -360,6 +352,25 @@ class ChatViewModel(
                     _uiState.update { it.copy(error = "Nie udało się wysłać zgłoszenia.") }
                 }
             }
+        }
+    }
+
+    private fun autoPickReportReason(categories: List<String>): String {
+        // Map auto-mod categories → conversation report reasons.
+        // Order matters: the first hit wins, so worst-case categories
+        // (hate, violence) outrank vulgar.
+        val priority = listOf("hate", "self_harm", "crime", "sex", "vulgar")
+        val first = priority.firstOrNull { it in categories } ?: return "inappropriate"
+        return when (first) {
+            "hate" -> "hate_speech"
+
+            "crime" -> "violence"
+
+            "self_harm" -> "other"
+
+            // vulgar + sex collapse to "inappropriate" — the picker
+            // doesn't have a finer-grained reason for them.
+            else -> "inappropriate"
         }
     }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -40,7 +40,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -56,7 +55,7 @@ import com.adamglin.phosphoricons.bold.ArrowBendUpLeft
 import com.adamglin.phosphoricons.bold.Check
 import com.adamglin.phosphoricons.bold.CheckCircle
 import com.adamglin.phosphoricons.bold.Clock
-import com.adamglin.phosphoricons.bold.Eye
+import com.adamglin.phosphoricons.bold.EyeSlash
 import com.adamglin.phosphoricons.bold.Flag
 import com.adamglin.phosphoricons.bold.WarningCircle
 import com.poziomki.app.chat.api.EventSendStatus
@@ -292,7 +291,7 @@ internal fun MessageEventRow(
                                 }
                                 val isFlagged =
                                     event.moderationVerdict in setOf("flag", "block")
-                                val isBlurred = isFlagged && !event.locallyRevealed
+                                val isHidden = isFlagged && !event.locallyRevealed
                                 val showReportFlag = isFlagged && event.locallyRevealed
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     val maxBubbleWidthForRow =
@@ -301,37 +300,29 @@ internal fun MessageEventRow(
                                         } else {
                                             maxBubbleWidth
                                         }
-                                    Box {
-                                        Surface(
-                                            color = bubbleColor,
-                                            shape = bubbleShape,
-                                            modifier =
-                                                Modifier
-                                                    .then(highlightBorderModifier)
-                                                    .widthIn(max = maxBubbleWidthForRow)
-                                                    .then(
-                                                        if (isBlurred) {
-                                                            Modifier.blur(radius = 22.dp)
-                                                        } else {
-                                                            Modifier
-                                                        },
-                                                    ).combinedClickable(
-                                                        onClick = {
-                                                            if (isBlurred) onRevealModeration()
-                                                        },
-                                                        onLongClick = onActionsLongPress,
-                                                    ),
-                                        ) {
+                                    Surface(
+                                        color = bubbleColor,
+                                        shape = bubbleShape,
+                                        modifier =
+                                            Modifier
+                                                .then(highlightBorderModifier)
+                                                .widthIn(max = maxBubbleWidthForRow)
+                                                .combinedClickable(
+                                                    onClick = {
+                                                        if (isHidden) onRevealModeration()
+                                                    },
+                                                    onLongClick = onActionsLongPress,
+                                                ),
+                                    ) {
+                                        if (isHidden) {
+                                            HiddenFlaggedContent(
+                                                categories = event.moderationCategories,
+                                            )
+                                        } else {
                                             BubbleContent(
                                                 event = event,
                                                 onFocusOnReply = onFocusOnReply,
                                                 compactTimestamp = compactTimestamp,
-                                            )
-                                        }
-                                        if (isBlurred) {
-                                            FlaggedRevealOverlay(
-                                                categories = event.moderationCategories,
-                                                modifier = Modifier.align(Alignment.Center),
                                             )
                                         }
                                     }
@@ -441,48 +432,42 @@ private fun BubbleContent(
 }
 
 @Composable
-private fun FlaggedRevealOverlay(
-    categories: List<String>,
-    modifier: Modifier = Modifier,
-) {
-    val label = polishCategoryList(categories)
-    Surface(
-        color = Background.copy(alpha = 0.78f),
-        shape = RoundedCornerShape(999.dp),
-        modifier = modifier,
+private fun HiddenFlaggedContent(categories: List<String>) {
+    // Replaces the bubble body with a deliberate "hidden content"
+    // placeholder. We don't try to gaussian-blur the live text — the
+    // Compose blur is API-31+ and produces inconsistent results; a
+    // typed placeholder is what mature apps (Reddit/Discord/Reddit
+    // NSFW filters) use and works on every device.
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-        ) {
-            Icon(
-                imageVector = PhosphorIcons.Bold.Eye,
-                contentDescription = null,
-                tint = Primary,
-                modifier = Modifier.size(14.dp),
-            )
-            Spacer(modifier = Modifier.width(6.dp))
+        Icon(
+            imageVector = PhosphorIcons.Bold.EyeSlash,
+            contentDescription = null,
+            tint = TextPrimary.copy(alpha = 0.7f),
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Column {
             Text(
-                text = "Pokaż",
-                style = MaterialTheme.typography.labelSmall,
-                color = Primary,
+                text = polishCategoryHeading(categories),
+                style = MaterialTheme.typography.bodyMedium,
+                color = TextPrimary,
                 fontWeight = FontWeight.SemiBold,
             )
-            Spacer(modifier = Modifier.width(8.dp))
-            Box(
-                modifier =
-                    Modifier
-                        .size(width = 1.dp, height = 10.dp)
-                        .background(TextSecondary.copy(alpha = 0.4f)),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
             Text(
-                text = label,
+                text = "Stuknij, aby pokazać",
                 style = MaterialTheme.typography.labelSmall,
-                color = TextSecondary,
+                color = Primary,
             )
         }
     }
+}
+
+private fun polishCategoryHeading(categories: List<String>): String {
+    val label = polishCategoryList(categories)
+    return "Treść oznaczona jako $label"
 }
 
 @Composable

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/model/ChatUiModels.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/model/ChatUiModels.kt
@@ -43,11 +43,6 @@ data class ChatUiState(
     val searchMatchIndices: List<Int> = emptyList(),
     val currentSearchMatchIndex: Int = -1,
     val isBlocked: Boolean = false,
-    /**
-     * Set when the user taps the floating flag on a flagged message
-     * — drives the report dialog. Cleared on submit/dismiss.
-     */
-    val pendingMessageReport: TimelineItem.Event? = null,
 )
 
 data class NewChatUiState(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
@@ -167,15 +167,6 @@ fun EventChatScreen(
             )
         }
 
-        if (chatState.pendingMessageReport != null) {
-            ReportDialog(
-                onConfirm = { reason, description ->
-                    chatViewModel.submitMessageReport(reason, description)
-                },
-                onDismiss = chatViewModel::dismissMessageReport,
-            )
-        }
-
         // Snackbar overlay
         eventState.snackbarMessage?.let { message ->
             AppSnackbar(


### PR DESCRIPTION
Three fixes after v0.18.11 testing.

1. **Report endpoint envelope**. New /chat/messages/:id/report and /chat/messages/:id/reveal returned raw {success: true}; mobile ApiClient expects {data: ...}. DB inserts were succeeding but the client surfaced an error. Wrap both in DataResponse.

2. **Replaced Modifier.blur** with a typed hidden-content placeholder. Compose runtime blur is API-31+ and inconsistent on older devices. New design shows eye-slash icon + Polish category label + 'Stuknij, aby pokazać' inside the bubble. Reads as intentional UI.

3. **Auto-picked report reason**. Tap the floating flag now skips the picker entirely and submits with a reason mapped from the auto-mod categories (hate→hate_speech, crime→violence, self_harm→other, vulgar/sex→inappropriate).

App version 0.18.12.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace report dialog with one-tap auto-reporting and hidden-content UI for flagged chat messages
> - Flagged, unrevealed messages now show a placeholder with an eye-slash icon and category heading instead of a blurred bubble with a reveal chip; tapping still reveals the content.
> - Reporting a flagged message no longer opens a dialog — `ChatViewModel.reportFlaggedMessage` immediately submits the report using an auto-picked reason derived from the message's moderation categories via the new `autoPickReportReason` helper.
> - The report dialog and related state (`pendingMessageReport`, `submitMessageReport`, `dismissMessageReport`) are removed from `ChatScreen`, `EventChatScreen`, and `ChatUiState`.
> - The backend report and reveal handlers now wrap their success response as `{"data":{"success":true}}` instead of `{"success":true}`.
> - Behavioral Change: reports are now submitted automatically with no user input; users can no longer provide a custom reason or description.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f854f7a. 7 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->