### PR TITLE
feat(chat): real indicators — receipts, delivery, mute, typing TTL

### DIFF
--- a/backend/migrations/2026-04-28-000000_chat_indicators/down.sql
+++ b/backend/migrations/2026-04-28-000000_chat_indicators/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.conversation_members DROP COLUMN IF EXISTS muted_until;
+DROP TABLE IF EXISTS public.message_deliveries;
+DROP TABLE IF EXISTS public.message_reads;

--- a/backend/migrations/2026-04-28-000000_chat_indicators/down.sql
+++ b/backend/migrations/2026-04-28-000000_chat_indicators/down.sql
@@ -1,4 +1,5 @@
 ALTER TABLE public.conversation_members DROP COLUMN IF EXISTS muted_until;
+DROP FUNCTION IF EXISTS app.record_deliveries(uuid, int[]);
 DROP FUNCTION IF EXISTS app.record_delivery(uuid, int);
 DROP TABLE IF EXISTS public.message_deliveries;
 DROP TABLE IF EXISTS public.message_reads;

--- a/backend/migrations/2026-04-28-000000_chat_indicators/down.sql
+++ b/backend/migrations/2026-04-28-000000_chat_indicators/down.sql
@@ -1,3 +1,4 @@
 ALTER TABLE public.conversation_members DROP COLUMN IF EXISTS muted_until;
+DROP FUNCTION IF EXISTS app.record_delivery(uuid, int);
 DROP TABLE IF EXISTS public.message_deliveries;
 DROP TABLE IF EXISTS public.message_reads;

--- a/backend/migrations/2026-04-28-000000_chat_indicators/up.sql
+++ b/backend/migrations/2026-04-28-000000_chat_indicators/up.sql
@@ -208,3 +208,20 @@ JOIN public.messages m
  AND (m.created_at < rm.created_at
       OR (m.created_at = rm.created_at AND m.id <= rm.id))
 ON CONFLICT (message_id, user_id) DO NOTHING;
+
+-- Backfill deliveries for the same (member, message) universe: every
+-- non-self, non-deleted message in a conversation the user belongs to.
+-- Without this, every existing chat regresses to a single grey ✓ on
+-- the sender's screen on first launch after the upgrade — even though
+-- the message was clearly delivered (the recipient already read some
+-- of them). We use the message's created_at as the delivered_at floor;
+-- in practice delivery happened within seconds of send, so anchoring
+-- at created_at is a safe lower bound that won't lie about ordering.
+INSERT INTO public.message_deliveries (message_id, user_id, delivered_at)
+SELECT m.id, cm.user_id, m.created_at
+FROM public.conversation_members cm
+JOIN public.messages m
+  ON m.conversation_id = cm.conversation_id
+ AND m.sender_id <> cm.user_id
+ AND m.deleted_at IS NULL
+ON CONFLICT (message_id, user_id) DO NOTHING;

--- a/backend/migrations/2026-04-28-000000_chat_indicators/up.sql
+++ b/backend/migrations/2026-04-28-000000_chat_indicators/up.sql
@@ -148,6 +148,49 @@ BEGIN
 END
 $$;
 
