### PR TITLE
fix: swipe-keep + dark status bar + sticky profile overlays

### DIFF
--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -63,14 +63,14 @@ class MainActivity : ComponentActivity() {
             handleIntent(intent)
         }
         enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(android.graphics.Color.TRANSPARENT),
+            statusBarStyle = SystemBarStyle.dark(android.graphics.Color.BLACK),
             navigationBarStyle = SystemBarStyle.dark(android.graphics.Color.BLACK),
         )
         setContent {
             // Remove when https://issuetracker.google.com/issues/364713509 is fixed
             LaunchedEffect(Unit) {
                 enableEdgeToEdge(
-                    statusBarStyle = SystemBarStyle.dark(android.graphics.Color.TRANSPARENT),
+                    statusBarStyle = SystemBarStyle.dark(android.graphics.Color.BLACK),
                     navigationBarStyle = SystemBarStyle.dark(android.graphics.Color.BLACK),
                 )
             }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
@@ -82,7 +83,7 @@ fun ProfilePreview(
     emojiAvatar: String? = null,
     gradientStart: String? = null,
     gradientEnd: String? = null,
-    onClose: () -> Unit,
+    onClose: (() -> Unit)? = null,
     bottomContent: @Composable (() -> Unit)? = null,
     headerAction: @Composable (() -> Unit)? = null,
 ) {
@@ -231,24 +232,29 @@ fun ProfilePreview(
                 }
             }
 
-            // Close button — respects status bar safe area
-            val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-            IconButton(
-                onClick = onClose,
-                modifier =
-                    Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = statusBarTop + 8.dp, end = 20.dp)
-                        .size(40.dp)
-                        .clip(CircleShape)
-                        .background(Black.copy(alpha = 0.45f)),
-            ) {
-                Icon(
-                    imageVector = PhosphorIcons.Bold.X,
-                    contentDescription = "Zamknij",
-                    tint = White,
-                    modifier = Modifier.size(24.dp),
-                )
+            // Close button — when ProfilePreview is hosted inside a dialog
+            // (ProfilePreviewDialog), the dialog gives us no chrome to overlay
+            // X on, so we render it here. ProfileViewScreen passes onClose=null
+            // and renders its own sticky X outside the scrolling content.
+            if (onClose != null) {
+                val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+                IconButton(
+                    onClick = onClose,
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(top = statusBarTop + 8.dp, end = 20.dp)
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(Black.copy(alpha = 0.45f)),
+                ) {
+                    Icon(
+                        imageVector = PhosphorIcons.Bold.X,
+                        contentDescription = "Zamknij",
+                        tint = White,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
             }
         }
 
@@ -333,6 +339,13 @@ fun ProfilePreview(
                 Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
                 bottomContent()
             }
+
+            // Headroom for a sticky bottom-end overlay button (e.g. "Wiadomość"
+            // FAB on ProfileViewScreen) plus the system navigation bar inset,
+            // so the last bit of content can always be scrolled clear of the
+            // overlay. Harmless when no overlay is rendered.
+            val navBars = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+            Spacer(modifier = Modifier.height(navBars + 96.dp))
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
@@ -30,7 +30,6 @@ data class EventsState(
     val selectedNearbyEventId: String? = null,
     val isLocationPermissionDenied: Boolean = false,
     val isLocationUnavailable: Boolean = false,
-    val dismissedEventIds: Set<String> = emptySet(),
     val selectedCategories: Set<String> = emptySet(),
     val showTagFilter: Boolean = false,
 )
@@ -104,7 +103,7 @@ class EventsViewModel(
                     lng = location?.longitude,
                     forceRefresh = forceRefresh,
                 )
-            _state.value = _state.value.copy(recommendedEvents = recommended, dismissedEventIds = emptySet())
+            _state.value = _state.value.copy(recommendedEvents = recommended)
             filterEvents()
         }
     }
