### PR TITLE
ci(android): build signed AAB + run lintRelease on tag

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -81,7 +81,9 @@ jobs:
           RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
         run: |
           ./gradlew \
+            :androidApp:lintRelease \
             :androidApp:assembleRelease \
+            :androidApp:bundleRelease \
             -PreleaseStoreFile="$RUNNER_TEMP/android-release.jks" \
             -PreleaseStorePassword="$RELEASE_STORE_PASSWORD" \
             -PreleaseKeyAlias="$RELEASE_KEY_ALIAS" \
@@ -97,5 +99,6 @@ jobs:
           tag_name: ${{ env.RELEASE_TAG }}
           files: |
             dist/android-release/*.apk
+            dist/android-release/*.aab
             dist/android-release/*.txt
             dist/android-release/*.tar.gz

--- a/scripts/prepare_android_release.sh
+++ b/scripts/prepare_android_release.sh
@@ -6,7 +6,7 @@ BUILD_FILE="$ROOT_DIR/mobile/androidApp/build.gradle.kts"
 OUTPUT_DIR="${1:-$ROOT_DIR/dist/android-release}"
 
 mkdir -p "$OUTPUT_DIR"
-rm -f "$OUTPUT_DIR"/*.apk "$OUTPUT_DIR"/*.txt "$OUTPUT_DIR"/*.tar.gz
+rm -f "$OUTPUT_DIR"/*.apk "$OUTPUT_DIR"/*.aab "$OUTPUT_DIR"/*.txt "$OUTPUT_DIR"/*.tar.gz
 
 # Read appVersionName (source of truth, bumped by release-please) and derive
 # versionCode from it using the same formula as build.gradle.kts.
@@ -56,9 +56,18 @@ for apk in "${apks[@]}"; do
   fi
 done
 
+# Google Play upload format. AAB is mandatory for new app submissions.
+aab_src="$ROOT_DIR/mobile/androidApp/build/outputs/bundle/release/androidApp-release.aab"
+if [[ -f "$aab_src" ]]; then
+  cp "$aab_src" "$OUTPUT_DIR/poziomki-${version_name}.aab"
+else
+  echo "No release AAB found at $aab_src" >&2
+  exit 1
+fi
+
 (
   cd "$OUTPUT_DIR"
-  sha256sum ./*.apk > "poziomki-${version_name}-sha256.txt"
+  sha256sum ./*.apk ./*.aab > "poziomki-${version_name}-sha256.txt"
 )
 
 # Bundle any distribution metadata that still lives in the repo (historical


### PR DESCRIPTION
- AAB is required by Google Play.
- lintRelease enforces the strict lint config before each tagged build.

## Test plan
- [ ] Tag a release; verify `poziomki-X.Y.Z.aab` lands in the GitHub release alongside the APKs.
- [ ] Confirm `lintRelease` failure aborts the workflow.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build signed AAB and run `lintRelease` in Android release CI on tag
> - The [android-release.yml](.github/workflows/android-release.yml) workflow now runs `:androidApp:lintRelease` and `:androidApp:bundleRelease` alongside the existing APK build, and uploads `*.aab` files to the GitHub release.
> - [prepare_android_release.sh](scripts/prepare_android_release.sh) copies the release AAB to the dist directory as a versioned filename and includes it in the SHA256 checksum file; the script exits with an error if the AAB is missing.
> - Behavioral Change: the release script now requires the AAB artifact to exist — builds that don't produce one will fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dc32c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->