### PR TITLE
fix(chat): guard against duplicate TimelineStart marker

### DIFF
--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTimeline.kt
@@ -301,7 +301,7 @@ class WsTimeline(
 
                 // Prepend history
                 current.addAll(0, newItems)
-                if (!msg.hasMore) {
+                if (!msg.hasMore && current.none { it is TimelineItem.TimelineStart }) {
                     current.add(0, TimelineItem.TimelineStart)
                 }
 


### PR DESCRIPTION
Repeated history responses with hasMore=false were inserting a second TimelineStart, which made LazyColumn crash with "Key timeline_start was already used".

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard against duplicate `TimelineStart` markers in chat history pagination
> In [WsTimeline.kt](https://github.com/poziomki-app/poziomki/pull/365/files#diff-a4793a22ae2cfc03c80ce1b4a619eaa913e8f753a169e77dfe60ba5726da5a48), the condition that appends `TimelineItem.TimelineStart` now also checks that the item is not already present in the list before adding it, preventing duplicates when history pagination completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 530352f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->