### PR TITLE
fix(android): use FusedLocationProviderClient with Warsaw fallback

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -185,7 +185,6 @@ fun EventsScreen(
                             userLat = state.userLat,
                             userLng = state.userLng,
                             isPermissionDenied = state.isLocationPermissionDenied,
-                            isLocationUnavailable = state.isLocationUnavailable,
                             onEventSelected = { viewModel.selectNearbyEvent(it) },
                             onEventClick = onNavigateToEventDetail,
                             onRequestPermission = requestLocationPermission,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
@@ -29,7 +29,6 @@ data class EventsState(
     val userLng: Double? = null,
     val selectedNearbyEventId: String? = null,
     val isLocationPermissionDenied: Boolean = false,
-    val isLocationUnavailable: Boolean = false,
     val selectedCategories: Set<String> = emptySet(),
     val showTagFilter: Boolean = false,
 )
@@ -191,16 +190,22 @@ class EventsViewModel(
             _state.value = _state.value.copy(isLocationPermissionDenied = true)
             return
         }
-        _state.value = _state.value.copy(isLocationPermissionDenied = false, isLocationUnavailable = false)
+        _state.value = _state.value.copy(isLocationPermissionDenied = false)
         viewModelScope.launch {
             val loc = locationProvider.getCurrentLocation()
             if (loc == null) {
-                _state.value = _state.value.copy(isLocationUnavailable = true)
+                loadNearbyEvents(FALLBACK_LAT, FALLBACK_LNG)
                 return@launch
             }
             _state.value = _state.value.copy(userLat = loc.latitude, userLng = loc.longitude)
             loadNearbyEvents(loc.latitude, loc.longitude)
         }
+    }
+
+    private companion object {
+        // Warsaw — used when device location can't be obtained despite permission.
+        const val FALLBACK_LAT = 52.2297
+        const val FALLBACK_LNG = 21.0122
     }
 
     fun loadNearbyEvents(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
@@ -40,7 +40,6 @@ import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.bold.MapPinLine
 import com.poziomki.app.network.Event
 import com.poziomki.app.network.GeocodingService
-import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.StackedAvatars
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
@@ -75,13 +74,13 @@ private const val DEFAULT_LNG = 21.0122
 private const val TAP_THRESHOLD_DEG = 0.005
 
 @Composable
+@Suppress("LongMethod", "CyclomaticComplexMethod", "LongParameterList")
 internal fun NearbyEventsContent(
     events: List<Event>,
     selectedEventId: String?,
     userLat: Double?,
     userLng: Double?,
     isPermissionDenied: Boolean,
-    isLocationUnavailable: Boolean,
     onEventSelected: (String) -> Unit,
     onEventClick: (String) -> Unit,
     onRequestPermission: () -> Unit = {},
@@ -115,11 +114,6 @@ internal fun NearbyEventsContent(
                 )
             }
         }
-        return
-    }
-
-    if (isLocationUnavailable) {
-        EmptyView("nie udało się pobrać lokalizacji")
         return
     }
 

