### PR TITLE
fix(chat): show "Xg" for sub-24h messages that crossed midnight

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -172,9 +172,7 @@ private fun formatRoomTimestamp(timestampMillis: Long): String {
     if (diffMillis < 60L * 60_000L) return "${diffMillis / 60_000L} min"
     if (diffMillis < 24L * 60L * 60_000L) {
         val hours = (diffMillis / (60L * 60_000L)).coerceAtLeast(1L)
-        val nowDate = Instant.fromEpochMilliseconds(nowMillis).toLocalDateTime(TimeZone.currentSystemDefault()).date
-        val tsDate = Instant.fromEpochMilliseconds(timestampMillis).toLocalDateTime(TimeZone.currentSystemDefault()).date
-        if (nowDate == tsDate) return "${hours}g"
+        return "${hours}g"
     }
 
     val zone = TimeZone.currentSystemDefault()


### PR DESCRIPTION
## Summary
- `formatRoomTimestamp` only returned `"Xg"` when the message and "now" landed on the same calendar day. A message sent at 23:30 yesterday and read at 00:30 today (1 hour ago) fell through and was rendered as a weekday name (e.g. "niedz."), even though the next branch — "show weekday for daysDiff in 1..6" — is meant for ≥24h-old messages.
- Drop the same-day gate so anything <24h is always `"Xg"`. Weekday/date format is preserved for ≥24h.

## Repro
1. Send a message in any conversation at 23:30.
2. Reopen the messages list at 00:30 (same TZ).
3. Before: timestamp shows `"niedz."` (or equivalent weekday). After: shows `"1g"`.

## Test plan
- [ ] Manual: push the clock past midnight with a recent send, confirm "Xg" rendering.
- [ ] No regression on ≥24h-old messages (still weekday / date / date+year).
- [ ] `./gradlew :app-ui:compileAndroidMain` ✓
- [ ] detekt + ktlintCheck (pre-commit) ✓

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `formatRoomTimestamp` to show hours format for sub-24h messages that crossed midnight
> Previously, `formatRoomTimestamp` in [RoomRow.kt](https://github.com/poziomki-app/poziomki/pull/286/files#diff-638303e155da802f51e452c8fad551f5d6f23cbe70f9b86990bf5cf49e95de0c) would skip the hours format if the timestamp fell on a different calendar date than today, even if it was under 24 hours ago. The fix removes the date equality check so any timestamp within the last 24 hours always returns the `"Xg"` format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63220db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->