### PR TITLE
fix(messages): stable layout — name and preview don't shift on unread

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -74,36 +74,45 @@ fun RoomRow(
                     text = displayName,
                     style = MaterialTheme.typography.titleMedium,
                     color = TextPrimary,
-                    fontWeight = if (room.unreadCount > 0) FontWeight.Bold else FontWeight.SemiBold,
+                    // Keep the name weight constant across read/unread so its
+                    // characters never reflow horizontally. Unread state is
+                    // signalled by the preview color + timestamp tint + the
+                    // count badge in the fixed-width slot below — none of
+                    // which shift the name's left/right edges.
+                    fontWeight = FontWeight.SemiBold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
                 )
-                if (room.latestTimestampMillis != null || room.unreadCount > 0) {
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column(horizontalAlignment = Alignment.End) {
-                        room.latestTimestampMillis?.let {
+                // Right-hand meta column. Width is reserved (not wrapContent)
+                // so adding/removing the unread badge does not change the
+                // column width — that was what made the name + preview jiggle
+                // a few pixels left when a new message arrived.
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(
+                    horizontalAlignment = Alignment.End,
+                    modifier = Modifier.width(48.dp),
+                ) {
+                    room.latestTimestampMillis?.let {
+                        Text(
+                            text = formatRoomTimestamp(it),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (room.unreadCount > 0) Primary else TextSecondary,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                    if (room.unreadCount > 0) {
+                        Surface(
+                            color = Primary,
+                            contentColor = Background,
+                            shape = CircleShape,
+                        ) {
                             Text(
-                                text = formatRoomTimestamp(it),
+                                text = if (room.unreadCount > 99) "99+" else room.unreadCount.toString(),
                                 style = MaterialTheme.typography.labelSmall,
-                                color = if (room.unreadCount > 0) Primary else TextSecondary,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
                             )
-                        }
-                        if (room.unreadCount > 0) {
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Surface(
-                                color = Primary,
-                                contentColor = Background,
-                                shape = CircleShape,
-                                modifier = Modifier,
-                            ) {
-                                Text(
-                                    text = if (room.unreadCount > 99) "99+" else room.unreadCount.toString(),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
-                                )
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
Reserve a fixed 48.dp width for the right-hand meta column so the unread badge appearing/disappearing never reflows the row, and keep the name SemiBold across read/unread states.

- [ ] open chat list, send a message from another account → name and preview don't shift left when the badge appears

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stable layout in `RoomRow` so name and preview don't shift on unread
> - The room name text now always uses `FontWeight.SemiBold` instead of toggling to `Bold` for unread rooms, preventing text reflow.
> - The right-hand meta column is now always rendered with a fixed width of 48dp, so the timestamp and unread badge no longer cause horizontal shifts when unread state changes.
> - Rows with no timestamp and no unread count reserve the 48dp space as empty, keeping all rows aligned consistently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07c9257.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->