### PR TITLE
ci(publish-apks): canonical poziomki-X.Y.Z.apk alias

### DIFF
--- a/.github/workflows/publish-apks.yml
+++ b/.github/workflows/publish-apks.yml
@@ -74,6 +74,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
           mkdir -p apks
           cd apks
@@ -84,6 +85,10 @@ jobs:
             --dir .
           ls -la
           test -n "$(ls *.apk 2>/dev/null)" || { echo "no APKs downloaded"; exit 1; }
+          # Canonical short alias `poziomki-X.Y.Z.apk` → universal APK. Lets
+          # the rest of the team share a single stable URL without committing
+          # to any specific architecture suffix.
+          cp "poziomki-${VERSION}-universal.apk" "poziomki-${VERSION}.apk"
 
       - name: Tailscale up
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
@@ -106,9 +111,9 @@ jobs:
         env:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          # Spot-check the universal APK; Caddy serves /download/ with
-          # file_server browse + Content-Disposition: attachment.
-          url="https://mobile.poziomki.app/download/poziomki-${VERSION}-universal.apk"
+          # Spot-check the canonical short alias; Caddy serves /download/
+          # with file_server browse + Content-Disposition: attachment.
+          url="https://mobile.poziomki.app/download/poziomki-${VERSION}.apk"
           for i in $(seq 1 10); do
             if curl -fsSI "$url" >/dev/null; then
               echo "OK: $url"


### PR DESCRIPTION
Adds a short, architecture-agnostic filename next to the per-arch + universal APKs so the team can share one stable URL like https://mobile.poziomki.app/download/poziomki-0.19.0.apk that always points at the universal APK.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add canonical `poziomki-X.Y.Z.apk` alias in publish-apks workflow
> In [publish-apks.yml](.github/workflows/publish-apks.yml), copies the universal APK to a short alias filename (`poziomki-X.Y.Z.apk`) without the `-universal` suffix and uploads it alongside the original. The HTTP availability spot-check now verifies the alias URL instead of the `-universal` filename.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 895a2e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->