### PR TITLE
fix: swipe bounce, mark-read after history, drop bell icon

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -25,6 +25,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -802,6 +806,21 @@ class ChatViewModel(
             }
 
         timelineController.enterLive()
+        // markAsRead reads the latest event id off the in-memory timeline,
+        // so calling it here is a no-op until history is actually loaded
+        // (a freshly bound room starts empty). Re-fire it the first time
+        // _uiState.timelineItems contains at least one event — that's when
+        // we have a concrete latest message id to advance the watermark to.
+        // The job lives in roomJobs so it cancels with the room.
+        roomJobs +=
+            viewModelScope.launch {
+                _uiState
+                    .map { it.timelineItems.isNotEmpty() }
+                    .distinctUntilChanged()
+                    .filter { it }
+                    .first()
+                runCatching { room.markAsRead() }
+            }
         runCatching { room.markAsRead() }
     }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -322,25 +323,39 @@ private fun SwipeableEventCard(
     onCreatorClick: (() -> Unit)?,
     onSwipeFeedback: (String) -> Unit,
 ) {
-    val dismissState = rememberSwipeToDismissBoxState()
+    // Capture the latest callback so SwipeToDismissBoxState — which we
+    // remember once per card — can call it without being recreated when
+    // the lambda identity changes on recomposition.
+    val currentFeedback by rememberUpdatedState(onSwipeFeedback)
 
-    LaunchedEffect(dismissState.currentValue) {
-        when (dismissState.currentValue) {
-            SwipeToDismissBoxValue.StartToEnd -> {
-                onSwipeFeedback("more")
-                dismissState.reset()
-            }
+    // confirmValueChange is deprecated upstream but still the cleanest way
+    // to short-circuit a SwipeToDismiss into "feedback only, no commit":
+    // we reject the new value and Material3 animates the card back to
+    // Settled itself — proper bounce-off, no reset() race against the
+    // dismissal animation. The deprecation suggests rewriting with dynamic
+    // anchors, which would be a much bigger change for a UI signal we
+    // never actually want to commit to.
+    @Suppress("DEPRECATION")
+    val dismissState =
+        rememberSwipeToDismissBoxState(
+            confirmValueChange = { value ->
+                when (value) {
+                    SwipeToDismissBoxValue.StartToEnd -> {
+                        currentFeedback("more")
+                        false
+                    }
 
-            SwipeToDismissBoxValue.EndToStart -> {
-                onSwipeFeedback("less")
-                dismissState.reset()
-            }
+                    SwipeToDismissBoxValue.EndToStart -> {
+                        currentFeedback("less")
+                        false
+                    }
 
-            SwipeToDismissBoxValue.Settled -> {
-                Unit
-            }
-        }
-    }
+                    SwipeToDismissBoxValue.Settled -> {
+                        true
+                    }
+                }
+            },
+        )
 
     SwipeToDismissBox(
         state = dismissState,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -65,7 +65,6 @@ fun MessagesScreen(
     val state by viewModel.state.collectAsState()
     var selectedFilter by remember { mutableStateOf(MessagesRoomFilter.All) }
 
-    val unreadTotal = state.rooms.sumOf { it.unreadCount }
     val filteredRooms =
         state.rooms.filterMessagesRooms(
             selectedFilter,
@@ -83,25 +82,6 @@ fun MessagesScreen(
                     .background(Background),
         ) {
             ScreenHeader(title = "wiadomości") {
-                if (unreadTotal > 0) {
-                    Box {
-                        Icon(
-                            imageVector = PhosphorIcons.Bold.Bell,
-                            contentDescription = "Powiadomienia",
-                            tint = TextSecondary,
-                            modifier = Modifier.size(24.dp),
-                        )
-                        Badge(
-                            containerColor = MaterialTheme.colorScheme.error,
-                            contentColor = TextPrimary,
-                            modifier =
-                                Modifier
-                                    .align(Alignment.TopEnd)
-                                    .size(10.dp),
-                        ) {}
-                    }
-                    Spacer(modifier = Modifier.width(4.dp))
-                }
                 profileAvatarAction()
             }
             PoziomkiSearchBar(


### PR DESCRIPTION
Three-in-one followup:

- swipe in 'polecane' uses Material3's confirmValueChange so the card animates back to Settled by the framework — proper bounce-off, no jerky reset() race.
- mark-as-read fires a second time once history loads (the first call right after enterLive() was a no-op against an empty timeline).
- removed the bell icon + red dot from the messages screen header.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix swipe bounce, delay mark-read until timeline loads, and remove bell icon from messages header
> - Fixes swipe feedback in `SwipeableEventCard` by rejecting state changes via `confirmValueChange` instead of calling `reset()` after dismissal, so the card bounces back automatically.
> - Adds a second `room.markAsRead()` call in `ChatViewModel` that fires once the timeline has at least one item, ensuring read state is marked after history loads.
> - Removes the bell icon and unread badge from the `MessagesScreen` header entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b93366.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->