### PR TITLE
fix(events): swipe keeps card + Polish DatePicker headline + chat preview top-aligned

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
@@ -81,6 +81,7 @@ import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.designsystem.theme.White
 import com.poziomki.app.ui.shared.decodeImageBytes
+import com.poziomki.app.ui.shared.formatPolishDateFromMillis
 import com.poziomki.app.ui.shared.rememberSingleImagePicker
 import com.poziomki.app.ui.shared.resolveImageUrl
 import kotlinx.datetime.DateTimeUnit
@@ -691,7 +692,24 @@ fun EventCreateScreen(
                 }
             },
         ) {
-            DatePicker(state = datePickerState)
+            DatePicker(
+                state = datePickerState,
+                title = {
+                    Text(
+                        text = "Wybierz datę",
+                        modifier = Modifier.padding(start = 24.dp, end = 12.dp, top = 16.dp),
+                    )
+                },
+                headline = {
+                    val headlineText =
+                        datePickerState.selectedDateMillis?.let { formatPolishDateFromMillis(it) }
+                            ?: "Brak daty"
+                    Text(
+                        text = headlineText,
+                        modifier = Modifier.padding(start = 24.dp, end = 12.dp, bottom = 12.dp),
+                    )
+                },
+            )
         }
     }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -326,9 +326,19 @@ private fun SwipeableEventCard(
 
     LaunchedEffect(dismissState.currentValue) {
         when (dismissState.currentValue) {
-            SwipeToDismissBoxValue.StartToEnd -> onSwipeFeedback("more")
-            SwipeToDismissBoxValue.EndToStart -> onSwipeFeedback("less")
-            SwipeToDismissBoxValue.Settled -> Unit
+            SwipeToDismissBoxValue.StartToEnd -> {
+                onSwipeFeedback("more")
+                dismissState.reset()
+            }
+
+            SwipeToDismissBoxValue.EndToStart -> {
+                onSwipeFeedback("less")
+                dismissState.reset()
+            }
+
+            SwipeToDismissBoxValue.Settled -> {
+                Unit
+            }
         }
     }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -8,10 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -23,13 +21,6 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.adamglin.PhosphorIcons
-import com.adamglin.phosphoricons.Bold
-import com.adamglin.phosphoricons.bold.Check
-import com.adamglin.phosphoricons.bold.CheckCircle
-import com.adamglin.phosphoricons.bold.Clock
-import com.adamglin.phosphoricons.bold.WarningCircle
-import com.poziomki.app.chat.api.EventSendStatus
 import com.poziomki.app.chat.api.RoomSummary
 import com.poziomki.app.ui.designsystem.components.UserAvatar
 import com.poziomki.app.ui.designsystem.theme.Background
@@ -58,7 +49,7 @@ fun RoomRow(
                 .fillMaxWidth()
                 .clickable(onClick = onClick)
                 .padding(vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = Alignment.Top,
     ) {
         Box(
             modifier =
@@ -78,15 +69,6 @@ fun RoomRow(
         Spacer(modifier = Modifier.width(12.dp))
 
         Column(modifier = Modifier.weight(1f)) {
-            val statusIcon =
-                if (room.unreadCount == 0 && room.latestMessageIsMine) {
-                    latestRoomStatusIconSpec(
-                        sendStatus = room.latestMessageSendStatus,
-                        readByCount = room.latestMessageReadByCount,
-                    )
-                } else {
-                    null
-                }
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = displayName,
@@ -128,15 +110,6 @@ fun RoomRow(
             }
             Spacer(modifier = Modifier.height(2.dp))
             Row(verticalAlignment = Alignment.CenterVertically) {
-                if (statusIcon != null) {
-                    Icon(
-                        imageVector = statusIcon.icon,
-                        contentDescription = null,
-                        tint = statusIcon.tint,
-                        modifier = Modifier.size(14.dp),
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                }
                 val flagged =
                     !room.latestMessageIsMine &&
                         room.latestModerationVerdict in setOf("flag", "block")
@@ -213,36 +186,4 @@ private fun monthShort(monthNumber: Int): String =
         11 -> "lis."
         12 -> "gru."
         else -> "?"
-    }
-
-private data class RoomStatusIconSpec(
-    val icon: androidx.compose.ui.graphics.vector.ImageVector,
-    val tint: androidx.compose.ui.graphics.Color,
-)
-
-@Composable
-private fun latestRoomStatusIconSpec(
-    sendStatus: EventSendStatus?,
-    readByCount: Int,
-): RoomStatusIconSpec? =
-    when {
-        sendStatus == EventSendStatus.Failed -> {
-            RoomStatusIconSpec(icon = PhosphorIcons.Bold.WarningCircle, tint = MaterialTheme.colorScheme.error)
-        }
-
-        sendStatus == EventSendStatus.Sending -> {
-            RoomStatusIconSpec(icon = PhosphorIcons.Bold.Clock, tint = TextSecondary)
-        }
-
-        readByCount > 0 -> {
-            RoomStatusIconSpec(icon = PhosphorIcons.Bold.CheckCircle, tint = Primary)
-        }
-
-        sendStatus == EventSendStatus.Sent -> {
-            RoomStatusIconSpec(icon = PhosphorIcons.Bold.Check, tint = TextSecondary)
-        }
-
-        else -> {
-            null
-        }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/shared/DateUtils.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/shared/DateUtils.kt
@@ -69,6 +69,15 @@ fun formatEventDateFull(isoString: String): String {
     return "$weekday, $day $month · $hour:$minute"
 }
 
+fun formatPolishDateFromMillis(millis: Long): String {
+    val tz = TimeZone.currentSystemDefault()
+    val dt = Instant.fromEpochMilliseconds(millis).toLocalDateTime(tz)
+    val weekday = POLISH_WEEKDAYS_FULL[dt.dayOfWeek.ordinal]
+    val day = dt.day
+    val month = POLISH_MONTHS_GENITIVE[dt.month.ordinal]
+    return "$weekday, $day $month ${dt.year}"
+}
+
 fun formatEventDateCompact(isoString: String): String {
     val tz = TimeZone.currentSystemDefault()
     val instant = Instant.parse(isoString)


### PR DESCRIPTION
Three related fixes (events / rooms list):

- SwipeableEventCard: swipe still sends the recommendation feedback but the card stays on the list (resets dismissState after feedback). Fixes \"events disappear after swiping\".
- DatePicker in EventCreate: headline shown in Polish (\"środa, 14 kwietnia 2026\") instead of en-US.
- RoomRow: verticalAlignment Top, removed pre-#290 sent/read ticks.

Stacked on #300.

- [ ] swipe an event card both ways — card stays, feedback lands
- [ ] open the date picker in event create — headline in Polish
- [ ] rooms list — message aligned to the top of the row

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix swipe to reset card state, top-align chat preview, and add Polish date headline to event DatePicker
> - Fixes `SwipeableEventCard` in [EventsScreen.kt](https://github.com/poziomki-app/poziomki/pull/301/files#diff-b1aad26129722f5aa103f55ac1d883a2b472203a3df536f251798d2ab83260dd): after emitting swipe feedback (`more`/`less`), the dismiss state now calls `reset()` so the card stays visible instead of remaining in a swiped-away state.
> - Adds a Polish-formatted headline and title to the `DatePicker` in [EventCreateScreen.kt](https://github.com/poziomki-app/poziomki/pull/301/files#diff-9e272942315a25548e3ad7e20394cb37de4deefa7fd99982d2c6b3e59469b028), showing the selected date via the new `formatPolishDateFromMillis` utility or `'Brak daty'` when no date is selected.
> - Changes `RoomRow` vertical alignment from `CenterVertically` to `Top` and removes the message send/read status icon and its supporting code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc7bc36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->