### PR TITLE
feat(ios): AppDelegate APNs + AVFoundation QR scanner

### DIFF
--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/Koin.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/Koin.kt
@@ -2,9 +2,11 @@ package com.poziomki.app
 
 import com.poziomki.app.cache.ImageCacheCleaner
 import com.poziomki.app.cache.NoopImageCacheCleaner
+import com.poziomki.app.chat.push.IosPushBridge
 import com.poziomki.app.di.appModule
 import com.poziomki.app.di.startAppKoin
 import org.koin.dsl.module
+import org.koin.mp.KoinPlatform
 
 fun initKoin(versionCode: Int) {
     startAppKoin(
@@ -17,4 +19,14 @@ fun initKoin(versionCode: Int) {
             ),
         properties = mapOf("APP_VERSION_CODE" to versionCode),
     )
+}
+
+/**
+ * Bridge entry point invoked from Swift `AppDelegate` once iOS hands us
+ * an APNs device token. Resolves the [IosPushBridge] Koin singleton and
+ * forwards the hex-encoded token. Safe to call before login — the bridge
+ * no-ops if the user isn't authenticated yet.
+ */
+fun registerApnsToken(hexToken: String) {
+    KoinPlatform.getKoin().get<IosPushBridge>().registerApnsToken(hexToken)
 }

--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/CodeScanner.ios.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/CodeScanner.ios.kt
@@ -1,7 +1,143 @@
+@file:OptIn(ExperimentalForeignApi::class, BetaInteropApi::class, ExperimentalObjCName::class)
+
 package com.poziomki.app.ui.shared
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.AVFoundation.AVCaptureConnection
+import platform.AVFoundation.AVCaptureDevice
+import platform.AVFoundation.AVCaptureDeviceInput
+import platform.AVFoundation.AVCaptureMetadataOutput
+import platform.AVFoundation.AVCaptureMetadataOutputObjectsDelegateProtocol
+import platform.AVFoundation.AVCaptureOutput
+import platform.AVFoundation.AVCaptureSession
+import platform.AVFoundation.AVCaptureSessionPresetHigh
+import platform.AVFoundation.AVCaptureVideoPreviewLayer
+import platform.AVFoundation.AVLayerVideoGravityResizeAspectFill
+import platform.AVFoundation.AVMediaTypeVideo
+import platform.AVFoundation.AVMetadataMachineReadableCodeObject
+import platform.AVFoundation.AVMetadataObjectTypeQRCode
+import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIApplication
+import platform.UIKit.UIButton
+import platform.UIKit.UIButtonTypeSystem
+import platform.UIKit.UIColor
+import platform.UIKit.UIControlEventTouchUpInside
+import platform.UIKit.UIControlStateNormal
+import platform.UIKit.UIModalPresentationFullScreen
+import platform.UIKit.UIViewController
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
+import kotlin.experimental.ExperimentalObjCName
+import kotlin.native.ObjCName
 
 @Composable
