### PR TITLE
fix(messages): row height stays the same on unread

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
@@ -84,35 +85,38 @@ fun RoomRow(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
                 )
-                // Right-hand meta column. Width is reserved (not wrapContent)
-                // so adding/removing the unread badge does not change the
-                // column width — that was what made the name + preview jiggle
-                // a few pixels left when a new message arrived.
+                // Right-hand meta column. Width AND height are reserved so
+                // adding/removing the unread badge never changes the row's
+                // size — neither this row's name + preview position, nor the
+                // surrounding rows in the LazyColumn. The badge slot is
+                // always laid out at full size; a transparent placeholder
+                // takes its place when there's nothing to show.
                 Spacer(modifier = Modifier.width(8.dp))
                 Column(
                     horizontalAlignment = Alignment.End,
                     modifier = Modifier.width(48.dp),
                 ) {
-                    room.latestTimestampMillis?.let {
-                        Text(
-                            text = formatRoomTimestamp(it),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = if (room.unreadCount > 0) Primary else TextSecondary,
-                        )
-                    }
+                    Text(
+                        text = room.latestTimestampMillis?.let { formatRoomTimestamp(it) } ?: " ",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (room.unreadCount > 0) Primary else TextSecondary,
+                    )
                     Spacer(modifier = Modifier.height(4.dp))
-                    if (room.unreadCount > 0) {
-                        Surface(
-                            color = Primary,
-                            contentColor = Background,
-                            shape = CircleShape,
-                        ) {
-                            Text(
-                                text = if (room.unreadCount > 99) "99+" else room.unreadCount.toString(),
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold,
-                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
-                            )
+                    Box(modifier = Modifier.size(width = 24.dp, height = 18.dp)) {
+                        if (room.unreadCount > 0) {
+                            Surface(
+                                color = Primary,
+                                contentColor = Background,
+                                shape = CircleShape,
+                                modifier = Modifier.align(Alignment.CenterEnd),
+                            ) {
+                                Text(
+                                    text = if (room.unreadCount > 99) "99+" else room.unreadCount.toString(),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    fontWeight = FontWeight.Bold,
+                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Width was reserved but height was still growing when the badge appeared, pushing every row below it down. Render the badge slot at a fixed size; show empty placeholder when there's nothing to show.

- [ ] open chat list, send a message from another account → that row + every row below stays put when the badge appears

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix row height shifts in `RoomRow` when unread badge or timestamp is absent
> The right-hand meta column in `RoomRow` previously changed height depending on whether a timestamp or unread badge was present, causing layout shifts between read and unread states.
>
> - The timestamp `Text` now always renders, using a blank placeholder when no timestamp is available, so its slot always occupies space.
> - The unread badge is wrapped in a fixed-size container so the row reserves that height even when `unreadCount` is 0.
> - The badge renders inside the container only when `unreadCount > 0`, aligned to the end of the slot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63e1cd4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->