### PR TITLE
explore: filter people by interest/activity tags

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/PoziomkiSearchBar.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/PoziomkiSearchBar.kt
@@ -61,7 +61,7 @@ fun PoziomkiSearchBar(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 16.dp),
+                    .padding(start = 16.dp, end = if (onFilterClick != null) 0.dp else 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
@@ -93,14 +93,14 @@ fun PoziomkiSearchBar(
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
-            VerticalDivider(
-                modifier = Modifier.height(20.dp),
-                thickness = 1.dp,
-                color = Border,
-            )
             // 48dp clickable wrapper around the 22dp glyph — Material a11y
             // touch-target minimum that Play pre-launch reports flag.
             if (onFilterClick != null) {
+                VerticalDivider(
+                    modifier = Modifier.height(20.dp),
+                    thickness = 1.dp,
+                    color = Border,
+                )
                 IconButton(
                     onClick = onFilterClick,
                     modifier = Modifier.size(48.dp),
@@ -112,14 +112,6 @@ fun PoziomkiSearchBar(
                         tint = if (filterActive) Primary else TextMuted,
                     )
                 }
-            } else {
-                Spacer(modifier = Modifier.width(12.dp))
-                Icon(
-                    PhosphorIcons.Bold.SlidersHorizontal,
-                    contentDescription = "Filtruj",
-                    modifier = Modifier.size(22.dp),
-                    tint = if (filterActive) Primary else TextMuted,
-                )
             }
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ScreenHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ScreenHeader.kt
@@ -35,7 +35,7 @@ fun ScreenHeader(
                 .fillMaxWidth()
                 .padding(
                     start = if (onBack != null) PoziomkiTheme.spacing.sm else PoziomkiTheme.spacing.lg,
-                    end = PoziomkiTheme.spacing.sm,
+                    end = PoziomkiTheme.spacing.md,
                     top = PoziomkiTheme.spacing.md,
                     bottom = PoziomkiTheme.spacing.md,
                 ).height(48.dp),

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -8,15 +8,25 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -27,16 +37,26 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Bold
+import com.adamglin.phosphoricons.bold.MagnifyingGlass
+import com.adamglin.phosphoricons.bold.X
+import com.poziomki.app.network.Tag
 import com.poziomki.app.ui.designsystem.components.AppSnackbar
 import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.PoziomkiSearchBar
 import com.poziomki.app.ui.designsystem.components.ProfileCard
 import com.poziomki.app.ui.designsystem.components.ScreenHeader
+import com.poziomki.app.ui.designsystem.theme.MontserratFamily
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
+import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
@@ -70,12 +90,71 @@ fun ExploreScreen(
             query = state.query,
             onQueryChange = viewModel::updateQuery,
             placeholder = "szukaj os\u00f3b, wydarze\u0144...",
+            filterActive = state.isFilterActive,
+            onFilterClick = { viewModel.toggleShowTagFilter() },
         )
+
+        if (state.showTagFilter) {
+            ExploreTagFilterDialog(
+                ownTags = state.ownTags,
+                selectedTags = state.selectedTags,
+                searchQuery = state.tagFilterQuery,
+                searchResults = state.tagFilterSearchResults,
+                isSearching = state.isSearchingFilterTags,
+                onSearchQueryChange = viewModel::updateTagFilterQuery,
+                onToggleTag = viewModel::toggleTagFilter,
+                onClear = viewModel::clearTagFilters,
+                onDismiss = { viewModel.toggleShowTagFilter() },
+            )
+        }
+
+        if (state.isFilterActive) {
+            ActiveTagFilterRow(
+                selectedTags = state.selectedTags,
+                onRemove = viewModel::toggleTagFilter,
+                onClear = viewModel::clearTagFilters,
+            )
+        }
 
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
 
+        val isFilterOnlyMode = !isSearchActive && state.isFilterActive
         Box(modifier = Modifier.fillMaxSize()) {
-            if (isSearchActive) {
+            if (isFilterOnlyMode) {
+                val results = state.filteredProfiles
+                if (results.isEmpty()) {
+                    EmptyView("brak osób pasujących do filtra")
+                } else {
+                    LazyColumn(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = PoziomkiTheme.spacing.md),
+                        contentPadding = PaddingValues(bottom = LocalNavBarPadding.current),
+                        verticalArrangement = Arrangement.spacedBy(PoziomkiTheme.spacing.sm),
+                    ) {
+                        item {
+                            Text(
+                                text = "osoby",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = TextSecondary,
+                                modifier = Modifier.padding(vertical = 4.dp),
+                            )
+                        }
+                        items(results, key = { it.id }) { profile ->
+                            val ownIds = state.ownTags.mapTo(mutableSetOf()) { it.id }
+                            ProfileCard(
+                                name = profile.name,
+                                profilePicture = profile.profilePicture,
+                                gradientStart = profile.gradientStart,
+                                gradientEnd = profile.gradientEnd,
+                                matchingTags = profile.tags.filter { it.id in ownIds },
+                                onClick = { onNavigateToProfile(profile.id) },
+                            )
+                        }
+                    }
+                }
+            } else if (isSearchActive) {
                 // Search results
                 when {
                     state.isSearching -> {
@@ -83,7 +162,16 @@ fun ExploreScreen(
                     }
 
                     state.searchResults != null -> {
-                        val results = state.searchResults!!
+                        val raw = state.searchResults!!
+                        val selectedIds = state.selectedTagIds
+                        val results =
+                            if (selectedIds.isEmpty()) {
+                                raw
+                            } else {
+                                raw.copy(
+                                    profiles = raw.profiles.filter { p -> p.tags.any { it in selectedIds } },
+                                )
+                            }
                         val hasResults =
                             results.profiles.isNotEmpty() ||
                                 results.events.isNotEmpty() ||
@@ -263,6 +351,274 @@ fun ExploreScreen(
                     viewModel.clearRefreshError()
                 }
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
+@Composable
+@Suppress("LongParameterList", "LongMethod")
+private fun ExploreTagFilterDialog(
+    ownTags: List<Tag>,
+    selectedTags: List<Tag>,
+    searchQuery: String,
+    searchResults: List<Tag>,
+    isSearching: Boolean,
+    onSearchQueryChange: (String) -> Unit,
+    onToggleTag: (Tag) -> Unit,
+    onClear: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val selectedIds = selectedTags.mapTo(mutableSetOf()) { it.id }
+    val ownInterests = ownTags.filter { it.scope == "interest" }.sortedBy { it.name }
+    val ownActivities = ownTags.filter { it.scope == "activity" }.sortedBy { it.name }
+    val ownIds = ownTags.mapTo(mutableSetOf()) { it.id }
+    val customSelected = selectedTags.filter { it.id !in ownIds }
+    val searchHits = searchResults.filter { it.id !in ownIds }
+
+    BasicAlertDialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            color = MaterialTheme.colorScheme.surface,
+        ) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "filtruj po tagach",
+                        fontFamily = MontserratFamily,
+                        fontWeight = FontWeight.ExtraBold,
+                        fontSize = 18.sp,
+                        color = TextPrimary,
+                    )
+                    if (selectedTags.isNotEmpty()) {
+                        Text(
+                            text = "wyczyść",
+                            fontFamily = NunitoFamily,
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 13.sp,
+                            color = Primary,
+                            modifier = Modifier.clickable(onClick = onClear),
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                TagFilterSearchField(
+                    query = searchQuery,
+                    onQueryChange = onSearchQueryChange,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Column(
+                    modifier =
+                        Modifier
+                            .heightIn(max = 420.dp)
+                            .verticalScroll(rememberScrollState()),
+                ) {
+                    if (searchQuery.length >= 2) {
+                        TagFilterSection(
+                            label = if (isSearching) "szukam..." else "wyniki",
+                            tags = searchHits,
+                            selectedIds = selectedIds,
+                            onToggleTag = onToggleTag,
+                            emptyText = if (isSearching) null else "brak wyników",
+                        )
+                    } else {
+                        if (customSelected.isNotEmpty()) {
+                            TagFilterSection(
+                                label = "wybrane",
+                                tags = customSelected,
+                                selectedIds = selectedIds,
+                                onToggleTag = onToggleTag,
+                            )
+                        }
+                        TagFilterSection(
+                            label = "twoje zainteresowania",
+                            tags = ownInterests,
+                            selectedIds = selectedIds,
+                            onToggleTag = onToggleTag,
+                            emptyText = "brak zainteresowań w profilu",
+                        )
+                        TagFilterSection(
+                            label = "twoje aktywności",
+                            tags = ownActivities,
+                            selectedIds = selectedIds,
+                            onToggleTag = onToggleTag,
+                            emptyText = "brak aktywności w profilu",
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagFilterSearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+) {
+    Surface(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .heightIn(min = 40.dp),
+        shape = RoundedCornerShape(20.dp),
+        color = SurfaceElevated,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                PhosphorIcons.Bold.MagnifyingGlass,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = TextMuted,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(modifier = Modifier.weight(1f)) {
+                if (query.isEmpty()) {
+                    Text(
+                        text = "szukaj więcej tagów...",
+                        fontFamily = NunitoFamily,
+                        color = TextMuted,
+                        fontSize = 14.sp,
+                    )
+                }
+                BasicTextField(
+                    value = query,
+                    onValueChange = onQueryChange,
+                    singleLine = true,
+                    textStyle =
+                        TextStyle(
+                            fontFamily = NunitoFamily,
+                            color = TextPrimary,
+                            fontSize = 14.sp,
+                        ),
+                    cursorBrush = SolidColor(Primary),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun TagFilterSection(
+    label: String,
+    tags: List<Tag>,
+    selectedIds: Set<String>,
+    onToggleTag: (Tag) -> Unit,
+    emptyText: String? = null,
+) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.titleSmall,
+        color = TextSecondary,
+        modifier = Modifier.padding(vertical = 4.dp),
+    )
+    if (tags.isEmpty()) {
+        if (emptyText != null) {
+            Text(
+                text = emptyText,
+                fontFamily = NunitoFamily,
+                color = TextMuted,
+                fontSize = 13.sp,
+                modifier = Modifier.padding(vertical = 4.dp),
+            )
+        }
+    } else {
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(bottom = 8.dp),
+        ) {
+            tags.forEach { tag ->
+                TagFilterChip(
+                    tag = tag,
+                    selected = tag.id in selectedIds,
+                    onClick = { onToggleTag(tag) },
+                )
+            }
+        }
+    }
+    Spacer(modifier = Modifier.height(4.dp))
+}
+
+@Composable
+private fun TagFilterChip(
+    tag: Tag,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val bg = if (selected) Primary else SurfaceElevated
+    val fg = if (selected) MaterialTheme.colorScheme.onPrimary else TextPrimary
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = bg,
+        modifier = Modifier.clickable(onClick = onClick),
+    ) {
+        Text(
+            text = "${tag.emoji ?: ""} ${tag.name}".trim(),
+            fontFamily = NunitoFamily,
+            fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+            color = fg,
+            fontSize = 13.sp,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ActiveTagFilterRow(
+    selectedTags: List<Tag>,
+    onRemove: (Tag) -> Unit,
+    onClear: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        FlowRow(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            selectedTags.forEach { tag ->
+                Surface(
+                    shape = RoundedCornerShape(12.dp),
+                    color = Primary,
+                    modifier = Modifier.clickable { onRemove(tag) },
+                ) {
+                    Text(
+                        text = "${tag.emoji ?: ""} ${tag.name} ×".trim(),
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        fontSize = 11.sp,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 1.dp),
+                    )
+                }
+            }
+        }
+        IconButton(
+            onClick = onClear,
+            modifier = Modifier.size(48.dp),
+        ) {
+            Icon(
+                PhosphorIcons.Bold.X,
+                contentDescription = "Wyczyść filtry",
+                modifier = Modifier.size(18.dp),
+                tint = Primary,
+            )
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreViewModel.kt
@@ -26,15 +26,32 @@ data class ExploreState(
     val searchResults: SearchResults? = null,
     val isSearching: Boolean = false,
     val ownTags: List<Tag> = emptyList(),
+    val selectedTags: List<Tag> = emptyList(),
+    val showTagFilter: Boolean = false,
+    val tagFilterQuery: String = "",
+    val tagFilterSearchResults: List<Tag> = emptyList(),
+    val isSearchingFilterTags: Boolean = false,
 ) {
     companion object {
         const val RECOMMENDED_COUNT = 4
     }
 
-    val recommendedProfiles get() = profiles.take(RECOMMENDED_COUNT)
-    val remainingProfiles get() = profiles.drop(RECOMMENDED_COUNT)
+    val selectedTagIds: Set<String> get() = selectedTags.mapTo(mutableSetOf()) { it.id }
+    val isFilterActive: Boolean get() = selectedTags.isNotEmpty()
+
+    val filteredProfiles: List<MatchProfile> get() =
+        if (selectedTags.isEmpty()) {
+            profiles
+        } else {
+            val ids = selectedTagIds
+            profiles.filter { p -> p.tags.any { it.id in ids } }
+        }
+
+    val recommendedProfiles get() = filteredProfiles.take(RECOMMENDED_COUNT)
+    val remainingProfiles get() = filteredProfiles.drop(RECOMMENDED_COUNT)
 }
 
+@Suppress("TooManyFunctions")
 class ExploreViewModel(
     private val matchProfileRepository: MatchProfileRepository,
     private val profileRepository: ProfileRepository,
@@ -43,6 +60,7 @@ class ExploreViewModel(
     private val _state = MutableStateFlow(ExploreState())
     val state: StateFlow<ExploreState> = _state.asStateFlow()
     private var searchJob: Job? = null
+    private var tagSearchJob: Job? = null
 
     init {
         observeProfiles()
@@ -114,6 +132,53 @@ class ExploreViewModel(
 
     fun clearRefreshError() {
         _state.value = _state.value.copy(refreshError = null)
+    }
+
+    fun toggleShowTagFilter() {
+        val nextOpen = !_state.value.showTagFilter
+        _state.value =
+            _state.value.copy(
+                showTagFilter = nextOpen,
+                tagFilterQuery = if (nextOpen) _state.value.tagFilterQuery else "",
+                tagFilterSearchResults = if (nextOpen) _state.value.tagFilterSearchResults else emptyList(),
+            )
+    }
+
+    fun toggleTagFilter(tag: Tag) {
+        val current = _state.value.selectedTags
+        val next =
+            if (current.any { it.id == tag.id }) current.filterNot { it.id == tag.id } else current + tag
+        _state.value = _state.value.copy(selectedTags = next)
+    }
+
+    fun clearTagFilters() {
+        _state.value = _state.value.copy(selectedTags = emptyList())
+    }
+
+    fun updateTagFilterQuery(query: String) {
+        _state.value = _state.value.copy(tagFilterQuery = query)
+        tagSearchJob?.cancel()
+        if (query.length < 2) {
+            _state.value = _state.value.copy(tagFilterSearchResults = emptyList(), isSearchingFilterTags = false)
+            return
+        }
+        tagSearchJob =
+            viewModelScope.launch {
+                delay(250)
+                _state.value = _state.value.copy(isSearchingFilterTags = true)
+                val interestResult = apiService.searchTags("interest", query)
+                val activityResult = apiService.searchTags("activity", query)
+                val merged =
+                    listOf(interestResult, activityResult)
+                        .mapNotNull { (it as? ApiResult.Success)?.data }
+                        .flatten()
+                        .distinctBy { it.id }
+                _state.value =
+                    _state.value.copy(
+                        tagFilterSearchResults = merged,
+                        isSearchingFilterTags = false,
+                    )
+            }
     }
 
     fun updateQuery(query: String) {


### PR DESCRIPTION
Tap filter icon in poznaj search bar to pick from your interests/activities or search the catalog. Active filters appear as chips above results. Also drops the placeholder filter icon from messages search bar and aligns header avatar with the filter button column.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tag-based filtering to the Explore screen
> - Adds a tag filter dialog (`ExploreTagFilterDialog`) to the Explore screen where users can search for, select, and deselect interest/activity tags.
> - Active filters are shown as removable chips in an `ActiveTagFilterRow` below the search bar, with a one-tap clear-all control.
> - When filters are active and no search query is entered, the screen shows tag-filtered profiles instead of recommendations; search results are also constrained by selected tags.
> - `ExploreViewModel` tracks filter state and performs debounced (250ms) remote tag searches across `interest` and `activity` scopes via `apiService.searchTags`.
> - `PoziomkiSearchBar` is updated to hide the static filter icon when no filter action is provided, and show a divider next to the clickable icon when one is.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd47037.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->