### PR TITLE
fix(backend): filter blocked profiles from bookmark list

### DIFF
--- a/backend/src/api/profiles/bookmarks.rs
+++ b/backend/src/api/profiles/bookmarks.rs
@@ -11,7 +11,7 @@ use crate::api::{error_response, ErrorSpec};
 use crate::db;
 use crate::db::models::profile_bookmarks::ProfileBookmark;
 use crate::db::models::profiles::Profile;
-use crate::db::schema::{profile_bookmarks, profiles};
+use crate::db::schema::{profile_blocks, profile_bookmarks, profiles};
 
 use super::profiles_view::profile_to_response;
 use crate::api::state::ProfileResponse;
@@ -106,8 +106,29 @@ pub(in crate::api) async fn profiles_bookmarked(
         .load(conn)
         .await?;
 
+    // Filter symmetric blocks. Mirrors matching/repo.rs:209-234 and
+    // search.rs — without this, a profile that bookmarked someone
+    // before either side blocked still sees the blocked profile's
+    // full data on `GET /api/v1/profiles/bookmarked`.
+    let block_rows: Vec<(Uuid, Uuid)> = profile_blocks::table
+        .filter(
+            profile_blocks::blocker_id
+                .eq(my_profile_id)
+                .or(profile_blocks::blocked_id.eq(my_profile_id)),
+        )
+        .select((profile_blocks::blocker_id, profile_blocks::blocked_id))
+        .load(conn)
+        .await?;
+    let blocked: std::collections::HashSet<Uuid> = block_rows
+        .into_iter()
+        .map(|(a, b)| if a == my_profile_id { b } else { a })
+        .collect();
+
     let mut responses = Vec::with_capacity(bookmarked_profiles.len());
     for (_bookmark, profile) in bookmarked_profiles {
+        if blocked.contains(&profile.id) {
+            continue;
+        }
         // Narrow public-projection helper avoids reading the owner's full
         // users row just to get their pid.
         let owner_pid = db::user_pid_for_id(conn, profile.user_id)


### PR DESCRIPTION
## Summary

\`profiles_bookmarked\` joined \`profile_bookmarks → profiles\` with no \`profile_blocks\` filter. PR #276 closed the same gap in search and event attendees, and \`matching/repo.rs:209-234\` filters symmetrically — bookmarks were missed.

## Symptom

1. Alice bookmarks Bob.
2. Either side later blocks.
3. \`GET /api/v1/profiles/bookmarked\` still returns Bob's full profile (name, bio, avatar, program, tags) to Alice.

This defeats the block on a path users implicitly trust ("my saved people").

## Fix

Load the symmetric block set for \`my_profile_id\` once, then skip rows whose target appears in either direction. Same shape as \`matching/repo.rs\` but simpler: bookmarks are scoped to a single \`my_profile_id\` rather than the full set of viewer profiles.

## Test plan

- [ ] As Alice: bookmark Bob → list contains Bob.
- [ ] As Alice: block Bob → \`GET /profiles/bookmarked\` no longer returns Bob.
- [ ] As Alice: unblock Bob → Bob reappears.
- [ ] Reverse direction: Bob blocks Alice → Bob is hidden from Alice's bookmarks too.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter blocked profiles from bookmark list in `profiles_bookmarked`
> Bookmarked profiles that have a block relationship with the requesting user are now excluded from results. The fix queries `profile_blocks` for all block relationships where `my_profile_id` is either the blocker or the blocked, then skips matching profiles when building the response.
>
> Behavioral Change: Users will no longer see bookmarked profiles they have blocked or been blocked by.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60d53d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->