-actual fun rememberCodeScanner(onResult: (String?) -> Unit): () -> Unit = remember { { onResult(null) } }
+actual fun rememberCodeScanner(onResult: (String?) -> Unit): () -> Unit {
+    val callback = remember(onResult) { onResult }
+    return {
+        val rootVC =
+            UIApplication.sharedApplication.keyWindow?.rootViewController?.let {
+                var vc: UIViewController? = it
+                while (vc?.presentedViewController != null) vc = vc.presentedViewController
+                vc
+            }
+        if (rootVC == null) {
+            callback(null)
+        } else {
+            val scanner = QrScannerViewController(callback)
+            scanner.modalPresentationStyle = UIModalPresentationFullScreen
+            rootVC.presentViewController(scanner, animated = true, completion = null)
+        }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class, ExperimentalObjCName::class)
+private class QrScannerViewController(
+    private val onResult: (String?) -> Unit,
+) : UIViewController(nibName = null, bundle = null),
+    AVCaptureMetadataOutputObjectsDelegateProtocol {
+    private var captureSession: AVCaptureSession? = null
+    private var resolved = false
+
+    override fun viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.blackColor
+
+        val device = AVCaptureDevice.defaultDeviceWithMediaType(AVMediaTypeVideo)
+        if (device == null) {
+            finishWith(null)
+            return
+        }
+        val session = AVCaptureSession()
+        session.sessionPreset = AVCaptureSessionPresetHigh
+
+        val input = AVCaptureDeviceInput.deviceInputWithDevice(device, error = null)
+        if (input == null || !session.canAddInput(input)) {
+            finishWith(null)
+            return
+        }
+        session.addInput(input)
+
+        val output = AVCaptureMetadataOutput()
+        if (!session.canAddOutput(output)) {
+            finishWith(null)
+            return
+        }
+        session.addOutput(output)
+        output.setMetadataObjectsDelegate(this, queue = dispatch_get_main_queue())
+        output.metadataObjectTypes = listOf(AVMetadataObjectTypeQRCode)
+
+        val preview = AVCaptureVideoPreviewLayer(session = session)
+        preview.frame = view.bounds
+        preview.videoGravity = AVLayerVideoGravityResizeAspectFill
+        view.layer.addSublayer(preview)
+
+        addCancelButton()
+        session.startRunning()
+        captureSession = session
+    }
+
+    private fun addCancelButton() {
+        val cancel = UIButton.buttonWithType(UIButtonTypeSystem)
+        cancel.setTitle("Anuluj", forState = UIControlStateNormal)
+        cancel.setTitleColor(UIColor.whiteColor, forState = UIControlStateNormal)
+        cancel.setFrame(CGRectMake(16.0, 56.0, 80.0, 36.0))
+        cancel.setBackgroundColor(UIColor.darkGrayColor.colorWithAlphaComponent(0.6))
+        cancel.layer.setCornerRadius(8.0)
+        cancel.addTarget(
+            target = this,
+            action = platform.objc.sel_registerName("cancelTapped"),
+            forControlEvents = UIControlEventTouchUpInside,
+        )
+        view.addSubview(cancel)
+    }
+
+    @ObjCName("cancelTapped")
+    fun cancelTapped() {
+        finishWith(null)
+    }
+
+    override fun captureOutput(
+        output: AVCaptureOutput,
+        didOutputMetadataObjects: List<*>,
+        fromConnection: AVCaptureConnection,
+    ) {
+        if (resolved) return
+        val first = didOutputMetadataObjects.firstOrNull() as? AVMetadataMachineReadableCodeObject
+        val code = first?.stringValue ?: return
+        finishWith(code)
+    }
+
+    private fun finishWith(value: String?) {
+        if (resolved) return
+        resolved = true
+        captureSession?.stopRunning()
+        dispatch_async(dispatch_get_main_queue()) {
+            dismissViewControllerAnimated(true) {
+                onResult(value)
+            }
+        }
+    }
+}

--- a/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		AB1A2B3C4D5E6F70010A0001 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AB1A2B3C4D5E6F70010A0002 /* PrivacyInfo.xcprivacy */; };
+		AB1A2B3C4D5E6F70010A0010 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1A2B3C4D5E6F70010A0011 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +26,7 @@
 		AB1A2B3C4D5E6F70010A0002 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AB1A2B3C4D5E6F70010A0003 /* iosAppDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosAppDebug.entitlements; sourceTree = "<group>"; };
 		AB1A2B3C4D5E6F70010A0004 /* iosAppRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosAppRelease.entitlements; sourceTree = "<group>"; };
+		AB1A2B3C4D5E6F70010A0011 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +80,7 @@
 				7555FF82242A565900829871 /* ContentView.swift */,
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
+				AB1A2B3C4D5E6F70010A0011 /* AppDelegate.swift */,
 				AB1A2B3C4D5E6F70010A0002 /* PrivacyInfo.xcprivacy */,
 				AB1A2B3C4D5E6F70010A0003 /* iosAppDebug.entitlements */,
 				AB1A2B3C4D5E6F70010A0004 /* iosAppRelease.entitlements */,
@@ -194,6 +197,7 @@
 			files = (
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
+				AB1A2B3C4D5E6F70010A0010 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mobile/iosApp/iosApp/AppDelegate.swift
+++ b/mobile/iosApp/iosApp/AppDelegate.swift
@@ -1,0 +1,74 @@
+import UIKit
+import UserNotifications
+import ComposeApp
+
+/// Wires APNs into the Compose Multiplatform app. The actual chat push
+/// dispatch happens server-side; iOS just needs to:
+///   1. Ask the user for permission to show notifications.
+///   2. Register with APNs to obtain a device token.
+///   3. Forward that token (as hex) to Kotlin so the backend can target it.
+///
+/// Swift can't construct the Koin-managed `IosPushBridge` directly, so we
+/// route through a top-level Kotlin entry point: `KoinKt.doRegisterApnsToken`.
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+            if let error = error {
+                NSLog("APNs authorization error: \(error.localizedDescription)")
+                return
+            }
+            guard granted else {
+                NSLog("APNs authorization declined")
+                return
+            }
+            DispatchQueue.main.async {
+                application.registerForRemoteNotifications()
+            }
+        }
+        return true
+    }
+
+    // MARK: APNs token
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let hex = deviceToken.map { String(format: "%02x", $0) }.joined()
+        KoinKt.doRegisterApnsToken(hexToken: hex)
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        NSLog("APNs registration failed: \(error.localizedDescription)")
+    }
+
+    // MARK: Notification presentation
+
+    /// Show banners for foreground notifications too — by default iOS
+    /// suppresses them, but chat messages should still surface.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound, .badge])
+    }
+
+    /// Notification tap → currently a no-op routing path. The payload's
+    /// `conversationId` is here for a future deep-link bridge; until then
+    /// tapping just opens the app.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        completionHandler()
+    }
+}

