### PR TITLE
messages+chat: CalendarDots fallback for event rooms

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/UserAvatar.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/UserAvatar.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
@@ -50,6 +51,7 @@ fun UserAvatar(
     backgroundColor: Color = Border,
     iconTint: Color = TextMuted,
     showFallbackIcon: Boolean = true,
+    fallbackIcon: ImageVector = PhosphorIcons.Regular.User,
 ) {
     val emojiSize: TextUnit = (size.value * 0.45f).sp
     val iconSize: Dp = size * 0.5f
@@ -111,7 +113,7 @@ fun UserAvatar(
 
             else -> {
                 if (showFallbackIcon) {
-                    FallbackUserIcon(iconSize, iconTint)
+                    FallbackUserIcon(iconSize, iconTint, fallbackIcon)
                 }
             }
         }
@@ -122,12 +124,13 @@ fun UserAvatar(
 private fun FallbackUserIcon(
     iconSize: Dp,
     iconTint: Color,
+    icon: ImageVector,
 ) {
     Box(
         contentAlignment = Alignment.Center,
     ) {
         Icon(
-            PhosphorIcons.Regular.User,
+            icon,
             contentDescription = null,
             modifier = Modifier.size(iconSize),
             tint = iconTint,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -59,6 +59,7 @@ import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.Error
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
+import com.adamglin.phosphoricons.Fill
 import com.adamglin.phosphoricons.bold.ArrowLeft
 import com.adamglin.phosphoricons.bold.CaretDown
 import com.adamglin.phosphoricons.bold.CaretUp
@@ -48,6 +49,7 @@ import com.adamglin.phosphoricons.bold.Flag
 import com.adamglin.phosphoricons.bold.MagnifyingGlass
 import com.adamglin.phosphoricons.bold.Prohibit
 import com.adamglin.phosphoricons.bold.X
+import com.adamglin.phosphoricons.fill.CalendarDots
 import com.poziomki.app.chat.ActiveChat
 import com.poziomki.app.chat.api.TimelineItem
 import com.poziomki.app.ui.designsystem.components.ConfirmDialog
@@ -57,7 +59,6 @@ import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.Error
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
-import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
@@ -132,6 +133,7 @@ fun ChatScreen(
                             initialTitle?.trim()?.takeIf { it.isNotBlank() } ?: ""
                         },
                     avatarUrl = state.roomAvatarUrl,
+                    isEvent = !state.isDirectRoom,
                     isBlocked = state.isBlocked,
                     onBack = onBack,
                     onSearchClick = viewModel::toggleSearch,
@@ -220,6 +222,7 @@ private fun ChatTopBar(
     title: String,
     avatarUrl: String?,
     isBlocked: Boolean,
+    isEvent: Boolean = false,
     onBack: () -> Unit,
     onSearchClick: () -> Unit,
     onProfileClick: (() -> Unit)? = null,
@@ -257,9 +260,8 @@ private fun ChatTopBar(
                     picture = avatarUrl,
                     displayName = title,
                     size = 34.dp,
-                    backgroundColor = Primary.copy(alpha = 0.2f),
-                    iconTint = Primary,
-                    showFallbackIcon = false,
+                    showFallbackIcon = isEvent,
+                    fallbackIcon = PhosphorIcons.Fill.CalendarDots,
                 )
                 Spacer(modifier = Modifier.width(10.dp))
                 Text(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -106,21 +106,6 @@ fun EventCoverImage(
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,
             )
-        } else {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .background(Background),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    PhosphorIcons.Fill.CalendarDots,
-                    contentDescription = null,
-                    modifier = Modifier.size(64.dp),
-                    tint = TextMuted,
-                )
-            }
         }
 
         Box(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -106,6 +106,21 @@ fun EventCoverImage(
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,
             )
+        } else {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(Background),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    PhosphorIcons.Fill.CalendarDots,
+                    contentDescription = null,
+                    modifier = Modifier.size(64.dp),
+                    tint = TextMuted,
+                )
+            }
         }
 
         Box(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -106,6 +106,7 @@ fun MessagesScreen(
                                 RoomRow(
                                     room = room,
                                     profilePictureUrl = profilePicture,
+                                    isEvent = room.roomId in state.eventRoomIds,
                                     onClick = { onNavigateToChat(room.roomId, profilePicture) },
                                     onAvatarClick =
                                         room.directUserId?.let { userId ->

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -21,6 +21,11 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Fill
+import com.adamglin.phosphoricons.Regular
+import com.adamglin.phosphoricons.fill.CalendarDots
+import com.adamglin.phosphoricons.regular.User
 import com.poziomki.app.chat.api.RoomSummary
 import com.poziomki.app.ui.designsystem.components.UserAvatar
 import com.poziomki.app.ui.designsystem.theme.Background
@@ -38,6 +43,7 @@ fun RoomRow(
     room: RoomSummary,
     profilePictureUrl: String? = null,
     displayNameOverride: String? = null,
+    isEvent: Boolean = false,
     onClick: () -> Unit,
     onAvatarClick: (() -> Unit)? = null,
 ) {
@@ -62,6 +68,7 @@ fun RoomRow(
                 picture = profilePictureUrl,
                 fallbackPicture = room.avatarUrl,
                 displayName = displayName,
+                fallbackIcon = if (isEvent) PhosphorIcons.Fill.CalendarDots else PhosphorIcons.Regular.User,
             )
         }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -39,6 +39,7 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 
 @Composable
+@Suppress("LongParameterList", "LongMethod")
 fun RoomRow(
     room: RoomSummary,
     profilePictureUrl: String? = null,


### PR DESCRIPTION
Match the events-screen fallback when an event room has no cover image, both in the chat list preview and the chat top header.

- [ ] Wiadomości row for an event chat shows calendar icon when no cover
- [ ] Event chat header shows calendar icon when no cover
- [ ] DM rooms still show person icon

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show `CalendarDots` fallback icon for event rooms in messages list and chat header
> - Adds an `isEvent` flag to `RoomRow` and `ChatTopBar` so event rooms display a `CalendarDots` icon instead of the default user icon when no avatar is available.
> - Extends `UserAvatar` with a `fallbackIcon` parameter (defaults to `PhosphorIcons.Regular.User`) so callers can supply any icon as the avatar fallback.
> - `MessagesScreen` passes `isEvent` based on whether a room ID appears in `state.eventRoomIds`; `ChatScreen` derives it from `!state.isDirectRoom`.
> - Behavioral Change: `ChatTopBar` no longer overrides `UserAvatar`'s background color and icon tint with explicit Primary-based values — it now uses the composable's defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 146bb2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->