@@ -245,27 +244,13 @@ class EventsViewModel(
         eventId: String,
         feedback: String,
     ) {
-        val removedFromRecommended = _state.value.recommendedEvents.find { it.id == eventId }
-        _state.value =
-            _state.value.copy(
-                dismissedEventIds = _state.value.dismissedEventIds + eventId,
-                recommendedEvents = _state.value.recommendedEvents.filter { it.id != eventId },
-            )
-        filterEvents()
-
-        // Only send feedback for events the recommendation engine actually surfaced
-        if (removedFromRecommended == null) return
-
+        // The card stays on the list — swipe is feedback only, not a dismiss.
+        // Send POST best-effort; the recommendation engine learns for future
+        // fetches but the current view never changes.
+        val isRecommended = _state.value.recommendedEvents.any { it.id == eventId }
+        if (!isRecommended) return
         viewModelScope.launch {
-            val result = apiService.postEventFeedback(eventId, feedback)
-            if (result is ApiResult.Error) {
-                _state.value =
-                    _state.value.copy(
-                        dismissedEventIds = _state.value.dismissedEventIds - eventId,
-                        recommendedEvents = _state.value.recommendedEvents + removedFromRecommended,
-                    )
-                filterEvents()
-            }
+            apiService.postEventFeedback(eventId, feedback)
         }
     }
 
