### PR TITLE
explore card: prettier matching tag pills

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -10,6 +10,9 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -37,6 +40,8 @@ import com.poziomki.app.network.Tag
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.PrimaryMuted
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
@@ -55,7 +60,7 @@ fun ProfileCard(
     modifier: Modifier = Modifier,
 ) {
     val cardShape = RoundedCornerShape(20.dp)
-    val photoSize = 90.dp
+    val cardHeight = 88.dp
 
     val startColor = parseHexColor(gradientStart)
     val endColor = parseHexColor(gradientEnd)
@@ -82,20 +87,22 @@ fun ProfileCard(
         modifier =
             modifier
                 .fillMaxWidth()
+                .height(cardHeight)
                 .clip(cardShape)
                 .border(1.dp, Border, cardShape)
                 .background(backgroundBrush)
                 .clickable(onClick = onClick),
     ) {
         Row(
+            modifier = Modifier.fillMaxSize(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Photo — fixed square, ContentScale.Crop fills it
+            // Photo — square that fills the full card height
             if (profilePicture != null) {
                 AsyncImage(
                     model = resolveImageUrl(profilePicture),
                     contentDescription = null,
-                    modifier = Modifier.size(photoSize),
+                    modifier = Modifier.fillMaxHeight().aspectRatio(1f),
                     contentScale = ContentScale.Crop,
                 )
             } else {
@@ -103,7 +110,7 @@ fun ProfileCard(
                     UserAvatar(
                         picture = null,
                         displayName = name,
-                        size = photoSize - 32.dp,
+                        size = cardHeight - 32.dp,
                     )
                 }
             }
@@ -115,33 +122,35 @@ fun ProfileCard(
                 modifier =
                     Modifier
                         .weight(1f)
-                        .padding(vertical = 16.dp),
+                        .padding(vertical = 12.dp),
+                verticalArrangement = Arrangement.Center,
             ) {
                 Text(
                     text = name,
                     fontFamily = MontserratFamily,
                     fontWeight = FontWeight.ExtraBold,
-                    fontSize = 20.sp,
+                    fontSize = 19.sp,
                     color = TextPrimary,
                 )
 
                 if (matchingTags.isNotEmpty()) {
-                    Spacer(modifier = Modifier.height(6.dp))
+                    Spacer(modifier = Modifier.height(4.dp))
                     FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
                         matchingTags.forEach { tag ->
                             Text(
                                 text = tag.name.lowercase(),
                                 fontFamily = NunitoFamily,
-                                fontWeight = FontWeight.Medium,
-                                fontSize = 13.sp,
-                                color = TextSecondary,
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 11.sp,
+                                color = PrimaryMuted,
                                 modifier =
                                     Modifier
-                                        .border(1.dp, Border, RoundedCornerShape(50))
-                                        .padding(horizontal = 8.dp, vertical = 3.dp),
+                                        .clip(RoundedCornerShape(50))
+                                        .background(Primary.copy(alpha = 0.14f))
+                                        .padding(horizontal = 8.dp, vertical = 2.dp),
                             )
                         }
                     }
@@ -151,7 +160,7 @@ fun ProfileCard(
                         text = program,
                         fontFamily = NunitoFamily,
                         fontWeight = FontWeight.Normal,
-                        fontSize = 14.sp,
+                        fontSize = 13.sp,
                         color = TextSecondary,
                     )
                 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
@@ -51,11 +52,12 @@ fun ProfileCard(
     gradientEnd: String? = null,
     matchingTags: List<Tag> = emptyList(),
     program: String? = null,
+    bio: String? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val cardShape = RoundedCornerShape(20.dp)
-    val cardHeight = 88.dp
+    val cardHeight = 108.dp
 
     val startColor = parseHexColor(gradientStart)
     val endColor = parseHexColor(gradientEnd)
@@ -136,6 +138,20 @@ fun ProfileCard(
                         fontSize = 12.sp,
                         lineHeight = 14.sp,
                         color = TextSecondary,
+                    )
+                }
+
+                if (!bio.isNullOrBlank()) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = bio.trim(),
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 13.sp,
+                        lineHeight = 15.sp,
+                        color = TextSecondary,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -39,6 +39,7 @@ import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.PrimaryMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
+import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.shared.resolveImageUrl
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -128,22 +129,33 @@ fun ProfileCard(
 
                 if (matchingTags.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(4.dp))
+                    // Activities first (stronger signal: shared IRL action),
+                    // then interests (talking points).
+                    val orderedTags =
+                        matchingTags.sortedByDescending { it.scope == "activity" }
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                         verticalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
-                        matchingTags.forEach { tag ->
+                        orderedTags.forEach { tag ->
+                            val isActivity = tag.scope == "activity"
                             Text(
                                 text = tag.name.lowercase(),
                                 fontFamily = NunitoFamily,
-                                fontWeight = FontWeight.SemiBold,
+                                fontWeight = if (isActivity) FontWeight.SemiBold else FontWeight.Medium,
                                 fontSize = 11.sp,
                                 lineHeight = 12.sp,
-                                color = PrimaryMuted,
+                                color = if (isActivity) PrimaryMuted else TextSecondary,
                                 modifier =
                                     Modifier
                                         .clip(RoundedCornerShape(50))
-                                        .background(Primary.copy(alpha = 0.14f))
+                                        .background(
+                                            if (isActivity) {
+                                                Primary.copy(alpha = 0.18f)
+                                            } else {
+                                                Color.White.copy(alpha = 0.06f)
+                                            },
+                                        )
                                         .padding(horizontal = 7.dp, vertical = 1.dp),
                             )
                         }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -33,25 +32,19 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
-import com.adamglin.PhosphorIcons
-import com.adamglin.phosphoricons.Bold
-import com.adamglin.phosphoricons.bold.ArrowUpRight
 import com.poziomki.app.network.Tag
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.PrimaryMuted
-import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
-import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.shared.resolveImageUrl
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ProfileCard(
     name: String,
-    program: String?,
     profilePicture: String?,
     gradientStart: String? = null,
     gradientEnd: String? = null,
@@ -155,29 +148,8 @@ fun ProfileCard(
                             )
                         }
                     }
-                } else if (program != null) {
-                    Spacer(modifier = Modifier.height(2.dp))
-                    Text(
-                        text = program,
-                        fontFamily = NunitoFamily,
-                        fontWeight = FontWeight.Normal,
-                        fontSize = 13.sp,
-                        color = TextSecondary,
-                    )
                 }
             }
-
-            // Expand arrow top-right
-            Icon(
-                PhosphorIcons.Bold.ArrowUpRight,
-                contentDescription = "View profile",
-                modifier =
-                    Modifier
-                        .padding(top = 12.dp, end = 12.dp)
-                        .size(20.dp)
-                        .align(Alignment.Top),
-                tint = TextMuted,
-            )
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -141,20 +141,6 @@ fun ProfileCard(
                     )
                 }
 
-                if (!bio.isNullOrBlank()) {
-                    Spacer(modifier = Modifier.height(2.dp))
-                    Text(
-                        text = bio.trim(),
-                        fontFamily = NunitoFamily,
-                        fontWeight = FontWeight.Normal,
-                        fontSize = 13.sp,
-                        lineHeight = 15.sp,
-                        color = TextSecondary,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-
                 if (matchingTags.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(4.dp))
                     // Activities first (stronger signal: shared IRL action),
@@ -188,6 +174,20 @@ fun ProfileCard(
                             )
                         }
                     }
+                }
+
+                if (!bio.isNullOrBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = bio.trim(),
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 13.sp,
+                        lineHeight = 15.sp,
+                        color = TextSecondary,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
             }
         }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -168,8 +168,7 @@ fun ProfileCard(
                                             } else {
                                                 Color.White.copy(alpha = 0.06f)
                                             },
-                                        )
-                                        .padding(horizontal = 7.dp, vertical = 1.dp),
+                                        ).padding(horizontal = 7.dp, vertical = 1.dp),
                             )
                         }
                     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -145,12 +145,13 @@ fun ProfileCard(
                                 fontFamily = NunitoFamily,
                                 fontWeight = FontWeight.SemiBold,
                                 fontSize = 11.sp,
+                                lineHeight = 12.sp,
                                 color = PrimaryMuted,
                                 modifier =
                                     Modifier
                                         .clip(RoundedCornerShape(50))
                                         .background(Primary.copy(alpha = 0.14f))
-                                        .padding(horizontal = 8.dp, vertical = 2.dp),
+                                        .padding(horizontal = 7.dp, vertical = 1.dp),
                             )
                         }
                     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -45,6 +45,7 @@ import com.poziomki.app.ui.shared.resolveImageUrl
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
+@Suppress("LongMethod", "LongParameterList")
 fun ProfileCard(
     name: String,
     profilePicture: String?,
@@ -57,7 +58,15 @@ fun ProfileCard(
     modifier: Modifier = Modifier,
 ) {
     val cardShape = RoundedCornerShape(20.dp)
-    val cardHeight = 108.dp
+    val cleanedBio = bio?.let(::cleanBioForPreview).orEmpty()
+    // 3 tiers driven by bio length so cards stay tight when there's
+    // little to show but expand for users who actually wrote something.
+    val cardHeight =
+        when {
+            cleanedBio.isBlank() -> 88.dp
+            cleanedBio.length < 80 -> 108.dp
+            else -> 140.dp
+        }
 
     val startColor = parseHexColor(gradientStart)
     val endColor = parseHexColor(gradientEnd)
@@ -176,12 +185,10 @@ fun ProfileCard(
                     }
                 }
 
-                if (!bio.isNullOrBlank()) {
+                if (cleanedBio.isNotBlank()) {
                     Spacer(modifier = Modifier.height(4.dp))
-                    // Collapse all whitespace (incl. newlines) so multi-line
-                    // bios render as a single paragraph in the card preview.
                     Text(
-                        text = bio.replace(Regex("\\s+"), " ").trim(),
+                        text = cleanedBio,
                         fontFamily = NunitoFamily,
                         fontWeight = FontWeight.Normal,
                         fontSize = 13.sp,
@@ -195,3 +202,18 @@ fun ProfileCard(
         }
     }
 }
+
+// Strip markdown image / link syntax for the card preview so a bio like
+// "kocham linuxa ![](https://api.poziomki.app/...)" doesn't leak the
+// embedded URL as raw text. Also collapses any whitespace runs to single
+// spaces so multi-line bios render as a single paragraph.
+private val MarkdownImageRegex = Regex("""!\[[^\]]*]\([^)]*\)""")
+private val MarkdownLinkRegex = Regex("""\[([^\]]+)]\([^)]*\)""")
+private val WhitespaceRunRegex = Regex("""\s+""")
+
+private fun cleanBioForPreview(raw: String): String =
+    raw
+        .replace(MarkdownImageRegex, "")
+        .replace(MarkdownLinkRegex, "$1")
+        .replace(WhitespaceRunRegex, " ")
+        .trim()

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -50,6 +50,7 @@ fun ProfileCard(
     gradientStart: String? = null,
     gradientEnd: String? = null,
     matchingTags: List<Tag> = emptyList(),
+    program: String? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -126,6 +127,17 @@ fun ProfileCard(
                     fontSize = 19.sp,
                     color = TextPrimary,
                 )
+
+                if (!program.isNullOrBlank()) {
+                    Text(
+                        text = program,
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 12.sp,
+                        lineHeight = 14.sp,
+                        color = TextSecondary,
+                    )
+                }
 
                 if (matchingTags.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(4.dp))

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
@@ -53,20 +52,11 @@ fun ProfileCard(
     gradientEnd: String? = null,
     matchingTags: List<Tag> = emptyList(),
     program: String? = null,
-    bio: String? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val cardShape = RoundedCornerShape(20.dp)
-    val cleanedBio = bio?.let(::cleanBioForPreview).orEmpty()
-    // 3 tiers driven by bio length so cards stay tight when there's
-    // little to show but expand for users who actually wrote something.
-    val cardHeight =
-        when {
-            cleanedBio.isBlank() -> 88.dp
-            cleanedBio.length < 80 -> 108.dp
-            else -> 140.dp
-        }
+    val cardHeight = 88.dp
 
     val startColor = parseHexColor(gradientStart)
     val endColor = parseHexColor(gradientEnd)
@@ -184,36 +174,7 @@ fun ProfileCard(
                         }
                     }
                 }
-
-                if (cleanedBio.isNotBlank()) {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = cleanedBio,
-                        fontFamily = NunitoFamily,
-                        fontWeight = FontWeight.Normal,
-                        fontSize = 13.sp,
-                        lineHeight = 15.sp,
-                        color = TextSecondary,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
             }
         }
     }
 }
