### PR TITLE
fix(chat): suppress event-creator avatar leak; plumb avatar through chat nav

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/UserAvatar.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/UserAvatar.kt
@@ -49,7 +49,7 @@ fun UserAvatar(
     size: Dp = 52.dp,
     backgroundColor: Color = Border,
     iconTint: Color = TextMuted,
-    hideFallbackIcon: Boolean = false,
+    showFallbackIcon: Boolean = true,
 ) {
     val emojiSize: TextUnit = (size.value * 0.45f).sp
     val iconSize: Dp = size * 0.5f
@@ -110,7 +110,7 @@ fun UserAvatar(
             }
 
             else -> {
-                if (!hideFallbackIcon) {
+                if (showFallbackIcon) {
                     FallbackUserIcon(iconSize, iconTint)
                 }
             }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/UserAvatar.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/UserAvatar.kt
@@ -40,6 +40,7 @@ private fun isEmoji(value: String): Boolean =
 private const val AVATAR_NULL_FALLBACK_DELAY_MS = 250L
 
 @Composable
+@Suppress("LongMethod", "LongParameterList")
 fun UserAvatar(
     picture: String?,
     fallbackPicture: String? = null,
@@ -48,6 +49,7 @@ fun UserAvatar(
     size: Dp = 52.dp,
     backgroundColor: Color = Border,
     iconTint: Color = TextMuted,
+    hideFallbackIcon: Boolean = false,
 ) {
     val emojiSize: TextUnit = (size.value * 0.45f).sp
     val iconSize: Dp = size * 0.5f
@@ -108,7 +110,9 @@ fun UserAvatar(
             }
 
             else -> {
-                FallbackUserIcon(iconSize, iconTint)
+                if (!hideFallbackIcon) {
+                    FallbackUserIcon(iconSize, iconTint)
+                }
             }
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -86,7 +86,7 @@ fun ChatScreen(
             fallbackDisplayName = initialTitle,
             fallbackDirectUserId = initialDirectUserId,
             fallbackProfileId = initialDirectProfileId,
-            fallbackAvatarUrl = initialAvatarUrl,
+            seedAvatarUrl = initialAvatarUrl,
         )
     }
 
@@ -259,7 +259,7 @@ private fun ChatTopBar(
                     size = 34.dp,
                     backgroundColor = Primary.copy(alpha = 0.2f),
                     iconTint = Primary,
-                    hideFallbackIcon = true,
+                    showFallbackIcon = false,
                 )
                 Spacer(modifier = Modifier.width(10.dp))
                 Text(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -71,6 +71,7 @@ fun ChatScreen(
     initialTitle: String? = null,
     initialDirectUserId: String? = null,
     initialDirectProfileId: String? = null,
+    initialAvatarUrl: String? = null,
     onBack: () -> Unit,
     onNavigateToProfile: (String) -> Unit,
     viewModel: ChatViewModel = koinViewModel(),
@@ -85,6 +86,7 @@ fun ChatScreen(
             fallbackDisplayName = initialTitle,
             fallbackDirectUserId = initialDirectUserId,
             fallbackProfileId = initialDirectProfileId,
+            fallbackAvatarUrl = initialAvatarUrl,
         )
     }
 
@@ -257,6 +259,7 @@ private fun ChatTopBar(
                     size = 34.dp,
                     backgroundColor = Primary.copy(alpha = 0.2f),
                     iconTint = Primary,
+                    hideFallbackIcon = true,
                 )
                 Spacer(modifier = Modifier.width(10.dp))
                 Text(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -626,7 +626,8 @@ class ChatViewModel(
                             roomId = roomId,
                             roomDisplayName = seededDisplayName,
                             roomAvatarUrl =
-                                fallbackDirectUserId?.let { resolveAvatarOverride(it, currentOverrides) },
+                                fallbackDirectUserId?.let { resolveAvatarOverride(it, currentOverrides) }
+                                    ?: fallbackAvatarUrl,
                             directProfileId = activeDirectProfileId ?: activeDirectUserId,
                             avatarOverrides = currentOverrides,
                             isLoading = false,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -85,6 +85,7 @@ class ChatViewModel(
         fallbackDisplayName: String? = null,
         fallbackDirectUserId: String? = null,
         fallbackProfileId: String? = null,
+        fallbackAvatarUrl: String? = null,
     ) {
         if (roomId.isBlank()) return
         if (roomId.length < 2) {
@@ -110,6 +111,7 @@ class ChatViewModel(
                             roomId = roomId,
                             fallbackDisplayName = fallbackDisplayName,
                             fallbackDirectUserId = fallbackDirectUserId,
+                            fallbackAvatarUrl = fallbackAvatarUrl,
                         )
                     } finally {
                         if (bindingRoomId == roomId) {
@@ -530,10 +532,12 @@ class ChatViewModel(
         super.onCleared()
     }
 
+    @Suppress("LongMethod", "CyclomaticComplexMethod")
     private suspend fun bindRoom(
         roomId: String,
         fallbackDisplayName: String?,
         fallbackDirectUserId: String?,
+        fallbackAvatarUrl: String? = null,
     ) {
         focusedTimeline?.close()
         focusedTimeline = null
@@ -566,13 +570,19 @@ class ChatViewModel(
                 ?.trim()
                 ?.takeIf { it.isNotBlank() }
                 ?: knownSummary?.displayName.orEmpty()
+        val seedAvatar =
+            resolveRoomAvatar(
+                summary = knownSummary,
+                overrides = avatarOverrides,
+                roomDisplayName = seededDisplayName,
+                currentAvatar = fallbackAvatarUrl,
+                directUserIdFallback = inferredDirectUserId,
+            ) ?: fallbackAvatarUrl
         _uiState.value =
             ChatUiState(
                 roomId = roomId,
                 roomDisplayName = seededDisplayName,
-                roomAvatarUrl =
-                    knownSummary?.avatarUrl
-                        ?: inferredDirectUserId?.let { resolveAvatarOverride(it, avatarOverrides) },
+                roomAvatarUrl = seedAvatar,
                 isDirectRoom = inferredIsDirect,
                 directProfileId = activeDirectProfileId ?: activeDirectUserId,
                 avatarOverrides = avatarOverrides,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -85,7 +85,7 @@ class ChatViewModel(
         fallbackDisplayName: String? = null,
         fallbackDirectUserId: String? = null,
         fallbackProfileId: String? = null,
-        fallbackAvatarUrl: String? = null,
+        seedAvatarUrl: String? = null,
     ) {
         if (roomId.isBlank()) return
         if (roomId.length < 2) {
@@ -111,7 +111,7 @@ class ChatViewModel(
                             roomId = roomId,
                             fallbackDisplayName = fallbackDisplayName,
                             fallbackDirectUserId = fallbackDirectUserId,
-                            fallbackAvatarUrl = fallbackAvatarUrl,
+                            seedAvatarUrl = seedAvatarUrl,
                         )
                     } finally {
                         if (bindingRoomId == roomId) {
@@ -537,7 +537,7 @@ class ChatViewModel(
         roomId: String,
         fallbackDisplayName: String?,
         fallbackDirectUserId: String?,
-        fallbackAvatarUrl: String? = null,
+        seedAvatarUrl: String? = null,
     ) {
         focusedTimeline?.close()
         focusedTimeline = null
@@ -575,9 +575,9 @@ class ChatViewModel(
                 summary = knownSummary,
                 overrides = avatarOverrides,
                 roomDisplayName = seededDisplayName,
-                currentAvatar = fallbackAvatarUrl,
+                currentAvatar = seedAvatarUrl,
                 directUserIdFallback = inferredDirectUserId,
-            ) ?: fallbackAvatarUrl
+            ) ?: seedAvatarUrl
         _uiState.value =
             ChatUiState(
                 roomId = roomId,
@@ -627,7 +627,7 @@ class ChatViewModel(
                             roomDisplayName = seededDisplayName,
                             roomAvatarUrl =
                                 fallbackDirectUserId?.let { resolveAvatarOverride(it, currentOverrides) }
-                                    ?: fallbackAvatarUrl,
+                                    ?: seedAvatarUrl,
                             directProfileId = activeDirectProfileId ?: activeDirectUserId,
                             avatarOverrides = currentOverrides,
                             isLoading = false,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -55,8 +55,9 @@ import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongMethod")
 fun MessagesScreen(
-    onNavigateToChat: (String) -> Unit,
+    onNavigateToChat: (String, String?) -> Unit,
     onNavigateToNewChat: () -> Unit,
     onNavigateToProfile: (String) -> Unit = {},
     profileAvatarAction: @Composable () -> Unit = {},
@@ -129,7 +130,7 @@ fun MessagesScreen(
                                     RoomRow(
                                         room = room,
                                         profilePictureUrl = profilePicture,
-                                        onClick = { onNavigateToChat(room.roomId) },
+                                        onClick = { onNavigateToChat(room.roomId, profilePicture) },
                                         onAvatarClick =
                                             room.directUserId?.let { userId ->
                                                 { onNavigateToProfile(userId) }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -190,7 +190,7 @@ fun AppNavigation(
                     }
                 }
 
-            navController.navigate(Route.Chat(id = roomId, avatarUrl = avatarHint))
+            navController.navigate(Route.Chat(id = roomId, seedAvatarUrl = avatarHint))
         }
     }
 
@@ -446,7 +446,7 @@ fun AppNavigation(
                 initialTitle = chat.title,
                 initialDirectUserId = chat.directUserId,
                 initialDirectProfileId = chat.directProfileId,
-                initialAvatarUrl = chat.avatarUrl,
+                initialAvatarUrl = chat.seedAvatarUrl,
                 onBack = { navController.popBackStack() },
                 onNavigateToProfile = { id -> navController.navigate(Route.ProfileView(id)) },
             )

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -171,7 +171,7 @@ fun AppNavigation(
         NotificationChatTarget.consume(roomId)
     }
 
-    val navigateToChat: (String) -> Unit = navigateToChat@{ chatTargetId ->
+    val navigateToChat: (String, String?) -> Unit = navigateToChat@{ chatTargetId, avatarHint ->
         if (chatTargetId.isBlank()) return@navigateToChat
         navigationScope.launch {
             val roomId =
@@ -190,7 +190,7 @@ fun AppNavigation(
                     }
                 }
 
-            navController.navigate(Route.Chat(roomId))
+            navController.navigate(Route.Chat(id = roomId, avatarUrl = avatarHint))
         }
     }
 
@@ -446,6 +446,7 @@ fun AppNavigation(
                 initialTitle = chat.title,
                 initialDirectUserId = chat.directUserId,
                 initialDirectProfileId = chat.directProfileId,
+                initialAvatarUrl = chat.avatarUrl,
                 onBack = { navController.popBackStack() },
                 onNavigateToProfile = { id -> navController.navigate(Route.ProfileView(id)) },
             )
@@ -476,7 +477,7 @@ fun MainScreen(
     onNavigateToProfileEdit: () -> Unit,
     onNavigateToPrivacy: () -> Unit,
     onNavigateToSaved: () -> Unit,
-    onNavigateToChat: (String) -> Unit,
+    onNavigateToChat: (String, String?) -> Unit,
     onNavigateToNewChat: () -> Unit,
     onNavigateToGamification: () -> Unit,
     onSignOut: () -> Unit,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/Route.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/Route.kt
@@ -75,6 +75,7 @@ sealed interface Route {
         val title: String? = null,
         val directUserId: String? = null,
         val directProfileId: String? = null,
+        val avatarUrl: String? = null,
     ) : Route
 
     @Serializable data object NewChat : Route

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/Route.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/Route.kt
@@ -75,7 +75,7 @@ sealed interface Route {
         val title: String? = null,
         val directUserId: String? = null,
         val directProfileId: String? = null,
-        val avatarUrl: String? = null,
+        val seedAvatarUrl: String? = null,
     ) : Route
 
     @Serializable data object NewChat : Route

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -345,7 +345,11 @@ private fun WsConversationPayload.toRoomSummary(): RoomSummary =
     RoomSummary(
         roomId = id,
         displayName = if (isDirect) directUserName ?: title ?: "" else title ?: "",
-        avatarUrl = directUserAvatar,
+        // Only direct (1:1) rooms get an avatar from the server payload.
+        // For event/group rooms the cover comes from EventRepository — using
+        // directUserAvatar here would leak the event creator's face as the
+        // room avatar in previews and chat header.
+        avatarUrl = if (isDirect) directUserAvatar else null,
         isDirect = isDirect,
         directUserId = directUserPid ?: directUserId,
         unreadCount = unreadCount.toInt(),


### PR DESCRIPTION
## Summary
- WsChatClient.toRoomSummary: avatarUrl is null for non-direct rooms — kills the event-creator-as-room-avatar leak at the source.
- UserAvatar gains hideFallbackIcon; chat header passes true so a transient null URL never renders the generic bust.
- Route.Chat carries avatarUrl; MessagesScreen passes the resolved row picture and ChatViewModel uses it as the first-frame seed in bindRoom.

## Test plan
- [ ] Open an event chat from Wiadomości — header never shows the creator's face
- [ ] Open a 1:1 chat from Wiadomości — header avatar matches the row from frame one, no generic-icon flash

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix event-creator avatar leak in non-direct rooms and seed chat nav with avatar URL
> - Fixes a bug in `WsConversationPayload.toRoomSummary` where non-direct rooms incorrectly received `directUserAvatar` as their avatar; it is now set to `null` for non-direct rooms.
> - Adds a `seedAvatarUrl` parameter to `Route.Chat` and threads it from `MessagesScreen` through navigation into `ChatScreen` and `ChatViewModel`, so the avatar is visible immediately before full room data loads.
> - Adds a `showFallbackIcon` flag to `UserAvatar` (default `true`) and sets it to `false` in `ChatTopBar` to suppress the placeholder icon when no avatar is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acaf5c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->