### PR TITLE
release: mobile 0.19.1

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "backend": "0.19.0",
-  "mobile/androidApp": "0.19.0"
+  "mobile/androidApp": "0.19.1"
 }

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.19.0" // x-release-please-version
+val appVersionName = "0.19.1" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }


### PR DESCRIPTION
Patch bump so APK reinstalls cleanly over older builds floating around (manual /var/www/download/ uploads + earlier daily builds with higher versionCodes than 0.19.0). Backend unchanged; only Android versionCode 19000 → 19001 moves.

After merge:
- [ ] tag v0.19.1 from main HEAD
- [ ] android-release + publish-apks fire automatically

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release mobile version 0.19.1 for Android
> Bumps `appVersionName` from `0.19.0` to `0.19.1` in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/310/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be) and updates the release-please manifest accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0eacd92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->