### PR TITLE
remove placeholder filter icon from search bar

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/PoziomkiSearchBar.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/PoziomkiSearchBar.kt
@@ -93,14 +93,14 @@ fun PoziomkiSearchBar(
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
-            VerticalDivider(
-                modifier = Modifier.height(20.dp),
-                thickness = 1.dp,
-                color = Border,
-            )
             // 48dp clickable wrapper around the 22dp glyph — Material a11y
             // touch-target minimum that Play pre-launch reports flag.
             if (onFilterClick != null) {
+                VerticalDivider(
+                    modifier = Modifier.height(20.dp),
+                    thickness = 1.dp,
+                    color = Border,
+                )
                 IconButton(
                     onClick = onFilterClick,
                     modifier = Modifier.size(48.dp),
@@ -112,14 +112,6 @@ fun PoziomkiSearchBar(
                         tint = if (filterActive) Primary else TextMuted,
                     )
                 }
-            } else {
-                Spacer(modifier = Modifier.width(12.dp))
-                Icon(
-                    PhosphorIcons.Bold.SlidersHorizontal,
-                    contentDescription = "Filtruj",
-                    modifier = Modifier.size(22.dp),
-                    tint = if (filterActive) Primary else TextMuted,
-                )
             }
         }
     }


### PR DESCRIPTION
Drops the non-functional filter icon shown next to the messages and explore search bars. Events keeps its real filter. Filters for explore (poznaj) will come in a follow-up.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove placeholder filter icon from `PoziomkiSearchBar` when no filter action is provided
> Previously, `PoziomkiSearchBar` rendered a non-clickable filter icon and spacer when `onFilterClick` was null. Now, both the vertical divider and filter icon are only rendered when `onFilterClick` is provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e896c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->