### PR TITLE
fix(chat): always request fresh history on room open

### DIFF
--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -51,6 +51,15 @@ class WsTimeline(
     private var pendingHistoryDeferred: CompletableDeferred<Boolean>? = null
     private var persistJob: Job? = null
 
+    /**
+     * Tracks how many init/backfill history requests are in flight that don't
+     * own pendingHistoryDeferred. The server processes History requests in
+     * send order and responds in order, so onHistoryResponse can drain this
+     * counter for the next n responses and route them away from any paginate
+     * deferred that may have been set in the meantime.
+     */
+    private var initHistoryRequestsInFlight = 0
+
     init {
         // Load cached items immediately so the UI paints, then always request
         // a fresh history page so any messages that arrived while the room
@@ -76,25 +85,26 @@ class WsTimeline(
                 _hasMoreBackwards.value = !cached.isHydrated
             }
             wsConnection.isConnected.first { it }
-            // Don't fire if a paginate is already in flight — onHistoryResponse
-            // routes every response to a single pendingHistoryDeferred, so an
-            // overlapping init request would complete the paginate's deferred
-            // with the wrong hasMore.
-            if (pendingHistoryDeferred == null && !_isPaginatingBackwards.value) {
-                requestInitialHistory()
-            }
+            sendInitHistoryRequest()
         }
     }
 
-    private suspend fun requestInitialHistory() {
+    private suspend fun sendInitHistoryRequest() {
         if (!wsConnection.isConnected.value) return
-        wsConnection.send(
-            WsClientMessage.History(
-                conversationId = conversationId,
-                before = null,
-                limit = 50,
-            ),
-        )
+        // Mark before sending: response ordering is FIFO, so the next n
+        // history responses are ours, not any concurrent paginate's.
+        initHistoryRequestsInFlight += 1
+        val sent =
+            wsConnection.send(
+                WsClientMessage.History(
+                    conversationId = conversationId,
+                    before = null,
+                    limit = 50,
+                ),
+            )
+        if (!sent) {
+            initHistoryRequestsInFlight = (initHistoryRequestsInFlight - 1).coerceAtLeast(0)
+        }
     }
 
     internal fun backfillOnReconnect() {
@@ -103,7 +113,7 @@ class WsTimeline(
                 _items.value = emptyList()
                 _hasMoreBackwards.value = true
             }
-            requestInitialHistory()
+            sendInitHistoryRequest()
         }
     }
 
@@ -255,6 +265,11 @@ class WsTimeline(
 
     internal fun onHistoryResponse(msg: WsServerMessage.HistoryResponse) {
         cacheHistoryMembers(msg.messages)
+        // Decide ownership before launching: if there's an outstanding
+        // init/backfill request, this response belongs to it (FIFO from
+        // the server) and must not complete a paginate's deferred.
+        val isInitResponse = initHistoryRequestsInFlight > 0
+        if (isInitResponse) initHistoryRequestsInFlight -= 1
         scope.launch {
             itemsMutex.withLock {
                 val uid = wsConnection.userId.value
@@ -279,11 +294,15 @@ class WsTimeline(
                 }
 
                 _hasMoreBackwards.value = msg.hasMore
-                _isPaginatingBackwards.value = false
+                if (!isInitResponse) {
+                    _isPaginatingBackwards.value = false
+                }
                 emitAndPersist(current)
             }
-            pendingHistoryDeferred?.complete(msg.hasMore)
-            pendingHistoryDeferred = null
+            if (!isInitResponse) {
+                pendingHistoryDeferred?.complete(msg.hasMore)
+                pendingHistoryDeferred = null
+            }
         }
     }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -76,7 +76,13 @@ class WsTimeline(
                 _hasMoreBackwards.value = !cached.isHydrated
             }
             wsConnection.isConnected.first { it }
-            requestInitialHistory()
+            // Don't fire if a paginate is already in flight — onHistoryResponse
+            // routes every response to a single pendingHistoryDeferred, so an
+            // overlapping init request would complete the paginate's deferred
+            // with the wrong hasMore.
+            if (pendingHistoryDeferred == null && !_isPaginatingBackwards.value) {
+                requestInitialHistory()
+            }
         }
     }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -24,6 +24,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.random.Random
 import kotlin.time.Clock
 
