### PR TITLE
feat(chat): nicer report snackbar + report-once per message

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.18.12" // x-release-please-version
+val appVersionName = "0.18.13" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
@@ -66,6 +66,7 @@ import com.adamglin.phosphoricons.bold.Trash
 import com.adamglin.phosphoricons.fill.PaperPlaneRight
 import com.poziomki.app.chat.api.Reaction
 import com.poziomki.app.chat.api.TimelineItem
+import com.poziomki.app.ui.designsystem.components.AppSnackbar
 import com.poziomki.app.ui.designsystem.components.UserAvatar
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Border
@@ -103,6 +104,7 @@ fun ChatContent(
     onRevealModeration: (TimelineItem.Event) -> Unit,
     onReportFlagged: (TimelineItem.Event) -> Unit,
     onClearError: () -> Unit,
+    onClearTransientNotice: () -> Unit,
     onNavigateToProfile: (String) -> Unit,
     resolveDisplayNames: suspend (List<String>) -> Map<String, String>,
     resolveAvatarUrls: suspend (List<String>) -> Map<String, String>,
@@ -268,6 +270,21 @@ fun ChatContent(
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
                         )
                     }
+                }
+
+                state.transientNotice?.let { notice ->
+                    LaunchedEffect(notice) {
+                        kotlinx.coroutines.delay(2_500L)
+                        onClearTransientNotice()
+                    }
+                    AppSnackbar(
+                        message = notice.message,
+                        type = notice.type,
+                        modifier =
+                            Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(bottom = 12.dp, start = 16.dp, end = 16.dp),
+                    )
                 }
 
                 if (state.isAwayFromLatest && state.unreadBelowCount > 0) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -165,6 +165,7 @@ fun ChatScreen(
             onRevealModeration = viewModel::revealModeration,
             onReportFlagged = viewModel::reportFlaggedMessage,
             onClearError = viewModel::clearError,
+            onClearTransientNotice = viewModel::clearTransientNotice,
             onNavigateToProfile = onNavigateToProfile,
             resolveDisplayNames = viewModel::resolveDisplayNames,
             resolveAvatarUrls = viewModel::resolveAvatarUrls,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -15,8 +15,10 @@ import com.poziomki.app.data.repository.MatchProfileRepository
 import com.poziomki.app.data.repository.XpRepository
 import com.poziomki.app.network.ApiResult
 import com.poziomki.app.network.ApiService
+import com.poziomki.app.ui.designsystem.components.SnackbarType
 import com.poziomki.app.ui.feature.chat.model.ChatUiState
 import com.poziomki.app.ui.feature.chat.model.ComposerMode
+import com.poziomki.app.ui.feature.chat.model.TransientNotice
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -340,19 +342,41 @@ class ChatViewModel(
      * matching report reason fall through to "inappropriate".
      */
     fun reportFlaggedMessage(event: TimelineItem.Event) {
+        if (event.locallyReported) return
         val messageId = event.eventId ?: return
         val reason = autoPickReportReason(event.moderationCategories)
         viewModelScope.launch {
             when (apiService.reportChatMessage(messageId, reason, null)) {
                 is ApiResult.Success -> {
-                    _uiState.update { it.copy(error = "Zgłoszenie wysłane. Dzięki.") }
+                    activeTimeline?.markModerationReported(event.eventOrTransactionId)
+                    _uiState.update {
+                        it.copy(
+                            transientNotice =
+                                TransientNotice(
+                                    message = "Zgłoszenie wysłane. Dzięki!",
+                                    type = SnackbarType.SUCCESS,
+                                ),
+                        )
+                    }
                 }
 
                 is ApiResult.Error -> {
-                    _uiState.update { it.copy(error = "Nie udało się wysłać zgłoszenia.") }
+                    _uiState.update {
+                        it.copy(
+                            transientNotice =
+                                TransientNotice(
+                                    message = "Nie udało się wysłać zgłoszenia.",
+                                    type = SnackbarType.ERROR,
+                                ),
+                        )
+                    }
                 }
             }
         }
+    }
+
+    fun clearTransientNotice() {
+        _uiState.update { it.copy(transientNotice = null) }
     }
 
     private fun autoPickReportReason(categories: List<String>): String {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -292,7 +292,10 @@ internal fun MessageEventRow(
                                 val isFlagged =
                                     event.moderationVerdict in setOf("flag", "block")
                                 val isHidden = isFlagged && !event.locallyRevealed
-                                val showReportFlag = isFlagged && event.locallyRevealed
+                                // Flag disappears once reported — one report per
+                                // device per message, idempotent at the server too.
+                                val showReportFlag =
+                                    isFlagged && event.locallyRevealed && !event.locallyReported
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     val maxBubbleWidthForRow =
                                         if (showSenderMeta) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/model/ChatUiModels.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/model/ChatUiModels.kt
@@ -2,6 +2,17 @@ package com.poziomki.app.ui.feature.chat.model
 
 import com.poziomki.app.chat.api.TimelineItem
 import com.poziomki.app.chat.api.TimelineMode
+import com.poziomki.app.ui.designsystem.components.SnackbarType
+
+/**
+ * Auto-dismissing toast-like message for one-off feedback (e.g.
+ * "Report sent. Thanks."). Distinct from `error` which is reserved
+ * for persistent errors that the user has to clear manually.
+ */
+data class TransientNotice(
+    val message: String,
+    val type: SnackbarType,
+)
 
 sealed interface ComposerMode {
     data object NewMessage : ComposerMode
@@ -43,6 +54,7 @@ data class ChatUiState(
     val searchMatchIndices: List<Int> = emptyList(),
     val currentSearchMatchIndex: Int = -1,
     val isBlocked: Boolean = false,
+    val transientNotice: TransientNotice? = null,
 )
 
 data class NewChatUiState(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
@@ -146,6 +146,7 @@ fun EventChatScreen(
                         onRevealModeration = chatViewModel::revealModeration,
                         onReportFlagged = chatViewModel::reportFlaggedMessage,
                         onClearError = chatViewModel::clearError,
+                        onClearTransientNotice = chatViewModel::clearTransientNotice,
                         onNavigateToProfile = onNavigateToProfile,
                         resolveDisplayNames = chatViewModel::resolveDisplayNames,
                         resolveAvatarUrls = chatViewModel::resolveAvatarUrls,

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/Timeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/Timeline.kt
@@ -72,6 +72,14 @@ sealed interface TimelineItem {
          * later carries the reveal state.
          */
         val locallyRevealed: Boolean = false,
+        /**
+         * `true` after the local viewer has filed a moderation
+         * report against this message. Hides the floating flag so
+         * a single message can only be reported once per device.
+         * Persisted via the timeline cache so reinstall-style
+         * resets don't allow stacking reports on the same row.
+         */
+        val locallyReported: Boolean = false,
     ) : TimelineItem
 
     data class DateDivider(
@@ -141,6 +149,12 @@ interface Timeline : AutoCloseable {
      * blocking the UI from updating. Idempotent.
      */
     suspend fun markModerationRevealed(eventId: String): Result<Unit>
+
+    /**
+     * Mark this message as reported locally so the floating flag
+     * is hidden. Idempotent.
+     */
+    suspend fun markModerationReported(eventId: String): Result<Unit>
 
     override fun close()
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt
@@ -135,6 +135,7 @@ private sealed interface CachedTimelineItem {
         val moderationVerdict: String? = null,
         val moderationCategories: List<String> = emptyList(),
         val locallyRevealed: Boolean = false,
+        val locallyReported: Boolean = false,
     ) : CachedTimelineItem {
         override fun toDomain(): TimelineItem =
             TimelineItem.Event(
@@ -156,6 +157,7 @@ private sealed interface CachedTimelineItem {
                 moderationVerdict = moderationVerdict,
                 moderationCategories = moderationCategories,
                 locallyRevealed = locallyRevealed,
+                locallyReported = locallyReported,
             )
     }
 
@@ -199,6 +201,7 @@ private sealed interface CachedTimelineItem {
                         moderationVerdict = item.moderationVerdict,
                         moderationCategories = item.moderationCategories,
                         locallyRevealed = item.locallyRevealed,
+                        locallyReported = item.locallyReported,
                     )
                 }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -443,6 +443,24 @@ class WsTimeline(
         return Result.success(Unit)
     }
 
+    override suspend fun markModerationReported(eventId: String): Result<Unit> {
+        itemsMutex.withLock {
+            val current = _items.value.toMutableList()
+            val idx =
+                current.indexOfFirst {
+                    it is TimelineItem.Event && it.eventId == eventId
+                }
+            if (idx >= 0) {
+                val event = current[idx] as TimelineItem.Event
+                if (!event.locallyReported) {
+                    current[idx] = event.copy(locallyReported = true)
+                    emitAndPersist(current)
+                }
+            }
+        }
+        return Result.success(Unit)
+    }
+
     private suspend fun <T> sendOrFail(
         msg: WsClientMessage,
         value: T,


### PR DESCRIPTION
Two follow-ups on the report flow:

1. **Proper success snackbar.** 'Zgłoszenie wysłane. Dzięki!' was being shoehorned into the persistent red error slot. Now uses the existing AppSnackbar with SUCCESS type (green/check) auto-dismissing after 2.5s. New TransientNotice field in ChatUiState — separate from `error` which stays for persistent errors.

2. **Report once per message.** After a successful report, the floating flag disappears (`locallyReported` on the timeline item). Server already enforces PK on `(message_id, reporter_user_id)`; client stops showing the affordance so the user doesn't tap twice and see 'Zgłoszenie wysłane' again. Persisted in the timeline cache.

App version 0.18.13.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add report-once enforcement and transient snackbar feedback to chat message reporting
> - Reporting a flagged message now marks it as `locallyReported` on success, preventing duplicate reports and hiding the report flag in [`MessageEventRow`](https://github.com/poziomki-app/poziomki/pull/289/files#diff-205e553f5f37749cbb095d7ebb6ef8fc7a522c33a70cef909b5d576b613450f3).
> - Success and error outcomes surface as a transient `AppSnackbar` that auto-dismisses after 2.5 seconds, replacing the previous persistent error state.
> - A new `locallyReported` field on `TimelineItem.Event` is persisted to and restored from the cache via [`SqlDelightRoomTimelineCacheStore`](https://github.com/poziomki-app/poziomki/pull/289/files#diff-0828598ef38a3e52fb5f7e4605d8d40d6b368da52a35229e584e6e7b69e4fe66).
> - `WsTimeline.markModerationReported` sets `locallyReported=true` in memory and persists the change atomically under `itemsMutex`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f74c353.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->