### PR TITLE
consistency: lowercase privacy labels, X icon for clear-filters

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -57,6 +58,7 @@ import com.adamglin.phosphoricons.bold.BookmarkSimple
 import com.adamglin.phosphoricons.bold.CaretDown
 import com.adamglin.phosphoricons.bold.CaretUp
 import com.adamglin.phosphoricons.bold.Plus
+import com.adamglin.phosphoricons.bold.X
 import com.adamglin.phosphoricons.fill.BookmarkSimple
 import com.adamglin.phosphoricons.fill.MapPin
 import com.poziomki.app.network.Event
@@ -692,14 +694,17 @@ private fun CategoryFilterDialog(
                         color = TextPrimary,
                     )
                     if (selectedCategories.isNotEmpty()) {
-                        Text(
-                            text = "wyczyść",
-                            fontFamily = NunitoFamily,
-                            fontWeight = FontWeight.Medium,
-                            fontSize = 13.sp,
-                            color = Primary,
-                            modifier = Modifier.clickable(onClick = onClear),
-                        )
+                        IconButton(
+                            onClick = onClear,
+                            modifier = Modifier.size(32.dp),
+                        ) {
+                            Icon(
+                                PhosphorIcons.Bold.X,
+                                contentDescription = "Wyczyść filtry",
+                                modifier = Modifier.size(18.dp),
+                                tint = Primary,
+                            )
+                        }
                     }
                 }
                 Spacer(modifier = Modifier.height(16.dp))

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -395,14 +395,17 @@ private fun ExploreTagFilterDialog(
                         color = TextPrimary,
                     )
                     if (selectedTags.isNotEmpty()) {
-                        Text(
-                            text = "wyczyść",
-                            fontFamily = NunitoFamily,
-                            fontWeight = FontWeight.Medium,
-                            fontSize = 13.sp,
-                            color = Primary,
-                            modifier = Modifier.clickable(onClick = onClear),
-                        )
+                        IconButton(
+                            onClick = onClear,
+                            modifier = Modifier.size(32.dp),
+                        ) {
+                            Icon(
+                                PhosphorIcons.Bold.X,
+                                contentDescription = "Wyczyść filtry",
+                                modifier = Modifier.size(18.dp),
+                                tint = Primary,
+                            )
+                        }
                     }
                 }
                 Spacer(modifier = Modifier.height(12.dp))

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
@@ -151,7 +151,7 @@ private fun PrivacyContent(
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
         PrivacyMessages(state.error, state.passwordSuccessMessage, nunito)
 
-        SectionLabel("WIDOCZNOŚĆ", color = TextMuted)
+        SectionLabel("widoczność", color = TextMuted)
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
         PrivacyToggleRow(
             label = "widoczność w rekomendacjach",
@@ -170,7 +170,7 @@ private fun PrivacyContent(
         )
 
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
-        SectionLabel("ZRZUTY EKRANU", color = TextMuted)
+        SectionLabel("zrzuty ekranu", color = TextMuted)
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
         PrivacyToggleRow(
             label = "zezwalaj na zrzuty ekranu",
@@ -181,7 +181,7 @@ private fun PrivacyContent(
         )
 
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
-        SectionLabel("HASŁO", color = TextMuted)
+        SectionLabel("hasło", color = TextMuted)
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
         AppButton(
             text = "zmień hasło",
@@ -233,7 +233,7 @@ private fun ExportDataSection(
     onExport: () -> Unit,
     nunito: androidx.compose.ui.text.font.FontFamily,
 ) {
-    SectionLabel("TWOJE DANE", color = TextMuted)
+    SectionLabel("twoje dane", color = TextMuted)
     Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
     Text(
         text =
@@ -273,7 +273,7 @@ private fun DeleteAccountSection(
     onDelete: () -> Unit,
     nunito: androidx.compose.ui.text.font.FontFamily,
 ) {
-    SectionLabel("USUŃ KONTO", color = TextMuted)
+    SectionLabel("usuń konto", color = TextMuted)
     Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
     Text(
         text =


### PR DESCRIPTION
Brings prywatność section headers in line with the lowercase brand voice used elsewhere, and replaces the "wyczyść" text in filter dialogs with an X icon to match the active-filter row.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace clear-filter text labels with X icon buttons and lowercase privacy section labels
> - Replaces the clickable `wyczyść` text in `CategoryFilterDialog` ([EventsScreen.kt](https://github.com/poziomki-app/poziomki/pull/375/files#diff-b1aad26129722f5aa103f55ac1d883a2b472203a3df536f251798d2ab83260dd)) and `ExploreTagFilterDialog` ([ExploreScreen.kt](https://github.com/poziomki-app/poziomki/pull/375/files#diff-bf348e96d4f4792f688f3ada76c82ab095ec913447f98bc5f143aff6edf3c079)) with a 32dp `IconButton` using `PhosphorIcons.Bold.X`.
> - Converts five section labels in [PrivacyScreen.kt](https://github.com/poziomki-app/poziomki/pull/375/files#diff-e10ce7b571ec968e2633b5f01d65183b9f5bac40d0bae88d29de94b15260e0fe) from uppercase (e.g. `WIDOCZNOŚĆ`) to lowercase (`widoczność`) for visual consistency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8465325.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->