--- a/mobile/core/build.gradle.kts
+++ b/mobile/core/build.gradle.kts
@@ -48,6 +48,7 @@ kotlin {
 
             implementation(libs.androidx.core.ktx)
             implementation(libs.androidx.security.crypto)
+            implementation(libs.play.services.location)
             implementation(libs.sqldelight.android.driver)
         }
         iosMain.dependencies {

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/location/LocationProvider.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/location/LocationProvider.kt
@@ -5,12 +5,17 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
-import android.os.Build
 import android.os.Looper
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.location.LocationListenerCompat
 import androidx.core.location.LocationManagerCompat
 import androidx.core.location.LocationRequestCompat
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
@@ -18,100 +23,135 @@ import kotlin.coroutines.resume
 actual class LocationProvider(
     private val context: Context,
 ) {
-    private val locationManager = context.getSystemService(LocationManager::class.java)
-
     actual fun isPermissionGranted(): Boolean =
         ContextCompat.checkSelfPermission(
             context,
             Manifest.permission.ACCESS_COARSE_LOCATION,
         ) == PackageManager.PERMISSION_GRANTED
 
-    @Suppress("MissingPermission")
     actual suspend fun getCurrentLocation(): LocationResult? {
-        if (!isPermissionGranted() || locationManager == null) return null
-        return try {
-            lastKnownLocation()?.let { return it.toLocationResult() }
+        if (!isPermissionGranted()) {
+            Log.w(TAG, "permission not granted")
+            return null
+        }
+        Log.i(TAG, "getCurrentLocation start")
+        // 1. Google Fused (FusedLocationProviderClient) — instant on Play Services,
+        //    routes through microG/UnifiedNlp on supported AOSP forks.
+        val fused = if (isFusedLikelyAvailable()) fusedLocation() else null
+        if (fused != null) {
+            Log.i(TAG, "fused fix=$fused")
+            return fused
+        }
+        // 2. Raw GPS one-shot — only useful outdoors. Skip if Fused already returned.
+        val gps = gpsLocation()
+        if (gps != null) {
+            Log.i(TAG, "gps fix=$gps")
+            return gps
+        }
+        // 3. ViewModel falls back to Warsaw on null.
+        Log.w(TAG, "no fix obtained")
+        return null
+    }
 
-            val provider = activeProvider() ?: return null
-            withTimeoutOrNull(LOCATION_TIMEOUT_MS) {
-                suspendCancellableCoroutine { continuation ->
-                    val request =
-                        LocationRequestCompat
-                            .Builder(LOCATION_TIMEOUT_MS)
-                            .setQuality(LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY)
-                            .setMaxUpdates(1)
-                            .setDurationMillis(LOCATION_TIMEOUT_MS)
-                            .build()
-                    val listener =
-                        object : LocationListenerCompat {
-                            override fun onLocationChanged(location: Location) {
-                                LocationManagerCompat.removeUpdates(locationManager, this)
-                                if (continuation.isActive) {
-                                    continuation.resume(location.toLocationResult())
-                                }
-                            }
-                        }
-                    continuation.invokeOnCancellation {
-                        LocationManagerCompat.removeUpdates(locationManager, listener)
+    // True if the device exposes a Play Services-compatible location backend.
+    // Accepts both genuine GMS and microG (where the official check fails without
+    // signature spoofing but the package exists and Fused requests are routed
+    // through UnifiedNlp).
+    private fun isFusedLikelyAvailable(): Boolean {
+        val official =
+            GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) ==
+                ConnectionResult.SUCCESS
+        if (official) return true
+        return runCatching {
+            context.packageManager.getPackageInfo(GMS_PACKAGE, 0)
+            true
+        }.getOrDefault(false)
+    }
+
+    @Suppress("MissingPermission", "TooGenericExceptionCaught")
+    private suspend fun fusedLocation(): LocationResult? =
+        try {
+            val client = LocationServices.getFusedLocationProviderClient(context)
+            fusedLastLocation(client) ?: fusedCurrentLocation(client)
+        } catch (e: Exception) {
+            Log.e(TAG, "fused location threw", e)
+            null
+        }
+
+    @Suppress("MissingPermission")
+    private suspend fun fusedLastLocation(client: FusedLocationProviderClient): LocationResult? =
+        withTimeoutOrNull(FUSED_LAST_TIMEOUT_MS) {
+            suspendCancellableCoroutine { continuation ->
+                client.lastLocation
+                    .addOnSuccessListener { location ->
+                        if (continuation.isActive) continuation.resume(location?.toLocationResult())
+                    }.addOnFailureListener {
+                        if (continuation.isActive) continuation.resume(null)
                     }
+            }
+        }
+
+    @Suppress("MissingPermission")
+    private suspend fun fusedCurrentLocation(client: FusedLocationProviderClient): LocationResult? =
+        withTimeoutOrNull(FUSED_CURRENT_TIMEOUT_MS) {
+            suspendCancellableCoroutine { continuation ->
+                client
+                    .getCurrentLocation(Priority.PRIORITY_BALANCED_POWER_ACCURACY, null)
+                    .addOnSuccessListener { location ->
+                        if (continuation.isActive) continuation.resume(location?.toLocationResult())
+                    }.addOnFailureListener { e ->
+                        Log.w(TAG, "fused getCurrentLocation failed", e)
+                        if (continuation.isActive) continuation.resume(null)
+                    }
+            }
+        }
+
+    @Suppress("MissingPermission")
+    private suspend fun gpsLocation(): LocationResult? {
+        val manager = context.getSystemService(LocationManager::class.java) ?: return null
+        if (!runCatching { manager.isProviderEnabled(LocationManager.GPS_PROVIDER) }.getOrDefault(false)) {
+            return null
+        }
+        return withTimeoutOrNull(GPS_TIMEOUT_MS) {
+            suspendCancellableCoroutine { continuation ->
+                val request =
+                    LocationRequestCompat
+                        .Builder(GPS_TIMEOUT_MS)
+                        .setQuality(LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY)
+                        .setMaxUpdates(1)
+                        .setDurationMillis(GPS_TIMEOUT_MS)
+                        .build()
+                val listener =
+                    object : LocationListenerCompat {
+                        override fun onLocationChanged(location: Location) {
+                            LocationManagerCompat.removeUpdates(manager, this)
+                            if (continuation.isActive) continuation.resume(location.toLocationResult())
+                        }
+                    }
+                continuation.invokeOnCancellation {
+                    LocationManagerCompat.removeUpdates(manager, listener)
+                }
+                runCatching {
                     LocationManagerCompat.requestLocationUpdates(
-                        locationManager,
-                        provider,
+                        manager,
+                        LocationManager.GPS_PROVIDER,
                         request,
                         listener,
                         Looper.getMainLooper(),
                     )
+                }.onFailure {
+                    if (continuation.isActive) continuation.resume(null)
                 }
             }
-        } catch (
-            @Suppress("TooGenericExceptionCaught") _: Exception,
-        ) {
-            null
         }
     }
 
-    private fun lastKnownLocation(): Location? =
-        LAST_KNOWN_PROVIDERS
-            .filter { provider ->
-                locationManager
-                    ?.let { manager -> runCatching { manager.isProviderEnabled(provider) }.getOrDefault(false) }
-                    ?: false
-            }.mapNotNull { provider ->
-                runCatching { locationManager?.getLastKnownLocation(provider) }.getOrNull()
-            }.maxByOrNull(Location::getTime)
-
-    private fun activeProvider(): String? =
-        ACTIVE_PROVIDERS.firstOrNull { provider ->
-            locationManager
-                ?.let { manager -> runCatching { manager.isProviderEnabled(provider) }.getOrDefault(false) }
-                ?: false
-        }
-
     private companion object {
-        const val LOCATION_TIMEOUT_MS = 15_000L
-
-        // FUSED on Android 12+ is the cheapest and most reliable; otherwise NETWORK
-        // (cell+wifi) under COARSE permission. PASSIVE is intentionally excluded —
-        // it only forwards fixes other apps already requested, so it cannot
-        // deliver an active update on its own.
-        val ACTIVE_PROVIDERS: List<String> =
-            buildList {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    add(LocationManager.FUSED_PROVIDER)
-                }
-                add(LocationManager.NETWORK_PROVIDER)
-                add(LocationManager.GPS_PROVIDER)
-            }
-
-        val LAST_KNOWN_PROVIDERS: List<String> =
-            buildList {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    add(LocationManager.FUSED_PROVIDER)
-                }
-                add(LocationManager.PASSIVE_PROVIDER)
-                add(LocationManager.NETWORK_PROVIDER)
-                add(LocationManager.GPS_PROVIDER)
-            }
+        const val TAG = "PoziomkiLocation"
+        const val GMS_PACKAGE = "com.google.android.gms"
+        const val FUSED_LAST_TIMEOUT_MS = 1_500L
+        const val FUSED_CURRENT_TIMEOUT_MS = 8_000L
+        const val GPS_TIMEOUT_MS = 8_000L
     }
 }
 

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-co
 phosphor-icons = { module = "com.adamglin:phosphor-icon", version.ref = "phosphorIcons" }
 
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
+play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 qrose = { module = "io.github.alexzhirkevich:qrose", version.ref = "qrose" }
 camerax-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "cameraX" }
 camerax-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "cameraX" }


### PR DESCRIPTION
Replaces the LocationManager-only path with Google's Fused location API. Raw GPS one-shot remains as outdoor backup. When everything fails, the map centers on Warsaw instead of dead-ending on "nie udało się pobrać lokalizacji".