### PR TITLE
fix(discover): filter out the viewers own profile

### DIFF
--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/MatchProfileRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/MatchProfileRepository.kt
@@ -7,9 +7,11 @@ import com.poziomki.app.db.PoziomkiDatabase
 import com.poziomki.app.network.ApiResult
 import com.poziomki.app.network.ApiService
 import com.poziomki.app.network.MatchProfile
+import com.poziomki.app.session.SessionManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
@@ -19,15 +21,31 @@ import kotlin.time.Clock
 class MatchProfileRepository(
     private val db: PoziomkiDatabase,
     private val api: ApiService,
+    private val sessionManager: SessionManager,
 ) {
     private val json = Json { ignoreUnknownKeys = true }
 
-    fun observeProfiles(): Flow<List<MatchProfile>> =
-        db.matchedProfileQueries
-            .selectAll()
-            .asFlow()
-            .mapToList(Dispatchers.IO)
-            .map { rows -> rows.map { it.toApiModel() } }
+    fun observeProfiles(): Flow<List<MatchProfile>> {
+        val cachedFlow =
+            db.matchedProfileQueries
+                .selectAll()
+                .asFlow()
+                .mapToList(Dispatchers.IO)
+                .map { rows -> rows.map { it.toApiModel() } }
+        // Hide the viewer's own profile from Discover. Fixes the post-relogin
+        // cache leak where the previously logged-in account's profile would
+        // appear in the list because matchedProfileQueries is shared across
+        // sessions.
+        return cachedFlow.combine(sessionManager.profileId) { profiles, ownProfileId ->
+            if (ownProfileId.isNullOrBlank()) profiles else profiles.filter { it.id != ownProfileId }
+        }
+    }
+
+    suspend fun clearCache() {
+        withContext(Dispatchers.IO) {
+            db.matchedProfileQueries.deleteAll()
+        }
+    }
 
     /** Emits userId -> profilePicture map for all cached match profiles. */
     fun observeProfilePicturesByUserId(): Flow<Map<String, String>> =

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
@@ -62,7 +62,7 @@ val sharedModule =
         single { ProfileRepository(get(), get(), get(), get()) }
         single { TagRepository(get(), get()) }
         single { DegreeRepository(get(), get()) }
-        single { MatchProfileRepository(get(), get()) }
+        single { MatchProfileRepository(get(), get(), get()) }
         single { SettingsRepository(get(), get(), get()) }
         single { XpRepository(get(), get()) }
         single {


### PR DESCRIPTION
MatchProfileRepository.observeProfiles() combines with SessionManager.profileId and filters out the entry where id == ownProfileId. Fixes \"Discover shows my account\" regardless of whether the source is a cache leak after relogin or a backend bug in /matching/profiles.

Tag/activity filter UI — TODO separate PR.

Stacked on #303.

- [ ] sign in to account A with an existing profile → open Discover → A not visible
- [ ] sign in as B → A visible, B not

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter the current user's own profile out of Discover results
> - `MatchProfileRepository.observeProfiles` now combines the cached profiles flow with `SessionManager.profileId` and filters out any profile whose id matches the current session.
> - `MatchProfileRepository` takes a new `SessionManager` constructor parameter; the DI module in [`SharedModule.kt`](https://github.com/poziomki-app/poziomki/pull/304/files#diff-beb23b728c25897bd35561316b2688e9ddfc12a55fb3cb4567681a6a14e623d5) is updated to pass it.
> - A new `clearCache` suspend function deletes all rows from the matched profiles cache.
> - Behavioral Change: constructing `MatchProfileRepository` without a `SessionManager` will now fail at compile time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3240863.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->