### PR TITLE
fix(push): bound ntfy SSE read timeout to 5 min

### DIFF
--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NtfyPushService.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NtfyPushService.kt
@@ -37,7 +37,11 @@ class NtfyPushService :
         HttpClient(OkHttp) {
             engine {
                 config {
-                    readTimeout(0, java.util.concurrent.TimeUnit.MILLISECONDS)
+                    // Bounded read timeout so a silently-dropped connection
+                    // (NAT rebind, router asleep) is detected and reconnected
+                    // instead of holding a wakelock-equivalent indefinitely.
+                    // ntfy sends keepalives every ~45s, so 5 min is safe.
+                    readTimeout(SSE_READ_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
                 }
             }
         }
@@ -139,5 +143,6 @@ class NtfyPushService :
         const val EXTRA_SSE_URL = "sse_url"
         private const val INITIAL_BACKOFF_MS = 1_000L
         private const val MAX_BACKOFF_MS = 60_000L
+        private const val SSE_READ_TIMEOUT_MS = 5L * 60_000L
     }
 }


### PR DESCRIPTION
- readTimeout(0) made a silently-dropped connection invisible; ntfy keepalives are ~45s, so 5 min is a safe ceiling that only fires on a dead link.
- The existing backoff loop reconnects automatically once the timeout trips.

## Test plan
- [ ] Toggle airplane mode for >5 min: service reconnects after returning online.
- [ ] Receive a message during a long idle period: notification still arrives.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound `NtfyPushService` SSE read timeout to 5 minutes
> Replaces an unbounded read timeout (`0ms`) with a 5-minute limit (`SSE_READ_TIMEOUT_MS`) in the OkHttp engine config of [NtfyPushService.kt](https://github.com/poziomki-app/poziomki/pull/337/files#diff-6b465d8f458ee8fa31d748cf0540eee4477742aaf83b3f7252bef065f127c59f). Risk: SSE connections that stay silent for more than 5 minutes will now time out and require reconnection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecdafd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->