### PR TITLE
fix(chat): open chat after picking user in NewChat

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -459,8 +459,8 @@ fun AppNavigation(
             NewChatScreen(
                 onBack = { navController.popBackStack() },
                 onUserSelected = { userId, displayName, profileId ->
-                    navigateToDm(userId, displayName, profileId)
                     navController.popBackStack(Route.NewChat, inclusive = true)
+                    navigateToDm(userId, displayName, profileId)
                 },
             )
         }


### PR DESCRIPTION
Picking a user in "nowa wiadomość" sometimes returned to the messages list instead of opening the chat.

`navigateToDm` schedules an async navigate to `Chat`; the immediate `popBackStack(NewChat, inclusive = true)` could race and pop the freshly pushed `Chat` along with `NewChat`. Pop first, then navigate.

## Test plan
- [ ] Wiadomości → napisz → pick user with no DM → lands in chat
- [ ] Repeat same selection (warm cache) → still lands in chat
- [ ] Pick user with existing DM → lands in chat
- [ ] Back from chat returns to Wiadomości

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chat navigation order when selecting a user in NewChat
> In [AppNavigation.kt](https://github.com/poziomki-app/poziomki/pull/363/files#diff-d0c4d4fb202ccaa45fc79b5e9a20b97727c5ae374c4bb3f074445da38252c7e8), the `NewChatScreen` `onUserSelected` callback now pops `Route.NewChat` from the back stack before navigating to the DM screen, instead of after. This prevents a broken navigation state where the DM screen was pushed before the NewChat route was removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e34e031.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->