### PR TITLE
ci(publish-apks): drop redundant ntfy notifications

### DIFF
--- a/.github/workflows/publish-apks.yml
+++ b/.github/workflows/publish-apks.yml
@@ -111,47 +111,21 @@ jobs:
             "ubuntu@${VPS_HOST}:/var/www/download/"
 
       - name: Verify HTTP availability
-        id: verify
         env:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           # Spot-check the canonical short alias; Caddy serves /download/
           # with file_server browse + Content-Disposition: attachment.
+          # /usr/local/bin/apk-notify.sh on the VPS picks the file up via
+          # inotifywait and fires its own ntfy notification (with the app
+          # logo + Zaktualizuj action button), so this workflow stays quiet.
           url="https://poziomki.app/download/poziomki-v${VERSION}.apk"
           for i in $(seq 1 10); do
             if curl -fsSI "$url" >/dev/null; then
               echo "OK: $url"
-              echo "url=$url" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             sleep 3
           done
           echo "FAIL: $url did not become available" >&2
-          echo "url=$url" >> "$GITHUB_OUTPUT"
           exit 1
-
-      - name: Notify ntfy on success
-        if: success()
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-          URL: ${{ steps.verify.outputs.url }}
-        run: |
-          curl -fsS \
-            -H "Title: poziomki ${TAG} APK published" \
-            -H "Priority: default" \
-            -H "Tags: rocket,android" \
-            -d "Live at ${URL}" \
-            https://ntfy.poziomki.app/server-alerts
-
-      - name: Notify ntfy on failure
-        if: failure()
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          curl -fsS \
-            -H "Title: poziomki ${TAG} APK publish FAILED" \
-            -H "Priority: high" \
-            -H "Tags: warning,android" \
-            -d "See https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}" \
-            https://ntfy.poziomki.app/server-alerts || true


### PR DESCRIPTION
The VPS already runs /usr/local/bin/apk-notify.sh which watches /var/www/download/ via inotifywait and sends a single ntfy notification with the app logo + Zaktualizuj action button. Drop the workflow's own success/failure posts so the user gets exactly one notification per release.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove ntfy notifications from the publish-apks CI workflow
> The workflow previously sent ntfy push notifications on success and failure of the HTTP availability check. These are now handled externally on the VPS via `/usr/local/bin/apk-notify.sh`, making the in-workflow notifications redundant. The verify step no longer sets a `url` output, and the two notification steps are removed from [publish-apks.yml](.github/workflows/publish-apks.yml). The HTTP availability check itself is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90ebdba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->