### PR TITLE
chore(infra): canonical poziomki-vX.Y.Z.apk + move /download/ to poziomki.app

### DIFF
--- a/.github/workflows/publish-apks.yml
+++ b/.github/workflows/publish-apks.yml
@@ -85,10 +85,13 @@ jobs:
             --dir .
           ls -la
           test -n "$(ls *.apk 2>/dev/null)" || { echo "no APKs downloaded"; exit 1; }
-          # Canonical short alias `poziomki-X.Y.Z.apk` → universal APK. Lets
-          # the rest of the team share a single stable URL without committing
-          # to any specific architecture suffix.
-          cp "poziomki-${VERSION}-universal.apk" "poziomki-${VERSION}.apk"
+          # Canonical short alias `poziomki-vX.Y.Z.apk` → arm64-v8a APK
+          # (~8 MB; covers virtually every Android device shipped since
+          # ~2017). The universal APK bundles every ABI and is roughly 3×
+          # the size, which we don't want for the default share link. The
+          # `v` prefix matches the release tag scheme (vX.Y.Z) used
+          # everywhere else.
+          cp "poziomki-${VERSION}-arm64-v8a.apk" "poziomki-v${VERSION}.apk"
 
       - name: Tailscale up
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
@@ -108,18 +111,47 @@ jobs:
             "ubuntu@${VPS_HOST}:/var/www/download/"
 
       - name: Verify HTTP availability
+        id: verify
         env:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           # Spot-check the canonical short alias; Caddy serves /download/
           # with file_server browse + Content-Disposition: attachment.
-          url="https://mobile.poziomki.app/download/poziomki-${VERSION}.apk"
+          url="https://poziomki.app/download/poziomki-v${VERSION}.apk"
           for i in $(seq 1 10); do
             if curl -fsSI "$url" >/dev/null; then
               echo "OK: $url"
+              echo "url=$url" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             sleep 3
           done
           echo "FAIL: $url did not become available" >&2
+          echo "url=$url" >> "$GITHUB_OUTPUT"
           exit 1
