### PR TITLE
build(deps): bump tokenizers to 0.23.1

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -626,6 +626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,13 +4029,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.22.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "aho-corasick",
  "compact_str",
+ "daachorse",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -81,7 +81,7 @@ deadpool = { version = "=0.13.0", features = ["rt_tokio_1"] }
 thiserror = "2"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "tls-rustls", "ndarray"] }
-tokenizers = { version = "=0.22.2", default-features = false, features = ["onig"] }
+tokenizers = { version = "=0.23.1", default-features = false, features = ["onig"] }
 ndarray = "0.17"
 
 [[bin]]


### PR DESCRIPTION
Replaces #349 (re-pins the `=` constraint to 0.23.1).

API used by the moderation engine (`Tokenizer::from_file`, `TruncationParams`, `token_to_id`) is unchanged.

## Test plan
- [x] cargo build
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --lib
- [ ] Smoke test the moderation classify endpoint after deploy

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `tokenizers` dependency to 0.23.1
> Updates the pinned `tokenizers` version in [Cargo.toml](https://github.com/poziomki-app/poziomki/pull/354/files#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1) from `=0.22.2` to `=0.23.1`. Feature flags (`onig`, no default features) are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca391d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->