### PR TITLE
explore: sequence own-profile refresh before feed

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreViewModel.kt
@@ -47,11 +47,14 @@ class ExploreViewModel(
     init {
         observeProfiles()
         observeOwnTags()
-        refreshProfiles()
-        // Pull own profile up-front so matchingTags can render on the
-        // first frame instead of waiting until the user navigates away
-        // and back (which is what previously primed the cache).
-        viewModelScope.launch { profileRepository.refreshOwnProfile() }
+        // Refresh own profile *before* the feed so the very first
+        // emission already has ownTags hydrated. Without this the
+        // initial cards on a fresh install render with empty matching
+        // tags until the own-profile observer catches up.
+        viewModelScope.launch {
+            profileRepository.refreshOwnProfile()
+            refreshFeed()
+        }
     }
 
     private fun observeOwnTags() {
@@ -91,14 +94,12 @@ class ExploreViewModel(
         }
     }
 
-    private fun refreshProfiles() {
-        viewModelScope.launch {
-            val success = matchProfileRepository.refreshProfiles()
-            if (!success && _state.value.profiles.isNotEmpty()) {
-                _state.value = _state.value.copy(refreshError = "Nie udało się odświeżyć profili")
-            }
-            _state.value = _state.value.copy(isLoading = false)
+    private suspend fun refreshFeed() {
+        val success = matchProfileRepository.refreshProfiles()
+        if (!success && _state.value.profiles.isNotEmpty()) {
+            _state.value = _state.value.copy(refreshError = "Nie udało się odświeżyć profili")
         }
+        _state.value = _state.value.copy(isLoading = false)
     }
 
     fun pullToRefresh() {


### PR DESCRIPTION
Fresh-install: own-profile cache empty until refresh completes, so the feed previously rendered with no matching tags until the user navigated away and back. Run them sequentially in init so the feed lands with ownTags hydrated.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sequence own-profile refresh before feed refresh in `ExploreViewModel`
> - Replaces two concurrent coroutines in `ExploreViewModel.init` with a single coroutine that refreshes the own profile first, then refreshes the feed.
> - Converts the private `refreshProfiles()` method to a suspend function `refreshFeed()`, eliminating nested coroutine launch and ensuring sequential execution.
> - `isLoading` is now cleared only after the feed refresh completes, rather than potentially concurrently with the own-profile refresh.
> - Behavioral Change: initialization order is now deterministic — own profile is always fetched before feed profiles.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c71931f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->