### PR TITLE
events: icon-only create FAB

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
@@ -111,9 +111,9 @@ fun AppButton(
                     modifier = Modifier.size(20.dp),
                     tint = tint,
                 )
-                Spacer(modifier = Modifier.width(8.dp))
+                if (text.isNotEmpty()) Spacer(modifier = Modifier.width(8.dp))
             }
-            ButtonLabel(text, tint)
+            if (text.isNotEmpty()) ButtonLabel(text, tint)
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
@@ -80,13 +80,20 @@ fun AppButton(
 
     val borderModifier = animatedBorder(variant, isEnabled)
 
+    val isIconOnly = text.isEmpty() && icon != null
     val rowModifier =
         modifier
             .then(borderModifier)
             .clip(ButtonShape)
             .background(backgroundFor(variant))
             .then(if (isEnabled) Modifier.clickable(onClick = onClick) else Modifier)
-            .padding(horizontal = 24.dp, vertical = 16.dp)
+            .then(
+                if (isIconOnly) {
+                    Modifier.padding(14.dp)
+                } else {
+                    Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+                },
+            )
 
     Row(
         modifier = rowModifier,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -247,7 +247,7 @@ fun EventsScreen(
 
             // FAB: create event
             AppButton(
-                text = "nowe",
+                text = "",
                 onClick = onNavigateToEventCreate,
                 variant = ButtonVariant.PRIMARY,
                 icon = PhosphorIcons.Bold.Plus,


### PR DESCRIPTION
Drop the 'nowe' label so the wydarzenia FAB is just (+).

- [ ] FAB on Wydarzenia is just a plus icon
- [ ] Tap still opens create-event screen

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change the create-event FAB on EventsScreen to icon-only
> - Sets the FAB text to an empty string in [EventsScreen.kt](https://github.com/poziomki-app/poziomki/pull/367/files#diff-b1aad26129722f5aa103f55ac1d883a2b472203a3df536f251798d2ab83260dd), leaving only the plus icon.
> - Updates [AppButton.kt](https://github.com/poziomki-app/poziomki/pull/367/files#diff-37fe2ab8c56db3e0875e1c8e6619d97b409e8d8e26307952be43e980635367fd) to detect icon-only mode (`text.isEmpty() && icon != null`) and apply 14dp uniform padding instead of the standard 24×16dp, and omits the spacer and label.
> - Risk: if `AppButton` is called with empty text and no icon, it renders an empty clickable container with no visual content.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1e75902. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->