@@ -308,8 +293,6 @@ class EventsViewModel(
             }
         val filtered =
             source.filter { event ->
-                val notDismissed =
-                    current.activeFilter != TimeFilter.ALL || event.id !in current.dismissedEventIds
                 val matchesSearch =
                     current.searchQuery.isBlank() ||
                         event.title.contains(current.searchQuery, ignoreCase = true)
@@ -320,7 +303,7 @@ class EventsViewModel(
                 val matchesTags =
                     current.selectedCategories.isEmpty() ||
                         event.tags.any { it.category in current.selectedCategories }
-                notDismissed && matchesSearch && matchesTime && matchesTags
+                matchesSearch && matchesTime && matchesTags
             }
         _state.value = current.copy(events = filtered)
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
@@ -5,10 +5,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -23,11 +24,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.Fill
 import com.adamglin.phosphoricons.bold.BookmarkSimple
+import com.adamglin.phosphoricons.bold.X
 import com.adamglin.phosphoricons.fill.BookmarkSimple
 import com.adamglin.phosphoricons.fill.PaperPlaneRight
 import com.poziomki.app.ui.designsystem.components.AppButton
@@ -63,66 +67,92 @@ fun ProfileViewScreen(
                     }
                 val emoji = p.profilePicture?.takeUnless { isImageUrl(it) }
 
+                val statusBarTop =
+                    WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
                 val bottomInsets =
                     WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-                ProfilePreview(
-                    name = p.name,
-                    program = p.program,
-                    bio = p.bio,
-                    tags = p.tags,
-                    images = images,
-                    emojiAvatar = emoji,
-                    gradientStart = p.gradientStart,
-                    gradientEnd = p.gradientEnd,
-                    onClose = onBack,
-                    headerAction =
-                        if (!state.isOwnProfile) {
-                            {
-                                IconButton(onClick = { viewModel.toggleBookmark() }) {
-                                    Icon(
-                                        imageVector =
-                                            if (state.isBookmarked) {
-                                                PhosphorIcons.Fill.BookmarkSimple
-                                            } else {
-                                                PhosphorIcons.Bold.BookmarkSimple
-                                            },
-                                        contentDescription =
-                                            if (state.isBookmarked) "Usuń zakładkę" else "Dodaj zakładkę",
-                                        tint = if (state.isBookmarked) Primary else White,
-                                        modifier = Modifier.size(22.dp),
-                                    )
+                Box(modifier = Modifier.fillMaxSize()) {
+                    ProfilePreview(
+                        name = p.name,
+                        program = p.program,
+                        bio = p.bio,
+                        tags = p.tags,
+                        images = images,
+                        emojiAvatar = emoji,
+                        gradientStart = p.gradientStart,
+                        gradientEnd = p.gradientEnd,
+                        // X is rendered as a sticky overlay below; tell
+                        // ProfilePreview not to draw its own (which would
+                        // scroll with the image carousel).
+                        onClose = null,
+                        headerAction =
+                            if (!state.isOwnProfile) {
+                                {
+                                    IconButton(onClick = { viewModel.toggleBookmark() }) {
+                                        Icon(
+                                            imageVector =
+                                                if (state.isBookmarked) {
+                                                    PhosphorIcons.Fill.BookmarkSimple
+                                                } else {
+                                                    PhosphorIcons.Bold.BookmarkSimple
+                                                },
+                                            contentDescription =
+                                                if (state.isBookmarked) {
+                                                    "Usuń zakładkę"
+                                                } else {
+                                                    "Dodaj zakładkę"
+                                                },
+                                            tint = if (state.isBookmarked) Primary else White,
+                                            modifier = Modifier.size(22.dp),
+                                        )
+                                    }
                                 }
-                            }
-                        } else {
-                            null
-                        },
-                    bottomContent =
-                        if (!state.isOwnProfile) {
-                            {
-                                Box(
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .padding(
-                                                start = 16.dp,
-                                                end = 16.dp,
-                                                top = 12.dp,
-                                                bottom = bottomInsets + 20.dp,
-                                            ),
-                                    contentAlignment = Alignment.CenterEnd,
-                                ) {
-                                    AppButton(
-                                        text = "Wiadomość",
-                                        onClick = { onNavigateToChat(p.userId, p.name, p.id) },
-                                        variant = ButtonVariant.PRIMARY,
-                                        icon = PhosphorIcons.Fill.PaperPlaneRight,
-                                    )
-                                }
-                            }
-                        } else {
-                            null
-                        },
-                )
+                            } else {
+                                null
+                            },
+                    )
+
+                    // Sticky X (close) — top-end, above status bar. Does NOT
+                    // scroll with the image carousel, so it's reachable at
+                    // every scroll position.
+                    IconButton(
+                        onClick = onBack,
+                        modifier =
+                            Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(top = statusBarTop + 8.dp, end = 20.dp)
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(Color.Black.copy(alpha = 0.45f)),
+                    ) {
+                        Icon(
+                            imageVector = PhosphorIcons.Bold.X,
+                            contentDescription = "Zamknij",
+                            tint = White,
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+
+                    // Sticky "Wiadomość" — bottom-end, above the system nav
+                    // bar. Same anchor on every screen of every profile so
+                    // the user always taps the same spot. ProfilePreview
+                    // adds bottom headroom so content scrolls clear of it.
+                    if (!state.isOwnProfile) {
+                        AppButton(
+                            text = "Wiadomość",
+                            onClick = { onNavigateToChat(p.userId, p.name, p.id) },
+                            variant = ButtonVariant.PRIMARY,
+                            icon = PhosphorIcons.Fill.PaperPlaneRight,
+                            modifier =
+                                Modifier
+                                    .align(Alignment.BottomEnd)
+                                    .padding(
+                                        end = 16.dp,
+                                        bottom = bottomInsets + 24.dp,
+                                    ),
+                        )
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
- swipe in 'polecane' no longer removes the card from the list (was filtered in EventsViewModel.onSwipeFeedback). Feedback still POSTs to the recommendation engine.
- status bar scrim flipped from TRANSPARENT to BLACK so it matches the dark nav bar; photos / event covers / map no longer bleed under it.
- 'Wiadomość' and X (close) on profile are now sticky overlays anchored to BottomEnd / TopEnd of the screen, with navigationBars + 96.dp of bottom headroom so content always scrolls clear of them.

Out of scope: map not loading at all (separate ticket).

- [ ] swipe a recommended event card both ways → card stays, feedback POSTs
- [ ] system status bar opaque black, ikony jasne
- [ ] open another user's profile → X top-right, Wiadomość bottom-right, both reachable at every scroll, click both works

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix swipe-keep behavior, dark status bar, and sticky profile overlay buttons
> - Swiping an event card now sends feedback via `postEventFeedback` without removing the card from the list; dismissed event ID tracking is removed from `EventsState` and `filterEvents` entirely
> - `ProfileViewScreen` wraps `ProfilePreview` in a `Box` and renders a sticky top-right close button and a sticky bottom-right 'Wiadomość' button, both inset-aware so they stay fixed during scroll
> - `ProfilePreview` makes `onClose` nullable (default `null`) and only renders its internal X button when a callback is provided; extra bottom spacing accounts for the navigation bar and overlay button
> - Android status bar background changes from transparent to black in `MainActivity`
> - Behavioral Change: swiped events remain visible in the list and there is no local rollback on feedback POST failure
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8e5b23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->