+-- Bulk variant. The WS hub fans out to N online recipients per send;
+-- looping `record_delivery` once per recipient meant N round trips per
+-- broadcast (one short tx each). For groups this becomes the dominant
+-- cost. This variant inserts every (message_id, user_id) row in a
+-- single statement and returns the (user_id, delivered_at) pairs that
+-- were actually inserted, so the caller still knows which sender
+-- broadcasts to emit. Membership is verified in the same statement.
+CREATE OR REPLACE FUNCTION app.record_deliveries(p_message_id uuid, p_user_ids int[])
+RETURNS TABLE (user_id int, delivered_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_conv_id uuid;
+BEGIN
+    SELECT conversation_id INTO v_conv_id
+    FROM public.messages
+    WHERE id = p_message_id;
+    IF v_conv_id IS NULL OR p_user_ids IS NULL OR array_length(p_user_ids, 1) IS NULL THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    INSERT INTO public.message_deliveries (message_id, user_id, delivered_at)
+    SELECT p_message_id, cm.user_id, now()
+    FROM public.conversation_members cm
+    WHERE cm.conversation_id = v_conv_id
+      AND cm.user_id = ANY (p_user_ids)
+    ON CONFLICT (message_id, user_id) DO NOTHING
+    RETURNING message_deliveries.user_id, message_deliveries.delivered_at;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION app.record_deliveries(uuid, int[]) FROM PUBLIC;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.record_deliveries(uuid, int[]) TO poziomki_api';
+    END IF;
+END
+$$;
+
 -- Backfill: synthesize read receipts from the existing watermarks so
 -- old conversations don't render with blank ticks after the upgrade.
 -- For each (member, conversation) pair, mark every non-self message

--- a/backend/migrations/2026-04-28-000000_chat_indicators/up.sql
+++ b/backend/migrations/2026-04-28-000000_chat_indicators/up.sql
@@ -1,0 +1,167 @@
+-- Chat indicators: per-message read receipts, server-confirmed delivery
+-- ACK, and per-conversation mute. Brings the chat closer to behavior
+-- users expect from real messaging apps:
+--
+--  * `message_reads` records WHO read WHICH message and WHEN, so the
+--    sender can render single/double/double-blue ticks and group chats
+--    can show a "read by" list. The existing
+--    `conversation_members.last_read_message_id` watermark stays as
+--    the fast-path for unread-count math; this table is the truth for
+--    UI ticks and survives reconnect (history hydration).
+--
+--  * `message_deliveries` records when a recipient's WS session has
+--    actually received a message. Today the mobile client guesses
+--    "sent" the moment it POSTs; with this table the server can emit
+--    a real Delivered ACK so the sender sees ✓ → ✓✓ accurately, even
+--    across reconnects.
+--
+--  * `conversation_members.muted_until` lets a user silence one DM or
+--    group without disabling all notifications. NULL = not muted.
+--    A far-future timestamp encodes "muted forever".
+
+CREATE TABLE IF NOT EXISTS public.message_reads (
+    message_id UUID NOT NULL REFERENCES public.messages(id) ON DELETE CASCADE,
+    user_id    INT4 NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    read_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (message_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_reads_user
+    ON public.message_reads (user_id, read_at DESC);
+
+COMMENT ON TABLE public.message_reads IS
+    'Per-(message, user) read receipts with timestamp. Powers ✓✓ ticks and "read by" UI; survives reconnect via history hydration.';
+
+CREATE TABLE IF NOT EXISTS public.message_deliveries (
+    message_id   UUID NOT NULL REFERENCES public.messages(id) ON DELETE CASCADE,
+    user_id      INT4 NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    delivered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (message_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_deliveries_user
+    ON public.message_deliveries (user_id, delivered_at DESC);
+
+COMMENT ON TABLE public.message_deliveries IS
+    'Per-(message, recipient) delivery confirmations written when the WS session actually receives the message. Powers single→double tick transition.';
+
+ALTER TABLE public.conversation_members
+    ADD COLUMN IF NOT EXISTS muted_until TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN public.conversation_members.muted_until IS
+    'Per-conversation mute. NULL = not muted; future timestamp = muted until that moment; far-future = "muted forever".';
+
+-- RLS: mirror messages — a member of the conversation can read their
+-- own and other members' read/delivery rows for that conversation.
+-- Inserts are gated to the current user (you can only mark your own
+-- read/delivery; the API sets app.current_user_id correctly).
+
+ALTER TABLE public.message_reads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.message_reads FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS message_reads_select ON public.message_reads;
+CREATE POLICY message_reads_select ON public.message_reads
+    FOR SELECT
+    USING (app.viewer_can_see_message(message_id));
+
+DROP POLICY IF EXISTS message_reads_insert ON public.message_reads;
+CREATE POLICY message_reads_insert ON public.message_reads
+    FOR INSERT
+    WITH CHECK (
+        user_id = app.current_user_id()
+        AND app.viewer_can_see_message(message_id)
+    );
+
+ALTER TABLE public.message_deliveries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.message_deliveries FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS message_deliveries_select ON public.message_deliveries;
+CREATE POLICY message_deliveries_select ON public.message_deliveries
+    FOR SELECT
+    USING (app.viewer_can_see_message(message_id));
+
+DROP POLICY IF EXISTS message_deliveries_insert ON public.message_deliveries;
+CREATE POLICY message_deliveries_insert ON public.message_deliveries
+    FOR INSERT
+    WITH CHECK (
+        user_id = app.current_user_id()
+        AND app.viewer_can_see_message(message_id)
+    );
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT INSERT, SELECT ON public.message_reads TO poziomki_api';
+        EXECUTE 'GRANT INSERT, SELECT ON public.message_deliveries TO poziomki_api';
+    END IF;
+END
+$$;
+
+-- Server-confirmed delivery is written by the API the moment the
+-- WS hub fans out a Message to a recipient — there is no per-user
+-- "I received it" call from the client, so we cannot rely on
+-- `app.current_user_id() = user_id` for the insert. The SECURITY
+-- DEFINER helper checks membership instead. The helper is the only
+-- way to insert into `message_deliveries` for a user other than
+-- `app.current_user_id()`.
+CREATE OR REPLACE FUNCTION app.record_delivery(p_message_id uuid, p_user_id int)
+RETURNS timestamptz
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_conv_id uuid;
+    v_at timestamptz;
+BEGIN
+    SELECT conversation_id INTO v_conv_id
+    FROM public.messages
+    WHERE id = p_message_id;
+    IF v_conv_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- Recipient must actually be a member of the conversation; the
+    -- WS handler computes that, but defense-in-depth here.
+    IF NOT EXISTS (
+        SELECT 1 FROM public.conversation_members
+        WHERE conversation_id = v_conv_id AND user_id = p_user_id
+    ) THEN
+        RETURN NULL;
+    END IF;
+
+    INSERT INTO public.message_deliveries (message_id, user_id, delivered_at)
+    VALUES (p_message_id, p_user_id, now())
+    ON CONFLICT (message_id, user_id) DO NOTHING
+    RETURNING delivered_at INTO v_at;
+
+    RETURN v_at;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION app.record_delivery(uuid, int) FROM PUBLIC;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.record_delivery(uuid, int) TO poziomki_api';
+    END IF;
+END
+$$;
+
+-- Backfill: synthesize read receipts from the existing watermarks so
+-- old conversations don't render with blank ticks after the upgrade.
+-- For each (member, conversation) pair, mark every non-self message
+-- created at or before the member's last_read_message_id as read by
+-- that member. read_at is best-effort (use the message's created_at
+-- as a lower bound — they read it at least that late).
+INSERT INTO public.message_reads (message_id, user_id, read_at)
+SELECT m.id, cm.user_id, m.created_at
+FROM public.conversation_members cm
+JOIN public.messages rm ON rm.id = cm.last_read_message_id
+JOIN public.messages m
+  ON m.conversation_id = cm.conversation_id
+ AND m.sender_id <> cm.user_id
+ AND m.deleted_at IS NULL
+ AND (m.created_at < rm.created_at
+      OR (m.created_at = rm.created_at AND m.id <= rm.id))
+ON CONFLICT (message_id, user_id) DO NOTHING;

--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -489,6 +489,7 @@ pub async fn list_for_user(
             direct_user_avatar,
             unread_count,
             latest_message: latest.map(|m| m.body.clone()),
+            latest_message_id: latest.map(|m| m.id),
             latest_timestamp: latest.map(|m| m.created_at.to_rfc3339()),
             latest_message_is_mine: latest_is_mine,
             latest_sender_name,

--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -520,6 +520,37 @@ struct UnreadCountRow {
 /// the lightweight `GET /api/v1/chat/unread` endpoint. `total`
 /// excludes conversations the user has muted, since the platform
 /// badge should reflect "things you actually want to see."
+/// Filter `memberships` to the set of conversation ids whose `muted_until`
+/// is strictly in the future relative to `now`. Pulled out of
+/// `unread_summary_for_user` so the mute-exclusion semantics can be
+/// unit-tested without a database — the bug class we care about
+/// ("a just-expired mute keeps suppressing unread counts") is purely a
+/// time-comparison rule and benefits from explicit coverage.
+pub(super) fn currently_muted_conversations(
+    memberships: &[(Uuid, Option<chrono::DateTime<chrono::Utc>>)],
+    now: chrono::DateTime<chrono::Utc>,
+) -> std::collections::HashSet<Uuid> {
+    memberships
+        .iter()
+        .filter_map(|(id, mu)| mu.filter(|t| *t > now).map(|_| *id))
+        .collect()
+}
+
+/// Sum per-conversation unread counts, dropping muted conversations from
+/// the total but leaving them in the per-conv map. Mirrors the read-path
+/// behavior: a muted DM still shows its own dot in the conversation list,
+/// it just doesn't contribute to the global badge.
+pub(super) fn unread_total_excluding_muted(
+    per_conv: &std::collections::HashMap<Uuid, i64>,
+    muted: &std::collections::HashSet<Uuid>,
+) -> i64 {
+    per_conv
+        .iter()
+        .filter(|(id, _)| !muted.contains(id))
+        .map(|(_, n)| *n)
+        .sum()
+}
+
 pub async fn unread_summary_for_user(
     conn: &mut AsyncPgConnection,
     user_id: i32,
@@ -542,10 +573,7 @@ pub async fn unread_summary_for_user(
 
     let conv_ids: Vec<Uuid> = memberships.iter().map(|(id, _)| *id).collect();
     let now = Utc::now();
-    let muted_set: std::collections::HashSet<Uuid> = memberships
-        .iter()
-        .filter_map(|(id, mu)| mu.filter(|t| *t > now).map(|_| *id))
-        .collect();
+    let muted_set = currently_muted_conversations(&memberships, now);
 
     let rows: Vec<UnreadCountRow> = diesel::sql_query(
         "SELECT m.conversation_id, COUNT(*) as cnt \
@@ -570,11 +598,7 @@ pub async fn unread_summary_for_user(
         .into_iter()
         .map(|r| (r.conversation_id, r.cnt))
         .collect();
-    let total: i64 = per_conv
-        .iter()
-        .filter(|(id, _)| !muted_set.contains(id))
-        .map(|(_, n)| *n)
-        .sum();
+    let total = unread_total_excluding_muted(&per_conv, &muted_set);
     Ok((per_conv, total))
 }
 
@@ -670,4 +694,84 @@ pub async fn sync_event_membership(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{currently_muted_conversations, unread_total_excluding_muted};
+    use chrono::{TimeZone, Utc};
+    use std::collections::{HashMap, HashSet};
+    use uuid::Uuid;
+
+    fn uuid(n: u8) -> Uuid {
+        Uuid::from_bytes([n; 16])
+    }
+
+    #[test]
+    fn mute_in_future_excludes_from_total() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 28, 12, 0, 0).unwrap();
+        let later = now + chrono::Duration::hours(1);
+        let memberships = vec![(uuid(1), Some(later)), (uuid(2), None)];
+        let muted = currently_muted_conversations(&memberships, now);
+        assert!(muted.contains(&uuid(1)));
+        assert!(!muted.contains(&uuid(2)));
+
+        let mut per_conv = HashMap::new();
+        per_conv.insert(uuid(1), 5);
+        per_conv.insert(uuid(2), 3);
+        // Muted DM has 5 unread but they don't count toward the badge.
+        assert_eq!(unread_total_excluding_muted(&per_conv, &muted), 3);
+    }
+
+    #[test]
+    fn just_expired_mute_no_longer_excludes() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 28, 12, 0, 0).unwrap();
+        let one_second_ago = now - chrono::Duration::seconds(1);
+        // Boundary: muted_until == now is treated as expired (strict >).
+        let exactly_now = now;
+        let memberships = vec![
+            (uuid(1), Some(one_second_ago)),
+            (uuid(2), Some(exactly_now)),
+        ];
+        let muted = currently_muted_conversations(&memberships, now);
+        assert!(muted.is_empty(), "expired mutes must not suppress totals");
+
+        let mut per_conv = HashMap::new();
+        per_conv.insert(uuid(1), 7);
+        per_conv.insert(uuid(2), 2);
+        assert_eq!(unread_total_excluding_muted(&per_conv, &muted), 9);
+    }
+
+    #[test]
+    fn mute_keeps_per_conv_count_visible() {
+        // Muted convs still appear in the per-conv map with their real
+        // count — only the global total drops them. The conversation
+        // list UI shows a dot on the row regardless of mute, the app-icon
+        // badge follows the total.
+        let now = Utc.with_ymd_and_hms(2026, 4, 28, 12, 0, 0).unwrap();
+        let later = now + chrono::Duration::days(1);
+        let memberships = vec![(uuid(1), Some(later))];
+        let muted = currently_muted_conversations(&memberships, now);
+
+        let mut per_conv = HashMap::new();
+        per_conv.insert(uuid(1), 4);
+        // per_conv is unchanged; only total filters.
+        assert_eq!(per_conv.get(&uuid(1)), Some(&4));
+        assert_eq!(unread_total_excluding_muted(&per_conv, &muted), 0);
+    }
+
+    #[test]
+    fn empty_inputs_are_zero() {
+        let muted: HashSet<Uuid> = HashSet::new();
+        assert_eq!(unread_total_excluding_muted(&HashMap::new(), &muted), 0);
+
+        let now = Utc::now();
+        assert!(currently_muted_conversations(&[], now).is_empty());
+    }
+
+    // Note: `mark_read` gap-fill logic is expressed in (created_at, id)
+    // SQL tuple comparisons against the `messages` table; reproducing
+    // it in Rust just to test the SQL would not catch the actual bug
+    // class. Coverage of the gap math lives in the integration-style
+    // RLS harness alongside other diesel queries.
 }

--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -215,15 +215,25 @@ pub async fn list_for_user(
     use super::protocol::ConversationPayload;
     use std::collections::HashMap;
 
-    let conv_ids: Vec<Uuid> = conversation_members::table
-        .filter(conversation_members::user_id.eq(user_id))
-        .select(conversation_members::conversation_id)
-        .load(conn)
-        .await?;
+    let my_memberships: Vec<(Uuid, Option<chrono::DateTime<chrono::Utc>>)> =
+        conversation_members::table
+            .filter(conversation_members::user_id.eq(user_id))
+            .select((
+                conversation_members::conversation_id,
+                conversation_members::muted_until,
+            ))
+            .load(conn)
+            .await?;
 
-    if conv_ids.is_empty() {
+    if my_memberships.is_empty() {
         return Ok(Vec::new());
     }
+
+    let conv_ids: Vec<Uuid> = my_memberships.iter().map(|(id, _)| *id).collect();
+    let muted_map: HashMap<Uuid, chrono::DateTime<chrono::Utc>> = my_memberships
+        .iter()
+        .filter_map(|(id, m)| m.map(|m| (*id, m)))
+        .collect();
 
     let all_convs: Vec<Conversation> = conversations::table
         .filter(conversations::id.eq_any(&conv_ids))
@@ -483,6 +493,7 @@ pub async fn list_for_user(
             latest_message_is_mine: latest_is_mine,
             latest_sender_name,
             is_blocked,
+            muted_until: muted_map.get(&conv.id).map(chrono::DateTime::to_rfc3339),
             latest_moderation_verdict: latest_verdict,
             latest_moderation_categories: latest_categories,
         });
@@ -501,6 +512,69 @@ struct UnreadCountRow {
     conversation_id: Uuid,
     #[diesel(sql_type = diesel::sql_types::BigInt)]
     cnt: i64,
+}
+
+/// Quick `(per_conv, total)` unread snapshot for a user. Used by
+/// `UnreadUpdate` pushes after a Read advances the watermark and by
+/// the lightweight `GET /api/v1/chat/unread` endpoint. `total`
+/// excludes conversations the user has muted, since the platform
+/// badge should reflect "things you actually want to see."
+pub async fn unread_summary_for_user(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+) -> Result<(std::collections::HashMap<Uuid, i64>, i64), crate::error::AppError> {
+    use std::collections::HashMap;
+
+    let memberships: Vec<(Uuid, Option<chrono::DateTime<chrono::Utc>>)> =
+        conversation_members::table
+            .filter(conversation_members::user_id.eq(user_id))
+            .select((
+                conversation_members::conversation_id,
+                conversation_members::muted_until,
+            ))
+            .load(conn)
+            .await?;
+
+    if memberships.is_empty() {
+        return Ok((HashMap::new(), 0));
+    }
+
+    let conv_ids: Vec<Uuid> = memberships.iter().map(|(id, _)| *id).collect();
+    let now = Utc::now();
+    let muted_set: std::collections::HashSet<Uuid> = memberships
+        .iter()
+        .filter_map(|(id, mu)| mu.filter(|t| *t > now).map(|_| *id))
+        .collect();
+
+    let rows: Vec<UnreadCountRow> = diesel::sql_query(
+        "SELECT m.conversation_id, COUNT(*) as cnt \
+             FROM messages m \
+             INNER JOIN conversation_members cm \
+                 ON cm.conversation_id = m.conversation_id AND cm.user_id = $1 \
+             LEFT JOIN messages rm ON rm.id = cm.last_read_message_id \
+             WHERE m.conversation_id = ANY($2) \
+               AND m.deleted_at IS NULL \
+               AND m.sender_id != $1 \
+               AND (rm.id IS NULL OR m.created_at > rm.created_at \
+                    OR (m.created_at = rm.created_at AND m.id > rm.id)) \
+               AND (rm.id IS NULL OR m.id != cm.last_read_message_id) \
+             GROUP BY m.conversation_id",
+    )
+    .bind::<Integer, _>(user_id)
+    .bind::<diesel::sql_types::Array<diesel::sql_types::Uuid>, _>(&conv_ids)
+    .load::<UnreadCountRow>(conn)
+    .await?;
+
+    let per_conv: HashMap<Uuid, i64> = rows
+        .into_iter()
+        .map(|r| (r.conversation_id, r.cnt))
+        .collect();
+    let total: i64 = per_conv
+        .iter()
+        .filter(|(id, _)| !muted_set.contains(id))
+        .map(|(_, n)| *n)
+        .sum();
+    Ok((per_conv, total))
 }
 
 /// Sync event membership: add or remove a user from the event conversation.

--- a/backend/src/api/chat/hub.rs
+++ b/backend/src/api/chat/hub.rs
@@ -1,8 +1,23 @@
 use dashmap::DashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+use uuid::Uuid;
 
 use super::protocol::ServerMessage;
+
+/// How long after the last typing-true frame the server treats a user
+/// as still typing. Picked to match the keystroke cadence of mobile
+/// keyboards (clients should re-emit `Typing(true)` every few seconds
+/// while still typing). Exposed publicly so the WS handler can echo
+/// the same TTL to clients via `expires_in_ms`, removing the need for
+/// a hardcoded client-side fallback.
+pub const TYPING_TTL: std::time::Duration = std::time::Duration::from_millis(6_000);
+
+/// How often the janitor sweeps the typing map for expired entries.
+/// Coarser than the TTL so a single tokio task can comfortably handle
+/// the chat-wide load; the worst-case ghost-typing window is
+/// `TYPING_TTL + JANITOR_INTERVAL`.
+const JANITOR_INTERVAL: std::time::Duration = std::time::Duration::from_millis(2_000);
 
 /// A handle to one WebSocket connection:
 /// * `sender` — outbound message channel (hub → writer task)
@@ -15,6 +30,16 @@ struct ConnHandle {
     kill: mpsc::UnboundedSender<()>,
 }
 
+/// Tracked typing state per `(user_id, conversation_id)`. We store the
+/// full member list so the janitor can fan out a stop-typing event
+/// without re-querying the DB; the WS handler captures it when the
+/// user originally signalled typing=true.
+#[derive(Debug, Clone)]
+struct TypingState {
+    expires_at: std::time::Instant,
+    members: Vec<i32>,
+}
+
 /// In-memory registry of active WebSocket connections, keyed by `users.id`.
 ///
 /// A single user may have multiple connections (e.g. phone + tablet),
@@ -22,14 +47,22 @@ struct ConnHandle {
 #[derive(Debug, Clone)]
 pub struct ChatHub {
     connections: Arc<DashMap<i32, Vec<ConnHandle>>>,
+    /// `(user_id, conversation_id) → typing state`. The janitor
+    /// scans this map every `JANITOR_INTERVAL` and broadcasts
+    /// `Typing(false)` for any entry past its deadline. Lets us
+    /// clear ghost typers when a client crashes mid-typing.
+    typing: Arc<DashMap<(i32, Uuid), TypingState>>,
 }
 
 impl ChatHub {
     #[must_use]
     pub fn new() -> Self {
-        Self {
+        let hub = Self {
             connections: Arc::new(DashMap::new()),
-        }
+            typing: Arc::new(DashMap::new()),
+        };
+        hub.spawn_typing_janitor();
+        hub
     }
 
     /// Register a new connection for the given user.
@@ -56,13 +89,20 @@ impl ChatHub {
         (rx, kill_rx)
     }
 
-    /// Remove closed senders for the given user.
-    /// Uses `remove_if_mut` for atomic retain-and-remove (no race with `register`).
+    /// Remove closed senders for the given user. If this empties the
+    /// user's connection list, also clear their typing state and emit
+    /// a stop-typing fanout so peers don't see a ghost typer for
+    /// `TYPING_TTL` seconds after a crash.
     pub fn unregister(&self, user_id: i32) {
+        let mut became_empty = false;
         self.connections.remove_if_mut(&user_id, |_, handles| {
             handles.retain(|h| !h.sender.is_closed());
-            handles.is_empty()
+            became_empty = handles.is_empty();
+            became_empty
         });
+        if became_empty {
+            self.flush_typing_for_user(user_id);
+        }
     }
 
     /// Send a message to all connections of the listed user IDs.
@@ -114,5 +154,114 @@ impl ChatHub {
                 let _ = handle.kill.send(());
             }
         }
+        self.flush_typing_for_user(user_id);
+    }
+
+    /// Note that `user_id` is currently typing in `conversation_id`.
+    /// Resets the TTL on every call. The WS handler is responsible for
+    /// providing the conversation member list once at typing-true; the
+    /// janitor keeps reusing it without re-querying.
+    pub fn note_typing(&self, user_id: i32, conversation_id: Uuid) {
+        let now = std::time::Instant::now();
+        let key = (user_id, conversation_id);
+        self.typing
+            .entry(key)
+            .and_modify(|s| s.expires_at = now + TYPING_TTL)
+            .or_insert_with(|| TypingState {
+                expires_at: now + TYPING_TTL,
+                members: Vec::new(),
+            });
+    }
+
+    /// Cache the conversation members for a typing entry so the janitor
+    /// can broadcast the eventual Typing(false) without DB access.
+    pub fn note_typing_members(&self, user_id: i32, conversation_id: Uuid, members: Vec<i32>) {
+        let key = (user_id, conversation_id);
+        if let Some(mut entry) = self.typing.get_mut(&key) {
+            entry.members = members;
+        }
+    }
+
+    /// Drop the typing entry for `(user, conv)`. Caller still
+    /// broadcasts the explicit `Typing(false)`.
+    pub fn clear_typing(&self, user_id: i32, conversation_id: Uuid) {
+        self.typing.remove(&(user_id, conversation_id));
+    }
+
+    /// Drop every typing entry for `user_id` and broadcast
+    /// `Typing(false)` to each affected conversation. Called from the
+    /// disconnect path so peers stop seeing "X is typing…" within ~the
+    /// next janitor tick rather than the full TTL.
+    fn flush_typing_for_user(&self, user_id: i32) {
+        let mut to_clear: Vec<(Uuid, Vec<i32>)> = Vec::new();
+        self.typing.retain(|(uid, conv_id), state| {
+            if *uid == user_id {
+                to_clear.push((*conv_id, state.members.clone()));
+                false
+            } else {
+                true
+            }
+        });
+        for (conv_id, members) in to_clear {
+            let others: Vec<i32> = members.into_iter().filter(|id| *id != user_id).collect();
+            if others.is_empty() {
+                continue;
+            }
+            self.broadcast(
+                &others,
+                &ServerMessage::Typing {
+                    conversation_id: conv_id,
+                    user_id,
+                    is_typing: false,
+                    expires_in_ms: None,
+                },
+            );
+        }
+    }
+
+    /// Spawn the periodic sweeper that fires `Typing(false)` for any
+    /// entry whose deadline has passed. Crash-resilient — the task
+    /// holds an `Arc` clone of the typing map and connections so the
+    /// hub itself can be cloned freely.
+    fn spawn_typing_janitor(&self) {
+        let typing = Arc::clone(&self.typing);
+        let connections = Arc::clone(&self.connections);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(JANITOR_INTERVAL);
+            // Skip the first immediate tick.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let now = std::time::Instant::now();
+                let mut expired: Vec<((i32, Uuid), Vec<i32>)> = Vec::new();
+                typing.retain(|key, state| {
+                    if state.expires_at <= now {
+                        expired.push((*key, state.members.clone()));
+                        false
+                    } else {
+                        true
+                    }
+                });
+                for ((user_id, conv_id), members) in expired {
+                    let others: Vec<i32> =
+                        members.into_iter().filter(|id| *id != user_id).collect();
+                    let msg = ServerMessage::Typing {
+                        conversation_id: conv_id,
+                        user_id,
+                        is_typing: false,
+                        expires_in_ms: None,
+                    };
+                    for uid in &others {
+                        connections.remove_if_mut(uid, |_, handles| {
+                            handles.retain(|h| !h.sender.is_closed());
+                            for handle in handles.iter() {
+                                let _ = handle.sender.send(msg.clone());
+                            }
+                            handles.is_empty()
+                        });
+                    }
+                }
+            }
+        });
     }
 }

--- a/backend/src/api/chat/hub.rs
+++ b/backend/src/api/chat/hub.rs
@@ -158,28 +158,26 @@ impl ChatHub {
     }
 
     /// Note that `user_id` is currently typing in `conversation_id`.
-    /// Resets the TTL on every call. The WS handler is responsible for
-    /// providing the conversation member list once at typing-true; the
-    /// janitor keeps reusing it without re-querying.
-    pub fn note_typing(&self, user_id: i32, conversation_id: Uuid) {
+    /// Resets the TTL on every call. `members` is the conversation
+    /// member list — initialised atomically with the entry so the
+    /// disconnect-flush and janitor paths always have someone to
+    /// broadcast `Typing(false)` to, even if the user disconnects
+    /// the instant after typing-true.
+    pub fn note_typing(&self, user_id: i32, conversation_id: Uuid, members: Vec<i32>) {
         let now = std::time::Instant::now();
         let key = (user_id, conversation_id);
         self.typing
             .entry(key)
-            .and_modify(|s| s.expires_at = now + TYPING_TTL)
+            .and_modify(|s| {
+                s.expires_at = now + TYPING_TTL;
+                if !members.is_empty() {
+                    s.members.clone_from(&members);
+                }
+            })
             .or_insert_with(|| TypingState {
                 expires_at: now + TYPING_TTL,
-                members: Vec::new(),
+                members,
             });
-    }
-
-    /// Cache the conversation members for a typing entry so the janitor
-    /// can broadcast the eventual Typing(false) without DB access.
-    pub fn note_typing_members(&self, user_id: i32, conversation_id: Uuid, members: Vec<i32>) {
-        let key = (user_id, conversation_id);
-        if let Some(mut entry) = self.typing.get_mut(&key) {
-            entry.members = members;
-        }
     }
 
     /// Drop the typing entry for `(user, conv)`. Caller still

--- a/backend/src/api/chat/messages.rs
+++ b/backend/src/api/chat/messages.rs
@@ -418,28 +418,40 @@ pub async fn set_mute(
     Ok(())
 }
 
-/// Record server-confirmed delivery for a single (message, user)
-/// pair via the SECURITY DEFINER helper. Idempotent — returns the
-/// stored `delivered_at` on first insert, `None` on a duplicate so
-/// the caller can suppress the Delivered broadcast. The function
-/// also verifies membership server-side, so an API bug that fans
-/// out a delivery to the wrong user can't silently insert a row.
-pub async fn record_delivery(
+#[derive(diesel::QueryableByName)]
+struct DeliveryRow {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    user_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+    delivered_at: chrono::DateTime<Utc>,
+}
+
+/// Bulk delivery insert via the SECURITY DEFINER helper. Inserts a row
+/// for every (`message_id`, recipient) pair in `user_ids` in one round
+/// trip and returns only the rows that were actually inserted, so the
+/// caller can emit a `Delivered` broadcast per success and stay
+/// idempotent across reconnects. Membership is verified in the same
+/// SQL statement against `conversation_members`. Replaces the
+/// per-recipient transaction loop that used to fan out N round trips
+/// per send.
+pub async fn record_deliveries(
     conn: &mut AsyncPgConnection,
     message_id: Uuid,
-    user_id: i32,
-) -> Result<Option<chrono::DateTime<Utc>>, crate::error::AppError> {
-    #[derive(diesel::QueryableByName)]
-    struct DeliveryAt {
-        #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Timestamptz>)]
-        delivered_at: Option<chrono::DateTime<Utc>>,
+    user_ids: &[i32],
+) -> Result<Vec<(i32, chrono::DateTime<Utc>)>, crate::error::AppError> {
+    if user_ids.is_empty() {
+        return Ok(Vec::new());
     }
-    let row: DeliveryAt = diesel::sql_query("SELECT app.record_delivery($1, $2) AS delivered_at")
-        .bind::<diesel::sql_types::Uuid, _>(message_id)
-        .bind::<diesel::sql_types::Integer, _>(user_id)
-        .get_result(conn)
-        .await?;
-    Ok(row.delivered_at)
+    let rows: Vec<DeliveryRow> =
+        diesel::sql_query("SELECT user_id, delivered_at FROM app.record_deliveries($1, $2)")
+            .bind::<diesel::sql_types::Uuid, _>(message_id)
+            .bind::<diesel::sql_types::Array<diesel::sql_types::Integer>, _>(user_ids)
+            .get_results(conn)
+            .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.user_id, r.delivered_at))
+        .collect())
 }
 
 /// Load all read receipts and delivery confirmations for the given

--- a/backend/src/api/chat/messages.rs
+++ b/backend/src/api/chat/messages.rs
@@ -3,10 +3,15 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
-use super::protocol::{MessagePayload, ReactionPayload, ReplyPayload};
+use super::protocol::{
+    DeliveryPayload, MessagePayload, ReactionPayload, ReadReceiptPayload, ReplyPayload,
+};
 use crate::db::models::message_reactions::NewMessageReaction;
+use crate::db::models::message_reads::NewMessageRead;
 use crate::db::models::messages::{Message, NewMessage};
-use crate::db::schema::{message_reactions, messages, profiles};
+use crate::db::schema::{
+    conversation_members, message_deliveries, message_reactions, message_reads, messages, profiles,
+};
 
 /// Convert a single message to a payload via the batch path.
 async fn single_message_payload(
@@ -258,13 +263,15 @@ pub async fn toggle_reaction(
     Ok((true, msg))
 }
 
-/// Update read watermark for a user in a conversation.
+/// Update read watermark for a user in a conversation, and record
+/// per-message read receipts for everything in the gap. Returns the
+/// `read_at` timestamp written. Caller broadcasts the receipt.
 pub async fn mark_read(
     conn: &mut AsyncPgConnection,
     conversation_id: Uuid,
     user_id: i32,
     message_id: Uuid,
-) -> Result<(), crate::error::AppError> {
+) -> Result<chrono::DateTime<Utc>, crate::error::AppError> {
     // Verify message belongs to this conversation
     let belongs = messages::table
         .filter(messages::id.eq(message_id))
@@ -279,6 +286,17 @@ pub async fn mark_read(
             "message does not belong to this conversation",
         ));
     }
+
+    // Capture the previous watermark so we can mark every message in
+    // (prev, message_id] as read in one batch insert.
+    let prev_watermark: Option<Uuid> = conversation_members::table
+        .filter(conversation_members::conversation_id.eq(conversation_id))
+        .filter(conversation_members::user_id.eq(user_id))
+        .select(conversation_members::last_read_message_id)
+        .first(conn)
+        .await
+        .optional()?
+        .flatten();
 
     // Only advance watermark forward (never move backwards).
     // Uses (created_at, id) compound comparison to match unread count query.
@@ -298,7 +316,178 @@ pub async fn mark_read(
     .execute(conn)
     .await?;
 
+    let read_at = Utc::now();
+
+    // Record per-message reads for the (prev, message_id] gap so the
+    // sender's UI gets ✓✓ ticks on every message the user just caught up
+    // on, not only the watermark tip. Skip the user's own messages.
+    let target_ts: Option<chrono::DateTime<Utc>> = messages::table
+        .filter(messages::id.eq(message_id))
+        .select(messages::created_at)
+        .first(conn)
+        .await
+        .optional()?;
+    let Some(target_ts) = target_ts else {
+        return Ok(read_at);
+    };
+
+    let gap_msg_ids: Vec<Uuid> = if let Some(prev_id) = prev_watermark {
+        let prev_ts: Option<chrono::DateTime<Utc>> = messages::table
+            .filter(messages::id.eq(prev_id))
+            .select(messages::created_at)
+            .first(conn)
+            .await
+            .optional()?;
+        match prev_ts {
+            Some(prev_ts) => {
+                messages::table
+                    .filter(messages::conversation_id.eq(conversation_id))
+                    .filter(messages::sender_id.ne(user_id))
+                    .filter(messages::deleted_at.is_null())
+                    .filter(
+                        messages::created_at.gt(prev_ts).or(messages::created_at
+                            .eq(prev_ts)
+                            .and(messages::id.gt(prev_id))),
+                    )
+                    .filter(
+                        messages::created_at.lt(target_ts).or(messages::created_at
+                            .eq(target_ts)
+                            .and(messages::id.le(message_id))),
+                    )
+                    .select(messages::id)
+                    .load(conn)
+                    .await?
+            }
+            // Watermark pointed at a now-deleted message; fall through
+            // and insert just the target.
+            None => vec![message_id],
+        }
+    } else {
+        // First read in this conversation: mark every message up through
+        // the target as read. This matches the unread-count math (which
+        // counts everything when watermark is NULL).
+        messages::table
+            .filter(messages::conversation_id.eq(conversation_id))
+            .filter(messages::sender_id.ne(user_id))
+            .filter(messages::deleted_at.is_null())
+            .filter(
+                messages::created_at.lt(target_ts).or(messages::created_at
+                    .eq(target_ts)
+                    .and(messages::id.le(message_id))),
+            )
+            .select(messages::id)
+            .load(conn)
+            .await?
+    };
+
+    if !gap_msg_ids.is_empty() {
+        let rows: Vec<NewMessageRead> = gap_msg_ids
+            .into_iter()
+            .map(|mid| NewMessageRead {
+                message_id: mid,
+                user_id,
+                read_at,
+            })
+            .collect();
+        diesel::insert_into(message_reads::table)
+            .values(&rows)
+            .on_conflict_do_nothing()
+            .execute(conn)
+            .await?;
+    }
+
+    Ok(read_at)
+}
+
+/// Set or clear per-conversation mute for a user. `muted_until = None`
+/// unmutes. The caller is responsible for verifying membership.
+pub async fn set_mute(
+    conn: &mut AsyncPgConnection,
+    conversation_id: Uuid,
+    user_id: i32,
+    muted_until: Option<chrono::DateTime<Utc>>,
+) -> Result<(), crate::error::AppError> {
+    diesel::update(
+        conversation_members::table
+            .filter(conversation_members::conversation_id.eq(conversation_id))
+            .filter(conversation_members::user_id.eq(user_id)),
+    )
+    .set(conversation_members::muted_until.eq(muted_until))
+    .execute(conn)
+    .await?;
     Ok(())
+}
+
+/// Record server-confirmed delivery for a single (message, user)
+/// pair via the SECURITY DEFINER helper. Idempotent — returns the
+/// stored `delivered_at` on first insert, `None` on a duplicate so
+/// the caller can suppress the Delivered broadcast. The function
+/// also verifies membership server-side, so an API bug that fans
+/// out a delivery to the wrong user can't silently insert a row.
+pub async fn record_delivery(
+    conn: &mut AsyncPgConnection,
+    message_id: Uuid,
+    user_id: i32,
+) -> Result<Option<chrono::DateTime<Utc>>, crate::error::AppError> {
+    #[derive(diesel::QueryableByName)]
+    struct DeliveryAt {
+        #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Timestamptz>)]
+        delivered_at: Option<chrono::DateTime<Utc>>,
+    }
+    let row: DeliveryAt = diesel::sql_query("SELECT app.record_delivery($1, $2) AS delivered_at")
+        .bind::<diesel::sql_types::Uuid, _>(message_id)
+        .bind::<diesel::sql_types::Integer, _>(user_id)
+        .get_result(conn)
+        .await?;
+    Ok(row.delivered_at)
+}
+
+/// Load all read receipts and delivery confirmations for the given
+/// message IDs. Used to hydrate `HistoryResponse` so a client that
+/// reconnects sees the up-to-date tick state on every message.
+pub async fn load_receipts_for_messages(
+    conn: &mut AsyncPgConnection,
+    msg_ids: &[Uuid],
+) -> Result<(Vec<ReadReceiptPayload>, Vec<DeliveryPayload>), crate::error::AppError> {
+    if msg_ids.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let reads: Vec<(Uuid, i32, chrono::DateTime<Utc>)> = message_reads::table
+        .filter(message_reads::message_id.eq_any(msg_ids))
+        .select((
+            message_reads::message_id,
+            message_reads::user_id,
+            message_reads::read_at,
+        ))
+        .load(conn)
+        .await?;
+    let deliveries: Vec<(Uuid, i32, chrono::DateTime<Utc>)> = message_deliveries::table
+        .filter(message_deliveries::message_id.eq_any(msg_ids))
+        .select((
+            message_deliveries::message_id,
+            message_deliveries::user_id,
+            message_deliveries::delivered_at,
+        ))
+        .load(conn)
+        .await?;
+    Ok((
+        reads
+            .into_iter()
+            .map(|(mid, uid, at)| ReadReceiptPayload {
+                message_id: mid,
+                user_id: uid,
+                read_at: at.to_rfc3339(),
+            })
+            .collect(),
+        deliveries
+            .into_iter()
+            .map(|(mid, uid, at)| DeliveryPayload {
+                message_id: mid,
+                user_id: uid,
+                delivered_at: at.to_rfc3339(),
+            })
+            .collect(),
+    ))
 }
 
 /// Look up the `conversation_id` for a given message.

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -497,7 +497,7 @@ pub struct MuteRequest {
 }
 
 pub async fn mute_conversation(
-    State(_ctx): State<AppContext>,
+    State(ctx): State<AppContext>,
     headers: HeaderMap,
     Path(conversation_id): Path<String>,
     Json(body): Json<MuteRequest>,
@@ -533,24 +533,33 @@ pub async fn mute_conversation(
     };
     let user_id = user.id;
 
-    let outcome: bool = db::with_viewer_tx(viewer, move |conn| {
+    // Mirror the WS handler: refresh unread totals in the same tx so we
+    // can fan an UnreadUpdate to the user's other live sessions. Without
+    // this, the device that called REST silences the badge but every
+    // other logged-in device keeps showing the stale count until the
+    // next listConversations.
+    let outcome: Option<(i64, i64)> = db::with_viewer_tx(viewer, move |conn| {
         async move {
             if !conversations::is_member(conn, conversation_id, user_id)
                 .await
                 .map_err(|_| diesel::result::Error::RollbackTransaction)?
             {
-                return Ok::<bool, diesel::result::Error>(false);
+                return Ok::<Option<(i64, i64)>, diesel::result::Error>(None);
             }
             messages::set_mute(conn, conversation_id, user_id, parsed)
                 .await
                 .map_err(|_| diesel::result::Error::RollbackTransaction)?;
-            Ok(true)
+            let (per, total) = conversations::unread_summary_for_user(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            let per_this = per.get(&conversation_id).copied().unwrap_or(0);
+            Ok(Some((per_this, total)))
         }
         .scope_boxed()
     })
     .await?;
 
-    if !outcome {
+    let Some((per_this, total)) = outcome else {
         return Ok(error_response(
             StatusCode::FORBIDDEN,
             &headers,
@@ -560,7 +569,16 @@ pub async fn mute_conversation(
                 details: None,
             },
         ));
-    }
+    };
+
+    ctx.chat_hub.broadcast(
+        &[user_id],
+        &protocol::ServerMessage::UnreadUpdate {
+            conversation_id,
+            unread_count: per_this,
+            total_unread: total,
+        },
+    );
 
     Ok((
         StatusCode::OK,

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -485,6 +485,137 @@ pub async fn push_unregister(
 }
 
 // ---------------------------------------------------------------------------
+// REST: Mute / unmute a conversation
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct MuteRequest {
+    /// RFC3339 timestamp; `null` clears the mute. A far-future
+    /// value encodes "muted forever" — the server stores it as-is.
+    #[serde(rename = "mutedUntil")]
+    muted_until: Option<String>,
+}
+
+pub async fn mute_conversation(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(conversation_id): Path<String>,
+    Json(body): Json<MuteRequest>,
+) -> Result<Response> {
+    let (_session, user) = auth_or_respond!(headers);
+
+    let conversation_id = match parse_uuid_response(&conversation_id, "conversation", &headers) {
+        Ok(id) => id,
+        Err(response) => return Ok(*response),
+    };
+
+    let parsed: Option<chrono::DateTime<chrono::Utc>> = match body.muted_until.as_deref() {
+        Some(s) => match chrono::DateTime::parse_from_rfc3339(s) {
+            Ok(t) => Some(t.with_timezone(&chrono::Utc)),
+            Err(_) => {
+                return Ok(error_response(
+                    StatusCode::BAD_REQUEST,
+                    &headers,
+                    ErrorSpec {
+                        error: "invalid mutedUntil; expected RFC3339".to_string(),
+                        code: "BAD_REQUEST",
+                        details: None,
+                    },
+                ));
+            }
+        },
+        None => None,
+    };
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+
+    let outcome: bool = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            if !conversations::is_member(conn, conversation_id, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            {
+                return Ok::<bool, diesel::result::Error>(false);
+            }
+            messages::set_mute(conn, conversation_id, user_id, parsed)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok(true)
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    if !outcome {
+        return Ok(error_response(
+            StatusCode::FORBIDDEN,
+            &headers,
+            ErrorSpec {
+                error: "not a member of this conversation".to_string(),
+                code: "FORBIDDEN",
+                details: None,
+            },
+        ));
+    }
+
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "data": {
+                "conversationId": conversation_id.to_string(),
+                "mutedUntil": body.muted_until,
+            }
+        })),
+    )
+        .into_response())
+}
+
+// ---------------------------------------------------------------------------
+// REST: Lightweight unread summary
+// ---------------------------------------------------------------------------
+
+pub async fn unread_summary(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+) -> Result<Response> {
+    let (_session, user) = auth_or_respond!(headers);
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+
+    let (per_conv, total) = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            conversations::unread_summary_for_user(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)
+        }
+        .scope_boxed()
+    })
+    .await?;
+    let per_conv_json: serde_json::Map<String, serde_json::Value> = per_conv
+        .into_iter()
+        .map(|(id, n)| (id.to_string(), serde_json::Value::from(n)))
+        .collect();
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "data": {
+                "total": total,
+                "perConversation": per_conv_json,
+            }
+        })),
+    )
+        .into_response())
+}
+
+// ---------------------------------------------------------------------------
 // REST: Chat config
 // ---------------------------------------------------------------------------
 

