### PR TITLE
feat(ui): smooth Material 3 shared-axis transitions

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/theme/Motion.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/theme/Motion.kt
@@ -1,0 +1,54 @@
+package com.poziomki.app.ui.designsystem.theme
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+
+object MotionDurations {
+    const val INSTANT = 90
+    const val SHORT = 200
+    const val MEDIUM = 280
+}
+
+// Material 3 "emphasized" easing (https://m3.material.io/styles/motion/easing-and-duration).
+// Both screens share this curve so they feel coupled instead of two independent animations.
+private val Emphasized = CubicBezierEasing(0.2f, 0.0f, 0.0f, 1.0f)
+
+// Material 3 shared-axis-X pattern, tuned tight. Both incoming and outgoing
+// screens travel at the same speed with the same easing, with the outgoing
+// fade weighted to the first ~30% so the new screen is fully visible by the
+// time it stops moving — that's what makes it feel smooth instead of "two
+// things at once".
+
+fun forwardSlide(): EnterTransition =
+    slideInHorizontally(
+        initialOffsetX = { fullWidth -> (fullWidth * 0.18f).toInt() },
+        animationSpec = tween(MotionDurations.MEDIUM, easing = Emphasized),
+    ) + fadeIn(tween(durationMillis = MotionDurations.SHORT, delayMillis = 60, easing = Emphasized))
+
+fun forwardSlideExit(): ExitTransition =
+    slideOutHorizontally(
+        targetOffsetX = { fullWidth -> -(fullWidth * 0.18f).toInt() },
+        animationSpec = tween(MotionDurations.MEDIUM, easing = Emphasized),
+    ) + fadeOut(tween(MotionDurations.INSTANT, easing = Emphasized))
+
+fun backSlide(): EnterTransition =
+    slideInHorizontally(
+        initialOffsetX = { fullWidth -> -(fullWidth * 0.18f).toInt() },
+        animationSpec = tween(MotionDurations.MEDIUM, easing = Emphasized),
+    ) + fadeIn(tween(durationMillis = MotionDurations.SHORT, delayMillis = 60, easing = Emphasized))
+
+fun backSlideExit(): ExitTransition =
+    slideOutHorizontally(
+        targetOffsetX = { fullWidth -> (fullWidth * 0.18f).toInt() },
+        animationSpec = tween(MotionDurations.MEDIUM, easing = Emphasized),
+    ) + fadeOut(tween(MotionDurations.INSTANT, easing = Emphasized))
+
+fun tabFadeIn(): EnterTransition = fadeIn(tween(MotionDurations.INSTANT, easing = Emphasized))
+
+fun tabFadeOut(): ExitTransition = fadeOut(tween(MotionDurations.INSTANT, easing = Emphasized))

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -1,7 +1,5 @@
 package com.poziomki.app.ui.navigation
 
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -78,6 +76,12 @@ import com.poziomki.app.ui.designsystem.components.UserAvatar
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.TextMuted
+import com.poziomki.app.ui.designsystem.theme.backSlide
+import com.poziomki.app.ui.designsystem.theme.backSlideExit
+import com.poziomki.app.ui.designsystem.theme.forwardSlide
+import com.poziomki.app.ui.designsystem.theme.forwardSlideExit
+import com.poziomki.app.ui.designsystem.theme.tabFadeIn
+import com.poziomki.app.ui.designsystem.theme.tabFadeOut
 import com.poziomki.app.ui.feature.auth.AuthViewModel
 import com.poziomki.app.ui.feature.auth.ForgotPasswordScreen
 import com.poziomki.app.ui.feature.auth.LoginScreen
@@ -225,10 +229,10 @@ fun AppNavigation(
         navController = navController,
         startDestination = startDestination,
         modifier = Modifier.fillMaxSize(),
-        enterTransition = { EnterTransition.None },
-        exitTransition = { ExitTransition.None },
-        popEnterTransition = { EnterTransition.None },
-        popExitTransition = { ExitTransition.None },
+        enterTransition = { forwardSlide() },
+        exitTransition = { forwardSlideExit() },
+        popEnterTransition = { backSlide() },
+        popExitTransition = { backSlideExit() },
     ) {
         // Auth graph
         navigation<Route.AuthGraph>(startDestination = Route.Login()) {
@@ -530,10 +534,10 @@ fun MainScreen(
                     NavHost(
                         navController = tabNavController,
                         startDestination = Route.Explore,
-                        enterTransition = { EnterTransition.None },
-                        exitTransition = { ExitTransition.None },
-                        popEnterTransition = { EnterTransition.None },
-                        popExitTransition = { ExitTransition.None },
+                        enterTransition = { tabFadeIn() },
+                        exitTransition = { tabFadeOut() },
+                        popEnterTransition = { tabFadeIn() },
+                        popExitTransition = { tabFadeOut() },
                         modifier = Modifier.fillMaxSize(),
                     ) {
                         composable<Route.Explore> {


### PR DESCRIPTION
> Stacked on #324

## Summary
- New Motion.kt design-system file with M3 emphasized easing, durations and slide/fade builders.
- Top-level NavHost gets shared-axis-X (forward/back). Both incoming and outgoing screens travel together at the same speed so they read as one motion.
- Tab-level NavHost crossfades at 90ms so bottom-bar taps still feel instant.

## Test plan
- [ ] Open chat from Wiadomości / event chat from Wydarzenia / profile from anywhere — slides in
- [ ] Back gesture / button — slides out
- [ ] Bottom-bar tab switches — soft crossfade, no slide

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Material 3 shared-axis transitions and seed avatar URL propagation to chat navigation
> - Adds [Motion.kt](https://github.com/poziomki-app/poziomki/pull/326/files#diff-b209694530e24204f7b90591145e12fe025b4ef42af4caf66bf09e673ef5e092) with slide and fade transition helpers; primary navigation now uses forward/back slide transitions and tab navigation uses fade in/out instead of no-op transitions.
> - Passes an optional avatar URL through the navigation route (`Route.Chat.seedAvatarUrl`) into `ChatViewModel` so the room avatar can be shown before the room data loads.
> - Fixes `WsConversationPayload.toRoomSummary` to only apply `directUserAvatar` for direct rooms, preventing group/event rooms from showing a user avatar.
> - Adds `showFallbackIcon` parameter to `UserAvatar`; the chat top bar sets it to `false` so no fallback icon appears while the avatar is loading.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c16b49.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->