--- a/mobile/iosApp/iosApp/iOSApp.swift
+++ b/mobile/iosApp/iosApp/iOSApp.swift
@@ -3,6 +3,8 @@ import ComposeApp
 
 @main
 struct iOSApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
     init() {
         let versionCode = (Bundle.main.infoDictionary?["CFBundleVersion"] as? String).flatMap(Int32.init) ?? 0
         KoinKt.doInitKoin(versionCode: versionCode)


### PR DESCRIPTION
Stacked on #331. Final Linux-side iOS code before shipping.

- `AppDelegate.swift`: requests notification authorization, registers for remote notifications, hex-encodes the APNs device token, forwards to Kotlin via `KoinKt.doRegisterApnsToken`. Foreground banners enabled.
- `iOSApp.swift`: \`@UIApplicationDelegateAdaptor\` wires the delegate.
- `Koin.kt`: top-level \`registerApnsToken(hex)\` entry point, resolves \`IosPushBridge\` from Koin.
- \`CodeScanner.ios\`: replaces null-returning stub with \`AVCaptureSession\` + \`AVCaptureMetadataOutput\` for QR codes. Presents full-screen preview with a Cancel button. On detection, stops session, dismisses, fires callback on main queue.

## What's left for the actual ship (not in this PR)
**You** at the Mac mini / browser:
- Apple Developer portal: create APNs Auth Key (.p8), enable Push Notifications capability for `com.poziomki.app`
- App Store Connect: create app record, screenshots, demo creds, privacy form
- Backend env vars on prod: \`APNS_KEY_ID\`, \`APNS_TEAM_ID\`, \`APNS_BUNDLE_ID=com.poziomki.app\`, \`APNS_KEY_PATH=/etc/poziomki/apns.p8\`, \`APNS_PRODUCTION=true\`
- Open Xcode, set TEAM_ID in \`Config.xcconfig\`, archive, upload to TestFlight

## Test plan
- [ ] Open in Xcode, build for iPhone 15 simulator → no errors
- [ ] Launch on simulator → notification permission prompt appears
- [ ] Real iPhone (TestFlight): grant notifications → backend receives APNs token at \`/chat/push/register\`
- [ ] QR scanner opens camera, decodes a QR code, returns string
- [ ] Send chat message Android → iOS → APNs banner appears

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add APNs registration and AVFoundation QR scanner to iOS app
> - Adds [AppDelegate.swift](https://github.com/poziomki-app/poziomki/pull/332/files#diff-7b0b0cd863cd8761a2aa8a0df680df5605d64228f813106cdafb61a0c0b75b45) that requests notification permissions on launch, registers with APNs if granted, and forwards the hex-encoded device token to Kotlin via `KoinKt.doRegisterApnsToken`.
> - Adds a top-level `registerApnsToken` function in [Koin.kt](https://github.com/poziomki-app/poziomki/pull/332/files#diff-f44fc04c92f71107c5ef0a2f44c1401ff87a419b9d5ac194cc425343d88b95b9) that resolves `IosPushBridge` from the Koin graph and forwards the token.
> - Replaces the stub `rememberCodeScanner` in [CodeScanner.ios.kt](https://github.com/poziomki-app/poziomki/pull/332/files#diff-94d152cf913f81797196b9f1a360f654d851c7b622414918cab71bf5305a906d) with a full AVFoundation-backed QR scanner; invoking the lambda now presents a live camera UI and returns scanned content (previously always returned null).
> - Behavioral Change: QR scanning now triggers a camera permission request and shows a full-screen `AVCaptureSession` UI instead of returning null immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c9de2d5. 4 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->