### PR TITLE
fix(messages): room row layout doesn't shift on unread

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "backend": "0.19.0",
-  "mobile/androidApp": "0.19.5"
+  "mobile/androidApp": "0.19.6"
 }

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.19.5" // x-release-please-version
+val appVersionName = "0.19.6" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -34,7 +34,6 @@ import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 import kotlin.time.Instant
 
-@Suppress("CyclomaticComplexMethod", "LongMethod")
 @Composable
 fun RoomRow(
     room: RoomSummary,
@@ -75,54 +74,25 @@ fun RoomRow(
                     text = displayName,
                     style = MaterialTheme.typography.titleMedium,
                     color = TextPrimary,
-                    // Keep the name weight constant across read/unread so its
-                    // characters never reflow horizontally. Unread state is
-                    // signalled by the preview color + timestamp tint + the
-                    // count badge in the fixed-width slot below — none of
-                    // which shift the name's left/right edges.
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
                 )
-                // Right-hand meta column. Width AND height are reserved so
-                // adding/removing the unread badge never changes the row's
-                // size — neither this row's name + preview position, nor the
-                // surrounding rows in the LazyColumn. The badge slot is
-                // always laid out at full size; a transparent placeholder
-                // takes its place when there's nothing to show.
-                Spacer(modifier = Modifier.width(8.dp))
-                Column(
-                    horizontalAlignment = Alignment.End,
-                    modifier = Modifier.width(48.dp),
-                ) {
+                room.latestTimestampMillis?.let {
+                    Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = room.latestTimestampMillis?.let { formatRoomTimestamp(it) } ?: " ",
+                        text = formatRoomTimestamp(it),
                         style = MaterialTheme.typography.labelSmall,
                         color = if (room.unreadCount > 0) Primary else TextSecondary,
                     )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Box(modifier = Modifier.size(width = 24.dp, height = 18.dp)) {
-                        if (room.unreadCount > 0) {
-                            Surface(
-                                color = Primary,
-                                contentColor = Background,
-                                shape = CircleShape,
-                                modifier = Modifier.align(Alignment.CenterEnd),
-                            ) {
-                                Text(
-                                    text = if (room.unreadCount > 99) "99+" else room.unreadCount.toString(),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
-                                )
-                            }
-                        }
-                    }
                 }
             }
             Spacer(modifier = Modifier.height(2.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 val flagged =
                     !room.latestMessageIsMine &&
                         room.latestModerationVerdict in setOf("flag", "block")
@@ -135,11 +105,28 @@ fun RoomRow(
                     overflow = TextOverflow.Ellipsis,
                     modifier =
                         if (flagged) {
-                            Modifier.blur(radius = 8.dp)
+                            Modifier.blur(radius = 8.dp).weight(1f)
                         } else {
-                            Modifier
+                            Modifier.weight(1f)
                         },
                 )
+                Box(modifier = Modifier.size(width = 24.dp, height = 18.dp)) {
+                    if (room.unreadCount > 0) {
+                        Surface(
+                            color = Primary,
+                            contentColor = Background,
+                            shape = CircleShape,
+                            modifier = Modifier.align(Alignment.CenterEnd),
+                        ) {
+                            Text(
+                                text = if (room.unreadCount > 99) "99+" else room.unreadCount.toString(),
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
+                            )
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Restructured the row so timestamp sits next to the name and the unread badge sits next to the preview. Both rows now keep constant height across read/unread, so the name no longer drifts down when a new message arrives.

Drops the prior workaround code (48dp meta column, `" "` placeholder timestamp, in-name-row badge slot).

- [ ] Verify on device: name + preview stay put when a room flips read → unread

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix room row layout shift by moving unread badge to the preview line
> - Moves the unread count badge from a fixed-width column in the top row to the second row, beside the message preview in [RoomRow.kt](https://github.com/poziomki-app/poziomki/pull/320/files#diff-638303e155da802f51e452c8fad551f5d6f23cbe70f9b86990bf5cf49e95de0c).
> - Removes the reserved right-hand meta column in the top row so the room name and timestamp no longer shift layout when unread count changes.
> - The timestamp is now omitted entirely when null instead of reserving space, and the preview text always fills available width.
> - Bumps the Android app version to 0.19.6.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d387060.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->