+private const val CACHE_FRESH_WINDOW_MS = 30_000L
+
 @Suppress("TooManyFunctions")
 class WsTimeline(
     private val conversationId: String,
@@ -51,20 +53,13 @@ class WsTimeline(
     private var pendingHistoryDeferred: CompletableDeferred<Boolean>? = null
     private var persistJob: Job? = null
 
-    /**
-     * Tracks how many init/backfill history requests are in flight that don't
-     * own pendingHistoryDeferred. The server processes History requests in
-     * send order and responds in order, so onHistoryResponse can drain this
-     * counter for the next n responses and route them away from any paginate
-     * deferred that may have been set in the meantime.
-     */
+    // Counter of init/backfill history requests we've sent but haven't yet
+    // matched to a HistoryResponse. Read and mutated only while holding
+    // itemsMutex so onHistoryResponse can safely route a response away from
+    // any paginate deferred set in the meantime.
     private var initHistoryRequestsInFlight = 0
 
     init {
-        // Load cached items immediately so the UI paints, then always request
-        // a fresh history page so any messages that arrived while the room
-        // was closed (and therefore only updated the room preview) are
-        // backfilled into the timeline. onMessage() dedupes by eventId.
         scope.launch {
             val cached = roomTimelineCacheStore.loadSnapshot(conversationId)
             if (cached.items.isNotEmpty()) {
@@ -84,16 +79,24 @@ class WsTimeline(
                 _items.value = corrected
                 _hasMoreBackwards.value = !cached.isHydrated
             }
-            wsConnection.isConnected.first { it }
-            sendInitHistoryRequest()
+            // Skip the server fetch only when the cache is fresh enough that
+            // the user couldn't have plausibly missed messages between close
+            // and reopen. Empty or stale cache always fetches — that's the
+            // backfill the unconditional version was solving for.
+            val nowMs = Clock.System.now().toEpochMilliseconds()
+            val cacheIsFresh =
+                cached.items.isNotEmpty() &&
+                    nowMs - cached.updatedAtMillis < CACHE_FRESH_WINDOW_MS
+            if (!cacheIsFresh) {
+                wsConnection.isConnected.first { it }
+                sendInitHistoryRequest()
+            }
         }
     }
 
     private suspend fun sendInitHistoryRequest() {
         if (!wsConnection.isConnected.value) return
-        // Mark before sending: response ordering is FIFO, so the next n
-        // history responses are ours, not any concurrent paginate's.
-        initHistoryRequestsInFlight += 1
+        itemsMutex.withLock { initHistoryRequestsInFlight += 1 }
         val sent =
             wsConnection.send(
                 WsClientMessage.History(
@@ -103,7 +106,9 @@ class WsTimeline(
                 ),
             )
         if (!sent) {
-            initHistoryRequestsInFlight = (initHistoryRequestsInFlight - 1).coerceAtLeast(0)
+            itemsMutex.withLock {
+                initHistoryRequestsInFlight = (initHistoryRequestsInFlight - 1).coerceAtLeast(0)
+            }
         }
     }
 
@@ -265,13 +270,11 @@ class WsTimeline(
 
     internal fun onHistoryResponse(msg: WsServerMessage.HistoryResponse) {
         cacheHistoryMembers(msg.messages)
-        // Decide ownership before launching: if there's an outstanding
-        // init/backfill request, this response belongs to it (FIFO from
-        // the server) and must not complete a paginate's deferred.
-        val isInitResponse = initHistoryRequestsInFlight > 0
-        if (isInitResponse) initHistoryRequestsInFlight -= 1
         scope.launch {
+            val isInitResponse: Boolean
             itemsMutex.withLock {
+                isInitResponse = initHistoryRequestsInFlight > 0
+                if (isInitResponse) initHistoryRequestsInFlight -= 1
                 val uid = wsConnection.userId.value
                 val historyItems = msg.messages.map { it.toTimelineItem(uid) }
                 val current = _items.value.toMutableList()

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -117,6 +117,12 @@ class WsTimeline(
             itemsMutex.withLock {
                 _items.value = emptyList()
                 _hasMoreBackwards.value = true
+                // Any prior init/backfill requests are stranded once the
+                // socket dropped — the server won't deliver responses for
+                // them. Reset the counter so the new request we're about
+                // to send is the only one we wait on; otherwise stale
+                // counter values misroute the next paginate response.
+                initHistoryRequestsInFlight = 0
             }
             sendInitHistoryRequest()
         }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -51,7 +52,10 @@ class WsTimeline(
     private var persistJob: Job? = null
 
     init {
-        // Load cached items on start, request history if empty
+        // Load cached items immediately so the UI paints, then always request
+        // a fresh history page so any messages that arrived while the room
+        // was closed (and therefore only updated the room preview) are
+        // backfilled into the timeline. onMessage() dedupes by eventId.
         scope.launch {
             val cached = roomTimelineCacheStore.loadSnapshot(conversationId)
             if (cached.items.isNotEmpty()) {
@@ -70,10 +74,9 @@ class WsTimeline(
                     }
                 _items.value = corrected
                 _hasMoreBackwards.value = !cached.isHydrated
-            } else {
-                // No cache — request initial history from server
-                requestInitialHistory()
             }
+            wsConnection.isConnected.first { it }
+            requestInitialHistory()
         }
     }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -88,8 +88,11 @@ class WsTimeline(
                 cached.items.isNotEmpty() &&
                     nowMs - cached.updatedAtMillis < CACHE_FRESH_WINDOW_MS
             if (!cacheIsFresh) {
-                wsConnection.isConnected.first { it }
-                sendInitHistoryRequest()
+                // Bound the wait so an offline open doesn't leave this
+                // coroutine suspended forever. backfillOnReconnect() will
+                // fire the request when the socket actually comes up.
+                val gotConnection = withTimeoutOrNull(10_000L) { wsConnection.isConnected.first { it } }
+                if (gotConnection != null) sendInitHistoryRequest()
             }
         }
     }


### PR DESCRIPTION
## Summary
- WsTimeline only fetched server history when its on-disk cache was empty, so messages that arrived while the room was closed never made it into the timeline.
- Load cache for an instant first paint, then await connection and always request initial history. Dedup by eventId already handles overlap.

## Test plan
- [ ] Send a message from device A while device B has the chat closed
- [ ] Open the chat on B and confirm the new message is in the timeline (not just the preview)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chat room history fetch to avoid overwriting pagination state on room open
> - Adds a `CACHE_FRESH_WINDOW_MS` (30s) freshness check in `WsTimeline` init: skips the initial history fetch if the cache is recent, otherwise waits up to 10s for a WebSocket connection before requesting history.
> - Tracks in-flight initial/backfill history requests via `initHistoryRequestsInFlight` so that `onHistoryResponse` can distinguish init responses from user-triggered pagination responses.
> - Fixes `onHistoryResponse` to only toggle `_isPaginatingBackwards` and resolve `pendingHistoryDeferred` for pagination responses, not for init/backfill responses.
> - On reconnect, `backfillOnReconnect` resets the in-flight counter before issuing a new request to prevent misrouting the next paginate response.
> - Behavioral Change: rooms with a fresh local cache no longer trigger a server history fetch on open; stale or empty caches still fetch from the server.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7a021b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->