### PR TITLE
fix(android): silence OldTargetApi lint check on CI

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -85,6 +85,9 @@ android {
         // monochrome layer, locked screen orientation, transitive
         // LogNotTimber). New violations still fail the build.
         baseline = file("lint-baseline.xml")
+        // CI lint is one minor version ahead of local and flags 36 as
+        // "old"; the release-please bot owns targetSdk bumps anyway.
+        disable += "OldTargetApi"
     }
 }
 


### PR DESCRIPTION
The previous v0.20.0 build still failed lintRelease on CI: AGP 9.0.1's lint flags \`targetSdk = 36\` as OldTargetApi (it knows about a newer in-development API). We're on the highest stable level; release-please owns the bumps. Disabling that single rule keeps the rest of the strict lint config intact.

## Test plan
- [ ] Re-tag v0.20.0 → Android Release run is green and produces the AAB.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Silence `OldTargetApi` lint check in Android CI builds
> Adds `OldTargetApi` to the disabled lint checks in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/341/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be) to prevent CI failures caused by this warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 729810f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->