### PR TITLE
events: compact card without cover + creator avatar + drop arrow

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -51,7 +52,6 @@ import coil3.compose.AsyncImage
 import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.Fill
-import com.adamglin.phosphoricons.bold.ArrowSquareOut
 import com.adamglin.phosphoricons.bold.BookmarkSimple
 import com.adamglin.phosphoricons.bold.CaretDown
 import com.adamglin.phosphoricons.bold.CaretUp
@@ -69,6 +69,7 @@ import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.PoziomkiSearchBar
 import com.poziomki.app.ui.designsystem.components.ScreenHeader
 import com.poziomki.app.ui.designsystem.components.StackedAvatars
+import com.poziomki.app.ui.designsystem.components.UserAvatar
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
@@ -316,10 +317,11 @@ private fun EventCard(
         border = BorderStroke(1.dp, Border),
     ) {
         Column {
-            // Cover image area with bookmark overlay
-            Box {
-                val coverImage = event.coverImage
-                if (coverImage != null) {
+            // Cover image area (only when present) — empty placeholder
+            // wastes space, so drop it entirely for cover-less events.
+            val coverImage = event.coverImage
+            if (coverImage != null) {
+                Box {
                     AsyncImage(
                         model = resolveImageUrl(coverImage),
                         contentDescription = event.title,
@@ -329,127 +331,137 @@ private fun EventCard(
                                 .aspectRatio(COVER_ASPECT_W / COVER_ASPECT_H),
                         contentScale = ContentScale.Crop,
                     )
-                } else {
-                    Box(
+
+                    BookmarkOverlay(
+                        isSaved = event.isSaved,
+                        onClick = onSaveClick,
                         modifier =
                             Modifier
-                                .fillMaxWidth()
-                                .aspectRatio(COVER_ASPECT_W / COVER_ASPECT_H)
-                                .background(Background),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Icon(
-                            PhosphorIcons.Fill.CalendarDots,
-                            contentDescription = null,
-                            modifier = Modifier.size(48.dp),
-                            tint = TextMuted,
-                        )
-                    }
-                }
-
-                // Bookmark overlay
-                Box(
-                    modifier =
-                        Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(PoziomkiTheme.spacing.sm)
-                            .size(36.dp)
-                            .clip(CircleShape)
-                            .background(Overlay)
-                            .clickable(onClick = onSaveClick),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        if (event.isSaved) {
-                            PhosphorIcons.Fill.BookmarkSimple
-                        } else {
-                            PhosphorIcons.Bold.BookmarkSimple
-                        },
-                        contentDescription = if (event.isSaved) "Usuń z zapisanych" else "Zapisz",
-                        modifier = Modifier.size(22.dp),
-                        tint = if (event.isSaved) Primary else TextPrimary,
+                                .align(Alignment.TopEnd)
+                                .padding(PoziomkiTheme.spacing.sm),
                     )
                 }
             }
 
-            // Metadata below the image
-            Column(
-                modifier =
-                    Modifier.padding(
-                        horizontal = PoziomkiTheme.spacing.md,
-                        vertical = PoziomkiTheme.spacing.sm,
-                    ),
-            ) {
-                // Title
-                Text(
-                    text = event.title,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = TextPrimary,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 2,
-                )
-
-                Spacer(modifier = Modifier.height(2.dp))
-
-                // Date/time + location
-                Row(verticalAlignment = Alignment.CenterVertically) {
+            // Metadata
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                start = PoziomkiTheme.spacing.md,
+                                end = if (coverImage == null) 56.dp else PoziomkiTheme.spacing.md,
+                                top = PoziomkiTheme.spacing.sm,
+                                bottom = PoziomkiTheme.spacing.sm,
+                            ),
+                ) {
+                    // Title
                     Text(
-                        text = formatEventDate(event.startsAt),
-                        fontFamily = NunitoFamily,
-                        fontWeight = FontWeight.Normal,
-                        fontSize = 15.sp,
-                        color = TextSecondary,
+                        text = event.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = TextPrimary,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 2,
                     )
-                    event.location?.let { location ->
+
+                    Spacer(modifier = Modifier.height(2.dp))
+
+                    // Date/time + location
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = " · ",
-                            fontFamily = NunitoFamily,
-                            fontSize = 15.sp,
-                            color = TextMuted,
-                        )
-                        Icon(
-                            PhosphorIcons.Fill.MapPin,
-                            contentDescription = null,
-                            modifier = Modifier.size(13.dp),
-                            tint = TextMuted,
-                        )
-                        Spacer(modifier = Modifier.width(2.dp))
-                        Text(
-                            text = location,
+                            text = formatEventDate(event.startsAt),
                             fontFamily = NunitoFamily,
                             fontWeight = FontWeight.Normal,
-                            fontSize = 14.sp,
-                            color = TextMuted,
-                            maxLines = 1,
-                            modifier = Modifier.weight(1f, fill = false),
+                            fontSize = 15.sp,
+                            color = TextSecondary,
                         )
+                        event.location?.let { location ->
+                            Text(
+                                text = " · ",
+                                fontFamily = NunitoFamily,
+                                fontSize = 15.sp,
+                                color = TextMuted,
+                            )
+                            Icon(
+                                PhosphorIcons.Fill.MapPin,
+                                contentDescription = null,
+                                modifier = Modifier.size(13.dp),
+                                tint = TextMuted,
+                            )
+                            Spacer(modifier = Modifier.width(2.dp))
+                            Text(
+                                text = location,
+                                fontFamily = NunitoFamily,
+                                fontWeight = FontWeight.Normal,
+                                fontSize = 14.sp,
+                                color = TextMuted,
+                                maxLines = 1,
+                                modifier = Modifier.weight(1f, fill = false),
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(6.dp))
+
+                    // Attendees row
+                    if (event.attendeesCount > 0 || event.maxAttendees != null) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            if (event.attendeesPreview.isNotEmpty()) {
+                                StackedAvatars(
+                                    imageUrls = event.attendeesPreview.map { it.profilePicture },
+                                    avatarSize = 36.dp,
+                                    modifier = onCreatorClick?.let { Modifier.clickable(onClick = it) } ?: Modifier,
+                                )
+                                Spacer(modifier = Modifier.width(PoziomkiTheme.spacing.sm))
+                            }
+                            Text(
+                                text = event.attendeeUsageLabel(),
+                                fontFamily = NunitoFamily,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 15.sp,
+                                color = TextPrimary,
+                            )
+                        }
                     }
                 }
 
-                Spacer(modifier = Modifier.height(6.dp))
-
-                // Attendees row
-                if (event.attendeesCount > 0 || event.maxAttendees != null) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        if (event.attendeesPreview.isNotEmpty()) {
-                            StackedAvatars(
-                                imageUrls = event.attendeesPreview.map { it.profilePicture },
-                                avatarSize = 36.dp,
-                                modifier = onCreatorClick?.let { Modifier.clickable(onClick = it) } ?: Modifier,
-                            )
-                            Spacer(modifier = Modifier.width(PoziomkiTheme.spacing.sm))
-                        }
-                        Text(
-                            text = event.attendeeUsageLabel(),
-                            fontFamily = NunitoFamily,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 15.sp,
-                            color = TextPrimary,
-                        )
-                    }
+                if (coverImage == null) {
+                    BookmarkOverlay(
+                        isSaved = event.isSaved,
+                        onClick = onSaveClick,
+                        modifier =
+                            Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(PoziomkiTheme.spacing.sm),
+                    )
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun BookmarkOverlay(
+    isSaved: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(Overlay)
+                .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            if (isSaved) PhosphorIcons.Fill.BookmarkSimple else PhosphorIcons.Bold.BookmarkSimple,
+            contentDescription = if (isSaved) "Usuń z zapisanych" else "Zapisz",
+            modifier = Modifier.size(22.dp),
+            tint = if (isSaved) Primary else TextPrimary,
+        )
     }
 }
 
@@ -540,7 +552,7 @@ internal fun EventRow(
     onClick: () -> Unit,
 ) {
     val cardShape = RoundedCornerShape(20.dp)
-    val photoSize = 90.dp
+    val coverImage = event.coverImage
 
     Box(
         modifier =
@@ -551,96 +563,96 @@ internal fun EventRow(
                 .background(SurfaceElevated)
                 .clickable(onClick = onClick),
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            val coverImage = event.coverImage
-            if (coverImage != null) {
+        if (coverImage != null) {
+            // Cover variant: fixed card height, photo fills the full
+            // square on the left flush with card edges.
+            Row(
+                modifier = Modifier.height(108.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 AsyncImage(
                     model = resolveImageUrl(coverImage),
                     contentDescription = event.title,
-                    modifier = Modifier.size(photoSize),
-                    contentScale = ContentScale.Crop,
-                )
-            } else {
-                Box(
                     modifier =
                         Modifier
-                            .size(photoSize)
-                            .background(Background),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        PhosphorIcons.Fill.CalendarDots,
-                        contentDescription = null,
-                        modifier = Modifier.size(32.dp),
-                        tint = TextMuted,
-                    )
-                }
+                            .fillMaxHeight()
+                            .aspectRatio(1f),
+                    contentScale = ContentScale.Crop,
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                EventRowContent(event, modifier = Modifier.weight(1f).padding(end = 16.dp))
             }
-
-            Spacer(modifier = Modifier.width(12.dp))
-
-            Column(
+        } else {
+            // Compact variant: no left column, content drives height.
+            EventRowContent(
+                event,
                 modifier =
                     Modifier
-                        .weight(1f)
-                        .padding(vertical = 12.dp),
-            ) {
-                Text(
-                    text = event.title,
-                    fontFamily = MontserratFamily,
-                    fontWeight = FontWeight.ExtraBold,
-                    fontSize = 20.sp,
-                    color = TextPrimary,
-                    maxLines = 1,
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EventRowContent(
+    event: Event,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = event.title,
+            fontFamily = MontserratFamily,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 18.sp,
+            color = TextPrimary,
+            maxLines = 1,
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = formatEventDate(event.startsAt),
+            fontFamily = NunitoFamily,
+            fontWeight = FontWeight.Normal,
+            fontSize = 13.sp,
+            color = TextSecondary,
+        )
+        event.location?.let { location ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    PhosphorIcons.Fill.MapPin,
+                    contentDescription = null,
+                    modifier = Modifier.size(12.dp),
+                    tint = TextMuted,
                 )
-                Spacer(modifier = Modifier.height(2.dp))
+                Spacer(modifier = Modifier.width(3.dp))
                 Text(
-                    text = formatEventDate(event.startsAt),
+                    text = location,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.Normal,
-                    fontSize = 14.sp,
-                    color = TextSecondary,
+                    fontSize = 13.sp,
+                    color = TextMuted,
+                    maxLines = 1,
                 )
-                event.location?.let { location ->
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            PhosphorIcons.Fill.MapPin,
-                            contentDescription = null,
-                            modifier = Modifier.size(12.dp),
-                            tint = TextMuted,
-                        )
-                        Spacer(modifier = Modifier.width(3.dp))
-                        Text(
-                            text = location,
-                            fontFamily = NunitoFamily,
-                            fontWeight = FontWeight.Normal,
-                            fontSize = 13.sp,
-                            color = TextMuted,
-                            maxLines = 1,
-                        )
-                    }
-                }
-                event.creator?.let { creator ->
-                    Text(
-                        text = "od ${creator.name}",
-                        fontFamily = NunitoFamily,
-                        fontWeight = FontWeight.Normal,
-                        fontSize = 14.sp,
-                        color = TextMuted,
-                    )
-                }
             }
-
-            Icon(
-                PhosphorIcons.Bold.ArrowSquareOut,
-                contentDescription = "Otwórz",
-                modifier =
-                    Modifier
-                        .padding(top = 12.dp, end = 12.dp)
-                        .size(20.dp)
-                        .align(Alignment.Top),
-                tint = TextMuted,
-            )
+        }
+        event.creator?.let { creator ->
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                UserAvatar(
+                    picture = creator.profilePicture,
+                    displayName = creator.name,
+                    size = 18.dp,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "od ${creator.name}",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 13.sp,
+                    color = TextMuted,
+                )
+            }
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -58,7 +58,6 @@ import com.adamglin.phosphoricons.bold.CaretDown
 import com.adamglin.phosphoricons.bold.CaretUp
 import com.adamglin.phosphoricons.bold.Plus
 import com.adamglin.phosphoricons.fill.BookmarkSimple
-import com.adamglin.phosphoricons.fill.CalendarDots
 import com.adamglin.phosphoricons.fill.MapPin
 import com.poziomki.app.network.Event
 import com.poziomki.app.ui.designsystem.components.AppButton

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -46,6 +47,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
@@ -564,10 +566,10 @@ internal fun EventRow(
                 .clickable(onClick = onClick),
     ) {
         if (coverImage != null) {
-            // Cover variant: fixed card height, photo fills the full
-            // square on the left flush with card edges.
+            // Cover variant: card height matches content; photo fills
+            // the full square on the left flush with card edges.
             Row(
-                modifier = Modifier.height(108.dp),
+                modifier = Modifier.height(IntrinsicSize.Min),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 AsyncImage(
@@ -580,7 +582,13 @@ internal fun EventRow(
                     contentScale = ContentScale.Crop,
                 )
                 Spacer(modifier = Modifier.width(12.dp))
-                EventRowContent(event, modifier = Modifier.weight(1f).padding(end = 16.dp))
+                EventRowContent(
+                    event,
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .padding(end = 16.dp, top = 12.dp, bottom = 12.dp),
+                )
             }
         } else {
             // Compact variant: no left column, content drives height.
@@ -633,16 +641,17 @@ private fun EventRowContent(
                     fontSize = 13.sp,
                     color = TextMuted,
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }
         event.creator?.let { creator ->
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(6.dp))
             Row(verticalAlignment = Alignment.CenterVertically) {
                 UserAvatar(
                     picture = creator.profilePicture,
                     displayName = creator.name,
-                    size = 18.dp,
+                    size = 22.dp,
                 )
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -564,40 +563,28 @@ internal fun EventRow(
                 .background(SurfaceElevated)
                 .clickable(onClick = onClick),
     ) {
-        if (coverImage != null) {
-            // Cover variant: fixed card height so the photo can flush
-            // to the edges. 116dp fits title + date + location +
-            // creator row comfortably without clipping.
-            Row(
-                modifier = Modifier.height(116.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (coverImage != null) {
                 AsyncImage(
                     model = resolveImageUrl(coverImage),
                     contentDescription = event.title,
                     modifier =
                         Modifier
-                            .fillMaxHeight()
-                            .aspectRatio(1f),
+                            .size(56.dp)
+                            .clip(RoundedCornerShape(12.dp)),
                     contentScale = ContentScale.Crop,
                 )
                 Spacer(modifier = Modifier.width(12.dp))
-                EventRowContent(
-                    event,
-                    modifier =
-                        Modifier
-                            .weight(1f)
-                            .padding(end = 16.dp, top = 10.dp, bottom = 10.dp),
-                )
             }
-        } else {
-            // Compact variant: no left column, content drives height.
             EventRowContent(
                 event,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                modifier = Modifier.weight(1f),
             )
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -566,10 +565,11 @@ internal fun EventRow(
                 .clickable(onClick = onClick),
     ) {
         if (coverImage != null) {
-            // Cover variant: card height matches content; photo fills
-            // the full square on the left flush with card edges.
+            // Cover variant: fixed card height so the photo can flush
+            // to the edges. 116dp fits title + date + location +
+            // creator row comfortably without clipping.
             Row(
-                modifier = Modifier.height(IntrinsicSize.Min),
+                modifier = Modifier.height(116.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 AsyncImage(
@@ -587,7 +587,7 @@ internal fun EventRow(
                     modifier =
                         Modifier
                             .weight(1f)
-                            .padding(end = 16.dp, top = 12.dp, bottom = 12.dp),
+                            .padding(end = 16.dp, top = 10.dp, bottom = 10.dp),
                 )
             }
         } else {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -563,28 +564,40 @@ internal fun EventRow(
                 .background(SurfaceElevated)
                 .clickable(onClick = onClick),
     ) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            if (coverImage != null) {
+        if (coverImage != null) {
+            // Cover variant: fixed card height so the photo can flush
+            // to the edges. 116dp fits title + date + location +
+            // creator row comfortably without clipping.
+            Row(
+                modifier = Modifier.height(116.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 AsyncImage(
                     model = resolveImageUrl(coverImage),
                     contentDescription = event.title,
                     modifier =
                         Modifier
-                            .size(56.dp)
-                            .clip(RoundedCornerShape(12.dp)),
+                            .fillMaxHeight()
+                            .aspectRatio(1f),
                     contentScale = ContentScale.Crop,
                 )
                 Spacer(modifier = Modifier.width(12.dp))
+                EventRowContent(
+                    event,
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .padding(end = 16.dp, top = 10.dp, bottom = 10.dp),
+                )
             }
+        } else {
+            // Compact variant: no left column, content drives height.
             EventRowContent(
                 event,
-                modifier = Modifier.weight(1f),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
             )
         }
     }


### PR DESCRIPTION
Three changes to event cards (both EventCard 'polecane' and EventRow 'ten tydzień'):

- Drop the empty-icon placeholder when there's no cover; render compact variant instead
- Show creator avatar inline with 'od {name}' so it matches RoomRow style
- Remove the ArrowSquareOut icon — it pointed inside the same app, not external

Cover-present rows now use fillMaxHeight + aspectRatio so the photo flushes to the card height instead of leaving a strip when content is taller.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove empty cover placeholders and add creator avatar to compact event cards
> - `EventCard` and `EventRow` no longer render a placeholder box when an event has no cover image; layout and padding adapt to the cover-less variant instead.
> - Bookmark button moves to the top-right of the metadata area when there is no cover image, and over the cover image when one is present; extracted into a reusable `BookmarkOverlay` composable.
> - `EventRow` with a cover now uses a fixed 116dp height with a square flush image; the trailing `ArrowSquareOut` icon is removed from all rows.
> - A new `EventRowContent` composable adds a `UserAvatar` before the creator name and ellipsizes long location text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08101ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->