### PR TITLE
feat(map): map fillMaxSize in nearby section

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
@@ -72,7 +72,6 @@ private const val MAP_STYLE = "https://tiles.openfreemap.org/styles/dark"
 private const val DEFAULT_ZOOM = 12.0
 private const val DEFAULT_LAT = 52.2297
 private const val DEFAULT_LNG = 21.0122
-private const val MAP_HEIGHT_DP = 280
 private const val TAP_THRESHOLD_DEG = 0.005
 
 @Composable
@@ -151,13 +150,13 @@ internal fun NearbyEventsContent(
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
-        // Map container
+        // Map container — fill the available height (weight=1f) instead of a fixed 280dp.
         Box(
             modifier =
                 Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
-                    .height(MAP_HEIGHT_DP.dp)
+                    .weight(1f)
                     .clip(RoundedCornerShape(20.dp)),
         ) {
             val cameraState =


### PR DESCRIPTION
NearbyEventsContent — map stretches to fill the available height (weight=1f) instead of 280dp. 2.5D buildings / pitch left as a follow-up.

Stacked on #302.

- [ ] verify the map fills the container and the selected-event panel sits below it

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace fixed map height with flexible fill in nearby section
> Removes the `MAP_HEIGHT_DP` constant (280dp) from [NearbyEventsContent.kt](https://github.com/poziomki-app/poziomki/pull/303/files#diff-4b254621a5c67acf73fc8f3619229de35cfcffe5ed1d64536e7e98375cc84e98) and replaces it with `.weight(1f)` so the map expands to fill remaining vertical space in its parent `Column`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82d8d72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->