### PR TITLE
feat(chat): reliable event-cover sync via /events/mine

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/App.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/App.kt
@@ -14,7 +14,9 @@ import coil3.compose.setSingletonImageLoaderFactory
 import coil3.disk.DiskCache
 import coil3.memory.MemoryCache
 import coil3.network.ktor3.KtorNetworkFetcherFactory
+import coil3.request.crossfade
 import com.poziomki.app.chat.api.ChatClient
+import com.poziomki.app.data.repository.EventRepository
 import com.poziomki.app.data.repository.XpRepository
 import com.poziomki.app.data.sync.SyncEngine
 import com.poziomki.app.session.SessionBootstrapState
@@ -99,14 +101,17 @@ fun App() {
         }
     }
 
-    // Warm up chat client in background so first chat open is fast. Wait
-    // for the migration first — chatClient.ensureStarted opens the WS,
-    // which immediately starts populating room/timeline caches that the
-    // migrator might otherwise wipe out from underneath it.
+    // Warm up chat client + event metadata in background so room previews
+    // and chat headers have correct event covers from first paint. Wait for
+    // the migration first — chatClient.ensureStarted opens the WS, which
+    // immediately starts populating room/timeline caches that the migrator
+    // might otherwise wipe out from underneath it.
+    val eventRepository = koinInject<EventRepository>()
     LaunchedEffect(startDestination) {
         if (startDestination == Route.MainGraph) {
             migrator.ready.await()
             chatClient.ensureStarted()
+            runCatching { eventRepository.refreshMyEvents() }
         }
     }
 
