### PR TITLE
feat(moderation): NSFW gate for user uploads via Marqo

### DIFF
--- a/backend/src/api/uploads/image_moderation.rs
+++ b/backend/src/api/uploads/image_moderation.rs
@@ -1,0 +1,95 @@
+//! Synchronous NSFW gate for user-uploaded images. Runs after the cheap
+//! validation chain (mime/size/magic/dimensions/strip) so we never spend
+//! inference cycles on already-rejected input.
+//!
+//! Behaviour mirrors the bio moderation gate in
+//! `api/profiles/write_handler.rs`: returns `Ok(None)` when the engine is
+//! disabled, the image is allowed, or moderation is unreachable for an
+//! infrastructural reason (we fail open on infra errors but log loudly —
+//! the alternative is dropping every upload during an ORT hiccup).
+
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::Response;
+
+use super::uploads_multipart::HandlerError;
+use crate::api::error_response;
+use crate::api::ErrorSpec;
+use crate::moderation::{shared_image, ImageVerdict};
+
+/// Run NSFW moderation against `bytes`. Bytes should already be the
+/// sanitized, re-encoded payload (smaller, predictable format) — both
+/// upload paths call this after `strip_image_metadata`.
+///
+/// Returns `Ok(None)` when the upload may proceed, or `Ok(Some(resp))`
+/// with a 422 the caller must surface verbatim. Inference errors are
+/// logged and treated as "allow"; we don't want a model hiccup to cause
+/// a global upload outage.
+pub(super) async fn moderate_upload_image(
+    headers: &HeaderMap,
+    bytes: &[u8],
+) -> std::result::Result<Option<Response>, HandlerError> {
+    let Some(engine) = shared_image() else {
+        return Ok(None);
+    };
+
+    let owned = bytes.to_vec();
+    let started = std::time::Instant::now();
+    let result = tokio::task::spawn_blocking(move || engine.score(&owned)).await;
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+    metrics::histogram!("image_moderation_inference_latency_ms").record(elapsed_ms);
+
+    let score = match result {
+        Ok(Ok(s)) => s,
+        Ok(Err(err)) => {
+            tracing::error!(%err, elapsed_ms, "image moderation inference failed; allowing upload");
+            metrics::counter!("image_moderation_errors_total", "kind" => "inference").increment(1);
+            return Ok(None);
+        }
+        Err(err) => {
+            tracing::error!(%err, elapsed_ms, "image moderation task join failed; allowing upload");
+            metrics::counter!("image_moderation_errors_total", "kind" => "join").increment(1);
+            return Ok(None);
+        }
+    };
+
+    let verdict = score.verdict();
+    metrics::counter!(
+        "image_moderation_verdicts_total",
+        "verdict" => verdict.as_str()
+    )
+    .increment(1);
+
+    match verdict {
+        ImageVerdict::Allow => Ok(None),
+        ImageVerdict::Block => {
+            tracing::warn!(
+                nsfw = score.nsfw,
+                elapsed_ms,
+                "image moderation: blocked on upload"
+            );
+            Ok(Some(error_response(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                headers,
+                ErrorSpec {
+                    error: "Przesłany obraz narusza zasady społeczności i nie może zostać \
+                            zapisany. Wybierz inne zdjęcie."
+                        .to_string(),
+                    code: "IMAGE_CONTENT_REJECTED",
+                    details: Some(serde_json::json!({ "nsfw": score.nsfw })),
+                },
+            )))
+        }
+    }
+}
+
+/// Convenience: wrap the rejection-or-pass tuple into the existing
+/// `bad_request`-shaped error type used by both upload paths so call
+/// sites stay symmetric with the rest of the validation chain.
+pub(super) async fn moderate_upload_image_or_reject(
+    headers: &HeaderMap,
+    bytes: &[u8],
+) -> std::result::Result<(), HandlerError> {
+    moderate_upload_image(headers, bytes)
+        .await?
+        .map_or_else(|| Ok(()), |resp| Err(Box::new(resp)))
+}

--- a/backend/src/api/uploads/mod.rs
+++ b/backend/src/api/uploads/mod.rs
@@ -2,6 +2,8 @@
 mod uploads_auth_service;
 #[path = "http.rs"]
 mod uploads_http;
+#[path = "image_moderation.rs"]
+mod uploads_image_moderation;
 #[path = "multipart.rs"]
 mod uploads_multipart;
 #[path = "read_handler.rs"]

