### PR TITLE
fix(mobile): guard EventCreate save against double-tap duplicates

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateViewModel.kt
@@ -203,6 +203,11 @@ class EventCreateViewModel(
 
     fun saveEvent(onSaved: () -> Unit) {
         val s = _state.value
+        // Reject re-entry while a create/update is in flight. Without
+        // this guard, isLoading is only set inside the launch block —
+        // two synchronous taps both pass the validation prelude and
+        // fire two POSTs, producing duplicate events on the server.
+        if (s.isLoading) return
         if (s.title.isBlank() || s.startsAt.isBlank()) return
         if (s.attendeeLimit.isNotBlank() && s.attendeeLimit.toIntOrNull().let { it == null || it <= 0 }) {
             parseAttendeeLimit(s)
@@ -210,8 +215,11 @@ class EventCreateViewModel(
         }
         val maxAttendees = if (s.attendeeLimit.isBlank()) null else s.attendeeLimit.toInt()
 
+        // Flip isLoading synchronously so a follow-up tap that lands
+        // before viewModelScope.launch is dispatched still sees the
+        // guard above.
+        _state.value = s.copy(isLoading = true, error = null)
         viewModelScope.launch {
-            _state.value = s.copy(isLoading = true, error = null)
             val eventId = s.eventId
             if (eventId != null) {
                 submitUpdate(s, eventId, maxAttendees, onSaved)


### PR DESCRIPTION
## Summary

\`EventCreateViewModel.saveEvent\` set \`isLoading = true\` *inside* \`viewModelScope.launch\`, after a suspension point. A laggy double-tap on the save button let both taps pass the validation prelude and fire two POSTs — producing duplicate events on the server (and duplicate PATCHes on edit).

The button's \`enabled\` flag didn't include \`!isLoading\`, so there was no visual feedback fallback either.

## Fix

- Reject re-entry at the top of \`saveEvent\` if \`isLoading\` is already set.
- Flip \`isLoading\` synchronously **before** \`viewModelScope.launch\` so a follow-up tap that lands before the coroutine is dispatched still hits the guard.

Both error branches in \`submitCreate\` / \`submitUpdate\` already reset \`isLoading = false\`. Success calls \`onSaved()\`, which navigates away and disposes the ViewModel — no extra cleanup needed.

## Test plan

- [ ] Tap "utwórz wydarzenie" twice in rapid succession — only one event created on server, button shows loading state.
- [ ] Same on edit screen — only one PATCH fires.
- [ ] On API error, button re-enables and the user can retry.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard `EventCreateViewModel.saveEvent` against double-tap duplicate submissions
> Adds a re-entry guard to `saveEvent` in [EventCreateViewModel.kt](https://github.com/poziomki-app/poziomki/pull/285/files#diff-f54d02ff30541a1dea7b224451228915a3226d908f641143e281b2171aae62c7) that returns early if `isLoading` is already true. The `isLoading = true` and `error = null` state updates are moved to before the coroutine is launched so they apply synchronously, closing the race window where a second tap could pass the guard before the coroutine sets loading state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b46ae8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->