--- a/backend/src/api/chat/protocol.rs
+++ b/backend/src/api/chat/protocol.rs
@@ -46,6 +46,15 @@ pub enum ClientMessage {
         #[serde(rename = "isTyping")]
         is_typing: bool,
     },
+    /// Mute or unmute one conversation. `mutedUntil` of `None` clears
+    /// the mute; a future RFC3339 timestamp sets it; a far-future
+    /// timestamp encodes "muted forever".
+    Mute {
+        #[serde(rename = "conversationId")]
+        conversation_id: Uuid,
+        #[serde(rename = "mutedUntil")]
+        muted_until: Option<String>,
+    },
     History {
         #[serde(rename = "conversationId")]
         conversation_id: Uuid,
@@ -110,6 +119,34 @@ pub enum ServerMessage {
         user_id: i32,
         #[serde(rename = "messageId")]
         message_id: Uuid,
+        /// RFC3339 timestamp of when the read happened. Lets the
+        /// sender's UI show "Read 14:32" instead of guessing.
+        #[serde(rename = "readAt")]
+        read_at: String,
+    },
+    /// Server-confirmed delivery: a recipient's WS session has
+    /// received this message. Powers the ✓ → ✓✓ tick transition
+    /// before any read receipt arrives.
+    Delivered {
+        #[serde(rename = "conversationId")]
+        conversation_id: Uuid,
+        #[serde(rename = "messageId")]
+        message_id: Uuid,
+        #[serde(rename = "userId")]
+        user_id: i32,
+        #[serde(rename = "deliveredAt")]
+        delivered_at: String,
+    },
+    /// Pushed to a user's own sessions after their `Read` advances
+    /// the watermark, so multi-device clients don't have to refetch
+    /// the conversation list to clear a badge.
+    UnreadUpdate {
+        #[serde(rename = "conversationId")]
+        conversation_id: Uuid,
+        #[serde(rename = "unreadCount")]
+        unread_count: i64,
+        #[serde(rename = "totalUnread")]
+        total_unread: i64,
     },
     Typing {
         #[serde(rename = "conversationId")]
@@ -118,6 +155,11 @@ pub enum ServerMessage {
         user_id: i32,
         #[serde(rename = "isTyping")]
         is_typing: bool,
+        /// Hint to the client: this typing state expires at most
+        /// after `expires_in_ms`. Lets clients use the server's
+        /// authoritative TTL instead of a hardcoded fallback.
+        #[serde(rename = "expiresInMs", skip_serializing_if = "Option::is_none")]
+        expires_in_ms: Option<u64>,
     },
     HistoryResponse {
         #[serde(rename = "conversationId")]
@@ -125,6 +167,14 @@ pub enum ServerMessage {
         messages: Vec<MessagePayload>,
         #[serde(rename = "hasMore")]
         has_more: bool,
+        /// All read receipts for messages in this page. Lets clients
+        /// rehydrate ✓✓ ticks after reconnect without keeping a
+        /// running journal of receipts they may have missed offline.
+        #[serde(rename = "readReceipts", default)]
+        read_receipts: Vec<ReadReceiptPayload>,
+        /// All delivery confirmations for messages in this page.
+        #[serde(default)]
+        deliveries: Vec<DeliveryPayload>,
     },
     Conversations {
         conversations: Vec<ConversationPayload>,
@@ -182,6 +232,22 @@ pub struct ReactionPayload {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ReadReceiptPayload {
+    pub message_id: Uuid,
+    pub user_id: i32,
+    pub read_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeliveryPayload {
+    pub message_id: Uuid,
+    pub user_id: i32,
+    pub delivered_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConversationPayload {
     pub id: Uuid,
     pub kind: String,
@@ -197,6 +263,11 @@ pub struct ConversationPayload {
     pub latest_message_is_mine: bool,
     pub latest_sender_name: Option<String>,
     pub is_blocked: bool,
+    /// RFC3339 timestamp; `None` means not muted. A far-future value
+    /// encodes "muted until I unmute". Clients render a muted-bell
+    /// icon and fade the unread badge when this is `Some`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub muted_until: Option<String>,
     /// Bielik-Guard verdict for the latest message body — `None` until
     /// scanned, `"allow"`/`"flag"`/`"block"` after. Clients render the
     /// blur overlay in the chat list using this field; the body is

--- a/backend/src/api/chat/protocol.rs
+++ b/backend/src/api/chat/protocol.rs
@@ -259,6 +259,7 @@ pub struct ConversationPayload {
     pub direct_user_avatar: Option<String>,
     pub unread_count: i64,
     pub latest_message: Option<String>,
+    pub latest_message_id: Option<Uuid>,
     pub latest_timestamp: Option<String>,
     pub latest_message_is_mine: bool,
     pub latest_sender_name: Option<String>,

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -336,6 +336,12 @@ async fn handle_client_message(
         } => {
             handle_typing(viewer, conversation_id, is_typing, hub).await;
         }
+        ClientMessage::Mute {
+            conversation_id,
+            muted_until,
+        } => {
+            handle_mute(viewer, conversation_id, muted_until.as_deref(), hub).await;
+        }
         ClientMessage::History {
             conversation_id,
             before,
@@ -497,7 +503,36 @@ async fn handle_send(
                     sender_id = user_id,
                     "message_sent"
                 );
+                let msg_id = match &server_msg {
+                    ServerMessage::Message { msg } => msg.id,
+                    _ => uuid::Uuid::nil(),
+                };
                 hub.broadcast(&outcome.members, &server_msg);
+
+                // Server-confirmed delivery: anyone with an active WS
+                // session in `members` (other than the sender) just
+                // received the broadcast. Record those deliveries and
+                // emit `Delivered` back to the sender so their UI can
+                // flip ✓ → ✓✓ before any read happens.
+                let online_recipients: Vec<i32> = outcome
+                    .members
+                    .iter()
+                    .copied()
+                    .filter(|&id| id != user_id && hub.is_online(id))
+                    .collect();
+                if !online_recipients.is_empty() {
+                    let hub_clone = hub.clone();
+                    tokio::spawn(async move {
+                        record_deliveries_and_notify(
+                            hub_clone,
+                            conversation_id,
+                            msg_id,
+                            user_id,
+                            online_recipients,
+                        )
+                        .await;
+                    });
+                }
 
                 let push_targets: Vec<i32> = outcome
                     .members
@@ -854,6 +889,51 @@ async fn handle_react(
     }
 }
 
+/// Insert `message_deliveries` rows for every online recipient and
+/// emit `Delivered` to the sender's sessions for each successful
+/// (idempotent) insert. Runs after the broadcast so a slow DB never
+/// stalls the fanout. Each delivery is recorded under the recipient's
+/// own viewer context so RLS policies stay consistent — but the
+/// SECURITY DEFINER helper does the real gating.
+async fn record_deliveries_and_notify(
+    hub: ChatHub,
+    conversation_id: uuid::Uuid,
+    message_id: uuid::Uuid,
+    sender_user_id: i32,
+    recipients: Vec<i32>,
+) {
+    if message_id.is_nil() {
+        return;
+    }
+    for uid in recipients {
+        let viewer = db::DbViewer {
+            user_id: uid,
+            is_review_stub: false,
+        };
+        let res: Result<Option<chrono::DateTime<chrono::Utc>>, diesel::result::Error> =
+            db::with_viewer_tx(viewer, move |conn| {
+                async move {
+                    chat_messages::record_delivery(conn, message_id, uid)
+                        .await
+                        .map_err(into_diesel)
+                }
+                .scope_boxed()
+            })
+            .await;
+        if let Ok(Some(at)) = res {
+            hub.broadcast(
+                &[sender_user_id],
+                &ServerMessage::Delivered {
+                    conversation_id,
+                    message_id,
+                    user_id: uid,
+                    delivered_at: at.to_rfc3339(),
+                },
+            );
+        }
+    }
+}
+
 async fn resolve_sender_for_reaction(
     conn: &mut AsyncPgConnection,
     user_id: i32,
@@ -875,6 +955,8 @@ async fn resolve_sender_for_reaction(
     (name, avatar_url)
 }
 
+type ReadOutcome = Option<(Vec<i32>, chrono::DateTime<chrono::Utc>, i64, i64)>;
+
 async fn handle_read(
     viewer: SocketViewer,
     conversation_id: uuid::Uuid,
@@ -883,34 +965,101 @@ async fn handle_read(
 ) {
     let user_id = viewer.user_id;
 
-    let members: std::result::Result<Option<Vec<i32>>, diesel::result::Error> =
+    let members: std::result::Result<ReadOutcome, diesel::result::Error> =
         db::with_viewer_tx(viewer.into(), move |conn| {
             async move {
                 if !conversations::is_member(conn, conversation_id, user_id)
                     .await
                     .map_err(into_diesel)?
                 {
-                    return Ok::<Option<Vec<i32>>, diesel::result::Error>(None);
+                    return Ok::<ReadOutcome, diesel::result::Error>(None);
                 }
-                chat_messages::mark_read(conn, conversation_id, user_id, message_id)
+                let read_at = chat_messages::mark_read(conn, conversation_id, user_id, message_id)
                     .await
                     .map_err(into_diesel)?;
                 let m = conversations::member_user_ids(conn, conversation_id)
                     .await
                     .map_err(into_diesel)?;
-                Ok(Some(m))
+                let (per_conv, total) = conversations::unread_summary_for_user(conn, user_id)
+                    .await
+                    .map_err(into_diesel)?;
+                let per_this = per_conv.get(&conversation_id).copied().unwrap_or(0);
+                Ok(Some((m, read_at, per_this, total)))
             }
             .scope_boxed()
         })
         .await;
 
-    if let Ok(Some(members)) = members {
+    if let Ok(Some((members, read_at, per_conv_unread, total_unread))) = members {
         let server_msg = ServerMessage::ReadReceipt {
             conversation_id,
             user_id,
             message_id,
+            read_at: read_at.to_rfc3339(),
         };
         hub.broadcast(&members, &server_msg);
+        // Also push the user's own multi-device sessions an UnreadUpdate
+        // so e.g. the tablet badge clears the moment the phone reads.
+        // (broadcast() will fan out to every active session of `user_id`.)
+        hub.broadcast(
+            &[user_id],
+            &ServerMessage::UnreadUpdate {
+                conversation_id,
+                unread_count: per_conv_unread,
+                total_unread,
+            },
+        );
+    }
+}
+
+async fn handle_mute(
+    viewer: SocketViewer,
+    conversation_id: uuid::Uuid,
+    muted_until: Option<&str>,
+    hub: &ChatHub,
+) {
+    let user_id = viewer.user_id;
+    let parsed: Option<chrono::DateTime<chrono::Utc>> = match muted_until {
+        Some(s) => match chrono::DateTime::parse_from_rfc3339(s) {
+            Ok(t) => Some(t.with_timezone(&chrono::Utc)),
+            Err(_) => return,
+        },
+        None => None,
+    };
+
+    let result: std::result::Result<Option<(i64, i64)>, diesel::result::Error> =
+        db::with_viewer_tx(viewer.into(), move |conn| {
+            async move {
+                if !conversations::is_member(conn, conversation_id, user_id)
+                    .await
+                    .map_err(into_diesel)?
+                {
+                    return Ok::<Option<(i64, i64)>, diesel::result::Error>(None);
+                }
+                chat_messages::set_mute(conn, conversation_id, user_id, parsed)
+                    .await
+                    .map_err(into_diesel)?;
+                let (per, total) = conversations::unread_summary_for_user(conn, user_id)
+                    .await
+                    .map_err(into_diesel)?;
+                let per_this = per.get(&conversation_id).copied().unwrap_or(0);
+                Ok(Some((per_this, total)))
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    if let Ok(Some((per_this, total))) = result {
+        // Mute affects which conversations contribute to total_unread,
+        // so refresh the user's other sessions.
+        hub.broadcast(
+            &[user_id],
+            &ServerMessage::UnreadUpdate {
+                conversation_id,
+                unread_count: per_this,
+                total_unread: total,
+            },
+        );
     }
 }
 
@@ -941,10 +1090,26 @@ async fn handle_typing(
         .await;
 
     if let Ok(Some(members)) = members {
+        if is_typing {
+            // Note typing TTL on the hub so the janitor can emit a
+            // stop-typing fanout if the user goes silent or
+            // disconnects without explicitly clearing it.
+            hub.note_typing(user_id, conversation_id);
+            hub.note_typing_members(user_id, conversation_id, members.clone());
+        } else {
+            hub.clear_typing(user_id, conversation_id);
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        let expires_in_ms = if is_typing {
+            Some(super::hub::TYPING_TTL.as_millis() as u64)
+        } else {
+            None
+        };
         let server_msg = ServerMessage::Typing {
             conversation_id,
             user_id,
             is_typing,
+            expires_in_ms,
         };
         let others: Vec<i32> = members.into_iter().filter(|id| *id != user_id).collect();
         hub.broadcast(&others, &server_msg);
@@ -968,6 +1133,8 @@ async fn handle_history(
         Ok {
             messages: Vec<super::protocol::MessagePayload>,
             has_more: bool,
+            read_receipts: Vec<super::protocol::ReadReceiptPayload>,
+            deliveries: Vec<super::protocol::DeliveryPayload>,
         },
         NotMember,
         Failed(String),
@@ -1000,18 +1167,35 @@ async fn handle_history(
                     ) => return Ok(Outcome::Failed(m)),
                     Err(e) => return Err(into_diesel(e)),
                 };
-                Ok(Outcome::Ok { messages, has_more })
+                let msg_ids: Vec<uuid::Uuid> = messages.iter().map(|m| m.id).collect();
+                let (read_receipts, deliveries) =
+                    chat_messages::load_receipts_for_messages(conn, &msg_ids)
+                        .await
+                        .map_err(into_diesel)?;
+                Ok(Outcome::Ok {
+                    messages,
+                    has_more,
+                    read_receipts,
+                    deliveries,
+                })
             }
             .scope_boxed()
         })
         .await;
 
     match result {
-        Ok(Outcome::Ok { messages, has_more }) => {
+        Ok(Outcome::Ok {
+            messages,
+            has_more,
+            read_receipts,
+            deliveries,
+        }) => {
             let _ = outbound_tx.send(ServerMessage::HistoryResponse {
                 conversation_id,
                 messages,
                 has_more,
+                read_receipts,
+                deliveries,
             });
         }
         Ok(Outcome::NotMember) => {

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -1094,8 +1094,7 @@ async fn handle_typing(
             // Note typing TTL on the hub so the janitor can emit a
             // stop-typing fanout if the user goes silent or
             // disconnects without explicitly clearing it.
-            hub.note_typing(user_id, conversation_id);
-            hub.note_typing_members(user_id, conversation_id, members.clone());
+            hub.note_typing(user_id, conversation_id, members.clone());
         } else {
             hub.clear_typing(user_id, conversation_id);
         }

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -889,12 +889,13 @@ async fn handle_react(
     }
 }
 
-/// Insert `message_deliveries` rows for every online recipient and
-/// emit `Delivered` to the sender's sessions for each successful
-/// (idempotent) insert. Runs after the broadcast so a slow DB never
-/// stalls the fanout. Each delivery is recorded under the recipient's
-/// own viewer context so RLS policies stay consistent — but the
-/// SECURITY DEFINER helper does the real gating.
+/// Insert `message_deliveries` rows for every online recipient in one
+/// batched round trip and emit `Delivered` to the sender's sessions
+/// for each successful (idempotent) insert. Runs after the broadcast
+/// so a slow DB never stalls the fanout. Membership gating happens
+/// inside the SECURITY DEFINER helper, so we run the bulk call under
+/// the sender's viewer rather than spinning up a tx per recipient —
+/// for a group of N online members this collapses N short txs into one.
 async fn record_deliveries_and_notify(
     hub: ChatHub,
     conversation_id: uuid::Uuid,
@@ -902,35 +903,37 @@ async fn record_deliveries_and_notify(
     sender_user_id: i32,
     recipients: Vec<i32>,
 ) {
-    if message_id.is_nil() {
+    if message_id.is_nil() || recipients.is_empty() {
         return;
     }
-    for uid in recipients {
-        let viewer = db::DbViewer {
-            user_id: uid,
-            is_review_stub: false,
-        };
-        let res: Result<Option<chrono::DateTime<chrono::Utc>>, diesel::result::Error> =
-            db::with_viewer_tx(viewer, move |conn| {
-                async move {
-                    chat_messages::record_delivery(conn, message_id, uid)
-                        .await
-                        .map_err(into_diesel)
-                }
-                .scope_boxed()
-            })
-            .await;
-        if let Ok(Some(at)) = res {
-            hub.broadcast(
-                &[sender_user_id],
-                &ServerMessage::Delivered {
-                    conversation_id,
-                    message_id,
-                    user_id: uid,
-                    delivered_at: at.to_rfc3339(),
-                },
-            );
-        }
+    let viewer = db::DbViewer {
+        user_id: sender_user_id,
+        is_review_stub: false,
+    };
+    let recipients_for_tx = recipients.clone();
+    let res: Result<Vec<(i32, chrono::DateTime<chrono::Utc>)>, diesel::result::Error> =
+        db::with_viewer_tx(viewer, move |conn| {
+            async move {
+                chat_messages::record_deliveries(conn, message_id, &recipients_for_tx)
+                    .await
+                    .map_err(into_diesel)
+            }
+            .scope_boxed()
+        })
+        .await;
+    let Ok(rows) = res else {
+        return;
+    };
+    for (uid, at) in rows {
+        hub.broadcast(
+            &[sender_user_id],
+            &ServerMessage::Delivered {
+                conversation_id,
+                message_id,
+                user_id: uid,
+                delivered_at: at.to_rfc3339(),
+            },
+        );
     }
 }
 

--- a/backend/src/api/chat/ws.rs
+++ b/backend/src/api/chat/ws.rs
@@ -522,12 +522,13 @@ async fn handle_send(
                     .collect();
                 if !online_recipients.is_empty() {
                     let hub_clone = hub.clone();
+                    let sender_viewer: db::DbViewer = viewer.into();
                     tokio::spawn(async move {
                         record_deliveries_and_notify(
                             hub_clone,
                             conversation_id,
                             msg_id,
-                            user_id,
+                            sender_viewer,
                             online_recipients,
                         )
                         .await;
@@ -900,19 +901,16 @@ async fn record_deliveries_and_notify(
     hub: ChatHub,
     conversation_id: uuid::Uuid,
     message_id: uuid::Uuid,
-    sender_user_id: i32,
+    sender: db::DbViewer,
     recipients: Vec<i32>,
 ) {
     if message_id.is_nil() || recipients.is_empty() {
         return;
     }
-    let viewer = db::DbViewer {
-        user_id: sender_user_id,
-        is_review_stub: false,
-    };
+    let sender_user_id = sender.user_id;
     let recipients_for_tx = recipients.clone();
     let res: Result<Vec<(i32, chrono::DateTime<chrono::Utc>)>, diesel::result::Error> =
-        db::with_viewer_tx(viewer, move |conn| {
+        db::with_viewer_tx(sender, move |conn| {
             async move {
                 chat_messages::record_deliveries(conn, message_id, &recipients_for_tx)
                     .await

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -205,6 +205,11 @@ fn chat_routes() -> Router<AppContext> {
         )
         .route("/push/register", post(chat::push_register))
         .route("/push/unregister", post(chat::push_unregister))
+        .route(
+            "/conversations/{id}/mute",
+            axum::routing::patch(chat::mute_conversation),
+        )
+        .route("/unread", get(chat::unread_summary))
         .layer(cache_layer("no-store"))
 }
 

--- a/backend/src/db/models/conversation_members.rs
+++ b/backend/src/db/models/conversation_members.rs
@@ -11,6 +11,7 @@ pub struct ConversationMember {
     pub user_id: i32,
     pub joined_at: DateTime<Utc>,
     pub last_read_message_id: Option<Uuid>,
+    pub muted_until: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Insertable)]

--- a/backend/src/db/models/message_deliveries.rs
+++ b/backend/src/db/models/message_deliveries.rs
@@ -1,0 +1,21 @@
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use crate::db::schema::message_deliveries;
+
+#[derive(Debug, Clone, Queryable, Selectable, Identifiable)]
+#[diesel(table_name = message_deliveries, primary_key(message_id, user_id))]
+pub struct MessageDelivery {
+    pub message_id: Uuid,
+    pub user_id: i32,
+    pub delivered_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = message_deliveries)]
+pub struct NewMessageDelivery {
+    pub message_id: Uuid,
+    pub user_id: i32,
+    pub delivered_at: DateTime<Utc>,
+}

--- a/backend/src/db/models/message_reads.rs
+++ b/backend/src/db/models/message_reads.rs
@@ -1,0 +1,21 @@
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use crate::db::schema::message_reads;
+
+#[derive(Debug, Clone, Queryable, Selectable, Identifiable)]
+#[diesel(table_name = message_reads, primary_key(message_id, user_id))]
+pub struct MessageRead {
+    pub message_id: Uuid,
+    pub user_id: i32,
+    pub read_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = message_reads)]
+pub struct NewMessageRead {
+    pub message_id: Uuid,
+    pub user_id: i32,
+    pub read_at: DateTime<Utc>,
+}

--- a/backend/src/db/models/mod.rs
+++ b/backend/src/db/models/mod.rs
@@ -8,7 +8,9 @@ pub mod event_tags;
 pub mod events;
 pub mod job_outbox;
 
+pub mod message_deliveries;
 pub mod message_reactions;
+pub mod message_reads;
 pub mod messages;
 pub mod otp_codes;
 pub mod profile_blocks;

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -20,6 +20,23 @@ diesel::table! {
         user_id -> Int4,
         joined_at -> Timestamptz,
         last_read_message_id -> Nullable<Uuid>,
+        muted_until -> Nullable<Timestamptz>,
+    }
+}
+
+diesel::table! {
+    message_reads (message_id, user_id) {
+        message_id -> Uuid,
+        user_id -> Int4,
+        read_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    message_deliveries (message_id, user_id) {
+        message_id -> Uuid,
+        user_id -> Int4,
+        delivered_at -> Timestamptz,
     }
 }
 
@@ -351,6 +368,10 @@ diesel::joinable!(conversations -> events (event_id));
 diesel::joinable!(messages -> conversations (conversation_id));
 diesel::joinable!(messages -> uploads (attachment_upload_id));
 diesel::joinable!(message_reactions -> messages (message_id));
+diesel::joinable!(message_reads -> messages (message_id));
+diesel::joinable!(message_reads -> users (user_id));
+diesel::joinable!(message_deliveries -> messages (message_id));
+diesel::joinable!(message_deliveries -> users (user_id));
 diesel::joinable!(chat_message_reveals -> messages (message_id));
 diesel::joinable!(chat_message_reveals -> users (viewer_user_id));
 diesel::joinable!(chat_message_reports -> messages (message_id));
@@ -386,6 +407,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     events,
     job_outbox,
     message_reactions,
+    message_reads,
+    message_deliveries,
     messages,
     otp_codes,
     profile_blocks,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -524,8 +524,20 @@ private fun translateCategory(category: String): String =
 
 @Composable
 private fun OutgoingMessageStatusIcon(event: TimelineItem.Event) {
-    when {
-        event.sendStatus == EventSendStatus.Failed -> {
+    // Renders the WhatsApp/iMessage status ladder. We bias to the
+    // explicit `sendStatus` ladder when present (server-confirmed) and
+    // fall back to the maps for clients that didn't set it (e.g.
+    // pre-update cache rows).
+    val effective =
+        when {
+            event.sendStatus == EventSendStatus.Failed -> EventSendStatus.Failed
+            event.sendStatus == EventSendStatus.Sending -> EventSendStatus.Sending
+            event.readBy.isNotEmpty() -> EventSendStatus.Read
+            event.deliveredTo.isNotEmpty() -> EventSendStatus.Delivered
+            else -> event.sendStatus ?: EventSendStatus.Sent
+        }
+    when (effective) {
+        EventSendStatus.Failed -> {
             Icon(
                 imageVector = PhosphorIcons.Bold.WarningCircle,
                 contentDescription = null,
@@ -534,7 +546,7 @@ private fun OutgoingMessageStatusIcon(event: TimelineItem.Event) {
             )
         }
 
-        event.sendStatus == EventSendStatus.Sending -> {
+        EventSendStatus.Sending -> {
             Icon(
                 imageVector = PhosphorIcons.Bold.Clock,
                 contentDescription = null,
@@ -543,7 +555,19 @@ private fun OutgoingMessageStatusIcon(event: TimelineItem.Event) {
             )
         }
 
-        event.readByCount > 0 -> {
+        EventSendStatus.Read -> {
+            Icon(
+                imageVector = PhosphorIcons.Bold.CheckCircle,
+                contentDescription = null,
+                // Read ticks are tinted blue (iMessage-ish) so the
+                // user can distinguish "they got it" from "they read it"
+                // at a glance.
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(14.dp),
+            )
+        }
+
+        EventSendStatus.Delivered -> {
             Icon(
                 imageVector = PhosphorIcons.Bold.CheckCircle,
                 contentDescription = null,
@@ -552,7 +576,7 @@ private fun OutgoingMessageStatusIcon(event: TimelineItem.Event) {
             )
         }
 
-        else -> {
+        EventSendStatus.Sent -> {
             Icon(
                 imageVector = PhosphorIcons.Bold.Check,
                 contentDescription = null,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
+import com.adamglin.phosphoricons.bold.BellSlash
 import com.adamglin.phosphoricons.bold.Check
 import com.adamglin.phosphoricons.bold.CheckCircle
 import com.adamglin.phosphoricons.bold.Clock
@@ -82,11 +83,17 @@ fun RoomRow(
                 if (room.unreadCount == 0 && room.latestMessageIsMine) {
                     latestRoomStatusIconSpec(
                         sendStatus = room.latestMessageSendStatus,
-                        readByCount = room.latestMessageReadByCount,
                     )
                 } else {
                     null
                 }
+            val isMuted =
+                room.mutedUntilMillis?.let {
+                    it >
+                        kotlinx.datetime.Clock.System
+                            .now()
+                            .toEpochMilliseconds()
+                } ?: false
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = displayName,
@@ -97,6 +104,15 @@ fun RoomRow(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
                 )
+                if (isMuted) {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Icon(
+                        imageVector = PhosphorIcons.Bold.BellSlash,
+                        contentDescription = "Wyciszone",
+                        tint = TextSecondary,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
                 if (room.latestTimestampMillis != null || room.unreadCount > 0) {
                     Spacer(modifier = Modifier.width(8.dp))
                     Column(horizontalAlignment = Alignment.End) {
@@ -110,7 +126,11 @@ fun RoomRow(
                         if (room.unreadCount > 0) {
                             Spacer(modifier = Modifier.height(4.dp))
                             Surface(
-                                color = Primary,
+                                // Muted rooms still get a count, but rendered
+                                // in a low-emphasis tone — they don't pull
+                                // the eye and don't roll into the platform
+                                // launcher badge either.
+                                color = if (isMuted) TextSecondary.copy(alpha = 0.6f) else Primary,
                                 contentColor = Background,
                                 shape = CircleShape,
                                 modifier = Modifier,
@@ -221,28 +241,29 @@ private data class RoomStatusIconSpec(
 )
 
 @Composable
-private fun latestRoomStatusIconSpec(
-    sendStatus: EventSendStatus?,
-    readByCount: Int,
-): RoomStatusIconSpec? =
-    when {
-        sendStatus == EventSendStatus.Failed -> {
+private fun latestRoomStatusIconSpec(sendStatus: EventSendStatus?): RoomStatusIconSpec? =
+    when (sendStatus) {
+        EventSendStatus.Failed -> {
             RoomStatusIconSpec(icon = PhosphorIcons.Bold.WarningCircle, tint = MaterialTheme.colorScheme.error)
         }
 
-        sendStatus == EventSendStatus.Sending -> {
+        EventSendStatus.Sending -> {
             RoomStatusIconSpec(icon = PhosphorIcons.Bold.Clock, tint = TextSecondary)
         }
 
-        readByCount > 0 -> {
+        EventSendStatus.Read -> {
             RoomStatusIconSpec(icon = PhosphorIcons.Bold.CheckCircle, tint = Primary)
         }
 
-        sendStatus == EventSendStatus.Sent -> {
+        EventSendStatus.Delivered -> {
+            RoomStatusIconSpec(icon = PhosphorIcons.Bold.CheckCircle, tint = TextSecondary)
+        }
+
+        EventSendStatus.Sent -> {
             RoomStatusIconSpec(icon = PhosphorIcons.Bold.Check, tint = TextSecondary)
         }
 
-        else -> {
+        null -> {
             null
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -83,6 +83,7 @@ fun RoomRow(
                 if (room.unreadCount == 0 && room.latestMessageIsMine) {
                     latestRoomStatusIconSpec(
                         sendStatus = room.latestMessageSendStatus,
+                        readByCount = room.latestMessageReadByCount,
                     )
                 } else {
                     null
@@ -241,8 +242,20 @@ private data class RoomStatusIconSpec(
 )
 
 @Composable
-private fun latestRoomStatusIconSpec(sendStatus: EventSendStatus?): RoomStatusIconSpec? =
-    when (sendStatus) {
+private fun latestRoomStatusIconSpec(
+    sendStatus: EventSendStatus?,
+    readByCount: Int,
+): RoomStatusIconSpec? {
+    // Defence-in-depth for the cold-start path: the conversation list
+    // payload from the server doesn't (yet) carry an explicit Read
+    // status, only the per-message `readByCount` counter restored from
+    // cache. Live ReadReceipt events flip [sendStatus] to Read at the
+    // data layer; until that fires after a fresh launch, fall back on
+    // the counter so the blue tick still renders.
+    if (readByCount > 0 && sendStatus != EventSendStatus.Failed && sendStatus != EventSendStatus.Sending) {
+        return RoomStatusIconSpec(icon = PhosphorIcons.Bold.CheckCircle, tint = Primary)
+    }
+    return when (sendStatus) {
         EventSendStatus.Failed -> {
             RoomStatusIconSpec(icon = PhosphorIcons.Bold.WarningCircle, tint = MaterialTheme.colorScheme.error)
         }
@@ -267,3 +280,4 @@ private fun latestRoomStatusIconSpec(sendStatus: EventSendStatus?): RoomStatusIc
             null
         }
     }
+}

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/api/BadgeUpdater.android.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/api/BadgeUpdater.android.kt
@@ -1,0 +1,19 @@
+package com.poziomki.app.chat.api
+
+/**
+ * Android: launcher badge support is OEM-specific (Samsung uses a
+ * BadgeProvider, Google's launcher reads `Notification.setNumber`).
+ * The most reliable common path is to attach the count to the
+ * persistent chat notification, which we don't yet maintain in core.
+ *
+ * For now this is a no-op stub; the higher-level Android app can
+ * supply a real implementation via DI when it owns the active
+ * notification handle. Keeping the surface here so the common code
+ * doesn't need a `// TODO platform-specific` branch.
+ */
+actual class BadgeUpdater actual constructor() {
+    actual fun setBadgeCount(count: Int) {
+        // no-op; replaced by the Android app module when wiring the
+        // foreground/notification badge.
+    }
+}

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/di/PlatformModule.android.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/di/PlatformModule.android.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.sqlite.db.SupportSQLiteDatabase
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import com.poziomki.app.chat.api.BadgeUpdater
 import com.poziomki.app.chat.api.ChatClient
 import com.poziomki.app.chat.push.NotificationHelper
 import com.poziomki.app.chat.push.PushManager
@@ -85,7 +86,8 @@ actual fun platformModule(): Module =
         }
         single { createDataStore(get<Context>()) }
         single<SessionTokenStore> { AndroidSecureSessionTokenStore(get<Context>()) }
-        single<ChatClient> { WsChatClient(get(), get(), get(), get()) }
+        single { BadgeUpdater() }
+        single<ChatClient> { WsChatClient(get(), get(), get(), get(), get()) }
         single<SqlDriver> {
             val context = get<Context>()
             val dbName = "poziomki.db"

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/BadgeUpdater.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/BadgeUpdater.kt
@@ -1,0 +1,15 @@
+package com.poziomki.app.chat.api
+
+/**
+ * Platform-specific launcher/notification badge updater. Called by
+ * the chat layer whenever [ChatClient.totalUnread] changes. The
+ * common layer doesn't try to hide badge differences — Android's
+ * shortcut badge and iOS's notification badge have different
+ * semantics — so this is just a thin actual-per-platform.
+ *
+ * Implementations should be cheap and idempotent: invoked on every
+ * unread tick.
+ */
+expect class BadgeUpdater() {
+    fun setBadgeCount(count: Int)
+}

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
@@ -36,6 +36,12 @@ data class RoomSummary(
     val latestMessageSendStatus: EventSendStatus? = null,
     val latestMessageReadByCount: Int = 0,
     val isBlocked: Boolean = false,
+    /**
+     * Epoch-millis until which this conversation is muted, or `null`
+     * if not muted. A far-future value encodes "muted forever".
+     * Renderer fades the unread badge and shows a muted-bell icon.
+     */
+    val mutedUntilMillis: Long? = null,
     /** Bielik-Guard verdict for the latest message body, or null when unscanned / mine. */
     val latestModerationVerdict: String? = null,
     /** Categories that exceeded the flag threshold for the latest message. */
@@ -53,6 +59,18 @@ data class RoomTimelineCacheSnapshot(
 interface ChatClient {
     val state: StateFlow<ChatClientState>
     val rooms: StateFlow<List<RoomSummary>>
+
+    /**
+     * Total unread across all *non-muted* conversations. Drives the
+     * platform launcher badge. Pushed by the server after every read,
+     * mute, or new message; persisted across app restarts.
+     */
+    val totalUnread: StateFlow<Int>
+
+    suspend fun setMute(
+        roomId: String,
+        mutedUntilMillis: Long?,
+    ): Result<Unit>
 
     suspend fun ensureStarted(): Result<Unit>
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
@@ -32,6 +32,7 @@ data class RoomSummary(
     val unreadCount: Int,
     val latestMessage: String?,
     val latestTimestampMillis: Long?,
+    val latestMessageId: String? = null,
     val latestMessageIsMine: Boolean = false,
     val latestMessageSendStatus: EventSendStatus? = null,
     val latestMessageReadByCount: Int = 0,

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/NoopChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/NoopChatClient.kt
@@ -10,6 +10,13 @@ class NoopChatClient : ChatClient {
 
     override val rooms: StateFlow<List<RoomSummary>> = MutableStateFlow(emptyList())
 
+    override val totalUnread: StateFlow<Int> = MutableStateFlow(0)
+
+    override suspend fun setMute(
+        roomId: String,
+        mutedUntilMillis: Long?,
+    ): Result<Unit> = Result.success(Unit)
+
     override suspend fun ensureStarted(): Result<Unit> = Result.success(Unit)
 
     override suspend fun refreshRooms(): Result<Unit> = Result.success(Unit)

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/Timeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/Timeline.kt
@@ -34,9 +34,24 @@ data class ReplyDetails(
     val body: String?,
 )
 
+/**
+ * Send-status ladder for the local viewer's own messages.
+ *
+ *   `Sending` — POSTed but no server confirmation.
+ *   `Sent` — server has accepted and persisted the message.
+ *   `Delivered` — at least one recipient's WS session has received it
+ *                 (server-confirmed via `Delivered` event).
+ *   `Read` — at least one recipient has read it (server `ReadReceipt`).
+ *   `Failed` — terminal error during send.
+ *
+ * Mirrors WhatsApp/iMessage tick semantics; the renderer chooses
+ * single/double/double-blue ticks from this enum.
+ */
 enum class EventSendStatus {
     Sending,
     Sent,
+    Delivered,
+    Read,
     Failed,
 }
 
@@ -55,7 +70,18 @@ sealed interface TimelineItem {
         val reactions: List<Reaction>,
         val isEditable: Boolean,
         val sendStatus: EventSendStatus?,
-        val readByCount: Int,
+        /**
+         * Per-user receipts captured server-side. Empty until at
+         * least one peer reads. Powers double-blue ticks and the
+         * "read by" sheet for groups.
+         */
+        val readBy: Map<Int, Long> = emptyMap(),
+        /**
+         * Per-user delivery confirmations (server-confirmed when the
+         * recipient's WS session received the message). Empty until
+         * a recipient is actually online or reconnects.
+         */
+        val deliveredTo: Map<Int, Long> = emptyMap(),
         val canReply: Boolean,
         /**
          * Bielik-Guard verdict for this message body. `null` until the

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/TypingLabel.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/TypingLabel.kt
@@ -1,0 +1,30 @@
+package com.poziomki.app.chat.api
+
+/**
+ * Render a localized "X is typing…" label from a set of typing users.
+ *
+ * Behavior matches Signal/iMessage for groups:
+ *   * 0 → null (caller hides indicator)
+ *   * 1 → "Anna pisze…"
+ *   * 2 → "Anna i Jan piszą…"
+ *   * 3+ → "Kilka osób pisze…"
+ *
+ * `nameOf` resolves user IDs to display names; the caller is
+ * expected to supply a member-cache lookup. Users without a
+ * resolvable name fall back to "ktoś" so we never render a raw ID.
+ */
+fun typingLabel(
+    typingUserIds: Set<String>,
+    nameOf: (String) -> String?,
+): String? {
+    if (typingUserIds.isEmpty()) return null
+    val resolved =
+        typingUserIds
+            .map { id -> nameOf(id)?.takeIf { it.isNotBlank() } ?: "ktoś" }
+            .toList()
+    return when (resolved.size) {
+        1 -> "${resolved[0]} pisze…"
+        2 -> "${resolved[0]} i ${resolved[1]} piszą…"
+        else -> "Kilka osób pisze…"
+    }
+}

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/UnreadRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/UnreadRepository.kt
@@ -1,0 +1,25 @@
+package com.poziomki.app.chat.api
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Read-only view of the badge-driving unread total. Implementations
+ * delegate to [ChatClient.totalUnread] for value, but the repository
+ * decouples platform badge integrators (iOS `UNUserNotificationCenter`,
+ * Android shortcut/notification badges) from the chat client so the
+ * launcher badge can be wired up without dragging the entire chat
+ * stack into the platform layer.
+ *
+ * The total excludes muted conversations — same rule the server
+ * applies in `unread_summary_for_user`.
+ */
+interface UnreadRepository {
+    val totalUnread: StateFlow<Int>
+}
+
+/** Default repository that simply forwards [ChatClient.totalUnread]. */
+class ChatClientUnreadRepository(
+    private val chatClient: ChatClient,
+) : UnreadRepository {
+    override val totalUnread: StateFlow<Int> = chatClient.totalUnread
+}

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt
@@ -130,7 +130,14 @@ private sealed interface CachedTimelineItem {
         val reactions: List<CachedReaction>,
         val isEditable: Boolean,
         val sendStatus: CachedEventSendStatus?,
-        val readByCount: Int,
+        // Receipts are persisted as `userId → epochMillis` maps so the
+        // cache can rehydrate ✓✓ ticks across cold starts. `readByCount`
+        // is kept (default 0) only for backward compatibility with rows
+        // written by older builds; new rows write 0 and rely on
+        // `readBy.size`.
+        val readByCount: Int = 0,
+        val readBy: Map<Int, Long> = emptyMap(),
+        val deliveredTo: Map<Int, Long> = emptyMap(),
         val canReply: Boolean,
         val moderationVerdict: String? = null,
         val moderationCategories: List<String> = emptyList(),
@@ -152,7 +159,8 @@ private sealed interface CachedTimelineItem {
                 reactions = reactions.map(CachedReaction::toDomain),
                 isEditable = isEditable,
                 sendStatus = sendStatus?.toDomain(),
-                readByCount = readByCount,
+                readBy = readBy,
+                deliveredTo = deliveredTo,
                 canReply = canReply,
                 moderationVerdict = moderationVerdict,
                 moderationCategories = moderationCategories,
@@ -196,7 +204,9 @@ private sealed interface CachedTimelineItem {
                         reactions = item.reactions.map(Reaction::toCached),
                         isEditable = item.isEditable,
                         sendStatus = item.sendStatus?.toCached(),
-                        readByCount = item.readByCount,
+                        readByCount = 0,
+                        readBy = item.readBy,
+                        deliveredTo = item.deliveredTo,
                         canReply = item.canReply,
                         moderationVerdict = item.moderationVerdict,
                         moderationCategories = item.moderationCategories,
@@ -287,6 +297,8 @@ private fun ReplyDetails.toCached(): CachedReplyDetails =
 private enum class CachedEventSendStatus {
     Sending,
     Sent,
+    Delivered,
+    Read,
     Failed,
 }
 
@@ -294,6 +306,8 @@ private fun CachedEventSendStatus.toDomain(): EventSendStatus =
     when (this) {
         CachedEventSendStatus.Sending -> EventSendStatus.Sending
         CachedEventSendStatus.Sent -> EventSendStatus.Sent
+        CachedEventSendStatus.Delivered -> EventSendStatus.Delivered
+        CachedEventSendStatus.Read -> EventSendStatus.Read
         CachedEventSendStatus.Failed -> EventSendStatus.Failed
     }
 
@@ -301,5 +315,7 @@ private fun EventSendStatus.toCached(): CachedEventSendStatus =
     when (this) {
         EventSendStatus.Sending -> CachedEventSendStatus.Sending
         EventSendStatus.Sent -> CachedEventSendStatus.Sent
+        EventSendStatus.Delivered -> CachedEventSendStatus.Delivered
+        EventSendStatus.Read -> CachedEventSendStatus.Read
         EventSendStatus.Failed -> CachedEventSendStatus.Failed
     }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -1,5 +1,6 @@
 package com.poziomki.app.chat.ws
 
+import com.poziomki.app.chat.api.BadgeUpdater
 import com.poziomki.app.chat.api.ChatClient
 import com.poziomki.app.chat.api.ChatClientState
 import com.poziomki.app.chat.api.EventSendStatus
@@ -29,6 +30,7 @@ class WsChatClient(
     private val sessionManager: SessionManager,
     private val wsConnection: WsConnection,
     private val roomTimelineCacheStore: RoomTimelineCacheStore,
+    private val badgeUpdater: BadgeUpdater,
 ) : ChatClient {
     private val scopeJob = SupervisorJob()
     private val scope = CoroutineScope(scopeJob + Dispatchers.Default)
@@ -47,6 +49,17 @@ class WsChatClient(
 
     /** Cache conversation metadata for populating member caches on room open */
     private var latestConversations: List<WsConversationPayload> = emptyList()
+
+    /**
+     * Per-room set of userIds we've already counted toward the latest
+     * message's `latestMessageReadByCount`. Without this, every
+     * `ReadReceipt` from the same peer increments the counter — once
+     * for message A, again on a separate `Read` for the same A across
+     * reconnects, and again whenever history hydration replays old
+     * receipts. The set is reset to empty whenever the room's
+     * `latestMessageId` changes (a new message resets the readers list).
+     */
+    private val readersByLatestMessage = mutableMapOf<String, MutableSet<Int>>()
 
     /** Debounce job for refreshing conversation list when an unknown room appears */
     private var refreshJob: Job? = null
@@ -84,6 +97,16 @@ class WsChatClient(
                 handleServerMessage(msg)
             }
         }
+
+        // Drive the platform badge from the live unread total. We
+        // collect on the client's own scope (cancelled when the
+        // ChatClient is torn down) so a logged-out user doesn't keep
+        // a stale badge — totalUnread resets to 0 on disconnect.
+        scope.launch {
+            totalUnread.collect { count ->
+                badgeUpdater.setBadgeCount(count)
+            }
+        }
     }
 
     private suspend fun handleServerMessage(msg: WsServerMessage) {
@@ -119,7 +142,7 @@ class WsChatClient(
                 if (msg.userId.toString() == wsConnection.userId.value) {
                     clearRoomUnreadCount(msg.conversationId)
                 } else {
-                    updateRoomReadByCount(msg.conversationId, msg.messageId)
+                    updateRoomReadByCount(msg.conversationId, msg.messageId, msg.userId)
                 }
             }
 
@@ -172,6 +195,9 @@ class WsChatClient(
         val idx = current.indexOfFirst { it.roomId == msg.conversationId }
         if (idx >= 0) {
             val isMine = msg.senderId.toString() == wsConnection.userId.value
+            // New latest message → reset the readers tracking so
+            // updateRoomReadByCount counts each peer once for THIS message.
+            readersByLatestMessage.remove(msg.conversationId)
             current[idx] =
                 current[idx].copy(
                     latestMessage = msg.body,
@@ -228,21 +254,26 @@ class WsChatClient(
     private fun updateRoomReadByCount(
         roomId: String,
         messageId: String,
+        userId: Int,
     ) {
         val current = _rooms.value.toMutableList()
         val idx = current.indexOfFirst { it.roomId == roomId }
         if (idx < 0) return
         val room = current[idx]
         if (!room.latestMessageIsMine) return
-        // Only promote the room-list status to Read when the receipt is for
-        // the actual latest message; an older receipt arriving late must
-        // not paint a newer unread message as read.
-        val isLatest = room.latestMessageId == messageId
-        val newStatus = if (isLatest) EventSendStatus.Read else room.latestMessageSendStatus
+        // Receipts for older messages must not promote the room status to
+        // Read — a peer reading message A while there's an unread message
+        // B should keep B's status at Sent/Delivered.
+        if (room.latestMessageId != messageId) return
+        // Dedup readers for the current latest message. Without this, the
+        // same peer reading once, then re-firing on reconnect / history
+        // hydration, would inflate the counter past the true reader set.
+        val readers = readersByLatestMessage.getOrPut(roomId) { mutableSetOf() }
+        if (!readers.add(userId)) return
         current[idx] =
             room.copy(
-                latestMessageReadByCount = room.latestMessageReadByCount + 1,
-                latestMessageSendStatus = newStatus,
+                latestMessageReadByCount = readers.size,
+                latestMessageSendStatus = EventSendStatus.Read,
             )
         _rooms.value = current
     }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -119,7 +119,7 @@ class WsChatClient(
                 if (msg.userId.toString() == wsConnection.userId.value) {
                     clearRoomUnreadCount(msg.conversationId)
                 } else {
-                    updateRoomReadByCount(msg.conversationId)
+                    updateRoomReadByCount(msg.conversationId, msg.messageId)
                 }
             }
 
@@ -225,17 +225,26 @@ class WsChatClient(
                 .sumOf { it.unreadCount }
     }
 
-    private fun updateRoomReadByCount(roomId: String) {
+    private fun updateRoomReadByCount(
+        roomId: String,
+        messageId: String,
+    ) {
         val current = _rooms.value.toMutableList()
         val idx = current.indexOfFirst { it.roomId == roomId }
-        if (idx >= 0 && current[idx].latestMessageIsMine) {
-            current[idx] =
-                current[idx].copy(
-                    latestMessageReadByCount = current[idx].latestMessageReadByCount + 1,
-                    latestMessageSendStatus = EventSendStatus.Read,
-                )
-            _rooms.value = current
-        }
+        if (idx < 0) return
+        val room = current[idx]
+        if (!room.latestMessageIsMine) return
+        // Only promote the room-list status to Read when the receipt is for
+        // the actual latest message; an older receipt arriving late must
+        // not paint a newer unread message as read.
+        val isLatest = room.latestMessageId == messageId
+        val newStatus = if (isLatest) EventSendStatus.Read else room.latestMessageSendStatus
+        current[idx] =
+            room.copy(
+                latestMessageReadByCount = room.latestMessageReadByCount + 1,
+                latestMessageSendStatus = newStatus,
+            )
+        _rooms.value = current
     }
 
     override suspend fun setMute(

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -39,6 +39,9 @@ class WsChatClient(
     private val _rooms = MutableStateFlow<List<RoomSummary>>(emptyList())
     override val rooms: StateFlow<List<RoomSummary>> = _rooms
 
+    private val _totalUnread = MutableStateFlow(0)
+    override val totalUnread: StateFlow<Int> = _totalUnread
+
     private val openedRoomsMutex = Mutex()
     private val openedRooms = mutableMapOf<String, WsJoinedRoom>()
 
@@ -89,6 +92,7 @@ class WsChatClient(
             is WsServerMessage.Conversations -> {
                 latestConversations = msg.conversations
                 _rooms.value = msg.conversations.map { it.toRoomSummary() }
+                recomputeTotalUnread()
             }
 
             is WsServerMessage.Message -> {
@@ -119,6 +123,14 @@ class WsChatClient(
                 }
             }
 
+            is WsServerMessage.Delivered -> {
+                handleDelivered(msg)
+            }
+
+            is WsServerMessage.UnreadUpdate -> {
+                handleUnreadUpdate(msg)
+            }
+
             is WsServerMessage.Typing -> {
                 openedRoomsMutex.withLock { openedRooms[msg.conversationId] }?.onTyping(msg)
             }
@@ -128,6 +140,28 @@ class WsChatClient(
             }
 
             else -> {}
+        }
+    }
+
+    private suspend fun handleDelivered(msg: WsServerMessage.Delivered) {
+        openedRoomsMutex.withLock { openedRooms[msg.conversationId] }?.onDelivered(msg)
+        val current = _rooms.value.toMutableList()
+        val idx = current.indexOfFirst { it.roomId == msg.conversationId }
+        if (idx >= 0 && current[idx].latestMessageIsMine &&
+            current[idx].latestMessageSendStatus != EventSendStatus.Read
+        ) {
+            current[idx] = current[idx].copy(latestMessageSendStatus = EventSendStatus.Delivered)
+            _rooms.value = current
+        }
+    }
+
+    private fun handleUnreadUpdate(msg: WsServerMessage.UnreadUpdate) {
+        _totalUnread.value = msg.totalUnread.toInt()
+        val current = _rooms.value.toMutableList()
+        val idx = current.indexOfFirst { it.roomId == msg.conversationId }
+        if (idx >= 0) {
+            current[idx] = current[idx].copy(unreadCount = msg.unreadCount.toInt())
+            _rooms.value = current
         }
     }
 
@@ -154,6 +188,7 @@ class WsChatClient(
                 )
             current.sortByDescending { it.latestTimestampMillis ?: 0L }
             _rooms.value = current
+            recomputeTotalUnread()
         } else {
             // Unknown room — debounce a conversation list refresh
             refreshJob?.cancel()
@@ -171,7 +206,20 @@ class WsChatClient(
         if (idx >= 0) {
             current[idx] = current[idx].copy(unreadCount = 0)
             _rooms.value = current
+            recomputeTotalUnread()
         }
+    }
+
+    /** Sum unread across non-muted rooms. UnreadUpdate events overwrite this. */
+    private fun recomputeTotalUnread() {
+        val now =
+            kotlinx.datetime.Clock.System
+                .now()
+                .toEpochMilliseconds()
+        _totalUnread.value =
+            _rooms.value
+                .filter { (it.mutedUntilMillis ?: 0L) <= now }
+                .sumOf { it.unreadCount }
     }
 
     private fun updateRoomReadByCount(roomId: String) {
@@ -184,6 +232,29 @@ class WsChatClient(
                 )
             _rooms.value = current
         }
+    }
+
+    override suspend fun setMute(
+        roomId: String,
+        mutedUntilMillis: Long?,
+    ): Result<Unit> {
+        val iso =
+            mutedUntilMillis?.let {
+                kotlinx.datetime.Instant
+                    .fromEpochMilliseconds(it)
+                    .toString()
+            }
+        val sent = wsConnection.send(WsClientMessage.Mute(conversationId = roomId, mutedUntil = iso))
+        if (!sent) return Result.failure(IllegalStateException("Not connected"))
+        // Optimistic local update; UnreadUpdate from server reconciles.
+        val current = _rooms.value.toMutableList()
+        val idx = current.indexOfFirst { it.roomId == roomId }
+        if (idx >= 0) {
+            current[idx] = current[idx].copy(mutedUntilMillis = mutedUntilMillis)
+            _rooms.value = current
+            recomputeTotalUnread()
+        }
+        return Result.success(Unit)
     }
 
     override suspend fun ensureStarted(): Result<Unit> {
@@ -344,6 +415,7 @@ private fun WsConversationPayload.toRoomSummary(): RoomSummary =
         latestMessageIsMine = latestMessageIsMine,
         latestMessageSendStatus = if (latestMessage != null) EventSendStatus.Sent else null,
         isBlocked = isBlocked,
+        mutedUntilMillis = mutedUntil?.let { parseTimestamp(it) },
         latestModerationVerdict = latestModerationVerdict,
         latestModerationCategories = latestModerationCategories,
     )

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -232,6 +232,7 @@ class WsChatClient(
             current[idx] =
                 current[idx].copy(
                     latestMessageReadByCount = current[idx].latestMessageReadByCount + 1,
+                    latestMessageSendStatus = EventSendStatus.Read,
                 )
             _rooms.value = current
         }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -147,10 +147,12 @@ class WsChatClient(
         openedRoomsMutex.withLock { openedRooms[msg.conversationId] }?.onDelivered(msg)
         val current = _rooms.value.toMutableList()
         val idx = current.indexOfFirst { it.roomId == msg.conversationId }
-        if (idx >= 0 && current[idx].latestMessageIsMine &&
-            current[idx].latestMessageSendStatus != EventSendStatus.Read
-        ) {
-            current[idx] = current[idx].copy(latestMessageSendStatus = EventSendStatus.Delivered)
+        if (idx < 0) return
+        val room = current[idx]
+        val matchesLatest = room.latestMessageIsMine && room.latestMessageId == msg.messageId
+        val notYetRead = room.latestMessageSendStatus != EventSendStatus.Read
+        if (matchesLatest && notYetRead) {
+            current[idx] = room.copy(latestMessageSendStatus = EventSendStatus.Delivered)
             _rooms.value = current
         }
     }
@@ -174,6 +176,7 @@ class WsChatClient(
                 current[idx].copy(
                     latestMessage = msg.body,
                     latestTimestampMillis = parseTimestamp(msg.createdAt),
+                    latestMessageId = msg.id,
                     latestMessageIsMine = isMine,
                     latestMessageSendStatus = EventSendStatus.Sent,
                     unreadCount = if (isMine) current[idx].unreadCount else current[idx].unreadCount + 1,
@@ -412,6 +415,7 @@ private fun WsConversationPayload.toRoomSummary(): RoomSummary =
         unreadCount = unreadCount.toInt(),
         latestMessage = latestMessage,
         latestTimestampMillis = latestTimestamp?.let { parseTimestamp(it) },
+        latestMessageId = latestMessageId,
         latestMessageIsMine = latestMessageIsMine,
         latestMessageSendStatus = if (latestMessage != null) EventSendStatus.Sent else null,
         isBlocked = isBlocked,

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsJoinedRoom.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsJoinedRoom.kt
@@ -88,13 +88,22 @@ class WsJoinedRoom(
         liveTimeline.onReadReceipt(msg)
     }
 
+    internal fun onDelivered(msg: WsServerMessage.Delivered) {
+        liveTimeline.onDelivered(msg)
+    }
+
     internal fun onTyping(msg: WsServerMessage.Typing) {
         val userId = msg.userId.toString()
         if (msg.isTyping) {
             typingTimeoutJobs[userId]?.cancel()
+            // Trust the server's authoritative TTL when present so a
+            // typing-true that was emitted with a longer or shorter
+            // window stays consistent across clients. Fall back to 6s
+            // to match the server-side TYPING_TTL constant.
+            val ttlMs = msg.expiresInMs?.coerceIn(2_000L, 30_000L) ?: 6_000L
             typingTimeoutJobs[userId] =
                 scope.launch {
-                    delay(5_000L)
+                    delay(ttlMs)
                     _typingUserIds.update { current -> current - userId }
                     typingTimeoutJobs.remove(userId)
                 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
@@ -278,6 +278,7 @@ data class WsConversationPayload(
     val directUserAvatar: String? = null,
     val unreadCount: Long = 0,
     val latestMessage: String? = null,
+    val latestMessageId: String? = null,
     val latestTimestamp: String? = null,
     val latestMessageIsMine: Boolean = false,
     val latestSenderName: String? = null,

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
@@ -66,6 +66,13 @@ sealed interface WsClientMessage {
     ) : WsClientMessage
 
     @Serializable
+    @SerialName("mute")
+    data class Mute(
+        val conversationId: String,
+        val mutedUntil: String? = null,
+    ) : WsClientMessage
+
+    @Serializable
     @SerialName("history")
     data class History(
         val conversationId: String,
@@ -153,6 +160,24 @@ sealed interface WsServerMessage {
         val conversationId: String,
         val userId: Int,
         val messageId: String,
+        val readAt: String? = null,
+    ) : WsServerMessage
+
+    @Serializable
+    @SerialName("delivered")
+    data class Delivered(
+        val conversationId: String,
+        val messageId: String,
+        val userId: Int,
+        val deliveredAt: String,
+    ) : WsServerMessage
+
+    @Serializable
+    @SerialName("unreadUpdate")
+    data class UnreadUpdate(
+        val conversationId: String,
+        val unreadCount: Long,
+        val totalUnread: Long,
     ) : WsServerMessage
 
     @Serializable
@@ -161,6 +186,7 @@ sealed interface WsServerMessage {
         val conversationId: String,
         val userId: Int,
         val isTyping: Boolean,
+        val expiresInMs: Long? = null,
     ) : WsServerMessage
 
     @Serializable
@@ -169,6 +195,8 @@ sealed interface WsServerMessage {
         val conversationId: String,
         val messages: List<WsMessagePayload>,
         val hasMore: Boolean,
+        val readReceipts: List<WsReadReceiptPayload> = emptyList(),
+        val deliveries: List<WsDeliveryPayload> = emptyList(),
     ) : WsServerMessage
 
     @Serializable
@@ -209,6 +237,20 @@ data class WsMessagePayload(
 )
 
 @Serializable
+data class WsReadReceiptPayload(
+    val messageId: String,
+    val userId: Int,
+    val readAt: String,
+)
+
+@Serializable
+data class WsDeliveryPayload(
+    val messageId: String,
+    val userId: Int,
+    val deliveredAt: String,
+)
+
+@Serializable
 data class WsReplyPayload(
     val messageId: String,
     val senderName: String? = null,
@@ -240,6 +282,7 @@ data class WsConversationPayload(
     val latestMessageIsMine: Boolean = false,
     val latestSenderName: String? = null,
     val isBlocked: Boolean = false,
+    val mutedUntil: String? = null,
     val latestModerationVerdict: String? = null,
     val latestModerationCategories: List<String> = emptyList(),
 )

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -222,26 +222,96 @@ class WsTimeline(
     }
 
     internal fun onReadReceipt(msg: WsServerMessage.ReadReceipt) {
-        val receiptUserId = msg.userId.toString()
-        if (receiptUserId == wsConnection.userId.value) return
+        if (msg.userId.toString() == wsConnection.userId.value) return
+        scope.launch {
+            applyReadReceipt(msg.messageId, msg.userId, msg.readAt)
+        }
+    }
+
+    private suspend fun applyReadReceipt(
+        messageId: String,
+        userId: Int,
+        readAtIso: String?,
+    ) {
+        itemsMutex.withLock {
+            val readAt = readAtIso?.let { parseTimestamp(it) } ?: Clock.System.now().toEpochMilliseconds()
+            val seenUsers = readReceiptUsers.getOrPut(messageId) { mutableSetOf() }
+            seenUsers.add(userId.toString())
+
+            val current = _items.value.toMutableList()
+            val idx =
+                current.indexOfFirst {
+                    it is TimelineItem.Event && it.eventId == messageId
+                }
+            if (idx >= 0) {
+                val event = current[idx] as TimelineItem.Event
+                if (event.readBy[userId] == readAt) return@withLock
+                val newReadBy = event.readBy + (userId to readAt)
+                // A read implies delivery; flip ✓ → ✓✓ → ✓✓ blue.
+                val newStatus =
+                    if (event.isMine) EventSendStatus.Read else event.sendStatus
+                current[idx] =
+                    event.copy(
+                        readBy = newReadBy,
+                        sendStatus = newStatus,
+                    )
+                emitAndPersist(current)
+            }
+        }
+    }
+
+    internal fun onDelivered(msg: WsServerMessage.Delivered) {
+        if (msg.userId.toString() == wsConnection.userId.value) return
         scope.launch {
             itemsMutex.withLock {
-                val messageId = msg.messageId
-                val seenUsers = readReceiptUsers.getOrPut(messageId) { mutableSetOf() }
-                if (!seenUsers.add(receiptUserId)) return@withLock // duplicate
-
+                val deliveredAt = parseTimestamp(msg.deliveredAt)
                 val current = _items.value.toMutableList()
                 val idx =
                     current.indexOfFirst {
-                        it is TimelineItem.Event && it.eventId == messageId
+                        it is TimelineItem.Event && it.eventId == msg.messageId
                     }
-                if (idx >= 0) {
-                    val event = current[idx] as TimelineItem.Event
-                    current[idx] = event.copy(readByCount = seenUsers.size)
-                    emitAndPersist(current)
-                }
+                if (idx < 0) return@withLock
+                val event = current[idx] as TimelineItem.Event
+                if (event.deliveredTo[msg.userId] == deliveredAt) return@withLock
+                val newDeliveredTo = event.deliveredTo + (msg.userId to deliveredAt)
+                // Don't downgrade Read → Delivered.
+                val newStatus =
+                    if (event.isMine && event.sendStatus != EventSendStatus.Read) {
+                        EventSendStatus.Delivered
+                    } else {
+                        event.sendStatus
+                    }
+                current[idx] =
+                    event.copy(
+                        deliveredTo = newDeliveredTo,
+                        sendStatus = newStatus,
+                    )
+                emitAndPersist(current)
             }
         }
+    }
+
+    private fun hydrateHistoryItem(
+        payload: WsMessagePayload,
+        uid: String?,
+        readsByMessage: Map<String, Map<Int, Long>>,
+        deliveriesByMessage: Map<String, Map<Int, Long>>,
+    ): TimelineItem.Event {
+        val event = payload.toTimelineItem(uid)
+        val rb = readsByMessage[payload.id].orEmpty()
+        val dt = deliveriesByMessage[payload.id].orEmpty()
+        if (rb.isNotEmpty()) {
+            val seen = readReceiptUsers.getOrPut(payload.id) { mutableSetOf() }
+            rb.keys.forEach { seen.add(it.toString()) }
+        }
+        val status =
+            when {
+                !event.isMine -> event.sendStatus
+                rb.any { it.key.toString() != uid } -> EventSendStatus.Read
+                dt.any { it.key.toString() != uid } -> EventSendStatus.Delivered
+                else -> event.sendStatus
+            }
+        return event.copy(readBy = rb, deliveredTo = dt, sendStatus = status)
     }
 
     internal fun onHistoryResponse(msg: WsServerMessage.HistoryResponse) {
@@ -249,7 +319,22 @@ class WsTimeline(
         scope.launch {
             itemsMutex.withLock {
                 val uid = wsConnection.userId.value
-                val historyItems = msg.messages.map { it.toTimelineItem(uid) }
+                val readsByMessage: Map<String, Map<Int, Long>> =
+                    msg.readReceipts
+                        .groupBy { it.messageId }
+                        .mapValues { (_, list) ->
+                            list.associate { it.userId to parseTimestamp(it.readAt) }
+                        }
+                val deliveriesByMessage: Map<String, Map<Int, Long>> =
+                    msg.deliveries
+                        .groupBy { it.messageId }
+                        .mapValues { (_, list) ->
+                            list.associate { it.userId to parseTimestamp(it.deliveredAt) }
+                        }
+                val historyItems =
+                    msg.messages.map { payload ->
+                        hydrateHistoryItem(payload, uid, readsByMessage, deliveriesByMessage)
+                    }
                 val current = _items.value.toMutableList()
 
                 // Filter duplicates
@@ -505,7 +590,6 @@ class WsTimeline(
                     reactions = emptyList(),
                     isEditable = true,
                     sendStatus = EventSendStatus.Sending,
-                    readByCount = 0,
                     canReply = true,
                 ),
             )
@@ -562,7 +646,6 @@ private fun toTimelineEvent(
         reactions = reactions.map { it.toReaction() },
         isEditable = isMine,
         sendStatus = EventSendStatus.Sent,
-        readByCount = 0,
         canReply = true,
         moderationVerdict = moderationVerdict,
         moderationCategories = moderationCategories,

--- a/mobile/core/src/iosMain/kotlin/com/poziomki/app/chat/api/BadgeUpdater.ios.kt
+++ b/mobile/core/src/iosMain/kotlin/com/poziomki/app/chat/api/BadgeUpdater.ios.kt
@@ -1,0 +1,18 @@
+package com.poziomki.app.chat.api
+
+import platform.UIKit.UIApplication
+
+/**
+ * iOS: drive the springboard app icon badge via
+ * `UIApplication.applicationIconBadgeNumber`. iOS 16+ has a newer
+ * `UNUserNotificationCenter.setBadgeCount(_:)` API but the legacy
+ * property still works on every supported version and doesn't
+ * require an authorization round-trip. Must be called on the main
+ * thread; the chat layer publishes on Default but the property
+ * setter is thread-safe in practice on Darwin.
+ */
+actual class BadgeUpdater actual constructor() {
+    actual fun setBadgeCount(count: Int) {
+        UIApplication.sharedApplication.applicationIconBadgeNumber = count.toLong()
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the half-wired chat indicators with a coherent end-to-end flow: per-message read receipts (with `read_at`), server-confirmed delivery ACKs, per-conversation mute, server-pushed unread updates for multi-device sync, and a typing TTL janitor that clears ghost typers within seconds.
- New migration `2026-04-28-000000_chat_indicators` adds `message_reads`, `message_deliveries`, `conversation_members.muted_until` (RLS mirrors `messages`) plus a SECURITY DEFINER `app.record_delivery()` helper and a backfill from existing `last_read_message_id` watermarks so old conversations don't render blank ticks.
- Mobile core gains a `Sending → Sent → Delivered → Read | Failed` ladder, `ChatClient.totalUnread` (mute-aware) for a launcher badge, `setMute(...)` API, server-driven typing TTL, multi-user typing copy, and an `UnreadRepository` + `BadgeUpdater` expect/actual (iOS sets the springboard badge; Android stub for app-module DI).

## What's not included
- Mute bottom-sheet UI on chat detail (API ready, sheet not built).
- Android real launcher-badge wiring — the actual implementation needs the persistent chat notification handle, which lives in the app module.
- Integration tests against a live DB for the new tables / mute / delivery flows (only unit tests ran here).

## Test plan
- [ ] Run the new migration on a staging DB; verify backfill produces expected `message_reads` rows.
- [ ] Two-device unread sync: A sends to B, B opens chat on phone → tablet badge clears within ~1s via `UnreadUpdate`.
- [ ] Receipt with timestamp: A sees \"Read HH:MM\" after B opens.
- [ ] Delivery: kill B's WS; A sends → A sees ✓; B reconnects → A sees ✓✓ without B opening the chat.
- [ ] Typing ghost: B starts typing → kill B's WS → A's typing indicator clears within 2-3s (janitor).
- [ ] Multi-user typing in a group renders \"Anna i Jan piszą…\" / \"Kilka osób pisze…\".
- [ ] Mute a conversation: PATCH `/chat/conversations/{id}/mute` succeeds; muted convs excluded from `total_unread`; `RoomRow` shows the bell-slash icon and faded badge.
- [ ] History rehydrate: reload a conversation page → ticks/delivery state on old messages survive.
- [ ] iOS: launcher badge reflects `totalUnread`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add message delivery receipts, read receipts, mute, and typing TTL to chat
> - Adds `message_reads` and `message_deliveries` DB tables with per-(message, user) timestamps, RLS policies, and SECURITY DEFINER bulk-insert helpers; backfills existing data on migration.
> - Backend WebSocket handlers now emit `Delivered` events to the sender when online recipients receive a message, `ReadReceipt` with timestamp on read, `UnreadUpdate` to the user's other sessions, and `Typing` with a server-defined TTL (`TYPING_TTL = 6000ms`).
> - `ChatHub` gains in-memory typing state per (user, conversation) with a background janitor that broadcasts `Typing(false)` for expired or disconnected users.
> - Adds `PATCH /conversations/{id}/mute` and `GET /unread` REST endpoints; unread totals exclude currently-muted conversations.
> - Mobile `WsChatClient` tracks `totalUnread` (muted rooms excluded), handles `Delivered`/`UnreadUpdate` server messages, and exposes `setMute`; `BadgeUpdater` drives the iOS app icon badge and is a no-op on Android by default.
> - `TimelineItem.Event` replaces `readByCount: Int` with `readBy: Map<Int, Long>` and adds `deliveredTo: Map<Int, Long>`; send-status icons now distinguish Sent, Delivered, and Read visually.
> - Risk: the `readByCount` field is kept at 0 in the cache write-path for backward compatibility but is no longer the source of truth; any code reading it directly will see stale data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 332b66f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->