### PR TITLE
fix(a11y): 48dp touch target on search bar filter button

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/PoziomkiSearchBar.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/PoziomkiSearchBar.kt
@@ -1,7 +1,6 @@
 package com.poziomki.app.ui.designsystem.components
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -98,19 +98,29 @@ fun PoziomkiSearchBar(
                 thickness = 1.dp,
                 color = Border,
             )
-            Spacer(modifier = Modifier.width(12.dp))
-            val filterModifier =
-                if (onFilterClick != null) {
-                    Modifier.size(22.dp).clickable(onClick = onFilterClick)
-                } else {
-                    Modifier.size(22.dp)
+            // 48dp clickable wrapper around the 22dp glyph — Material a11y
+            // touch-target minimum that Play pre-launch reports flag.
+            if (onFilterClick != null) {
+                IconButton(
+                    onClick = onFilterClick,
+                    modifier = Modifier.size(48.dp),
+                ) {
+                    Icon(
+                        PhosphorIcons.Bold.SlidersHorizontal,
+                        contentDescription = "Filtruj",
+                        modifier = Modifier.size(22.dp),
+                        tint = if (filterActive) Primary else TextMuted,
+                    )
                 }
-            Icon(
-                PhosphorIcons.Bold.SlidersHorizontal,
-                contentDescription = "Filtruj",
-                modifier = filterModifier,
-                tint = if (filterActive) Primary else TextMuted,
-            )
+            } else {
+                Spacer(modifier = Modifier.width(12.dp))
+                Icon(
+                    PhosphorIcons.Bold.SlidersHorizontal,
+                    contentDescription = "Filtruj",
+                    modifier = Modifier.size(22.dp),
+                    tint = if (filterActive) Primary else TextMuted,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
- Filter glyph was 22dp clickable — below Material's 48dp minimum.
- Wrap in IconButton when interactive so Play pre-launch a11y reports stop flagging it.

## Test plan
- [ ] Visual: filter button still looks the same.
- [ ] Tapping the area around the glyph (within 48dp) triggers the filter.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 48dp touch target on search bar filter button for accessibility
> Replaces the `clickable` modifier on the 22dp filter `Icon` in [`PoziomkiSearchBar`](https://github.com/poziomki-app/poziomki/pull/336/files#diff-0499bc081f3f2d11552580174651021d709cc10dc6e7ed275278d026565d023c) with a Material `IconButton` wrapper, giving the tappable area the required 48dp minimum. The non-clickable path (no `onFilterClick`) retains the plain `Icon` with an explicit 12dp leading `Spacer`. Behavioral Change: the 12dp leading spacer no longer applies in the clickable case, slightly shifting icon alignment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5254e2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->