+
+      - name: Notify ntfy on success
+        if: success()
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          URL: ${{ steps.verify.outputs.url }}
+        run: |
+          curl -fsS \
+            -H "Title: poziomki ${TAG} APK published" \
+            -H "Priority: default" \
+            -H "Tags: rocket,android" \
+            -d "Live at ${URL}" \
+            https://ntfy.poziomki.app/server-alerts
+
+      - name: Notify ntfy on failure
+        if: failure()
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          curl -fsS \
+            -H "Title: poziomki ${TAG} APK publish FAILED" \
+            -H "Priority: high" \
+            -H "Tags: warning,android" \
+            -d "See https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}" \
+            https://ntfy.poziomki.app/server-alerts || true

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -38,7 +38,6 @@ type Result<T> = crate::error::AppResult<T>;
 const ALLOWED_WS_ORIGINS: &[&str] = &[
     "https://poziomki.app",
     "https://www.poziomki.app",
-    "https://mobile.poziomki.app",
     "https://api.poziomki.app",
     "http://localhost",
     "http://127.0.0.1",
@@ -92,7 +91,6 @@ mod origin_tests {
     #[test]
     fn accepts_allowlisted() {
         assert!(is_allowed_ws_origin("https://poziomki.app"));
-        assert!(is_allowed_ws_origin("https://mobile.poziomki.app"));
         assert!(is_allowed_ws_origin("https://api.poziomki.app"));
         assert!(is_allowed_ws_origin("http://localhost:5173"));
         assert!(is_allowed_ws_origin("http://127.0.0.1:3000"));

--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -60,6 +60,17 @@ poziomki.app, www.poziomki.app {
 		file_server
 	}
 
+	# APK mirror — populated by the Publish APKs to VPS workflow which rsyncs
+	# release artefacts into /var/www/download/ (universal + per-arch + a
+	# canonical poziomki-vX.Y.Z.apk alias). file_server browse exposes a
+	# directory listing; Content-Disposition: attachment forces download
+	# instead of in-browser open for direct .apk links.
+	handle_path /download/* {
+		header Content-Disposition "attachment"
+		root * /var/www/download
+		file_server browse
+	}
+
 	# Umami public tracker. Served under neutral paths to dodge ad-blocker
 	# heuristics; dashboard stays bound to Tailscale/localhost on :3090.
 	@umami_script path /berry.js
@@ -90,29 +101,6 @@ poziomki.app, www.poziomki.app {
 		root * /home/ubuntu/landing-static
 		try_files {path} {path}/index.html =404
 		file_server
-	}
-}
-
-mobile.poziomki.app {
-	import secure_headers
-	header Referrer-Policy "strict-origin-when-cross-origin"
-
-	handle_path /download/* {
-		header Content-Disposition "attachment"
-		root * /var/www/download
-		file_server browse
-	}
-
-	handle {
-		reverse_proxy localhost:5150 {
-			# Set an authoritative client-IP header the backend rate
-			# limiter can trust. We also replace X-Forwarded-For
-			# (Caddy would otherwise append, letting a client forge
-			# the first hop).
-			header_up X-Real-IP {client_ip}
-			header_up X-Forwarded-For {client_ip}
-			header_down -X-Powered-By
-		}
 	}
 }
 
@@ -181,8 +169,9 @@ api.poziomki.app {
 
 	handle {
 		reverse_proxy localhost:5150 {
-			# See comment on mobile.poziomki.app for rationale —
-			# authoritative client IP for the backend limiter.
+			# Authoritative client-IP for the backend rate limiter.
+			# Replace X-Forwarded-For (Caddy would otherwise append,
+			# letting a client forge the first hop).
 			header_up X-Real-IP {client_ip}
 			header_up X-Forwarded-For {client_ip}
 			header_down -X-Powered-By


### PR DESCRIPTION
- Canonical short alias is now `poziomki-vX.Y.Z.apk` (with `v` prefix matching release tags).
- `/download/` is now served from `poziomki.app` instead of `mobile.poziomki.app`.
- Drops the `mobile.poziomki.app` vhost — mobile clients use `api.poziomki.app` via `SERVER_HOST`, nothing relied on the old subdomain. Backend WS origin allowlist + tests cleaned up too.
- Adds an ntfy `server-alerts` notification on success/failure of the APK publish workflow.

Manual VPS step after merge:
1. `cp infra/caddy/Caddyfile.prod /etc/caddy/Caddyfile`
2. `sudo systemctl reload caddy`
3. (optional) drop the `mobile.poziomki.app` DNS record

- [ ] verify `https://poziomki.app/download/poziomki-v0.19.0.apk` returns 200 after Caddy reload + republish

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move `/download/` from `mobile.poziomki.app` to `poziomki.app` and rename canonical APK to `poziomki-vX.Y.Z.apk`
> - Adds a `/download/*` handler under `poziomki.app` in [Caddyfile.prod](https://github.com/poziomki-app/poziomki/pull/309/files#diff-507ac62fa8220af2d08c3d8f2ef5aee0806600e1d1085fc4c641c643ea9f4e36) serving files from `/var/www/download` with forced attachment disposition; removes the `mobile.poziomki.app` virtual host entirely.
> - Updates the publish workflow in [publish-apks.yml](https://github.com/poziomki-app/poziomki/pull/309/files#diff-a06f01889fe807ca1be0de8d83c1b6d397455f4a73453c05f52d03d64a3a58f2) to alias the arm64-v8a APK as `poziomki-v${VERSION}.apk` (was universal APK named `poziomki-${VERSION}.apk`) and verify it at the new URL.
> - Adds ntfy success/failure notifications to the publish workflow, emitting the verified URL as a step output.
> - Removes `https://mobile.poziomki.app` from the WebSocket origin allowlist in [mod.rs](https://github.com/poziomki-app/poziomki/pull/309/files#diff-5e07944cd52759fed0f90311e982e992339a7f7aa1a48ecacd35d11e547d1a4e).
> - Risk: WebSocket connections from `https://mobile.poziomki.app` will now be rejected; any existing download links pointing to `mobile.poziomki.app` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88869f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->