### PR TITLE
fix(backend): verify upload ownership for profile images and event covers

### DIFF
--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -37,7 +37,7 @@ use super::events_tags_service::{
 };
 use super::events_view::{build_event_response_raw, created_event_response, resolve_event_images};
 use super::events_write_repo::{self, is_serialization_failure};
-use super::events_write_service::prepare_update_changeset;
+use super::events_write_service::{prepare_update_changeset, verify_event_cover_ownership};
 
 /// Run Bielik-Guard against the supplied event text. Returns
 /// `Ok(None)` when moderation passes (allow / flag) or is disabled,
@@ -206,6 +206,7 @@ fn build_new_event(
 
 enum CreateOutcome {
     NoProfile,
+    CoverInvalid(Box<Response>),
     Created { event: Box<Event>, profile_id: Uuid },
 }
 
@@ -238,8 +239,13 @@ pub(in crate::api) async fn event_create(
 
     let tag_names = payload.tags.clone();
     let user_id = viewer.user_id;
+    let headers_for_tx = headers.clone();
 
-    let outcome = db::with_viewer_tx(viewer, |conn| {
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        let headers = headers_for_tx;
+        let mut payload = payload;
+        let validated = validated;
+        let tag_names = tag_names;
         async move {
             let Some(profile) = load_profile_for_user(conn, user_id)
                 .await
@@ -247,6 +253,18 @@ pub(in crate::api) async fn event_create(
             else {
                 return Ok::<CreateOutcome, diesel::result::Error>(CreateOutcome::NoProfile);
             };
+
+            // Validate cover image ownership before INSERT so a creator
+            // can't republish another user's upload as their event
+            // cover. Skipped when no cover is supplied.
+            if let Some(raw) = payload.cover_image.as_deref() {
+                match verify_event_cover_ownership(conn, &headers, profile.id, raw).await {
+                    Ok(filename) => payload.cover_image = Some(filename),
+                    Err(response) => {
+                        return Ok(CreateOutcome::CoverInvalid(response));
+                    }
+                }
+            }
 
             let (new_event, event_id) = build_new_event(profile.id, &validated, &payload);
             let inserted = events_write_repo::insert_event_with_conn(conn, &new_event)
@@ -297,6 +315,7 @@ pub(in crate::api) async fn event_create(
 
     match outcome {
         CreateOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        CreateOutcome::CoverInvalid(response) => Ok(*response),
         CreateOutcome::Created { event, profile_id } => {
             let mut response = build_response_after_tx(viewer, &event, profile_id).await?;
             resolve_single(&mut response).await;
@@ -417,8 +436,24 @@ pub(in crate::api) async fn event_update(
                         return Ok(UpdateOutcome::Forbidden);
                     }
 
+                    // Verify cover image ownership (if being set) before
+                    // prepare_update_changeset, so a creator can't swap
+                    // their event's cover to another user's upload. Clone
+                    // payload locally so the verified filename can replace
+                    // the raw one (extract_filename strips path noise).
+                    let mut payload_local = payload.clone();
+                    if let Some(Some(raw)) = payload_local.cover_image.as_ref() {
+                        match verify_event_cover_ownership(conn, headers, profile.id, raw).await {
+                            Ok(filename) => {
+                                payload_local.cover_image = Some(Some(filename));
+                            }
+                            Err(response) => return Ok(UpdateOutcome::Invalid(response)),
+                        }
+                    }
+
                     let changeset: EventChangeset =
-                        match prepare_update_changeset(headers, &event, profile.id, payload) {
+                        match prepare_update_changeset(headers, &event, profile.id, &payload_local)
+                        {
                             Ok(c) => c,
                             Err(response) => return Ok(UpdateOutcome::Invalid(response)),
                         };

--- a/backend/src/api/events/write_service.rs
+++ b/backend/src/api/events/write_service.rs
@@ -1,14 +1,52 @@
 use axum::http::HeaderMap;
 use chrono::Utc;
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
+use crate::api::extract_filename;
 use crate::api::state::UpdateEventBody;
 use crate::db::models::events::{Event, EventChangeset};
+use crate::db::schema::uploads;
 
 use super::events_service::{
     self, forbidden, validate_event_category, validate_event_description, validate_event_location,
     validate_max_attendees,
 };
+
+/// Verify that `filename` is a non-deleted upload owned by `profile_id`.
+/// Without this, a creator could set `cover_image` to any filename they
+/// observed (e.g. extracted from a public profile/event URL) and the
+/// API would issue signed URLs pointing at the original owner's bytes.
+pub(in crate::api) async fn verify_event_cover_ownership(
+    conn: &mut AsyncPgConnection,
+    headers: &HeaderMap,
+    profile_id: Uuid,
+    raw: &str,
+) -> std::result::Result<String, Box<axum::response::Response>> {
+    let filename = extract_filename(raw);
+    let owned: Option<String> = uploads::table
+        .filter(uploads::owner_id.eq(Some(profile_id)))
+        .filter(uploads::filename.eq(&filename))
+        .filter(uploads::deleted.eq(false))
+        .select(uploads::filename)
+        .first::<String>(conn)
+        .await
+        .optional()
+        .map_err(|_| {
+            Box::new(events_service::validation_error(
+                headers,
+                "Upload storage is temporarily unavailable",
+            ))
+        })?;
+    if owned.is_none() {
+        return Err(Box::new(events_service::validation_error(
+            headers,
+            "Cover image must reference your uploaded file",
+        )));
+    }
+    Ok(filename)
+}
 
 type EventDates = (chrono::DateTime<Utc>, Option<chrono::DateTime<Utc>>);
 

--- a/backend/src/api/profiles/write_service.rs
+++ b/backend/src/api/profiles/write_service.rs
@@ -151,15 +151,20 @@ pub(super) async fn verify_uploads_ownership(
     if filenames.is_empty() {
         return Ok(());
     }
-    let owned: Vec<String> = uploads::table
+    let owned: std::collections::HashSet<String> = uploads::table
         .filter(uploads::owner_id.eq(Some(profile_id)))
         .filter(uploads::filename.eq_any(filenames))
         .filter(uploads::deleted.eq(false))
         .select(uploads::filename)
         .load::<String>(conn)
         .await
-        .map_err(|_| uploads_unavailable(headers))?;
-    if owned.len() != filenames.len() {
+        .map_err(|_| uploads_unavailable(headers))?
+        .into_iter()
+        .collect();
+    // Compare set membership, not lengths: `eq_any` -> SQL IN dedupes,
+    // so `["a.jpg", "a.jpg"]` would yield owned.len() = 1 even when
+    // a.jpg is owned, and a length comparison would falsely reject.
+    if filenames.iter().any(|f| !owned.contains(f)) {
         return Err(Box::new(validation_error(
             headers,
             "Profile images must reference your uploaded files",

--- a/backend/src/api/profiles/write_service.rs
+++ b/backend/src/api/profiles/write_service.rs
@@ -78,6 +78,25 @@ pub(super) async fn validate_create(
 ) -> std::result::Result<crate::db::models::users::User, Box<Response>> {
     let (_session, user) = require_auth_db(headers).await?;
     validate_profile_fields(headers, payload)?;
+    // Reject image references on create: uploads require an existing
+    // profile (uploads/write_handler.rs:198) so a not-yet-created
+    // profile cannot legitimately own any. Allowing arbitrary
+    // filenames here lets a fresh account claim another user's
+    // uploads as their profile picture or gallery. The canonical flow
+    // is create-with-no-images → upload (now owner_id = new profile)
+    // → PATCH images.
+    if payload.profile_picture.is_some() {
+        return Err(Box::new(validation_error(
+            headers,
+            "Profile picture cannot be set on create — upload it after the profile exists",
+        )));
+    }
+    if payload.images.as_ref().is_some_and(|v| !v.is_empty()) {
+        return Err(Box::new(validation_error(
+            headers,
+            "Gallery images cannot be set on create — upload them after the profile exists",
+        )));
+    }
     check_no_existing_profile(conn, headers, user.id).await?;
     Ok(user)
 }
@@ -114,6 +133,36 @@ async fn verify_upload_ownership(
         return Err(Box::new(validation_error(
             headers,
             "Profile picture must reference your uploaded image",
+        )));
+    }
+    Ok(())
+}
+
+/// Verify that every entry in `filenames` is a non-deleted upload owned
+/// by `profile_id`. Without this, a caller could PATCH their profile
+/// with another user's filename and the API would issue signed URLs
+/// pointing at the original owner's bytes — content theft, no copy.
+pub(super) async fn verify_uploads_ownership(
+    conn: &mut AsyncPgConnection,
+    headers: &HeaderMap,
+    profile_id: Uuid,
+    filenames: &[String],
+) -> std::result::Result<(), Box<Response>> {
+    if filenames.is_empty() {
+        return Ok(());
+    }
+    let owned: Vec<String> = uploads::table
+        .filter(uploads::owner_id.eq(Some(profile_id)))
+        .filter(uploads::filename.eq_any(filenames))
+        .filter(uploads::deleted.eq(false))
+        .select(uploads::filename)
+        .load::<String>(conn)
+        .await
+        .map_err(|_| uploads_unavailable(headers))?;
+    if owned.len() != filenames.len() {
+        return Err(Box::new(validation_error(
+            headers,
+            "Profile images must reference your uploaded files",
         )));
     }
     Ok(())
@@ -192,6 +241,15 @@ pub(super) async fn validate_and_prepare_update(
             Some(filename) // Some(Some(filename))
         }
     };
+    // Gallery images get the same ownership check as profile_picture —
+    // every filename must reference an upload that this profile owns.
+    if let Some(images) = payload.images.as_ref() {
+        let filenames: Vec<String> = images.iter().map(|raw| extract_filename(raw)).collect();
+        for f in &filenames {
+            check_validation(headers, validate_filename(f))?;
+        }
+        verify_uploads_ownership(conn, headers, profile.id, &filenames).await?;
+    }
     Ok((profile, user, picture))
 }
 

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -1462,3 +1462,109 @@ async fn event_report_flow() {
     })
     .await;
 }
+
+// Regression: PATCH /profiles/{id} with `images: [F, F]` was rejected
+// because `verify_uploads_ownership` compared `owned.len()` to the raw
+// `filenames.len()` while SQL `IN` dedupes — owned came back as 1 even
+// when F was owned. Set-membership now passes iff every requested
+// filename is owned, so duplicates are accepted.
+#[tokio::test]
+#[serial]
+async fn profile_images_patch_accepts_duplicate_owned_filename() {
+    request(|request, _ctx| async move {
+        let (auth_key, auth_value) =
+            create_user_with_profile(&request, "dup_owner@example.com", "Dup").await;
+
+        let upload = upload_png(&request, &auth_key, &auth_value).await;
+        let filename = upload["data"]["filename"]
+            .as_str()
+            .expect("upload returns filename")
+            .to_string();
+
+        let me = request
+            .get("/api/v1/profiles/me")
+            .add_header(auth_key.clone(), auth_value.clone())
+            .await;
+        assert_eq!(me.status_code(), 200);
+        let profile_id = me.json::<serde_json::Value>()["data"]["id"]
+            .as_str()
+            .expect("profile id")
+            .to_string();
+
+        let resp = request
+            .patch(&format!("/api/v1/profiles/{profile_id}"))
+            .add_header(auth_key.clone(), auth_value.clone())
+            .json(&serde_json::json!({
+                "images": [filename.clone(), filename.clone()],
+            }))
+            .await;
+        assert_eq!(
+            resp.status_code(),
+            200,
+            "duplicate owned filenames must be accepted, body: {}",
+            resp.text()
+        );
+
+        // And both copies of the filename should appear in the rendered
+        // gallery — server returns signed URLs, so just look for the
+        // base filename as a substring twice.
+        let payload: serde_json::Value = resp.json();
+        let images = payload["data"]["images"].as_array().expect("images array");
+        assert_eq!(images.len(), 2);
+        for url in images {
+            let s = url.as_str().expect("image url is a string");
+            assert!(
+                s.contains(&filename),
+                "expected url {s} to reference {filename}"
+            );
+        }
+    })
+    .await;
+}
+
+// Companion negative test: a stranger's filename in `images[]` must be
+// rejected. Without the ownership check, the API would issue signed
+// URLs over the original owner's bytes — a content-theft, no-copy.
+#[tokio::test]
+#[serial]
+async fn profile_images_patch_rejects_other_users_filename() {
+    request(|request, _ctx| async move {
+        let (a_key, a_val) = create_user_with_profile(&request, "stealer_a@example.com", "A").await;
+        let upload_a = upload_png(&request, &a_key, &a_val).await;
+        let a_filename = upload_a["data"]["filename"]
+            .as_str()
+            .expect("a filename")
+            .to_string();
+
+        let (b_key, b_val) = create_user_with_profile(&request, "stealer_b@example.com", "B").await;
+        let upload_b = upload_png(&request, &b_key, &b_val).await;
+        let b_filename = upload_b["data"]["filename"]
+            .as_str()
+            .expect("b filename")
+            .to_string();
+
+        let me_b = request
+            .get("/api/v1/profiles/me")
+            .add_header(b_key.clone(), b_val.clone())
+            .await;
+        let b_profile_id = me_b.json::<serde_json::Value>()["data"]["id"]
+            .as_str()
+            .expect("b profile id")
+            .to_string();
+
+        let resp = request
+            .patch(&format!("/api/v1/profiles/{b_profile_id}"))
+            .add_header(b_key.clone(), b_val.clone())
+            .json(&serde_json::json!({
+                "images": [b_filename.clone(), a_filename.clone()],
+            }))
+            .await;
+        assert_eq!(
+            resp.status_code(),
+            400,
+            "B must not be able to claim A's filename, body: {}",
+            resp.text()
+        );
+    })
+    .await;
+}


### PR DESCRIPTION
## Summary

Three image fields stored whatever filename the request supplied, with no ownership check:

- \`profiles.images[]\` — only \`profile_picture\` went through \`verify_upload_ownership\`; the gallery slipped past.
- \`events.cover_image\` on create — \`build_new_event\` cloned the payload filename verbatim.
- \`events.cover_image\` on update — \`build_update_changeset\` did the same.

## Attack

1. Mallory observes filename \`abc.jpg\` (extracted from a public profile/event URL, or anywhere imgproxy-signed URLs leak through).
2. Mallory PATCHes her own profile with \`{"images":["abc.jpg"]}\` or sets her event's \`coverImage\` to it.
3. The API stores the filename. The response builder issues a fresh imgproxy-signed URL pointing at the original owner's bytes.

No bytes are copied, but the platform now serves another user's image as Mallory's content. Breaks attribution; enables impersonation in profile photos and event covers.

## Fix

- **profiles/write_service.rs**: new slice-aware \`verify_uploads_ownership(profile_id, &[String])\` that asserts every filename is owned and not deleted. Called from \`validate_and_prepare_update\` whenever \`payload.images\` is present.
- **profiles/write_service.rs**: reject \`profile_picture\` and non-empty \`images\` on **create**. Uploads require an existing profile, so a not-yet-created profile cannot legitimately own any uploads — allowing arbitrary filenames at signup let a fresh account claim any user's uploads. The canonical flow is create → upload → PATCH images.
- **events/write_service.rs**: new \`verify_event_cover_ownership\` (async helper mirroring the profile-side check).
- **events/write_handler.rs**:
  - \`event_create\`: ownership check inside the viewer tx, after profile load, before insert. New \`CreateOutcome::CoverInvalid\` variant carries the validation response back out.
  - \`event_update\`: check inside the serializable tx, after creator-ownership and before \`prepare_update_changeset\`. Reuses the existing \`UpdateOutcome::Invalid\`. Verified filename replaces the raw payload value so storage stays consistent.

## Test plan

- [ ] As Alice: upload \`alice.jpg\` (succeeds, owned by Alice's profile).
- [ ] As Mallory: PATCH \`/profiles/{mallory}\` with \`{"images":["alice.jpg"]}\` → \`422 VALIDATION_ERROR\`.
- [ ] As Mallory: PATCH with her own filenames → still works.
- [ ] As Mallory: POST \`/events\` with \`coverImage: "alice.jpg"\` → \`400 VALIDATION_ERROR\`.
- [ ] As Alice: POST \`/events\` with \`coverImage: "alice.jpg"\` → succeeds.
- [ ] As Alice: PATCH her event with \`coverImage: "<other-user's-file>"\` → \`400 VALIDATION_ERROR\`.
- [ ] Fresh user signup: POST \`/profiles\` with \`profilePicture\` or non-empty \`images\` → \`422 VALIDATION_ERROR\` (confirms canonical flow).
- [ ] Existing \`rls_tier_{a,b,c}\` fixtures still pass (already use \`profile_picture: None\` / \`images: None\` on create).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify upload ownership for profile images and event cover images on write
> - Profile creation now rejects any `profile_picture` or `images` in the request body, returning a validation error that instructs clients to upload after the profile exists.
> - PATCH profile validates that all `images[]` filenames reference non-deleted uploads owned by the requesting profile via `verify_uploads_ownership` in [profiles/write_service.rs](https://github.com/poziomki-app/poziomki/pull/288/files#diff-2e0fe1aadfd666529c425ce4cd93d0ca387b24bd0086804a90455a2ea6bd5dcf).
> - Event create and update handlers verify `cover_image` ownership using `verify_event_cover_ownership` in [events/write_service.rs](https://github.com/poziomki-app/poziomki/pull/288/files#diff-ada2a2f92389ea1b77313ad3b32b98a453c88072f480e16e959b478774f4bbb5), normalizing the value to a sanitized filename or returning a 400 validation error.
> - Regression tests added for duplicate owned filenames (accepted) and cross-user filenames (rejected) on PATCH `/profiles/{id}`.
> - Behavioral Change: requests that previously accepted unverified image references on profile or event writes will now receive validation errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c067c12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->