### PR TITLE
build(deps): bump camerax to 1.6.0

### DIFF
--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ lifecycleCompose = "2.10.0"
 securityCrypto = "1.1.0"
 playServicesLocation = "21.3.0"
 qrose = "1.1.2"
-cameraX = "1.5.0"
+cameraX = "1.6.0"
 zxingCore = "3.5.4"
 sqldelight = "2.3.2"
 


### PR DESCRIPTION
Used by the QR scanner. Release builds clean; needs a manual on-device QR-scan smoke before merge.

## Test plan
- [x] :androidApp:assembleRelease succeeds
- [ ] On-device: QR scan flow still works

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump CameraX dependency to 1.6.0
> Updates the CameraX version in [libs.versions.toml](https://github.com/poziomki-app/poziomki/pull/359/files#diff-da7313e5ea25a5de4765d29946874ca6296d66b5d74c58c3589a6801eb595434) from 1.5.0 to 1.6.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a70e74a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->