### PR TITLE
build(deps): bump diesel-async to 0.8 and deadpool to 0.13

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -716,21 +716,20 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deadpool"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
 dependencies = [
  "deadpool-runtime",
- "lazy_static",
  "num_cpus",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-runtime"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+checksum = "2657f61fb1dd8bf37a8d51093cc7cee4e77125b22f7753f49b289f831bec2bae"
 dependencies = [
  "tokio",
 ]
@@ -817,14 +816,15 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13096fb8dae53f2d411c4b523bec85f45552ed3044a2ab4d85fb2092d9cb4f34"
+checksum = "b95864e58597509106f1fddfe0600de7e589e1fddddd87f54eee0a49fd111bbc"
 dependencies = [
  "deadpool",
  "diesel",
  "futures-core",
  "futures-util",
+ "pin-project-lite",
  "scoped-futures",
  "tokio",
  "tokio-postgres",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -75,9 +75,9 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 jsonwebtoken = "=10.3.0"
 dotenvy = "=0.15.7"
 diesel = { version = "2.3", features = ["postgres", "uuid", "chrono", "serde_json"] }
-diesel-async = { version = "0.7", features = ["postgres", "deadpool"] }
+diesel-async = { version = "0.8", features = ["postgres", "deadpool"] }
 diesel_migrations = { version = "2.3", features = ["postgres"] }
-deadpool = { version = "=0.12.3", features = ["rt_tokio_1"] }
+deadpool = { version = "=0.13.0", features = ["rt_tokio_1"] }
 thiserror = "2"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "tls-rustls", "ndarray"] }


### PR DESCRIPTION
Replaces #262 and #263. They had to be paired — diesel-async 0.8 transitively pulls deadpool 0.13, so bumping either alone caused duplicate-version conflicts.

Runtime/Timeouts API unchanged between deadpool 0.12 → 0.13, so no code changes needed.

## Test plan
- [ ] CI green (check, cargo-deny)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `diesel-async` to 0.8 and `deadpool` to 0.13
> Updates two backend dependencies in [Cargo.toml](https://github.com/poziomki-app/poziomki/pull/291/files#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1): `diesel-async` from 0.7 to 0.8 and `deadpool` from 0.12.3 to 0.13.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c9fa5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->