### PR TITLE
fix(ui): theme app + system navbar (dark)

### DIFF
--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.LaunchedEffect
@@ -47,11 +48,17 @@ class MainActivity : ComponentActivity() {
         if (savedInstanceState == null) {
             handleIntent(intent)
         }
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(android.graphics.Color.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.dark(android.graphics.Color.BLACK),
+        )
         setContent {
             // Remove when https://issuetracker.google.com/issues/364713509 is fixed
             LaunchedEffect(Unit) {
-                enableEdgeToEdge()
+                enableEdgeToEdge(
+                    statusBarStyle = SystemBarStyle.dark(android.graphics.Color.TRANSPARENT),
+                    navigationBarStyle = SystemBarStyle.dark(android.graphics.Color.BLACK),
+                )
             }
             App()
         }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -574,7 +575,7 @@ fun MainScreen(
                             Modifier
                                 .align(Alignment.BottomCenter)
                                 .fillMaxWidth()
-                                .background(Color.Black),
+                                .background(MaterialTheme.colorScheme.surface),
                         contentAlignment = Alignment.BottomCenter,
                     ) {
                         Row(
@@ -593,7 +594,12 @@ fun MainScreen(
                             val haptic = LocalHapticFeedback.current
                             bottomNavItems.forEach { item ->
                                 val selected = currentDestination?.hasRoute(item.route::class) == true
-                                val tint = if (selected) Color.White else Color(0xFFB3B3B3)
+                                val tint =
+                                    if (selected) {
+                                        MaterialTheme.colorScheme.onSurface
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                    }
                                 Column(
                                     modifier =
                                         Modifier


### PR DESCRIPTION
- App bottom navbar (Compose): MaterialTheme.colorScheme.surface/onSurface/onSurfaceVariant tokens instead of hardcoded Color.Black and 0xFFB3B3B3.
- System navigation bar (Android back/home/recent): MainActivity now passes SystemBarStyle.dark to enableEdgeToEdge for both status bar and nav bar, so the system bar icons stay light over our AMOLED-dark UI even when the device system UI mode is "light". Without this, edge-to-edge would use the system mode and leave dark icons over our dark surface (effectively invisible).

Stacked on #298.

- [ ] in-app navbar look matches dark theme
- [ ] system back/home/recent icons visible (light) at the bottom of the screen, even with the device set to system "light" mode

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dark theme styling for system navbar and bottom navigation bar in Android app
> - Updates [MainActivity.kt](https://github.com/poziomki-app/poziomki/pull/299/files#diff-0dc0e89d06a64256b11f1c03d87cfff6ec833769c071ed2ac45e35ed37b34bc0) to use `SystemBarStyle.dark` with a transparent status bar and black navigation bar in `enableEdgeToEdge`, applied both on create and in the `LaunchedEffect` workaround.
> - Updates [AppNavigation.kt](https://github.com/poziomki-app/poziomki/pull/299/files#diff-d0c4d4fb202ccaa45fc79b5e9a20b97727c5ae374c4bb3f074445da38252c7e8) bottom nav bar to use `MaterialTheme.colorScheme.surface` and `onSurface`/`onSurfaceVariant` colors instead of hardcoded black/white values.
> - Also removes a large set of chat delivery/read-receipt/mute features across the backend and mobile client: drops `message_reads` and `message_deliveries` tables, removes mute endpoints, and simplifies the WebSocket protocol to remove `Delivered`, `UnreadUpdate`, and mute messages.
> - Behavioral Change: `EventSendStatus` no longer has `Delivered` or `Read` states; chat history responses no longer include per-message read/delivery metadata; the mute conversation API and unread summary endpoint are removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e3f67b2. 23 files reviewed, 8 issues evaluated, 4 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 293](https://github.com/poziomki-app/poziomki/blob/e3f67b2ed89e171abbb4a20255266d4935e1bca9/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/SqlDelightRoomTimelineCacheStore.kt#L293): Deserializing cached timeline data written by older app versions will crash. Old cache entries may contain `CachedEventSendStatus` values `Delivered` or `Read` which no longer exist in the enum. When `kotlinx.serialization` attempts to deserialize JSON like `"sendStatus": "Delivered"`, it will throw `SerializationException` because the enum variant is undefined. This breaks the offline cache loading path in `loadSnapshot()`. <b>[ Failed validation ]</b>
> </details>
>
> <details>
> <summary>mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt — 0 comments posted, 3 evaluated, 1 filtered</summary>
>
> - [line 222](https://github.com/poziomki-app/poziomki/blob/e3f67b2ed89e171abbb4a20255266d4935e1bca9/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt#L222): Race condition in `getJoinedRoom`: The check-then-create pattern with two separate `openedRoomsMutex.withLock` calls allows two concurrent callers to both find the room absent, create separate `WsJoinedRoom` instances, and then overwrite each other in the map. The first caller's room becomes orphaned—its `SupervisorJob` and typing timeout jobs continue running without being closed, leaking resources. The check and insert should be atomic within a single `withLock` block. <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt — 0 comments posted, 3 evaluated, 2 filtered</summary>
>
> - [line 240](https://github.com/poziomki-app/poziomki/blob/e3f67b2ed89e171abbb4a20255266d4935e1bca9/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt#L240): In `onReadReceipt`, the `readByCount` is set to `seenUsers.size`, but `readReceiptUsers` is an in-memory map that is never populated from persisted cache data. When the app restarts, cached timeline items may have `readByCount = 5`, but `readReceiptUsers` is empty. When a new read receipt arrives, a fresh empty set is created via `getOrPut`, so `seenUsers.size` becomes 1, overwriting the previous count of 5. This causes the read count to incorrectly drop from the cached value to the number of receipts seen in the current session only. <b>[ Posting failed ]</b>
> - [line 252](https://github.com/poziomki-app/poziomki/blob/e3f67b2ed89e171abbb4a20255266d4935e1bca9/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt#L252): The refactored code no longer processes `msg.readReceipts` or `msg.deliveries` from the `HistoryResponse`. The old code built `readsByMessage` and `deliveriesByMessage` maps and passed them to `hydrateHistoryItem()` to populate read counts and delivery status on historical timeline items. The new code calls `it.toTimelineItem(uid)` which has no access to this receipt/delivery data. This means `readByCount` on historical `TimelineItem.Event` objects will be incorrect (likely 0), and the `readReceiptUsers` tracking map won't be populated for historical messages, causing subsequent real-time read receipts to potentially show incorrect counts. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->