### PR TITLE
fix(location): Android nearby — longer timeout, FUSED first, drop PASSIVE

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -91,7 +91,7 @@ fun RoomRow(
             val isMuted =
                 room.mutedUntilMillis?.let {
                     it >
-                        kotlinx.datetime.Clock.System
+                        kotlin.time.Clock.System
                             .now()
                             .toEpochMilliseconds()
                 } ?: false

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/location/LocationProvider.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/location/LocationProvider.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
+import android.os.Build
 import android.os.Looper
 import androidx.core.content.ContextCompat
 import androidx.core.location.LocationListenerCompat
@@ -87,19 +88,30 @@ actual class LocationProvider(
         }
 
     private companion object {
-        const val LOCATION_TIMEOUT_MS = 5_000L
-        val ACTIVE_PROVIDERS =
-            listOf(
-                LocationManager.NETWORK_PROVIDER,
-                LocationManager.GPS_PROVIDER,
-                LocationManager.PASSIVE_PROVIDER,
-            )
-        val LAST_KNOWN_PROVIDERS =
-            listOf(
-                LocationManager.PASSIVE_PROVIDER,
-                LocationManager.NETWORK_PROVIDER,
-                LocationManager.GPS_PROVIDER,
-            )
+        const val LOCATION_TIMEOUT_MS = 15_000L
+
+        // FUSED on Android 12+ is the cheapest and most reliable; otherwise NETWORK
+        // (cell+wifi) under COARSE permission. PASSIVE is intentionally excluded —
+        // it only forwards fixes other apps already requested, so it cannot
+        // deliver an active update on its own.
+        val ACTIVE_PROVIDERS: List<String> =
+            buildList {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    add(LocationManager.FUSED_PROVIDER)
+                }
+                add(LocationManager.NETWORK_PROVIDER)
+                add(LocationManager.GPS_PROVIDER)
+            }
+
+        val LAST_KNOWN_PROVIDERS: List<String> =
+            buildList {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    add(LocationManager.FUSED_PROVIDER)
+                }
+                add(LocationManager.PASSIVE_PROVIDER)
+                add(LocationManager.NETWORK_PROVIDER)
+                add(LocationManager.GPS_PROVIDER)
+            }
     }
 }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -242,7 +242,7 @@ class WsChatClient(
     /** Sum unread across non-muted rooms. UnreadUpdate events overwrite this. */
     private fun recomputeTotalUnread() {
         val now =
-            kotlinx.datetime.Clock.System
+            kotlin.time.Clock.System
                 .now()
                 .toEpochMilliseconds()
         _totalUnread.value =
@@ -284,7 +284,7 @@ class WsChatClient(
     ): Result<Unit> {
         val iso =
             mutedUntilMillis?.let {
-                kotlinx.datetime.Instant
+                kotlin.time.Instant
                     .fromEpochMilliseconds(it)
                     .toString()
             }


### PR DESCRIPTION
Users hit 'nie udało się pobrać lokalizacji' on the Nearby tab.

- 5s timeout was too short for a cold network/GPS fix on devices with no recent fix from another app.
- PASSIVE_PROVIDER was in the active providers list but it can't generate updates on its own — it forwards fixes other apps already requested — so it never resolved.
- Prefer FUSED on Android 12+ since it's cheap and works under COARSE-only permission.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android nearby location to use FUSED provider first and increase timeout to 15s
> - Increases `LOCATION_TIMEOUT_MS` from 5,000 ms to 15,000 ms in [LocationProvider.kt](https://github.com/poziomki-app/poziomki/pull/293/files#diff-07cb777522b21a553b5c63269948abf47cd82064334b214773c56c6b7a8780c8).
> - On Android 12+ (API S), active provider list now includes FUSED first and drops PASSIVE; last-known lookups also try FUSED first.
> - Migrates `Clock.System.now()` and `Instant.fromEpochMilliseconds()` calls from `kotlinx.datetime` to `kotlin.time` in [WsChatClient.kt](https://github.com/poziomki-app/poziomki/pull/293/files#diff-9a9b65838807237edb61674d0befbb11c15865288666a548feac7d0b5fc6f61f) and [RoomRow.kt](https://github.com/poziomki-app/poziomki/pull/293/files#diff-638303e155da802f51e452c8fad551f5d6f23cbe70f9b86990bf5cf49e95de0c).
> - Behavioral Change: active location requests on Android 12+ no longer use the PASSIVE provider, and all location requests wait up to 15 s before timing out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17d8802.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->