@@ -131,6 +136,7 @@ private fun buildImageLoaderFactory(imageHttpClient: HttpClient): (PlatformConte
     { context: PlatformContext ->
         ImageLoader
             .Builder(context)
+            .crossfade(150)
             .memoryCache {
                 MemoryCache
                     .Builder()

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -1170,7 +1170,10 @@ class ChatViewModel(
         // through to summary.avatarUrl, currentAvatar, or by-name lookups —
         // those can carry the creator's face or another person's profile pic
         // that happens to match the event title.
-        if (rid != null && (rid in eventRoomIds || summary?.isDirect == false)) {
+        // Scope this strictly to known event rooms; non-direct group rooms
+        // that aren't events should still resolve through the normal fallback
+        // chain so their avatars don't disappear.
+        if (rid != null && rid in eventRoomIds) {
             return eventCoverByRoomId[rid]
         }
         val eventCover = rid?.let { eventCoverByRoomId[it] }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -74,10 +74,12 @@ class ChatViewModel(
     private var activeDirectProfileId: String? = null
     private var latestAvatarByName: Map<String, String> = emptyMap()
     private var eventCoverByRoomId: Map<String, String> = emptyMap()
+    private var eventRoomIds: Set<String> = emptySet()
 
     init {
         observeAvatarOverrides()
         observeEventCovers()
+        observeEventRoomIds()
     }
 
     fun loadRoom(
@@ -564,6 +566,27 @@ class ChatViewModel(
         val inferredIsDirect = knownSummary?.isDirect ?: (inferredDirectUserId != null)
         activeDirectUserId = inferredDirectUserId
 
+        // If this room is an event, prefer the cover from the local event DB
+        // so we never paint the creator's avatar that the server may send as
+        // directUserAvatar. Read synchronously before the first frame so the
+        // cover is in eventCoverByRoomId by the time resolveRoomAvatar runs.
+        val knownEvent =
+            runCatching { eventRepository.findByConversationId(roomId) }.getOrNull()
+        if (knownEvent != null) {
+            eventRoomIds = eventRoomIds + roomId
+            knownEvent.coverImage?.let { cover ->
+                eventCoverByRoomId = eventCoverByRoomId + (roomId to cover)
+            }
+        } else if (knownSummary?.isDirect == false) {
+            // Non-direct room not yet in local event DB — pull /events/mine
+            // (the dataset that maps conversations to events) so the cover
+            // lands as soon as possible. Don't await; the observers rebind
+            // the avatar when the row arrives.
+            viewModelScope.launch {
+                runCatching { eventRepository.refreshMyEvents(forceRefresh = true) }
+            }
+        }
+
         val avatarOverrides = _uiState.value.avatarOverrides
         val seededDisplayName =
             fallbackDisplayName
@@ -571,13 +594,20 @@ class ChatViewModel(
                 ?.takeIf { it.isNotBlank() }
                 ?: knownSummary?.displayName.orEmpty()
         val seedAvatar =
-            resolveRoomAvatar(
-                summary = knownSummary,
-                overrides = avatarOverrides,
-                roomDisplayName = seededDisplayName,
-                currentAvatar = seedAvatarUrl,
-                directUserIdFallback = inferredDirectUserId,
-            ) ?: seedAvatarUrl
+            if (knownEvent != null) {
+                // Event room: only the cover is acceptable. Never fall back
+                // to seedAvatarUrl or summary avatar — those can hold
+                // the creator's face.
+                knownEvent.coverImage
+            } else {
+                resolveRoomAvatar(
+                    summary = knownSummary,
+                    overrides = avatarOverrides,
+                    roomDisplayName = seededDisplayName,
+                    currentAvatar = seedAvatarUrl,
+                    directUserIdFallback = inferredDirectUserId,
+                ) ?: seedAvatarUrl
+            }
         _uiState.value =
             ChatUiState(
                 roomId = roomId,
@@ -1083,12 +1113,35 @@ class ChatViewModel(
         }
     }
 
+    private fun observeEventRoomIds() {
+        viewModelScope.launch {
+            eventRepository.observeEventConversationIds().collect { ids ->
+                eventRoomIds = ids
+                _uiState.update { current ->
+                    val rid = current.roomId
+                    if (rid in ids) {
+                        // Force the event-room avatar resolution for the
+                        // currently bound room so a stale creator avatar
+                        // can't survive in roomAvatarUrl.
+                        current.copy(roomAvatarUrl = eventCoverByRoomId[rid])
+                    } else {
+                        current
+                    }
+                }
+            }
+        }
+    }
+
     private fun observeEventCovers() {
         viewModelScope.launch {
-            eventRepository.observeEvents().collect { events ->
+            // observeEventsWithConversation includes events fetched via
+            // /events/mine that aren't in the public feed (in_list_feed=0),
+            // so chat headers can find their covers regardless of how the
+            // event row was hydrated.
+            eventRepository.observeEventsWithConversation().collect { events ->
                 val covers =
                     events
-                        .filter { it.isAttending && it.conversationId != null && it.coverImage != null }
+                        .filter { it.conversationId != null && it.coverImage != null }
                         .associate { it.conversationId!! to it.coverImage!! }
                 eventCoverByRoomId = covers
                 _uiState.update { current ->
@@ -1112,7 +1165,15 @@ class ChatViewModel(
         timelineAvatar: String? = null,
         directUserIdFallback: String? = null,
     ): String? {
-        val eventCover = summary?.roomId?.let { eventCoverByRoomId[it] }
+        val rid = (summary?.roomId ?: _uiState.value.roomId).takeIf { it.isNotBlank() }
+        // Event rooms must resolve only to the event cover. Never fall
+        // through to summary.avatarUrl, currentAvatar, or by-name lookups —
+        // those can carry the creator's face or another person's profile pic
+        // that happens to match the event title.
+        if (rid != null && (rid in eventRoomIds || summary?.isDirect == false)) {
+            return eventCoverByRoomId[rid]
+        }
+        val eventCover = rid?.let { eventCoverByRoomId[it] }
         if (eventCover != null) return eventCover
         val directUserId = summary?.directUserId ?: directUserIdFallback
         val summaryAvatar =

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -578,8 +578,11 @@ class ChatViewModel(
                 eventCoverByRoomId = eventCoverByRoomId + (roomId to cover)
             }
         } else if (knownSummary?.isDirect == false) {
+            // Don't force-refresh: rely on CachePolicy so /events/mine fires at
+            // most once per stale window, regardless of how many plain group
+            // chats the user opens.
             viewModelScope.launch {
-                runCatching { eventRepository.refreshMyEvents(forceRefresh = true) }
+                runCatching { eventRepository.refreshMyEvents() }
             }
         }
 
@@ -1114,11 +1117,15 @@ class ChatViewModel(
             eventRepository.observeEventsWithConversation().collect { events ->
                 val withConversation =
                     events.filter { !it.conversationId.isNullOrBlank() }
-                eventRoomIds = withConversation.mapNotNull { it.conversationId }.toSet()
-                eventCoverByRoomId =
+                // Union rather than reassign so a synchronously seeded id
+                // (see bindRoom) survives until the local DB row appears in
+                // the next emission.
+                eventRoomIds = eventRoomIds + withConversation.mapNotNull { it.conversationId }
+                val newCovers =
                     withConversation
                         .filter { it.coverImage != null }
                         .associate { it.conversationId!! to it.coverImage!! }
+                eventCoverByRoomId = eventCoverByRoomId + newCovers
                 _uiState.update { current ->
                     val rid = current.roomId
                     if (rid in eventRoomIds) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -78,8 +78,7 @@ class ChatViewModel(
 
     init {
         observeAvatarOverrides()
-        observeEventCovers()
-        observeEventRoomIds()
+        observeEventRooms()
     }
 
     fun loadRoom(
@@ -566,22 +565,19 @@ class ChatViewModel(
         val inferredIsDirect = knownSummary?.isDirect ?: (inferredDirectUserId != null)
         activeDirectUserId = inferredDirectUserId
 
-        // If this room is an event, prefer the cover from the local event DB
-        // so we never paint the creator's avatar that the server may send as
-        // directUserAvatar. Read synchronously before the first frame so the
-        // cover is in eventCoverByRoomId by the time resolveRoomAvatar runs.
-        val knownEvent =
-            runCatching { eventRepository.findByConversationId(roomId) }.getOrNull()
+        // Seed eventRoomIds + eventCoverByRoomId synchronously before
+        // resolveRoomAvatar runs, so an event-room first-frame can't fall
+        // back to the creator's avatar in the gap between bind and the
+        // observeEventRooms emission. For non-direct rooms not yet in the
+        // local event DB, kick off /events/mine so the cover lands ASAP;
+        // observers rebind the avatar when the row arrives.
+        val knownEvent = runCatching { eventRepository.findByConversationId(roomId) }.getOrNull()
         if (knownEvent != null) {
             eventRoomIds = eventRoomIds + roomId
             knownEvent.coverImage?.let { cover ->
                 eventCoverByRoomId = eventCoverByRoomId + (roomId to cover)
             }
         } else if (knownSummary?.isDirect == false) {
-            // Non-direct room not yet in local event DB — pull /events/mine
-            // (the dataset that maps conversations to events) so the cover
-            // lands as soon as possible. Don't await; the observers rebind
-            // the avatar when the row arrives.
             viewModelScope.launch {
                 runCatching { eventRepository.refreshMyEvents(forceRefresh = true) }
             }
@@ -594,20 +590,13 @@ class ChatViewModel(
                 ?.takeIf { it.isNotBlank() }
                 ?: knownSummary?.displayName.orEmpty()
         val seedAvatar =
-            if (knownEvent != null) {
-                // Event room: only the cover is acceptable. Never fall back
-                // to seedAvatarUrl or summary avatar — those can hold
-                // the creator's face.
-                knownEvent.coverImage
-            } else {
-                resolveRoomAvatar(
-                    summary = knownSummary,
-                    overrides = avatarOverrides,
-                    roomDisplayName = seededDisplayName,
-                    currentAvatar = seedAvatarUrl,
-                    directUserIdFallback = inferredDirectUserId,
-                ) ?: seedAvatarUrl
-            }
+            resolveRoomAvatar(
+                summary = knownSummary,
+                overrides = avatarOverrides,
+                roomDisplayName = seededDisplayName,
+                currentAvatar = seedAvatarUrl,
+                directUserIdFallback = inferredDirectUserId,
+            ) ?: seedAvatarUrl.takeUnless { roomId in eventRoomIds }
         _uiState.value =
             ChatUiState(
                 roomId = roomId,
@@ -1113,42 +1102,28 @@ class ChatViewModel(
         }
     }
 
-    private fun observeEventRoomIds() {
+    private fun observeEventRooms() {
+        // observeEventsWithConversation includes events fetched via
+        // /events/mine that aren't in the public feed (in_list_feed=0),
+        // so chat headers can find their covers regardless of how the
+        // event row was hydrated. Both eventRoomIds (used by the resolver
+        // to short-circuit fallback) and eventCoverByRoomId (the cover
+        // value itself) are derived from the same emission so they can't
+        // disagree.
         viewModelScope.launch {
-            eventRepository.observeEventConversationIds().collect { ids ->
-                eventRoomIds = ids
-                _uiState.update { current ->
-                    val rid = current.roomId
-                    if (rid in ids) {
-                        // Force the event-room avatar resolution for the
-                        // currently bound room so a stale creator avatar
-                        // can't survive in roomAvatarUrl.
-                        current.copy(roomAvatarUrl = eventCoverByRoomId[rid])
-                    } else {
-                        current
-                    }
-                }
-            }
-        }
-    }
-
-    private fun observeEventCovers() {
-        viewModelScope.launch {
-            // observeEventsWithConversation includes events fetched via
-            // /events/mine that aren't in the public feed (in_list_feed=0),
-            // so chat headers can find their covers regardless of how the
-            // event row was hydrated.
             eventRepository.observeEventsWithConversation().collect { events ->
-                val covers =
-                    events
-                        .filter { it.conversationId != null && it.coverImage != null }
+                val withConversation =
+                    events.filter { !it.conversationId.isNullOrBlank() }
+                eventRoomIds = withConversation.mapNotNull { it.conversationId }.toSet()
+                eventCoverByRoomId =
+                    withConversation
+                        .filter { it.coverImage != null }
                         .associate { it.conversationId!! to it.coverImage!! }
-                eventCoverByRoomId = covers
                 _uiState.update { current ->
                     val rid = current.roomId
-                    val eventCover = covers[rid]
-                    if (eventCover != null && current.roomAvatarUrl != eventCover) {
-                        current.copy(roomAvatarUrl = eventCover)
+                    if (rid in eventRoomIds) {
+                        val cover = eventCoverByRoomId[rid]
+                        if (current.roomAvatarUrl != cover) current.copy(roomAvatarUrl = cover) else current
                     } else {
                         current
                     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesViewModel.kt
@@ -88,6 +88,13 @@ class MessagesViewModel(
                 return@launch
             }
 
+            // Pull events the user is involved in so event-room covers are
+            // available in the room list and chat header without the user
+            // first having to visit Wydarzenia. /events/mine returns the
+            // events with conversations the user actually has — this is the
+            // dataset that backs eventRoomAvatars.
+            launch { runCatching { eventRepository.refreshMyEvents() } }
+
             pendingConnectivityRetry = false
             _state.update { current ->
                 if (current.rooms.isNotEmpty()) {
@@ -186,6 +193,7 @@ class MessagesViewModel(
             chatClient.rooms.collect { rooms ->
                 val deduplicatedRooms = deduplicateAndSortRooms(rooms)
                 warmupMissingRoomPreviews(deduplicatedRooms)
+                ensureEventCoversFor(deduplicatedRooms)
                 _state.update { current ->
                     if (current.rooms == deduplicatedRooms && (!current.isLoading || deduplicatedRooms.isEmpty())) {
                         return@update current
@@ -197,6 +205,25 @@ class MessagesViewModel(
                 }
             }
         }
+    }
+
+    private var eventCoverSyncJob: Job? = null
+
+    private fun ensureEventCoversFor(rooms: List<RoomSummary>) {
+        // Whenever non-direct rooms show up without a known event cover,
+        // pull /events/mine. The repo's stale-check keeps this cheap on
+        // subsequent emissions.
+        val needsSync =
+            rooms.any { room ->
+                !room.isDirect &&
+                    _state.value.eventRoomAvatars[room.roomId] == null
+            }
+        if (!needsSync) return
+        if (eventCoverSyncJob?.isActive == true) return
+        eventCoverSyncJob =
+            viewModelScope.launch {
+                runCatching { eventRepository.refreshMyEvents() }
+            }
     }
 
     private fun warmupMissingRoomPreviews(rooms: List<RoomSummary>) {
@@ -252,10 +279,13 @@ class MessagesViewModel(
 
     private fun observeEventRoomAvatars() {
         viewModelScope.launch {
-            eventRepository.observeEvents().collect { events ->
+            // observeEventsWithConversation skips the in_list_feed filter so
+            // events fetched via /events/mine (which we don't put in the feed)
+            // still surface their covers here.
+            eventRepository.observeEventsWithConversation().collect { events ->
                 val avatars =
                     events
-                        .filter { it.isAttending && it.conversationId != null && it.coverImage != null }
+                        .filter { it.conversationId != null && it.coverImage != null }
                         .associate { it.conversationId!! to it.coverImage!! }
                 _state.update { it.copy(eventRoomAvatars = avatars) }
             }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.withContext
 import kotlin.concurrent.Volatile
 import kotlin.time.Clock
 import kotlin.time.Instant
+import com.poziomki.app.db.Event as DbEvent
 
 private fun Event.hasFinished(now: Instant): Boolean {
     val end = endsAt ?: startsAt
@@ -48,6 +49,7 @@ class EventRepository(
         private const val EVENTS_LIST_CACHE_KEY = "events_list"
         private const val RECOMMENDED_CACHE_KEY = "recommended_events"
         private const val SAVED_CACHE_KEY = "saved_events"
+        private const val MY_EVENTS_CACHE_KEY = "my_events"
 
         @Volatile
         private var lastLat: Double? = null
@@ -117,10 +119,24 @@ class EventRepository(
             .mapToList(Dispatchers.IO)
             .map { rows -> rows.map { it.toApiModel() } }
 
+    fun observeEventsWithConversation(): Flow<List<Event>> =
+        db.eventQueries
+            .selectAllWithConversation(::DbEvent)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toApiModel() } }
+
+    suspend fun findByConversationId(conversationId: String): Event? =
+        withContext(Dispatchers.IO) {
+            db.eventQueries
+                .selectByConversationId(conversationId)
+                .executeAsOneOrNull()
+                ?.toApiModel()
+        }
+
     fun observeEventConversationIds(): Flow<Set<String>> =
-        observeEvents().map { events ->
+        observeEventsWithConversation().map { events ->
             events
-                .filter { it.isAttending }
                 .mapNotNull(Event::conversationId)
                 .filter { it.isNotBlank() }
                 .toSet()
@@ -233,6 +249,34 @@ class EventRepository(
                             )
                         }
                         db.cacheStateQueries.upsert(SAVED_CACHE_KEY, now)
+                    }
+                    true
+                }
+
+                is ApiResult.Error -> {
+                    false
+                }
+            }
+        }
+
+    suspend fun refreshMyEvents(forceRefresh: Boolean = false): Boolean =
+        withContext(Dispatchers.IO) {
+            if (!forceRefresh) {
+                val cachedAt =
+                    db.cacheStateQueries
+                        .selectByKey(MY_EVENTS_CACHE_KEY)
+                        .executeAsOneOrNull()
+                        ?.cached_at
+                if (cachedAt != null && !CachePolicy.isStale(cachedAt)) return@withContext true
+            }
+            when (val result = api.getMyEvents()) {
+                is ApiResult.Success -> {
+                    val now = Clock.System.now().toEpochMilliseconds()
+                    db.transaction {
+                        result.data.forEach { event ->
+                            eventMutationManager.upsertEvent(event, now, inListFeed = false)
+                        }
+                        db.cacheStateQueries.upsert(MY_EVENTS_CACHE_KEY, now)
                     }
                     true
                 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
@@ -16,9 +16,11 @@ import com.poziomki.app.network.CreateEventRequest
 import com.poziomki.app.network.Event
 import com.poziomki.app.network.EventAttendee
 import com.poziomki.app.network.UpdateEventRequest
+import com.poziomki.app.session.SessionManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlin.concurrent.Volatile
@@ -37,6 +39,7 @@ private fun List<Event>.dropFinished(): List<Event> {
     return filterNot { it.hasFinished(now) }
 }
 
+@Suppress("LongParameterList")
 class EventRepository(
     private val db: PoziomkiDatabase,
     private val api: ApiService,
@@ -44,12 +47,13 @@ class EventRepository(
     private val pendingOps: PendingOperationsManager,
     private val chatClient: ChatClient,
     syncEngine: SyncEngine,
+    private val sessionManager: SessionManager,
 ) {
     companion object {
         private const val EVENTS_LIST_CACHE_KEY = "events_list"
         private const val RECOMMENDED_CACHE_KEY = "recommended_events"
         private const val SAVED_CACHE_KEY = "saved_events"
-        private const val MY_EVENTS_CACHE_KEY = "my_events"
+        private const val MY_EVENTS_CACHE_KEY_PREFIX = "my_events:"
 
         @Volatile
         private var lastLat: Double? = null
@@ -261,10 +265,15 @@ class EventRepository(
 
     suspend fun refreshMyEvents(forceRefresh: Boolean = false): Boolean =
         withContext(Dispatchers.IO) {
+            // Scope the cache-freshness state to the signed-in user so a
+            // logout/login as a different account never reads from the prior
+            // user's freshness window.
+            val userId = sessionManager.userId.first() ?: return@withContext false
+            val cacheKey = MY_EVENTS_CACHE_KEY_PREFIX + userId
             if (!forceRefresh) {
                 val cachedAt =
                     db.cacheStateQueries
-                        .selectByKey(MY_EVENTS_CACHE_KEY)
+                        .selectByKey(cacheKey)
                         .executeAsOneOrNull()
                         ?.cached_at
                 if (cachedAt != null && !CachePolicy.isStale(cachedAt)) return@withContext true
@@ -276,7 +285,7 @@ class EventRepository(
                         result.data.forEach { event ->
                             eventMutationManager.upsertEvent(event, now, inListFeed = false)
                         }
-                        db.cacheStateQueries.upsert(MY_EVENTS_CACHE_KEY, now)
+                        db.cacheStateQueries.upsert(cacheKey, now)
                     }
                     true
                 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
@@ -58,7 +58,7 @@ val sharedModule =
         single { CacheManager(get()) }
         single { PendingOperationsManager(get()) }
         single { ChatRoomRepository(get()) }
-        single { EventRepository(get(), get(), get(), get(), get(), get()) }
+        single { EventRepository(get(), get(), get(), get(), get(), get(), get()) }
         single { ProfileRepository(get(), get(), get(), get()) }
         single { TagRepository(get(), get()) }
         single { DegreeRepository(get(), get()) }

--- a/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/Event.sq
+++ b/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/Event.sq
@@ -51,6 +51,17 @@ SELECT *
 FROM event
 WHERE id = ?;
 
+selectByConversationId:
+SELECT *
+FROM event
+WHERE conversation_id = ?
+LIMIT 1;
+
+selectAllWithConversation:
+SELECT *
+FROM event
+WHERE conversation_id IS NOT NULL AND conversation_id != '';
+
 upsert:
 INSERT OR REPLACE INTO event(
     id, title, description, cover_image, location,


### PR DESCRIPTION
> Stacked on #324

## Summary
- New refreshMyEvents (api.getMyEvents) so events the user has chats with are pulled regardless of public feed inclusion.
- selectByConversationId + selectAllWithConversation queries; non-feed observers so covers surface even when in_list_feed=0.
- App boot pulls /events/mine alongside chat warm-up; MessagesViewModel and ChatViewModel re-pull on demand when an event-shaped room is missing its cover.
- ChatViewModel hard-suppresses non-cover avatar sources for event rooms; synchronous bindRoom lookup seeds the cover before first paint.
- Coil ImageLoader gains 150ms crossfade for smoother avatar transitions.

## Test plan
- [ ] Fresh install, open Wiadomości — event covers appear without first visiting Wydarzenia
- [ ] Brand-new event chat created mid-session — cover lands without manual nav
- [ ] Event chat header never shows the creator's face

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync event covers in chat via `/events/mine` endpoint
> - Adds `EventRepository.refreshMyEvents()` which fetches the current user's events from the API with per-user cache debouncing and upserts them into the local DB.
> - Adds `EventRepository.findByConversationId()` and `observeEventsWithConversation()` so callers can look up event metadata directly by room/conversation ID without filtering by attendance or feed inclusion.
> - `ChatViewModel` now seeds event cover state synchronously on room open, triggers a background refresh when no local event is found for a non-direct room, and skips user-based avatar fallbacks for event rooms.
> - `MessagesViewModel` refreshes the user's events on load and when non-direct rooms with missing covers appear, using a debounced job to avoid redundant requests.
> - `App` triggers `refreshMyEvents()` at startup after chat client initialization so covers are available before the user opens any room.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3341fb6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->