### PR TITLE
fix(chat): 8s timeout for openEventChat + retry button

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
@@ -102,6 +102,14 @@ fun EventChatScreen(
                     )
                 }
 
+                eventState.chatOpenError != null && !eventState.isOpeningChat -> {
+                    EventChatErrorView(
+                        message = eventState.chatOpenError ?: "",
+                        onRetry = eventDetailViewModel::retryOpenEventChat,
+                        onBack = onBack,
+                    )
+                }
+
                 eventState.isOpeningChat || eventState.event?.conversationId?.isNullOrBlank() ?: true -> {
                     var showSpinner by remember { mutableStateOf(false) }
                     LaunchedEffect(Unit) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -63,6 +63,49 @@ fun EventChatLoadingView(onBack: () -> Unit) {
 }
 
 @Composable
+fun EventChatErrorView(
+    message: String,
+    onRetry: () -> Unit,
+    onBack: () -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding(),
+    ) {
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+        ) {
+            Icon(
+                imageVector = PhosphorIcons.Bold.ArrowLeft,
+                contentDescription = "Wstecz",
+                tint = TextPrimary,
+            )
+        }
+        Column(
+            modifier = Modifier.align(Alignment.Center).padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = message,
+                color = TextSecondary,
+                fontFamily = NunitoFamily,
+                fontSize = 15.sp,
+            )
+            Spacer(Modifier.height(16.dp))
+            AppButton(
+                text = "Spróbuj ponownie",
+                onClick = onRetry,
+                variant = ButtonVariant.PRIMARY,
+            )
+        }
+    }
+}
+
+@Composable
 fun EventChatNotFoundView(onBack: () -> Unit) {
     Box(
         modifier =

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventDetailViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventDetailViewModel.kt
@@ -12,23 +12,27 @@ import com.poziomki.app.network.Event
 import com.poziomki.app.network.EventAttendee
 import com.poziomki.app.ui.designsystem.components.SnackbarType
 import com.poziomki.app.ui.navigation.Route
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 
 data class EventDetailState(
     val event: Event? = null,
     val attendees: List<EventAttendee> = emptyList(),
     val isLoading: Boolean = true,
     val isOpeningChat: Boolean = false,
+    val chatOpenError: String? = null,
     val isUpdatingAttendance: Boolean = false,
     val isCreator: Boolean = false,
     val snackbarMessage: String? = null,
     val snackbarType: SnackbarType = SnackbarType.ERROR,
 )
 
+@Suppress("TooManyFunctions")
 class EventDetailViewModel(
     savedStateHandle: SavedStateHandle,
     private val eventRepository: EventRepository,
@@ -194,19 +198,47 @@ class EventDetailViewModel(
         }
 
         viewModelScope.launch {
-            _state.value = _state.value.copy(isOpeningChat = true)
+            _state.value = _state.value.copy(isOpeningChat = true, chatOpenError = null)
 
-            eventRepository
-                .ensureEventRoom(eventId = eventId)
-                .onFailure { throwable ->
-                    _state.value =
-                        _state.value.copy(
-                            snackbarMessage = throwable.message ?: "Nie udało się otworzyć czatu wydarzenia",
-                            snackbarType = SnackbarType.ERROR,
-                        )
+            val result =
+                runCatching {
+                    withTimeout(EVENT_CHAT_OPEN_TIMEOUT_MS) {
+                        eventRepository.ensureEventRoom(eventId = eventId)
+                    }
                 }
 
-            _state.value = _state.value.copy(isOpeningChat = false)
+            val errorMessage: String? =
+                result.fold(
+                    onSuccess = { roomResult ->
+                        roomResult.exceptionOrNull()?.let { throwable ->
+                            throwable.message ?: "Nie udało się otworzyć czatu wydarzenia"
+                        }
+                    },
+                    onFailure = { throwable ->
+                        if (throwable is TimeoutCancellationException) {
+                            "Nie udało się otworzyć czatu, spróbuj ponownie"
+                        } else {
+                            throwable.message ?: "Nie udało się otworzyć czatu wydarzenia"
+                        }
+                    },
+                )
+
+            _state.value =
+                _state.value.copy(
+                    isOpeningChat = false,
+                    chatOpenError = errorMessage,
+                    snackbarMessage = errorMessage ?: _state.value.snackbarMessage,
+                    snackbarType = if (errorMessage != null) SnackbarType.ERROR else _state.value.snackbarType,
+                )
         }
+    }
+
+    fun retryOpenEventChat() {
+        _state.value = _state.value.copy(chatOpenError = null)
+        openEventChat()
+    }
+
+    companion object {
+        private const val EVENT_CHAT_OPEN_TIMEOUT_MS = 8_000L
     }
 }


### PR DESCRIPTION
Opening an event chat now has an 8s withTimeout. On error/timeout EventChatScreen shows EventChatErrorView with a Try Again button instead of an infinite spinner.

Stacked on #297.

- [ ] enter a freshly joined event → chat loads ≤8s, otherwise error+retry

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 8s timeout and retry UI to event chat opening in `EventDetailViewModel`
> - `openEventChat` now wraps `ensureEventRoom` in an 8-second `withTimeout`, recording a user-facing error in the new `chatOpenError` state field on timeout or failure instead of only showing a snackbar.
> - A new `EventChatErrorView` composable in [EventChatStateViews.kt](https://github.com/poziomki-app/poziomki/pull/298/files#diff-dc77fa9f64ddb97ec56b309fbfe774d102483e0b8dbdce72772de14e65b0380a) displays the error message with a retry button and back navigation.
> - `EventChatScreen` renders this error view when `chatOpenError` is non-null and chat is not loading; `retryOpenEventChat` clears the error and re-attempts the operation.
> - Behavioral Change: chat open failures now surface a persistent error screen in addition to a snackbar, requiring the user to explicitly retry or go back.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d06f9c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->