--- a/backend/src/api/uploads/multipart.rs
+++ b/backend/src/api/uploads/multipart.rs
@@ -290,5 +290,11 @@ pub(in crate::api) async fn read_multipart(
         apply_field(headers, &mut draft, field).await?;
     }
 
-    build_parsed_upload(headers, draft)
+    let parsed = build_parsed_upload(headers, draft)?;
+    // NSFW gate runs last — after the cheap rejections and after
+    // metadata stripping, so the engine sees the same canonical bytes
+    // that downstream consumers will.
+    super::uploads_image_moderation::moderate_upload_image_or_reject(headers, &parsed.bytes)
+        .await?;
+    Ok(parsed)
 }

--- a/backend/src/api/uploads/write_handler.rs
+++ b/backend/src/api/uploads/write_handler.rs
@@ -145,7 +145,18 @@ async fn sanitize_direct_upload(
         }
     };
 
-    // 4. Overwrite with sanitized bytes so downstream readers +
+    // 4. NSFW gate on the sanitized payload. Runs before the storage
+    //    overwrite so a rejected image never lands in the canonical
+    //    bucket, only the presigner's raw upload does — and that gets
+    //    purged below.
+    if let Err(rejection) =
+        super::uploads_image_moderation::moderate_upload_image_or_reject(headers, &sanitized).await
+    {
+        purge_rejected_upload(upload.id, filename).await;
+        return Err(rejection);
+    }
+
+    // 5. Overwrite with sanitized bytes so downstream readers +
     //    variant generation see metadata-stripped content.
     if let Err(err) = uploads_storage::upload(filename, &sanitized, &upload.mime_type).await {
         tracing::warn!(filename, ?err.kind, "failed to overwrite sanitized direct upload");

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -282,8 +282,9 @@ pub async fn run_outbox_worker_process() -> crate::error::AppResult<()> {
     crate::telemetry::init_metrics_exporter(crate::telemetry::ProcessKind::Worker)?;
     crate::moderation::init_from_env()
         .map_err(|e| crate::error::AppError::Message(format!("moderation init: {e}")))?;
-    crate::moderation::init_image_from_env()
-        .map_err(|e| crate::error::AppError::Message(format!("image moderation init: {e}")))?;
+    // Image moderation is upload-path only — the worker has no upload
+    // handlers, so loading the ~22 MB ONNX session here would waste RSS.
+    // If the outbox ever grows an image-scan job, re-add the init.
     let _cfg = load_runtime_config()?;
     let ctx = build_app_context(PoolRole::Worker)?;
     assert_pool_role(PoolRole::Worker).await?;

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -252,6 +252,8 @@ pub async fn run_api_server() -> crate::error::AppResult<()> {
     crate::telemetry::init_metrics_exporter(crate::telemetry::ProcessKind::Api)?;
     crate::moderation::init_from_env()
         .map_err(|e| crate::error::AppError::Message(format!("moderation init: {e}")))?;
+    crate::moderation::init_image_from_env()
+        .map_err(|e| crate::error::AppError::Message(format!("image moderation init: {e}")))?;
     let cfg = load_runtime_config()?;
     let ctx = build_app_context(PoolRole::Api)?;
     assert_pool_role(PoolRole::Api).await?;
@@ -280,6 +282,8 @@ pub async fn run_outbox_worker_process() -> crate::error::AppResult<()> {
     crate::telemetry::init_metrics_exporter(crate::telemetry::ProcessKind::Worker)?;
     crate::moderation::init_from_env()
         .map_err(|e| crate::error::AppError::Message(format!("moderation init: {e}")))?;
+    crate::moderation::init_image_from_env()
+        .map_err(|e| crate::error::AppError::Message(format!("image moderation init: {e}")))?;
     let _cfg = load_runtime_config()?;
     let ctx = build_app_context(PoolRole::Worker)?;
     assert_pool_role(PoolRole::Worker).await?;

--- a/backend/src/moderation/image_engine.rs
+++ b/backend/src/moderation/image_engine.rs
@@ -1,0 +1,220 @@
+//! Image NSFW moderation via ONNX Runtime against the Marqo
+//! `nsfw-image-detection-384` model (ViT-tiny, ~5M params, Apache-2.0).
+//!
+//! Binary classifier — output is a single sigmoid-style probability that
+//! the image is NSFW. We keep the API surface tiny on purpose: the caller
+//! turns the score into an [`ImageVerdict`] via the upload-side threshold,
+//! mirroring the text-moderation flow but without the multi-category
+//! plumbing (no need yet — Marqo only emits NSFW/SFW).
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use fast_image_resize::images::Image as FirImage;
+use fast_image_resize::{PixelType, ResizeOptions, Resizer};
+use image::ImageReader;
+use ndarray::Array4;
+use ort::{
+    session::{builder::GraphOptimizationLevel, Session},
+    value::Tensor,
+};
+use thiserror::Error;
+
+const MODEL_FILE: &str = "model.onnx";
+const INPUT_DIM: u32 = 384;
+
+// ImageNet statistics — Marqo's timm checkpoint uses the standard
+// preprocessing (mean/std applied per channel after /255.0).
+const MEAN: [f32; 3] = [0.485, 0.456, 0.406];
+const STD: [f32; 3] = [0.229, 0.224, 0.225];
+
+#[derive(Debug, Error)]
+pub enum ImageModerationError {
+    #[error("image moderation model directory missing required file: {0}")]
+    MissingFile(PathBuf),
+
+    #[error("failed to load ONNX session: {0}")]
+    Session(#[from] ort::Error),
+
+    #[error("failed to decode image: {0}")]
+    Decode(String),
+
+    #[error("failed to resize image")]
+    Resize,
+
+    #[error("model returned unexpected output shape: {got:?}, expected [1, 2]")]
+    BadOutputShape { got: Vec<usize> },
+
+    #[error("image moderation engine lock poisoned")]
+    LockPoisoned,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct ImageScore {
+    /// Probability in `[0, 1]` that the image is NSFW.
+    pub nsfw: f32,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ImageVerdict {
+    Allow,
+    Block,
+}
+
+impl ImageVerdict {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Block => "block",
+        }
+    }
+}
+
+impl ImageScore {
+    /// Synchronous gate threshold for user-uploaded images. 0.85 favours
+    /// precision — Marqo's binary head is well-calibrated above this band
+    /// (see model card AUC), and false positives on uploads are a worse
+    /// product experience than letting a borderline through to async
+    /// review.
+    pub const BLOCK_THRESHOLD: f32 = 0.85;
+
+    #[must_use]
+    pub fn verdict(self) -> ImageVerdict {
+        if self.nsfw >= Self::BLOCK_THRESHOLD {
+            ImageVerdict::Block
+        } else {
+            ImageVerdict::Allow
+        }
+    }
+}
+
+pub struct ImageModerationEngine {
+    // Same single-session-behind-mutex pattern as the text engine — ORT
+    // intra-op threading already saturates available cores per call, so a
+    // pool buys nothing on CPU.
+    session: Mutex<Session>,
+}
+
+impl ImageModerationEngine {
+    /// Load the Marqo ONNX model from a directory.
+    ///
+    /// Expected layout (produced by `scripts/marqo-export/export_onnx.py`):
+    /// ```text
+    ///   <dir>/model.onnx
+    /// ```
+    ///
+    /// # Errors
+    /// [`ImageModerationError::MissingFile`] if `model.onnx` isn't present;
+    /// [`ImageModerationError::Session`] for ORT init failures.
+    pub fn load_from_dir(dir: &Path, intra_threads: usize) -> Result<Self, ImageModerationError> {
+        let model_path = dir.join(MODEL_FILE);
+        if !model_path.is_file() {
+            return Err(ImageModerationError::MissingFile(model_path));
+        }
+
+        let session = Session::builder()?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(ort::Error::from)?
+            .with_intra_threads(intra_threads)
+            .map_err(ort::Error::from)?
+            .with_memory_pattern(false)
+            .map_err(ort::Error::from)?
+            .commit_from_file(&model_path)?;
+
+        Ok(Self {
+            session: Mutex::new(session),
+        })
+    }
+
+    /// Score raw image bytes. Caller is responsible for `spawn_blocking`.
+    ///
+    /// # Errors
+    /// Decode failures become [`ImageModerationError::Decode`]; downstream
+    /// resize/inference failures map to their respective variants.
+    #[allow(clippy::significant_drop_tightening)]
+    pub fn score(&self, bytes: &[u8]) -> Result<ImageScore, ImageModerationError> {
+        let rgb = decode_to_rgb(bytes)?;
+        let resized = resize_to_input(&rgb)?;
+        let tensor = to_chw_tensor(&resized)?;
+
+        let logits_owned: Vec<f32> = {
+            let mut session = self
+                .session
+                .lock()
+                .map_err(|_| ImageModerationError::LockPoisoned)?;
+            let outputs = session.run(ort::inputs!["input" => tensor])?;
+            // The exporter pins the output name to `output` (see script).
+            let value = outputs
+                .get("output")
+                .ok_or(ImageModerationError::BadOutputShape { got: vec![] })?;
+            let (shape, logits) = value.try_extract_tensor::<f32>()?;
+            let dims: Vec<usize> = shape
+                .iter()
+                .map(|&d| usize::try_from(d).unwrap_or(0))
+                .collect();
+            if dims != [1, 2] {
+                return Err(ImageModerationError::BadOutputShape { got: dims });
+            }
+            logits.to_vec()
+        };
+
+        // timm `vit_tiny_patch16_384` finetune from Marqo emits class
+        // order `[NSFW, SFW]` — softmax index 0 is the NSFW probability.
+        let nsfw = softmax2_first(
+            logits_owned.first().copied().unwrap_or(0.0),
+            logits_owned.get(1).copied().unwrap_or(0.0),
+        );
+        Ok(ImageScore { nsfw })
+    }
+}
+
+fn decode_to_rgb(bytes: &[u8]) -> Result<image::RgbImage, ImageModerationError> {
+    let cursor = std::io::Cursor::new(bytes);
+    let reader = ImageReader::new(cursor)
+        .with_guessed_format()
+        .map_err(|e| ImageModerationError::Decode(e.to_string()))?;
+    let dynamic = reader
+        .decode()
+        .map_err(|e| ImageModerationError::Decode(e.to_string()))?;
+    Ok(dynamic.to_rgb8())
+}
+
+fn resize_to_input(src: &image::RgbImage) -> Result<Vec<u8>, ImageModerationError> {
+    let (w, h) = src.dimensions();
+    let src_image = FirImage::from_vec_u8(w, h, src.as_raw().clone(), PixelType::U8x3)
+        .map_err(|_| ImageModerationError::Resize)?;
+    let mut dst = FirImage::new(INPUT_DIM, INPUT_DIM, PixelType::U8x3);
+    let mut resizer = Resizer::new();
+    resizer
+        .resize(&src_image, &mut dst, &ResizeOptions::default())
+        .map_err(|_| ImageModerationError::Resize)?;
+    Ok(dst.into_vec())
+}
+
+fn to_chw_tensor(rgb: &[u8]) -> Result<Tensor<f32>, ImageModerationError> {
+    let dim = INPUT_DIM as usize;
+    let mut chw = vec![0f32; 3 * dim * dim];
+    let plane = dim * dim;
+    for (idx, chunk) in rgb.chunks_exact(3).enumerate() {
+        for c in 0..3 {
+            let raw = f32::from(chunk.get(c).copied().unwrap_or(0)) / 255.0;
+            let normalized =
+                (raw - MEAN.get(c).copied().unwrap_or(0.0)) / STD.get(c).copied().unwrap_or(1.0);
+            if let Some(slot) = chw.get_mut(c * plane + idx) {
+                *slot = normalized;
+            }
+        }
+    }
+    let arr = Array4::<f32>::from_shape_vec((1, 3, dim, dim), chw)
+        .map_err(|_| ImageModerationError::Resize)?;
+    Tensor::from_array(arr).map_err(ImageModerationError::Session)
+}
+
+#[inline]
+fn softmax2_first(a: f32, b: f32) -> f32 {
+    let m = a.max(b);
+    let ea = (a - m).exp();
+    let eb = (b - m).exp();
+    ea / (ea + eb)
+}

--- a/backend/src/moderation/image_engine.rs
+++ b/backend/src/moderation/image_engine.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use fast_image_resize::images::Image as FirImage;
-use fast_image_resize::{PixelType, ResizeOptions, Resizer};
+use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
 use image::ImageReader;
 use ndarray::Array4;
 use ort::{
@@ -23,10 +23,13 @@ use thiserror::Error;
 const MODEL_FILE: &str = "model.onnx";
 const INPUT_DIM: u32 = 384;
 
-// ImageNet statistics — Marqo's timm checkpoint uses the standard
-// preprocessing (mean/std applied per channel after /255.0).
-const MEAN: [f32; 3] = [0.485, 0.456, 0.406];
-const STD: [f32; 3] = [0.229, 0.224, 0.225];
+// ViT preprocessing per Marqo's pretrained_cfg
+// (https://huggingface.co/Marqo/nsfw-image-detection-384/blob/main/config.json):
+// mean/std are [0.5, 0.5, 0.5] — NOT ImageNet stats. Using ImageNet
+// here silently shifts the input distribution and miscalibrates the
+// NSFW probability.
+const MEAN: [f32; 3] = [0.5, 0.5, 0.5];
+const STD: [f32; 3] = [0.5, 0.5, 0.5];
 
 #[derive(Debug, Error)]
 pub enum ImageModerationError {
@@ -186,8 +189,14 @@ fn resize_to_input(src: &image::RgbImage) -> Result<Vec<u8>, ImageModerationErro
         .map_err(|_| ImageModerationError::Resize)?;
     let mut dst = FirImage::new(INPUT_DIM, INPUT_DIM, PixelType::U8x3);
     let mut resizer = Resizer::new();
+    // HF pretrained_cfg specifies bicubic resampling. CatmullRom is the
+    // canonical bicubic kernel (Keys cubic, a=-0.5) — the same one PIL
+    // uses for `Image.BICUBIC`, which is the de-facto reference for timm
+    // preprocessing. fast_image_resize defaults to Lanczos3, which would
+    // bias the input distribution relative to training.
+    let opts = ResizeOptions::new().resize_alg(ResizeAlg::Convolution(FilterType::CatmullRom));
     resizer
-        .resize(&src_image, &mut dst, &ResizeOptions::default())
+        .resize(&src_image, &mut dst, &opts)
         .map_err(|_| ImageModerationError::Resize)?;
     Ok(dst.into_vec())
 }

--- a/backend/src/moderation/image_global.rs
+++ b/backend/src/moderation/image_global.rs
@@ -1,0 +1,101 @@
+//! Process-wide [`ImageModerationEngine`] singleton, mirroring
+//! [`super::global`] for the text engine. Same env-var contract:
+//!
+//! - `IMAGE_MODERATION_MODEL_PATH` unset → moderation disabled, all
+//!   uploads pass through.
+//! - `IMAGE_MODERATION_REQUIRED` truthy → strict; missing path or files
+//!   is fatal at boot.
+//! - `IMAGE_MODERATION_THREADS` (default 2) — ORT intra-op cap.
+
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+
+use super::image_engine::{ImageModerationEngine, ImageModerationError};
+
+static ENGINE: OnceLock<Option<Arc<ImageModerationEngine>>> = OnceLock::new();
+
+const ENV_MODEL_PATH: &str = "IMAGE_MODERATION_MODEL_PATH";
+const ENV_THREADS: &str = "IMAGE_MODERATION_THREADS";
+const ENV_REQUIRED: &str = "IMAGE_MODERATION_REQUIRED";
+
+fn required_mode() -> bool {
+    std::env::var(ENV_REQUIRED).is_ok_and(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+/// Initialise the global image moderation engine from env. Idempotent.
+///
+/// # Errors
+/// Returns [`ImageModerationError`] when `IMAGE_MODERATION_MODEL_PATH`
+/// is set but the model fails to load (or strictly required and missing).
+pub fn init_image_from_env() -> Result<(), ImageModerationError> {
+    if ENGINE.get().is_some() {
+        return Ok(());
+    }
+
+    let path = std::env::var(ENV_MODEL_PATH)
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty());
+    let strict = required_mode();
+
+    let Some(path) = path else {
+        if strict {
+            return Err(ImageModerationError::MissingFile(PathBuf::from(format!(
+                "${ENV_MODEL_PATH} is required ({ENV_REQUIRED}={})",
+                std::env::var(ENV_REQUIRED).unwrap_or_default()
+            ))));
+        }
+        tracing::warn!(
+            env = ENV_MODEL_PATH,
+            "image moderation disabled: env var unset or empty"
+        );
+        let _ = ENGINE.set(None);
+        metrics::gauge!("image_moderation_engine_loaded").set(0.0);
+        return Ok(());
+    };
+
+    let threads: usize = std::env::var(ENV_THREADS)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(2);
+
+    let dir = PathBuf::from(&path);
+    tracing::info!(path = %path, threads, "loading image moderation engine");
+    let started = std::time::Instant::now();
+    match ImageModerationEngine::load_from_dir(&dir, threads) {
+        Ok(engine) => {
+            let elapsed_ms = started.elapsed().as_millis();
+            tracing::info!(elapsed_ms, "image moderation engine loaded");
+            let _ = ENGINE.set(Some(Arc::new(engine)));
+            metrics::gauge!("image_moderation_engine_loaded").set(1.0);
+            Ok(())
+        }
+        Err(ImageModerationError::MissingFile(missing)) => {
+            if strict {
+                return Err(ImageModerationError::MissingFile(missing));
+            }
+            tracing::warn!(
+                path = %path,
+                missing = %missing.display(),
+                "image moderation disabled: model directory missing required files"
+            );
+            let _ = ENGINE.set(None);
+            metrics::gauge!("image_moderation_engine_loaded").set(0.0);
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Return the shared image engine, or `None` if disabled. Treat `None`
+/// as "allow" at all call sites.
+#[must_use]
+pub fn shared_image() -> Option<Arc<ImageModerationEngine>> {
+    ENGINE.get().and_then(Option::as_ref).map(Arc::clone)
+}

--- a/backend/src/moderation/mod.rs
+++ b/backend/src/moderation/mod.rs
@@ -1,9 +1,18 @@
-//! Text moderation via ONNX Runtime inference against the Bielik-Guard model.
+//! Moderation engines (text + image).
+//!
+//! Text moderation runs the Bielik-Guard model against free-text fields
+//! (bios, event descriptions, chat). Image moderation runs the Marqo
+//! `nsfw-image-detection-384` model against user uploads. Both engines
+//! are independent process-wide singletons.
 
 mod engine;
 mod global;
+mod image_engine;
+mod image_global;
 mod scores;
 
 pub use engine::{ModerationEngine, ModerationError};
 pub use global::{init_from_env, shared};
+pub use image_engine::{ImageModerationEngine, ImageModerationError, ImageScore, ImageVerdict};
+pub use image_global::{init_image_from_env, shared_image};
 pub use scores::{Category, Scores, Thresholds, Verdict};

--- a/backend/tests/image_moderation.rs
+++ b/backend/tests/image_moderation.rs
@@ -1,0 +1,85 @@
+//! End-to-end regression test for the image NSFW engine.
+//!
+//! Loads the real Marqo ONNX model from `IMAGE_MODERATION_MODEL_PATH`
+//! (or skips if unset) and verifies the Rust preprocessing + inference
+//! path matches the Python timm reference within a small tolerance.
+//!
+//! Generate fixtures + reference scores (one-time) with
+//! `scripts/marqo-export/run_reference.py`, then:
+//!
+//! ```text
+//!   IMAGE_MODERATION_MODEL_PATH=$HOME/models/marqo-nsfw-onnx \
+//!   IMAGE_MODERATION_FIXTURES=/tmp/nsfw-e2e/fixtures \
+//!     cargo test --test image_moderation -- --nocapture
+//! ```
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::print_stdout)]
+#![allow(clippy::print_stderr)]
+#![allow(clippy::float_cmp)]
+#![allow(clippy::items_after_statements)]
+
+use std::path::PathBuf;
+
+use poziomki_backend::moderation::ImageModerationEngine;
+
+#[derive(serde::Deserialize)]
+struct RefEntry {
+    path: String,
+    nsfw: f32,
+}
+
+#[test]
+fn rust_inference_matches_python_timm_reference() {
+    let Ok(model_dir) = std::env::var("IMAGE_MODERATION_MODEL_PATH") else {
+        eprintln!("IMAGE_MODERATION_MODEL_PATH unset — skipping image-moderation E2E test");
+        return;
+    };
+    let Ok(fixtures_dir) = std::env::var("IMAGE_MODERATION_FIXTURES") else {
+        eprintln!("IMAGE_MODERATION_FIXTURES unset — skipping image-moderation E2E test");
+        return;
+    };
+
+    let engine = ImageModerationEngine::load_from_dir(&PathBuf::from(&model_dir), 4)
+        .expect("failed to load image moderation engine");
+
+    let ref_path = PathBuf::from(&fixtures_dir).join("reference.json");
+    let raw = std::fs::read_to_string(&ref_path).expect("read reference.json");
+    let refs: std::collections::BTreeMap<String, RefEntry> =
+        serde_json::from_str(&raw).expect("parse reference.json");
+
+    // Tolerance: Rust resize (fast_image_resize CatmullRom) and PIL
+    // BICUBIC are both Keys cubic but the internal pixel-grid math
+    // differs by sub-pixel offsets, which is most visible on smooth
+    // gradients downscaled by large factors. Empirically ≤0.05 absolute
+    // on the softmax probability after fixing mean/std. >0.05 indicates
+    // a real preprocessing bug (mean/std swap, channel swap, missing
+    // /255, etc) — for reference, the original ImageNet-stats bug
+    // produced 0.08–0.14 deltas on these fixtures.
+    const TOLERANCE: f32 = 0.05;
+
+    let mut max_delta: f32 = 0.0;
+    let mut failures = Vec::new();
+    for (name, entry) in &refs {
+        let bytes = std::fs::read(&entry.path).expect("read fixture image");
+        let score = engine.score(&bytes).expect("score fixture");
+        let delta = (score.nsfw - entry.nsfw).abs();
+        max_delta = max_delta.max(delta);
+        println!(
+            "fixture={name} python_nsfw={:.6} rust_nsfw={:.6} delta={:.6}",
+            entry.nsfw, score.nsfw, delta
+        );
+        if delta >= TOLERANCE {
+            failures.push(format!(
+                "{name}: rust={:.6} python={:.6} delta={:.6}",
+                score.nsfw, entry.nsfw, delta
+            ));
+        }
+    }
+    println!("max_delta across fixtures: {max_delta:.6}");
+    assert!(
+        failures.is_empty(),
+        "fixtures exceeded tolerance {TOLERANCE}: {failures:?}"
+    );
+}

--- a/scripts/marqo-export/export_onnx.py
+++ b/scripts/marqo-export/export_onnx.py
@@ -1,0 +1,52 @@
+"""Export Marqo nsfw-image-detection-384 to ONNX (fp32) for the Rust
+image-moderation engine.
+
+Run:
+  uv run --with 'timm>=1.0' --with 'onnx>=1.16' --with torch \
+      --python 3.12 scripts/marqo-export/export_onnx.py
+
+Produces ~/models/marqo-nsfw-onnx/model.onnx (~20 MB fp32). The Rust
+loader expects the file at exactly that name; input tensor `input`
+shape [1, 3, 384, 384] float32, output tensor `output` shape [1, 2].
+"""
+import os
+import pathlib
+import time
+
+import timm
+import torch
+
+OUT = pathlib.Path(os.path.expanduser("~/models/marqo-nsfw-onnx"))
+MODEL_ID = "hf_hub:Marqo/nsfw-image-detection-384"
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    out_path = OUT / "model.onnx"
+
+    print(f"loading {MODEL_ID}")
+    t = time.perf_counter()
+    model = timm.create_model(MODEL_ID, pretrained=True).eval()
+    print(f"  loaded in {time.perf_counter() - t:.1f}s")
+
+    dummy = torch.zeros(1, 3, 384, 384, dtype=torch.float32)
+    print(f"exporting -> {out_path}")
+    t = time.perf_counter()
+    torch.onnx.export(
+        model,
+        dummy,
+        str(out_path),
+        input_names=["input"],
+        output_names=["output"],
+        opset_version=17,
+        dynamic_axes=None,
+    )
+    size_mb = out_path.stat().st_size / 1e6
+    print(f"  done in {time.perf_counter() - t:.1f}s ({size_mb:.1f} MB)")
+
+    cfg = model.pretrained_cfg
+    print(f"label order: {cfg.get('label_names')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/marqo-export/run_reference.py
+++ b/scripts/marqo-export/run_reference.py
@@ -1,0 +1,81 @@
+"""Generate fixture images and Python timm reference NSFW scores for the
+Rust image-moderation E2E test.
+
+Writes deterministic synthetic fixtures (a uniform colour patch, a
+gradient, and a seeded random-noise tile) plus a `reference.json` that
+the Rust integration test (`backend/tests/image_moderation.rs`) compares
+its own inference against. Synthetic inputs are intentional — we don't
+want the repo to ship real NSFW imagery, and the goal is preprocessing
+parity, not classifier accuracy.
+
+Run:
+  uv run --with timm --with torch --with pillow --with numpy \\
+      --python 3.12 scripts/marqo-export/run_reference.py \\
+      [--out /tmp/nsfw-e2e/fixtures]
+"""
+import argparse
+import json
+import pathlib
+
+import numpy as np
+import timm
+import torch
+from PIL import Image
+from timm.data import create_transform, resolve_model_data_config
+
+MODEL_ID = "hf_hub:Marqo/nsfw-image-detection-384"
+
+
+def synth(name: str, kind: str, out_dir: pathlib.Path) -> pathlib.Path:
+    rng = np.random.default_rng(hash(name) & 0xFFFFFFFF)
+    if kind == "noise":
+        arr = rng.integers(0, 256, size=(800, 600, 3), dtype=np.uint8)
+    elif kind == "gradient":
+        x = np.linspace(0, 255, 600, dtype=np.uint8)
+        y = np.linspace(0, 255, 800, dtype=np.uint8)
+        r = np.tile(x, (800, 1))
+        g = np.tile(y[:, None], (1, 600))
+        b = ((r.astype(int) + g.astype(int)) // 2).astype(np.uint8)
+        arr = np.stack([r, g, b], axis=-1)
+    elif kind == "solid":
+        arr = np.full((800, 600, 3), 200, dtype=np.uint8)
+    else:
+        raise ValueError(f"unknown kind: {kind}")
+    p = out_dir / f"{name}.png"
+    Image.fromarray(arr).save(p)
+    return p
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="/tmp/nsfw-e2e/fixtures")
+    args = ap.parse_args()
+    out = pathlib.Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"loading {MODEL_ID}")
+    model = timm.create_model(MODEL_ID, pretrained=True).eval()
+    cfg = resolve_model_data_config(model)
+    print(f"data cfg: {cfg}")
+    print(f"label_names: {model.pretrained_cfg.get('label_names')}")
+    transform = create_transform(**cfg, is_training=False)
+
+    results: dict = {}
+    for name, kind in [("noise", "noise"), ("gradient", "gradient"), ("solid", "solid")]:
+        p = synth(name, kind, out)
+        img = Image.open(p).convert("RGB")
+        x = transform(img).unsqueeze(0)
+        with torch.no_grad():
+            logits = model(x).cpu().numpy()[0]
+        probs = np.exp(logits - logits.max())
+        probs = probs / probs.sum()
+        nsfw = float(probs[0])
+        print(f"{name}: logits={logits} nsfw={nsfw:.6f}")
+        results[name] = {"path": str(p), "nsfw": nsfw, "logits": logits.tolist()}
+
+    (out / "reference.json").write_text(json.dumps(results, indent=2))
+    print(f"wrote {out / 'reference.json'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Runs `Marqo/nsfw-image-detection-384` against every user-uploaded image (multipart and presigned-direct paths, which together cover avatars, gallery photos, and event covers). Engine sits next to the existing Bielik-Guard text engine and shares its env-var contract.

- Set `IMAGE_MODERATION_MODEL_PATH` (and optionally `IMAGE_MODERATION_REQUIRED=1`) on api + worker. Without it, the gate is a no-op.
- Export the model via `scripts/marqo-export/export_onnx.py`.
- Block threshold 0.85 — synchronous reject with 422 `IMAGE_CONTENT_REJECTED`.
- Inference errors fail open and log; we don't drop uploads on an ORT hiccup.

To do:
- [ ] Provision `IMAGE_MODERATION_MODEL_PATH` on prod compose
- [ ] Smoke-test against a labeled set, tune threshold if needed
- [ ] Add a Grafana panel for `image_moderation_verdicts_total`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add NSFW moderation gate for user image uploads via Marqo ONNX model
> - Introduces an ONNX-based NSFW image moderation engine in [`moderation/image_engine.rs`](https://github.com/poziomki-app/poziomki/pull/327/files#diff-935859aa6b7cb222f9b9a077a221752e3cad3005bf8d42522cead60b0d91074c) using the Marqo `nsfw-image-detection-384` timm model, scoring images at 384×384 with a block threshold of 0.85.
> - Both multipart uploads ([`multipart.rs`](https://github.com/poziomki-app/poziomki/pull/327/files#diff-f35db40c939f48f2f9053c69f5c9d51796f03816d25ccdfed0b322475f4e2c12)) and direct uploads ([`write_handler.rs`](https://github.com/poziomki-app/poziomki/pull/327/files#diff-fe37b1660668b738d2e667d0b9bc967035d78d1eda334da04db54a10e601ad0c)) now run moderation on sanitized bytes; rejected images return a 422 `IMAGE_CONTENT_REJECTED` error and are not written to the canonical bucket.
> - The engine is initialized at API server startup via `init_image_from_env()`, configured by `IMAGE_MODERATION_MODEL_PATH`, `IMAGE_MODERATION_THREADS`, and `IMAGE_MODERATION_REQUIRED` env vars.
> - A Python export script ([`export_onnx.py`](https://github.com/poziomki-app/poziomki/pull/327/files#diff-e9a6e58c12ce98fd83d3329a9c3041cbeccf98bf944eb0387817190c0597eff3)) and reference fixture generator ([`run_reference.py`](https://github.com/poziomki-app/poziomki/pull/327/files#diff-e3346eaacbd6d661f67637401a4c0f364c2b41d23bfe2581048e671d101c6d52)) are included for model preparation and test validation.
> - Risk: inference errors fail open (uploads are allowed); in `IMAGE_MODERATION_REQUIRED` mode, initialization failures prevent server startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf7b800.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->