### PR TITLE
fix(profile): bookmark next to name, message under content

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
@@ -84,6 +84,7 @@ fun ProfilePreview(
     gradientEnd: String? = null,
     onClose: () -> Unit,
     bottomContent: @Composable (() -> Unit)? = null,
+    headerAction: @Composable (() -> Unit)? = null,
 ) {
     val nunito = NunitoFamily
     val montserrat = MontserratFamily
@@ -259,24 +260,27 @@ fun ProfilePreview(
                     .padding(horizontal = PoziomkiTheme.spacing.lg)
                     .padding(top = PoziomkiTheme.spacing.lg, bottom = PoziomkiTheme.spacing.xl),
         ) {
-            // Name
-            Text(
-                text = name.ifBlank { "imi\u0119" },
-                fontFamily = montserrat,
-                fontWeight = FontWeight.ExtraBold,
-                fontSize = 28.sp,
-                color = TextPrimary,
-            )
-
-            // Program
-            if (!program.isNullOrBlank()) {
-                Text(
-                    text = program,
-                    fontFamily = nunito,
-                    fontWeight = FontWeight.Normal,
-                    fontSize = 16.sp,
-                    color = TextSecondary,
-                )
+            // Name + optional header action (bookmark) on the right.
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = name.ifBlank { "imi\u0119" },
+                        fontFamily = montserrat,
+                        fontWeight = FontWeight.ExtraBold,
+                        fontSize = 28.sp,
+                        color = TextPrimary,
+                    )
+                    if (!program.isNullOrBlank()) {
+                        Text(
+                            text = program,
+                            fontFamily = nunito,
+                            fontWeight = FontWeight.Normal,
+                            fontSize = 16.sp,
+                            color = TextSecondary,
+                        )
+                    }
+                }
+                headerAction?.invoke()
             }
 
             // Bio

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
@@ -1,20 +1,18 @@
 package com.poziomki.app.ui.feature.profile
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -25,8 +23,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
@@ -39,7 +35,6 @@ import com.poziomki.app.ui.designsystem.components.ButtonVariant
 import com.poziomki.app.ui.designsystem.components.ProfileImage
 import com.poziomki.app.ui.designsystem.components.ProfilePreview
 import com.poziomki.app.ui.designsystem.theme.Background
