### PR TITLE
fix(chat): cap message reports at 30 per reporter per 24h

### DIFF
--- a/backend/src/api/chat/message_report_handler.rs
+++ b/backend/src/api/chat/message_report_handler.rs
@@ -50,8 +50,14 @@ pub struct ReportMessageBody {
 
 enum ReportOutcome {
     NotFound,
+    RateLimited,
     Inserted,
 }
+
+/// Cap on new reports per reporter per rolling 24h. Idempotent re-reports
+/// of the same message don't count (they're absorbed by the PK conflict),
+/// so this only bites someone trying to flood the moderation queue.
+const REPORTS_PER_DAY: i64 = 30;
 
 pub(in crate::api) async fn message_report(
     State(_ctx): State<AppContext>,
@@ -120,6 +126,17 @@ pub(in crate::api) async fn message_report(
                 return Ok::<_, diesel::result::Error>(ReportOutcome::NotFound);
             };
 
+            let day_ago = chrono::Utc::now() - chrono::Duration::hours(24);
+            let recent: i64 = r::chat_message_reports
+                .filter(r::reporter_user_id.eq(reporter_user_id))
+                .filter(r::created_at.gt(day_ago))
+                .count()
+                .get_result(conn)
+                .await?;
+            if recent >= REPORTS_PER_DAY {
+                return Ok(ReportOutcome::RateLimited);
+            }
+
             diesel::insert_into(r::chat_message_reports)
                 .values((
                     r::message_id.eq(message_id),
@@ -149,6 +166,16 @@ pub(in crate::api) async fn message_report(
             ErrorSpec {
                 error: "Message not found".to_string(),
                 code: "NOT_FOUND",
+                details: None,
+            },
+        )),
+        ReportOutcome::RateLimited => Ok(error_response(
+            StatusCode::TOO_MANY_REQUESTS,
+            &headers,
+            ErrorSpec {
+                error: "Osiągnięto dzienny limit zgłoszeń. Spróbuj ponownie za 24 godziny."
+                    .to_string(),
+                code: "RATE_LIMITED",
                 details: None,
             },
         )),


### PR DESCRIPTION
- Re-reports of the same message are already idempotent (PK conflict), but a user could still flood the moderation queue with 30+ distinct messages.
- Cap new reports at 30 per rolling 24h, return 429 with a Polish message.

## Test plan
- [ ] First 30 reports in a day succeed.
- [ ] Report #31 returns 429 with code RATE_LIMITED.
- [ ] Re-reporting an already-reported message still returns success (idempotent).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap chat message reports at 30 per reporter per 24-hour rolling window
> Adds a rate-limit check in [message_report_handler.rs](https://github.com/poziomki-app/poziomki/pull/338/files#diff-76237a34cfefe43a5b358e455185a64d2c94bd6afee7b55af599acf027915891) that counts reports submitted by the same `reporter_user_id` in the past 24 hours. If the count reaches the new `REPORTS_PER_DAY` constant (30), the handler skips insertion and returns HTTP 429 with error code `RATE_LIMITED`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d32de7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->