### PR TITLE
build(deps): drop unused direct rand_core dep

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2750,7 +2750,6 @@ dependencies = [
  "metrics-exporter-prometheus",
  "ndarray",
  "ort",
- "rand_core 0.6.4",
  "reqwest 0.13.3",
  "rust-s3",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -71,7 +71,6 @@ thumbhash = "=0.1.0"
 base64 = "=0.22.1"
 tower-http = { version = "=0.6.8", features = ["limit", "set-header", "trace"] }
 argon2 = { version = "=0.5.3", features = ["rand"] }
-rand_core = { version = "0.6", features = ["getrandom"] }
 jsonwebtoken = "=10.3.0"
 dotenvy = "=0.15.7"
 diesel = { version = "2.3", features = ["postgres", "uuid", "chrono", "serde_json"] }


### PR DESCRIPTION
The only `rand_core` usage is `password_hash::rand_core::OsRng` (re-export). The direct dependency wasn't pulling its weight, so removing it lets us track whatever `password_hash` ships.

## Test plan
- [x] cargo build / clippy / test --lib security

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused direct `rand_core` dependency from backend
> Removes the explicit `rand_core` entry from [Cargo.toml](https://github.com/poziomki-app/poziomki/pull/356/files#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1). The crate was not directly used and will still be available transitively if needed by other dependencies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 237886e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->