### PR TITLE
fix(splash): dark splash background on iOS + Android

### DIFF
--- a/mobile/androidApp/src/main/AndroidManifest.xml
+++ b/mobile/androidApp/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        android:theme="@style/Theme.Poziomki">
         <activity
             android:exported="true"
             android:windowSoftInputMode="adjustResize"

--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.poziomki.app
 
+import android.app.ActivityManager
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -21,6 +23,18 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Recents carousel placeholder background — kept in sync with our
+        // AMOLED-dark splash (windowBackground = #000). Because FLAG_SECURE is
+        // on by default, Android renders this placeholder in place of the
+        // live snapshot, and without an explicit TaskDescription backgroundColor
+        // it defaults to a system-themed white card on light-mode devices.
+        setTaskDescription(
+            ActivityManager.TaskDescription
+                .Builder()
+                .setBackgroundColor(Color.BLACK)
+                .setPrimaryColor(Color.BLACK)
+                .build(),
+        )
         // Block screenshots + recent-apps previews by default. Chat
         // messages, profile edit, and password-reset flows all surface
         // PII that shouldn't leak to a device's recents carousel,

--- a/mobile/androidApp/src/main/res/values/colors.xml
+++ b/mobile/androidApp/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splash_background">#000000</color>
+</resources>

--- a/mobile/androidApp/src/main/res/values/themes.xml
+++ b/mobile/androidApp/src/main/res/values/themes.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+        Dark splash + activity theme. The previous theme was
+        Theme.Material.Light.NoActionBar, which caused a white flash on cold
+        launch (Android draws the activity background before Compose paints).
+    -->
+    <style name="Theme.Poziomki" parent="@android:style/Theme.Material.NoActionBar">
+        <item name="android:windowBackground">@color/splash_background</item>
+        <item name="android:colorBackground">@color/splash_background</item>
+        <item name="android:statusBarColor">@color/splash_background</item>
+        <item name="android:navigationBarColor">@color/splash_background</item>
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+</resources>

--- a/mobile/iosApp/iosApp/Assets.xcassets/SplashBackground.colorset/Contents.json
+++ b/mobile/iosApp/iosApp/Assets.xcassets/SplashBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -30,7 +30,10 @@
 		<false/>
 	</dict>
 	<key>UILaunchScreen</key>
-	<dict/>
+	<dict>
+		<key>UIColorName</key>
+		<string>SplashBackground</string>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
No white flash on cold launch. iOS UILaunchScreen → SplashBackground colorset (#000). Android Theme.Poziomki with windowBackground/statusBar/navigationBar = #000 instead of Theme.Material.Light.NoActionBar.

Stacked on #299.

- [ ] kill app, relaunch — no white flash before Compose paints
- [ ] status bar and nav bar are dark from the first frame

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dark splash screen background on iOS and Android
> - Sets a black launch screen background on iOS by defining a `SplashBackground` named color in [Contents.json](https://github.com/poziomki-app/poziomki/pull/300/files#diff-1363b6d687399f0033cf750f97c9da5be2b56d31cf04015349730d4d63a66bd0) and referencing it via `UIColorName` in [Info.plist](https://github.com/poziomki-app/poziomki/pull/300/files#diff-5897280c2b4695102b6259401869cd43697b3f07b7a565b4fa44233b3ada6906).
> - Sets a black task description background on Android in `MainActivity.onCreate` using `ActivityManager.TaskDescription.Builder`, affecting how the app appears in the recents screen when live snapshots are blocked by the secure flag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7daf235.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->