### PR TITLE
messages: hide rooms with no messages yet

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/MessagesRoomFiltering.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/MessagesRoomFiltering.kt
@@ -11,6 +11,10 @@ fun List<RoomSummary>.filterMessagesRooms(
     val normalizedQuery = searchQuery.trim().lowercase()
 
     return asSequence()
+        // Hide rooms that have never received a message — empty shells from
+        // resolved DMs or freshly-joined event chats only clutter the list
+        // until somebody actually says hi.
+        .filter { it.latestTimestampMillis != null }
         .filter { room ->
             when (selectedFilter) {
                 MessagesRoomFilter.All -> true


### PR DESCRIPTION
Empty DM/event shells (resolved but never written to) only add noise to Wiadomości. Filter them by missing latestTimestampMillis.

- [ ] empty rooms gone from list
- [ ] room re-appears once first message lands

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide rooms with no messages in the messages room list
> Adds a filter step in [`filterMessagesRooms`](https://github.com/poziomki-app/poziomki/pull/369/files#diff-bf1cb9bb074307a31361cd2e46041237763913a519c4956849172544d97a1da1) to exclude rooms where `latestTimestampMillis` is null, meaning rooms that have never received a message no longer appear in the messages view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6e5781.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->