### PR TITLE
fix(release): split AAB build into its own gradle invocation

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -80,14 +80,17 @@ jobs:
           RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
         run: |
-          ./gradlew \
-            :androidApp:lintRelease \
-            :androidApp:assembleRelease \
-            :androidApp:bundleRelease \
-            -PreleaseStoreFile="$RUNNER_TEMP/android-release.jks" \
-            -PreleaseStorePassword="$RELEASE_STORE_PASSWORD" \
-            -PreleaseKeyAlias="$RELEASE_KEY_ALIAS" \
+          common_args=(
+            -PreleaseStoreFile="$RUNNER_TEMP/android-release.jks"
+            -PreleaseStorePassword="$RELEASE_STORE_PASSWORD"
+            -PreleaseKeyAlias="$RELEASE_KEY_ALIAS"
             -PreleaseKeyPassword="$RELEASE_KEY_PASSWORD"
+          )
+          # APKs (with ABI splits) for sideload + GitHub release.
+          ./gradlew :androidApp:lintRelease :androidApp:assembleRelease "${common_args[@]}"
+          # Play AAB — splits must be off for the same invocation
+          # (issuetracker.google.com/402800800).
+          ./gradlew :androidApp:bundleRelease -PnoAbiSplits=true "${common_args[@]}"
 
       - name: Prepare release assets
         run: bash scripts/prepare_android_release.sh

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -57,7 +57,11 @@ android {
 
     splits {
         abi {
-            isEnable = true
+            // AGP 9 refuses APK splits + AAB in the same gradle invocation
+            // (issuetracker.google.com/402800800). Release CI calls
+            // assembleRelease (splits on) and then bundleRelease with
+            // -PnoAbiSplits=true so each task produces a clean output.
+            isEnable = !project.hasProperty("noAbiSplits")
             reset()
             include("arm64-v8a", "armeabi-v7a", "x86_64")
             isUniversalApk = true


### PR DESCRIPTION
v0.20.0 build #3 failed: AGP 9 refuses APK splits + AAB in one gradle invocation (issuetracker.google.com/402800800). Two separate calls now: assembleRelease (splits on) for sideload APKs, then bundleRelease -PnoAbiSplits=true for the Play AAB. Verified locally — both outputs produced.

## Test plan
- [ ] Re-tag v0.20.0 → Android Release green; both per-ABI APKs and the AAB land on the GitHub release.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split AAB build into a separate Gradle invocation with ABI splits disabled
> - The release workflow previously built the APK and AAB in a single Gradle invocation, causing ABI splits to be included in the AAB (unwanted for Play Store uploads).
> - [android-release.yml](.github/workflows/android-release.yml) now runs `:androidApp:lintRelease :androidApp:assembleRelease` and `:androidApp:bundleRelease` as two separate Gradle calls, sharing signing args via a Bash array.
> - [build.gradle.kts](mobile/androidApp/build.gradle.kts) disables ABI splits when the `noAbiSplits` Gradle property is set; `bundleRelease` is invoked with `-PnoAbiSplits=true` so the AAB is produced without splits while APKs retain them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df73329.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->