-import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.White
@@ -48,7 +43,7 @@ import kotlinx.coroutines.delay
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 fun ProfileViewScreen(
     onBack: () -> Unit,
     onNavigateToChat: (String, String, String?) -> Unit,
@@ -68,80 +63,66 @@ fun ProfileViewScreen(
                     }
                 val emoji = p.profilePicture?.takeUnless { isImageUrl(it) }
 
-                Box(Modifier.fillMaxSize()) {
-                    ProfilePreview(
-                        name = p.name,
-                        program = p.program,
-                        bio = p.bio,
-                        tags = p.tags,
-                        images = images,
-                        emojiAvatar = emoji,
-                        gradientStart = p.gradientStart,
-                        gradientEnd = p.gradientEnd,
-                        onClose = onBack,
-                    )
-
-                    val bottomInsets =
-                        WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-
-                    if (!state.isOwnProfile) {
-                        // Bookmark button
-                        Surface(
-                            modifier =
-                                Modifier
-                                    .align(Alignment.BottomStart)
-                                    .padding(
-                                        start = 16.dp,
-                                        bottom = bottomInsets + 20.dp,
-                                    ),
-                            shape = RoundedCornerShape(28.dp),
-                            color = Color.Transparent,
-                            border = BorderStroke(1.dp, Border),
-                        ) {
-                            IconButton(
-                                onClick = { viewModel.toggleBookmark() },
-                                modifier =
-                                    Modifier.background(
-                                        Brush.verticalGradient(
-                                            colors =
-                                                listOf(
-                                                    Color(0xFF1A2029),
-                                                    Color(0xFF161B22),
-                                                ),
-                                        ),
-                                    ),
-                            ) {
-                                Icon(
-                                    imageVector =
-                                        if (state.isBookmarked) {
-                                            PhosphorIcons.Fill.BookmarkSimple
-                                        } else {
-                                            PhosphorIcons.Bold.BookmarkSimple
-                                        },
-                                    contentDescription =
-                                        if (state.isBookmarked) "Usuń zakładkę" else "Dodaj zakładkę",
-                                    tint = if (state.isBookmarked) Primary else White,
-                                    modifier = Modifier.size(22.dp),
-                                )
+                val bottomInsets =
+                    WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                ProfilePreview(
+                    name = p.name,
+                    program = p.program,
+                    bio = p.bio,
+                    tags = p.tags,
+                    images = images,
+                    emojiAvatar = emoji,
+                    gradientStart = p.gradientStart,
+                    gradientEnd = p.gradientEnd,
+                    onClose = onBack,
+                    headerAction =
+                        if (!state.isOwnProfile) {
+                            {
+                                IconButton(onClick = { viewModel.toggleBookmark() }) {
+                                    Icon(
+                                        imageVector =
+                                            if (state.isBookmarked) {
+                                                PhosphorIcons.Fill.BookmarkSimple
+                                            } else {
+                                                PhosphorIcons.Bold.BookmarkSimple
+                                            },
+                                        contentDescription =
+                                            if (state.isBookmarked) "Usuń zakładkę" else "Dodaj zakładkę",
+                                        tint = if (state.isBookmarked) Primary else White,
+                                        modifier = Modifier.size(22.dp),
+                                    )
+                                }
                             }
-                        }
-
-                        // Message button
-                        AppButton(
-                            text = "Wiadomość",
-                            onClick = { onNavigateToChat(p.userId, p.name, p.id) },
-                            variant = ButtonVariant.PRIMARY,
-                            icon = PhosphorIcons.Fill.PaperPlaneRight,
-                            modifier =
-                                Modifier
-                                    .align(Alignment.BottomEnd)
-                                    .padding(
-                                        end = 16.dp,
-                                        bottom = bottomInsets + 20.dp,
-                                    ),
-                        )
-                    }
-                }
+                        } else {
+                            null
+                        },
+                    bottomContent =
+                        if (!state.isOwnProfile) {
+                            {
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(
+                                                start = 16.dp,
+                                                end = 16.dp,
+                                                top = 12.dp,
+                                                bottom = bottomInsets + 20.dp,
+                                            ),
+                                    contentAlignment = Alignment.CenterEnd,
+                                ) {
+                                    AppButton(
+                                        text = "Wiadomość",
+                                        onClick = { onNavigateToChat(p.userId, p.name, p.id) },
+                                        variant = ButtonVariant.PRIMARY,
+                                        icon = PhosphorIcons.Fill.PaperPlaneRight,
+                                    )
+                                }
+                            }
+                        } else {
+                            null
+                        },
+                )
             }
         }
 


### PR DESCRIPTION
ProfilePreview gains a headerAction slot (bookmark rendered in the right-hand row next to name + program). The message button moves into the bottomContent slot — neither is a floating overlay anymore, so they no longer cover interests or other content, and the safe area is respected.

Stacked on #304.

- [ ] open someone else’s profile → bookmark in the header next to the name, message FAB below the interests list, nothing covered
- [ ] check on own profile (isOwnProfile=true) — bookmark/message hidden

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move bookmark button to profile header and message button to bottom content slot
> - Adds an optional `headerAction` slot to `ProfilePreview` that renders a composable to the right of the name/program section; used to place the bookmark `IconButton` next to the user's name.
> - Replaces the previous `Box` overlay approach in `ProfileViewScreen` (which used a bordered, gradient-backed button at the bottom-left) with the new `headerAction` and `bottomContent` slots.
> - The message button is now rendered via `bottomContent` as a full-width container aligned to the end, with bottom navigation bar inset padding.
> - Behavioral Change: The bookmark button loses its `Surface`/`BorderStroke`/gradient styling and becomes a plain `IconButton` in the header row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06e69c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->