### PR TITLE
fix(chat): RLS rejects first DM/event chat insert

### DIFF
--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -74,26 +74,25 @@ pub async fn resolve_or_create_dm(
         updated_at: now,
     };
 
-    let inserted = diesel::insert_into(conversations::table)
+    // Insert without RETURNING: the conversations_viewer SELECT policy
+    // would filter the new row (the viewer isn't a member yet, members
+    // get inserted below), and PG raises "new row violates RLS" on the
+    // RETURNING projection. Re-fetch via the SD helper instead — that
+    // also doubles as the race-fallback if a concurrent request won
+    // the insert.
+    diesel::insert_into(conversations::table)
         .values(&new_conv)
         .on_conflict_do_nothing()
-        .get_result::<Conversation>(conn)
-        .await
-        .optional()?;
+        .execute(conn)
+        .await?;
 
-    // Handle race condition: another request may have created it. The
-    // fallback uses the SD helper so RLS doesn't filter the row out
-    // when the viewer's membership hasn't been inserted yet.
-    let created = match inserted {
-        Some(c) => c,
-        None => find_dm_conversation(conn, low, high)
-            .await?
-            .ok_or_else(|| {
-                crate::error::AppError::message(format!(
-                    "DM conversation race-fallback lookup returned None for pair ({low}, {high})"
-                ))
-            })?,
-    };
+    let created = find_dm_conversation(conn, low, high)
+        .await?
+        .ok_or_else(|| {
+            crate::error::AppError::message(format!(
+                "DM conversation lookup returned None after insert for pair ({low}, {high})"
+            ))
+        })?;
 
     // Ensure both users are members
     let members = vec![
@@ -143,23 +142,22 @@ pub async fn resolve_or_create_event_conversation(
         updated_at: now,
     };
 
-    let inserted = diesel::insert_into(conversations::table)
+    // See DM path for why we skip RETURNING and re-fetch via the SD
+    // helper: conversations_viewer would filter the new row before the
+    // creator's membership row exists.
+    diesel::insert_into(conversations::table)
         .values(&new_conv)
         .on_conflict_do_nothing()
-        .get_result::<Conversation>(conn)
-        .await
-        .optional()?;
+        .execute(conn)
+        .await?;
 
-    let created = match inserted {
-        Some(c) => c,
-        None => find_event_conversation(conn, event_id)
-            .await?
-            .ok_or_else(|| {
-                crate::error::AppError::message(format!(
-                    "event conversation race-fallback lookup returned None for event {event_id}"
-                ))
-            })?,
-    };
+    let created = find_event_conversation(conn, event_id)
+        .await?
+        .ok_or_else(|| {
+            crate::error::AppError::message(format!(
+                "event conversation lookup returned None after insert for event {event_id}"
+            ))
+        })?;
 
     // Add creator as first member
     diesel::insert_into(conversation_members::table)


### PR DESCRIPTION
First-time DM (and event chat) creation always 500'd with `new row violates row-level security policy for table "conversations"`. The trigger is the `RETURNING *` projection: PG re-runs `conversations_viewer` against the new row, which filters by `app.viewer_conversation_ids()` — empty until the `conversation_members` row is inserted on the next statement. Latent since Tier B RLS landed (2026-04-19); only surfaced now because no fresh DM had been opened since.

Insert without `RETURNING` and re-fetch via the existing `find_dm_conversation` / `find_event_conversation` SD helpers (also subsumes the previous race-fallback).

- [ ] open a DM with a contact you don't yet have a conversation with
- [ ] open an event chat as a non-creator attendee

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLS rejection on first DM and event chat conversation insert
> RLS policies reject `INSERT ... RETURNING` when the inserting user's membership row doesn't exist yet at the time the `RETURNING` clause is evaluated. Both `resolve_or_create_dm` and the event conversation resolver in [conversations.rs](https://github.com/poziomki-app/poziomki/pull/294/files#diff-5a9a538ec12a48526c8fde752b98cccf545f577ca7b816e6e57820607ce81c62) now use a plain `execute()` for the insert, then unconditionally re-fetch the row via a follow-up `SELECT`. This avoids the RLS violation while still returning the created conversation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1249fe8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->