-
-// Strip markdown image / link syntax for the card preview so a bio like
-// "kocham linuxa ![](https://api.poziomki.app/...)" doesn't leak the
-// embedded URL as raw text. Also collapses any whitespace runs to single
-// spaces so multi-line bios render as a single paragraph.
-private val MarkdownImageRegex = Regex("""!\[[^\]]*]\([^)]*\)""")
-private val MarkdownLinkRegex = Regex("""\[([^\]]+)]\([^)]*\)""")
-private val WhitespaceRunRegex = Regex("""\s+""")
-
-private fun cleanBioForPreview(raw: String): String =
-    raw
-        .replace(MarkdownImageRegex, "")
-        .replace(MarkdownLinkRegex, "$1")
-        .replace(WhitespaceRunRegex, " ")
-        .trim()

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -178,8 +178,10 @@ fun ProfileCard(
 
                 if (!bio.isNullOrBlank()) {
                     Spacer(modifier = Modifier.height(4.dp))
+                    // Collapse all whitespace (incl. newlines) so multi-line
+                    // bios render as a single paragraph in the card preview.
                     Text(
-                        text = bio.trim(),
+                        text = bio.replace(Regex("\\s+"), " ").trim(),
                         fontFamily = NunitoFamily,
                         fontWeight = FontWeight.Normal,
                         fontSize = 13.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -239,6 +239,7 @@ fun ExploreScreen(
                                         gradientStart = profile.gradientStart,
                                         gradientEnd = profile.gradientEnd,
                                         matchingTags = profile.tags.filter { it.id in ownIds },
+                                        bio = profile.bio,
                                         onClick = { onNavigateToProfile(profile.id) },
                                         modifier = Modifier.padding(horizontal = PoziomkiTheme.spacing.md),
                                     )

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -146,6 +146,7 @@ fun ExploreScreen(
                                             name = profile.name,
                                             profilePicture = profile.profilePicture,
                                             matchingTags = state.ownTags.filter { it.id in profile.tags },
+                                            program = profile.program,
                                             onClick = { onNavigateToProfile(profile.id) },
                                         )
                                     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -239,7 +239,6 @@ fun ExploreScreen(
                                         gradientStart = profile.gradientStart,
                                         gradientEnd = profile.gradientEnd,
                                         matchingTags = profile.tags.filter { it.id in ownIds },
-                                        bio = profile.bio,
                                         onClick = { onNavigateToProfile(profile.id) },
                                         modifier = Modifier.padding(horizontal = PoziomkiTheme.spacing.md),
                                     )

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -144,7 +144,6 @@ fun ExploreScreen(
                                     items(results.profiles, key = { "p-${it.id}" }) { profile ->
                                         ProfileCard(
                                             name = profile.name,
-                                            program = null,
                                             profilePicture = profile.profilePicture,
                                             matchingTags = state.ownTags.filter { it.id in profile.tags },
                                             onClick = { onNavigateToProfile(profile.id) },
@@ -235,7 +234,6 @@ fun ExploreScreen(
                                     val ownIds = state.ownTags.mapTo(mutableSetOf()) { it.id }
                                     ProfileCard(
                                         name = profile.name,
-                                        program = null,
                                         profilePicture = profile.profilePicture,
                                         gradientStart = profile.gradientStart,
                                         gradientEnd = profile.gradientEnd,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreViewModel.kt
@@ -48,6 +48,10 @@ class ExploreViewModel(
         observeProfiles()
         observeOwnTags()
         refreshProfiles()
+        // Pull own profile up-front so matchingTags can render on the
+        // first frame instead of waiting until the user navigates away
+        // and back (which is what previously primed the cache).
+        viewModelScope.launch { profileRepository.refreshOwnProfile() }
     }
 
     private fun observeOwnTags() {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
@@ -99,7 +99,6 @@ fun ProfileScreen(
                                 // ProfileCard
                                 ProfileCard(
                                     name = profile.name,
-                                    program = profile.program,
                                     profilePicture = profile.profilePicture,
                                     gradientStart = profile.gradientStart,
                                     gradientEnd = profile.gradientEnd,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
@@ -103,7 +103,6 @@ fun ProfileScreen(
                                     gradientStart = profile.gradientStart,
                                     gradientEnd = profile.gradientEnd,
                                     program = profile.program,
-                                    bio = profile.bio,
                                     onClick = { onNavigateToProfileView(profile.id) },
                                 )
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
@@ -102,6 +102,8 @@ fun ProfileScreen(
                                     profilePicture = profile.profilePicture,
                                     gradientStart = profile.gradientStart,
                                     gradientEnd = profile.gradientEnd,
+                                    program = profile.program,
+                                    bio = profile.bio,
                                     onClick = { onNavigateToProfileView(profile.id) },
                                 )
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
@@ -102,7 +102,6 @@ fun SavedScreen(
                                             gradientStart = profile.gradientStart,
                                             gradientEnd = profile.gradientEnd,
                                             program = profile.program,
-                                            bio = profile.bio,
                                             onClick = { onNavigateToProfileView(profile.id) },
                                         )
                                     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
@@ -101,6 +101,8 @@ fun SavedScreen(
                                             profilePicture = profile.profilePicture,
                                             gradientStart = profile.gradientStart,
                                             gradientEnd = profile.gradientEnd,
+                                            program = profile.program,
+                                            bio = profile.bio,
                                             onClick = { onNavigateToProfileView(profile.id) },
                                         )
                                     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
@@ -98,7 +98,6 @@ fun SavedScreen(
                                     items(state.profiles, key = { it.id }) { profile ->
                                         ProfileCard(
                                             name = profile.name,
-                                            program = profile.program,
                                             profilePicture = profile.profilePicture,
                                             gradientStart = profile.gradientStart,
                                             gradientEnd = profile.gradientEnd,


### PR DESCRIPTION
Tighter primary-tinted pills, fixed card height so the photo always fills.

- [ ] tags more visible (cyan tint vs gray border)
- [ ] all cards same height regardless of tag presence
- [ ] photo aligned flush with card edges

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restyle explore card tag pills and add program display in `ProfileCard`
> - Fixes card height to 88dp with a square photo that fills the card height, replacing the previous fixed photo size.
> - Sorts matching tag chips so `activity`-scoped tags appear first, and replaces the bordered chip style with rounded chips using `Primary`/`PrimaryMuted` theme colors.
> - Displays the profile's program name below the name when available; removes the top-right arrow icon.
> - Refreshes the own profile in the background on `ExploreViewModel` initialization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d79d9c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->