### PR TITLE
chore(infra): raise Postgres max_connections to 60

### DIFF
--- a/infra/ops/postgres/postgresql.conf
+++ b/infra/ops/postgres/postgresql.conf
@@ -4,7 +4,9 @@ shared_buffers = 128MB
 work_mem = 4MB
 maintenance_work_mem = 64MB
 effective_cache_size = 512MB
-max_connections = 30
+# pgdog runs an api pool + worker pool, each up to DEFAULT_POOL_SIZE (20).
+# Plus headroom for ad-hoc psql sessions during ops work.
+max_connections = 60
 wal_buffers = 4MB
 
 # Safety timeouts (backstop — pgdog enforces tighter limits)


### PR DESCRIPTION
- pgdog runs two pools (api + worker) of size 20 each — 40 connections from pooled traffic alone, against a cap of 30.
- Bump to 60 to leave headroom for ad-hoc ops sessions.

## Test plan
- [ ] After redeploy, \`SHOW max_connections\` returns 60.
- [ ] Both pgdog pools warm up without \`too many clients\` errors under sustained load.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise Postgres `max_connections` from 30 to 60
> Updates [postgresql.conf](https://github.com/poziomki-app/poziomki/pull/335/files#diff-bd0d15922a7516cc5dc86f4c8c17d64be11ec7e48e3bc1b9e6ac15c15ff9ba6e) to double the connection limit, with comments explaining the allocation across pgdog API and worker pools plus ad-hoc psql sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec64e0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->