### PR TITLE
fix(xp): atomic award for both sides on QR scan

### DIFF
--- a/backend/src/api/xp/handler.rs
+++ b/backend/src/api/xp/handler.rs
@@ -230,9 +230,12 @@ pub(in crate::api) async fn scan_token(
         ));
     };
 
-    // Load scanner profile + insert scan record atomically. The scan row
-    // is owned by the scanner (scanner_id = viewer's profile), so
-    // Tier-A policy on xp_scans can enforce write-on-own-row.
+    // Load scanner profile, record the scan, AND award XP to both parties
+    // atomically — all in one tx. The scan row is owned by the scanner
+    // (scanner_id = viewer's profile), and `app.award_profile_xp` is
+    // SECURITY DEFINER so it can credit the scanned profile across the RLS
+    // boundary. If either award fails the whole tx rolls back so we never
+    // record a scan without paying out both sides.
     let headers_tx = headers.clone();
     let tx_result = db::with_viewer_tx(viewer, move |conn| {
         async move {
@@ -251,30 +254,33 @@ pub(in crate::api) async fn scan_token(
                     },
                 ))));
             }
-            match service::try_record_scan(conn, scanner.id, scanned_id).await {
-                Ok(awarded) => Ok::<_, diesel::result::Error>(Ok((scanner.id, awarded))),
-                Err(_) => Err(diesel::result::Error::RollbackTransaction),
+            let Ok(awarded) = service::try_record_scan(conn, scanner.id, scanned_id).await else {
+                return Err(diesel::result::Error::RollbackTransaction);
+            };
+            if awarded {
+                if db::award_profile_xp(conn, scanner.id, SCAN_XP_REWARD)
+                    .await
+                    .is_err()
+                {
+                    return Err(diesel::result::Error::RollbackTransaction);
+                }
+                if db::award_profile_xp(conn, scanned_id, SCAN_XP_REWARD)
+                    .await
+                    .is_err()
+                {
+                    return Err(diesel::result::Error::RollbackTransaction);
+                }
             }
+            Ok::<_, diesel::result::Error>(Ok((scanner.id, awarded)))
         }
         .scope_boxed()
     })
     .await;
 
-    let (my_profile_id, awarded) = match unwrap_viewer_tx(tx_result, &headers) {
+    let (_my_profile_id, awarded) = match unwrap_viewer_tx(tx_result, &headers) {
         Ok(v) => v,
         Err(resp) => return Ok(*resp),
     };
-
-    if awarded {
-        tokio::spawn(async move {
-            if let Err(e) = service::award_xp(my_profile_id, SCAN_XP_REWARD).await {
-                tracing::warn!(error = %e, profile_id = %my_profile_id, "failed to award XP to scanner");
-            }
-            if let Err(e) = service::award_xp(scanned_id, SCAN_XP_REWARD).await {
-                tracing::warn!(error = %e, profile_id = %scanned_id, "failed to award XP to scanned");
-            }
-        });
-    }
 
     Ok(Json(DataResponse {
         data: ScanResponse {


### PR DESCRIPTION
QR scan in a single tx — load profile + insert xp_scans + award scanner + award scanned. If either side fails, the transaction rolls back. Replaces the previous tokio::spawn (race / silent fail) with a synchronous award before the HTTP response. SECURITY DEFINER app.award_profile_xp lets us credit the scanned profile across RLS.

Stacked on #301.

- [ ] from two accounts: scan → both see +25xp in /xp/me
- [ ] re-scan the same person within 24h → 0xp (no double payout)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Award XP atomically within the scan transaction in `scan_token`
> - Moves XP awards for both scanner and scanned profiles into the same database transaction that records the QR scan, replacing the previous `tokio::spawn` background task.
> - Both `db::award_profile_xp` calls now execute synchronously inside the transaction; any failure rolls back the entire transaction.
> - Behavioral Change: award failures now return an error response instead of silently logging a warning while returning a successful API response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 991a8ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->