### PR TITLE
feat(chat): mark room read on enter, gate unread bump

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -90,7 +90,11 @@ fun ChatScreen(
 
     DisposableEffect(chatId) {
         ActiveChat.roomId = chatId
-        onDispose { ActiveChat.roomId = null }
+        viewModel.setActiveRoom(chatId)
+        onDispose {
+            ActiveChat.roomId = null
+            viewModel.setActiveRoom(null)
+        }
     }
 
     // Scroll to current search match

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -805,6 +805,18 @@ class ChatViewModel(
         runCatching { room.markAsRead() }
     }
 
+    /**
+     * Track the focused room from the UI layer (DisposableEffect in ChatScreen
+     * and EventChatScreen). Doing this here, instead of from bindRoom +
+     * onCleared, means the focus flag is cleared the moment the screen leaves
+     * composition — not whenever Android decides to clear the ViewModel,
+     * which is unreliable (the VM may outlive the screen, or onCleared may
+     * run inside a launch that is canceled before the call lands).
+     */
+    fun setActiveRoom(roomId: String?) {
+        viewModelScope.launch { runCatching { chatClient.setActiveRoom(roomId) } }
+    }
+
     private fun scheduleTypingStart() {
         typingStartJob?.cancel()
         typingStartJob =

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
@@ -50,7 +50,11 @@ fun EventChatScreen(
 
     DisposableEffect(conversationId) {
         ActiveChat.roomId = conversationId
-        onDispose { ActiveChat.roomId = null }
+        chatViewModel.setActiveRoom(conversationId)
+        onDispose {
+            ActiveChat.roomId = null
+            chatViewModel.setActiveRoom(null)
+        }
     }
 
     LaunchedEffect(eventState.event?.id, eventState.event?.isAttending, eventState.event?.conversationId) {

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
@@ -83,5 +83,21 @@ interface ChatClient {
 
     suspend fun hideConversation(roomId: String)
 
+    /**
+     * Optimistically clears `unreadCount` for [roomId] in the local rooms
+     * StateFlow so the UI un-bolds the row immediately. Server confirmation
+     * (via Read → ReadReceipt round-trip) still happens, but the user sees
+     * the room as "read" the moment they open it, not after the network
+     * round-trip completes.
+     */
+    suspend fun markRoomReadLocally(roomId: String)
+
+    /**
+     * Marks [roomId] as the currently focused room. Inbound messages for
+     * this room won't bump `unreadCount` while it's focused — the user is
+     * actively reading. Pass `null` when the user leaves the chat screen.
+     */
+    suspend fun setActiveRoom(roomId: String?)
+
     suspend fun stop()
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/NoopChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/NoopChatClient.kt
@@ -45,6 +45,10 @@ class NoopChatClient : ChatClient {
 
     override suspend fun hideConversation(roomId: String) = Unit
 
+    override suspend fun markRoomReadLocally(roomId: String) = Unit
+
+    override suspend fun setActiveRoom(roomId: String?) = Unit
+
     override suspend fun stop() {
         _state.value = ChatClientState.Idle
     }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -42,6 +42,9 @@ class WsChatClient(
     private val openedRoomsMutex = Mutex()
     private val openedRooms = mutableMapOf<String, WsJoinedRoom>()
 
+    /** RoomId currently focused on the chat screen — incoming messages skip the unread bump. */
+    private var activeRoomId: String? = null
+
     /** Cache conversation metadata for populating member caches on room open */
     private var latestConversations: List<WsConversationPayload> = emptyList()
 
@@ -139,13 +142,20 @@ class WsChatClient(
         val idx = current.indexOfFirst { it.roomId == msg.conversationId }
         if (idx >= 0) {
             val isMine = msg.senderId.toString() == wsConnection.userId.value
+            val isFocusedRoom = msg.conversationId == activeRoomId
+            val nextUnread =
+                if (isMine || isFocusedRoom) {
+                    current[idx].unreadCount
+                } else {
+                    current[idx].unreadCount + 1
+                }
             current[idx] =
                 current[idx].copy(
                     latestMessage = msg.body,
                     latestTimestampMillis = parseTimestamp(msg.createdAt),
                     latestMessageIsMine = isMine,
                     latestMessageSendStatus = EventSendStatus.Sent,
-                    unreadCount = if (isMine) current[idx].unreadCount else current[idx].unreadCount + 1,
+                    unreadCount = nextUnread,
                     latestMessageReadByCount = 0,
                     // Live broadcasts pre-date the worker scan (verdict
                     // is null at this point). Carry whatever the WS
@@ -289,6 +299,15 @@ class WsChatClient(
             is ApiResult.Success -> Result.success(Unit)
             is ApiResult.Error -> Result.failure(IllegalStateException(result.message))
         }
+    }
+
+    override suspend fun markRoomReadLocally(roomId: String) {
+        clearRoomUnreadCount(roomId)
+    }
+
+    override suspend fun setActiveRoom(roomId: String?) {
+        activeRoomId = roomId
+        if (roomId != null) clearRoomUnreadCount(roomId)
     }
 
     override suspend fun hideConversation(roomId: String) {


### PR DESCRIPTION
Entering a room clears unreadCount/bold immediately (setActiveRoom + markRoomReadLocally) without waiting for Read→ReadReceipt. Inbound messages for the active room do not bump unread. Fixes \"message stays bolded even though it is being read\".

Stacked on #296.

- [ ] open a room with N unread → unreadCount=0 immediately
- [ ] send a message to me while I have the room open → no badge bump

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark chat room read on enter and gate unread count bumps by active room
> - Removes server-side delivery receipts, mute, and per-message read receipt tracking; drops `message_reads`, `message_deliveries` tables and `muted_until` column via migration in [`up.sql`](https://github.com/poziomki-app/poziomki/pull/297/files#diff-ff3fc1f63a835279b97ea5598d8f34eca3159bcf16c1229f6ce59478b6520268).
> - `WsChatClient` gains `setActiveRoom` and `markRoomReadLocally`; entering a room clears its unread count and prevents further unread bumps while it is focused.
> - `ChatScreen` and `EventChatScreen` call `chatViewModel.setActiveRoom` on enter/dispose so the active room is tracked through the ViewModel.
> - WebSocket protocol drops `Delivered`, `UnreadUpdate`, and `Mute` message types; `ReadReceipt` loses `readAt`; `HistoryResponse` no longer includes receipt or delivery arrays.
> - Timeline items and room rows replace per-user `readBy`/`deliveredTo` maps with a single `readByCount`; outgoing bubble icons now only render for `Sending` and `Failed` states.
> - Risk: existing clients referencing `Delivered`, `Read` send statuses, `totalUnread`, or `setMute` will break at compile time; mute state and delivery confirmations are permanently removed with no UI replacement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b63e9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->