### PR TITLE
fix(mobile): replace stray kotlinx.datetime.Clock/Instant FQNs after merge

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -91,7 +91,7 @@ fun RoomRow(
             val isMuted =
                 room.mutedUntilMillis?.let {
                     it >
-                        kotlinx.datetime.Clock.System
+                        kotlin.time.Clock.System
                             .now()
                             .toEpochMilliseconds()
                 } ?: false

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -242,7 +242,7 @@ class WsChatClient(
     /** Sum unread across non-muted rooms. UnreadUpdate events overwrite this. */
     private fun recomputeTotalUnread() {
         val now =
-            kotlinx.datetime.Clock.System
+            kotlin.time.Clock.System
                 .now()
                 .toEpochMilliseconds()
         _totalUnread.value =
@@ -284,7 +284,7 @@ class WsChatClient(
     ): Result<Unit> {
         val iso =
             mutedUntilMillis?.let {
-                kotlinx.datetime.Instant
+                kotlin.time.Instant
                     .fromEpochMilliseconds(it)
                     .toString()
             }


### PR DESCRIPTION
Two new fully-qualified `kotlinx.datetime.Clock/Instant` references slipped in via #290 after the kotlinx-datetime 0.7 migration landed in #265, breaking main.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `kotlinx.datetime` FQNs with `kotlin.time` equivalents after merge
> Fixes stray fully-qualified references to `kotlinx.datetime.Clock.System` and `kotlinx.datetime.Instant` left behind after a merge. Updates [RoomRow.kt](https://github.com/poziomki-app/poziomki/pull/292/files#diff-638303e155da802f51e452c8fad551f5d6f23cbe70f9b86990bf5cf49e95de0c) and [WsChatClient.kt](https://github.com/poziomki-app/poziomki/pull/292/files#diff-9a9b65838807237edb61674d0befbb11c15865288666a548feac7d0b5fc6f61f) to use `kotlin.time.Clock.System` and `kotlin.time.Instant.fromEpochMilliseconds` consistently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa6738f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->