### PR TITLE
fix(messages): align unread badge to row's right edge

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
@@ -34,7 +33,6 @@ import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 import kotlin.time.Instant
 
-@Suppress("CyclomaticComplexMethod", "LongMethod")
 @Composable
 fun RoomRow(
     room: RoomSummary,
@@ -75,54 +73,25 @@ fun RoomRow(
                     text = displayName,
                     style = MaterialTheme.typography.titleMedium,
                     color = TextPrimary,
-                    // Keep the name weight constant across read/unread so its
-                    // characters never reflow horizontally. Unread state is
-                    // signalled by the preview color + timestamp tint + the
-                    // count badge in the fixed-width slot below — none of
-                    // which shift the name's left/right edges.
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
                 )
-                // Right-hand meta column. Width AND height are reserved so
-                // adding/removing the unread badge never changes the row's
-                // size — neither this row's name + preview position, nor the
-                // surrounding rows in the LazyColumn. The badge slot is
-                // always laid out at full size; a transparent placeholder
-                // takes its place when there's nothing to show.
-                Spacer(modifier = Modifier.width(8.dp))
-                Column(
-                    horizontalAlignment = Alignment.End,
-                    modifier = Modifier.width(48.dp),
-                ) {
+                room.latestTimestampMillis?.let {
+                    Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = room.latestTimestampMillis?.let { formatRoomTimestamp(it) } ?: " ",
+                        text = formatRoomTimestamp(it),
                         style = MaterialTheme.typography.labelSmall,
                         color = if (room.unreadCount > 0) Primary else TextSecondary,
                     )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Box(modifier = Modifier.size(width = 24.dp, height = 18.dp)) {
-                        if (room.unreadCount > 0) {
-                            Surface(
-                                color = Primary,
-                                contentColor = Background,
-                                shape = CircleShape,
-                                modifier = Modifier.align(Alignment.CenterEnd),
-                            ) {
-                                Text(
-                                    text = if (room.unreadCount > 99) "99+" else room.unreadCount.toString(),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
-                                )
-                            }
-                        }
-                    }
                 }
             }
             Spacer(modifier = Modifier.height(2.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 val flagged =
                     !room.latestMessageIsMine &&
                         room.latestModerationVerdict in setOf("flag", "block")
@@ -135,11 +104,26 @@ fun RoomRow(
                     overflow = TextOverflow.Ellipsis,
                     modifier =
                         if (flagged) {
-                            Modifier.blur(radius = 8.dp)
+                            Modifier.blur(radius = 8.dp).weight(1f)
                         } else {
-                            Modifier
+                            Modifier.weight(1f)
                         },
                 )
+                if (room.unreadCount > 0) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Surface(
+                        color = Primary,
+                        contentColor = Background,
+                        shape = CircleShape,
+                    ) {
+                        Text(
+                            text = if (room.unreadCount > 99) "99+" else room.unreadCount.toString(),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- The unread badge sat inside a fixed 24dp Box with CenterEnd, which created a visible gap vs the timestamp's right edge.
- Drop the wrapper, place the Surface directly after the message preview with the same 8dp spacer used by the title row.

## Test plan
- [ ] Open Wiadomości with rooms that have unread counts
- [ ] Confirm badge right edge aligns with the timestamp ("1 min" / "5", "2") above it

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align unread badge to the right edge of the preview row in `RoomRow`
> - Moves the unread count badge from a separate fixed-width meta column into the trailing position of the message preview row, so it sits at the right edge when present.
> - Removes the reserved meta column and blank timestamp placeholder; the timestamp now renders inline next to the display name only when present.
> - Applies `Modifier.weight(1f)` to the preview `Text` so it truncates correctly and leaves space for the trailing badge.
> - Behavioral Change: row layout and text truncation behavior change due to removal of the fixed-width right-hand column; the name line gains horizontal space when no timestamp is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b314438.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->