### PR TITLE
fix(uploads): fail-closed image moderation when engine errors

### DIFF
--- a/backend/src/api/uploads/image_moderation.rs
+++ b/backend/src/api/uploads/image_moderation.rs
@@ -2,11 +2,11 @@
 //! validation chain (mime/size/magic/dimensions/strip) so we never spend
 //! inference cycles on already-rejected input.
 //!
-//! Behaviour mirrors the bio moderation gate in
-//! `api/profiles/write_handler.rs`: returns `Ok(None)` when the engine is
-//! disabled, the image is allowed, or moderation is unreachable for an
-//! infrastructural reason (we fail open on infra errors but log loudly —
-//! the alternative is dropping every upload during an ORT hiccup).
+//! When the engine is disabled (env unset, dev/CI), uploads are allowed
+//! through unmoderated — that's intentional. When the engine is supposed
+//! to run (`IMAGE_MODERATION_REQUIRED=true`) but the inference call errors,
+//! the upload is rejected with 503 so a transient model outage cannot be
+//! used to slip NSFW content past the gate.
 
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::Response;
@@ -14,16 +14,31 @@ use axum::response::Response;
 use super::uploads_multipart::HandlerError;
 use crate::api::error_response;
 use crate::api::ErrorSpec;
-use crate::moderation::{shared_image, ImageVerdict};
+use crate::moderation::{image_moderation_required, shared_image, ImageVerdict};
+
+fn moderation_unavailable_response(headers: &HeaderMap) -> Response {
+    error_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        headers,
+        ErrorSpec {
+            error: "Moderacja zdjęć jest tymczasowo niedostępna. Spróbuj ponownie za chwilę."
+                .to_string(),
+            code: "IMAGE_MODERATION_UNAVAILABLE",
+            details: None,
+        },
+    )
+}
 
 /// Run NSFW moderation against `bytes`. Bytes should already be the
 /// sanitized, re-encoded payload (smaller, predictable format) — both
 /// upload paths call this after `strip_image_metadata`.
 ///
-/// Returns `Ok(None)` when the upload may proceed, or `Ok(Some(resp))`
-/// with a 422 the caller must surface verbatim. Inference errors are
-/// logged and treated as "allow"; we don't want a model hiccup to cause
-/// a global upload outage.
+/// Returns `Ok(None)` when the upload may proceed, `Ok(Some(resp))` with
+/// a 422 (rejected content) or 503 (engine unavailable in strict mode).
+/// In strict mode (`IMAGE_MODERATION_REQUIRED=true`), inference errors
+/// fail closed — a model hiccup must not become a way to bypass NSFW
+/// checks. Outside strict mode, errors are logged and the upload is let
+/// through (dev/CI behaviour).
 pub(super) async fn moderate_upload_image(
     headers: &HeaderMap,
     bytes: &[u8],
@@ -38,17 +53,26 @@ pub(super) async fn moderate_upload_image(
     let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
     metrics::histogram!("image_moderation_inference_latency_ms").record(elapsed_ms);
 
+    let strict = image_moderation_required();
     let score = match result {
         Ok(Ok(s)) => s,
         Ok(Err(err)) => {
-            tracing::error!(%err, elapsed_ms, "image moderation inference failed; allowing upload");
+            tracing::error!(%err, elapsed_ms, strict, "image moderation inference failed");
             metrics::counter!("image_moderation_errors_total", "kind" => "inference").increment(1);
-            return Ok(None);
+            return if strict {
+                Ok(Some(moderation_unavailable_response(headers)))
+            } else {
+                Ok(None)
+            };
         }
         Err(err) => {
-            tracing::error!(%err, elapsed_ms, "image moderation task join failed; allowing upload");
+            tracing::error!(%err, elapsed_ms, strict, "image moderation task join failed");
             metrics::counter!("image_moderation_errors_total", "kind" => "join").increment(1);
-            return Ok(None);
+            return if strict {
+                Ok(Some(moderation_unavailable_response(headers)))
+            } else {
+                Ok(None)
+            };
         }
     };
 

--- a/backend/src/moderation/image_global.rs
+++ b/backend/src/moderation/image_global.rs
@@ -18,7 +18,8 @@ const ENV_MODEL_PATH: &str = "IMAGE_MODERATION_MODEL_PATH";
 const ENV_THREADS: &str = "IMAGE_MODERATION_THREADS";
 const ENV_REQUIRED: &str = "IMAGE_MODERATION_REQUIRED";
 
-fn required_mode() -> bool {
+#[must_use]
+pub fn is_required() -> bool {
     std::env::var(ENV_REQUIRED).is_ok_and(|v| {
         matches!(
             v.trim().to_ascii_lowercase().as_str(),
@@ -41,7 +42,7 @@ pub fn init_image_from_env() -> Result<(), ImageModerationError> {
         .ok()
         .map(|s| s.trim().to_owned())
         .filter(|s| !s.is_empty());
-    let strict = required_mode();
+    let strict = is_required();
 
     let Some(path) = path else {
         if strict {

--- a/backend/src/moderation/mod.rs
+++ b/backend/src/moderation/mod.rs
@@ -14,5 +14,7 @@ mod scores;
 pub use engine::{ModerationEngine, ModerationError};
 pub use global::{init_from_env, shared};
 pub use image_engine::{ImageModerationEngine, ImageModerationError, ImageScore, ImageVerdict};
-pub use image_global::{init_image_from_env, shared_image};
+pub use image_global::{
+    init_image_from_env, is_required as image_moderation_required, shared_image,
+};
 pub use scores::{Category, Scores, Thresholds, Verdict};


### PR DESCRIPTION
- Inference / spawn_blocking failures used to return Ok(None), letting uploads slip past the NSFW gate during a Marqo outage.
- In strict mode (\`IMAGE_MODERATION_REQUIRED=true\`, prod default) the upload now returns 503; dev/CI keeps fail-open.

## Test plan
- [ ] With \`IMAGE_MODERATION_REQUIRED=true\` and a broken model, upload returns 503.
- [ ] With \`IMAGE_MODERATION_REQUIRED\` unset, uploads still go through during dev.
- [ ] A clean upload still passes the gate.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail closed on image moderation engine errors when `IMAGE_MODERATION_REQUIRED` is set
> - When `IMAGE_MODERATION_REQUIRED=true` (strict mode), any inference or task join error in `moderate_upload_image` now returns HTTP 503 (`IMAGE_MODERATION_UNAVAILABLE`) instead of allowing the upload through.
> - In non-strict mode, errors continue to allow the upload (fail-open behavior is preserved).
> - Adds a `moderation_unavailable_response` helper in [image_moderation.rs](https://github.com/poziomki-app/poziomki/pull/334/files#diff-6f75ed1b68bda13c13997b7fab53bf3ae7bdffc6fc5891ea84de8145cfd33f74) that builds the standardized 503 response.
> - Renames the internal `required_mode()` to `is_required()` and re-exports it as `image_moderation_required` from the moderation module.
> - Behavioral Change: uploads that previously succeeded silently on moderation engine failure will now be rejected with 503 when strict mode is enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bc673f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->