### PR TITLE
build(deps): bump AGP to 9.2.0

### DIFF
--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.1"
+agp = "9.2.0"
 androidx-activityCompose = "1.13.0"
 androidx-core = "1.18.0"
 androidx-ui-tooling = "1.11.0"


### PR DESCRIPTION
Both assembleRelease (APK with ABI splits + universal) and bundleRelease (AAB via `-PnoAbiSplits=true`) build clean locally.

## Test plan
- [x] :androidApp:assembleRelease
- [x] :androidApp:bundleRelease -PnoAbiSplits=true
- [ ] CI release build green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump Android Gradle Plugin to 9.2.0
> Updates the `agp` version in [libs.versions.toml](https://github.com/poziomki-app/poziomki/pull/360/files#diff-da7313e5ea25a5de4765d29946874ca6296d66b5d74c58c3589a6801eb595434) from 9.0.1 to 9.2.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c52613.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->