### PR TITLE
fix(chat): preserve seeded avatar when binding room

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -682,7 +682,7 @@ class ChatViewModel(
                 summary = initialSummary,
                 overrides = _uiState.value.avatarOverrides,
                 roomDisplayName = initialDisplayName,
-                currentAvatar = null,
+                currentAvatar = _uiState.value.roomAvatarUrl,
                 directUserIdFallback = activeDirectUserId,
             )
         val initialIsDirect = initialSummary?.isDirect ?: (activeDirectUserId != null)


### PR DESCRIPTION
Drops the avatar flicker on chat open. Second resolveRoomAvatar pass was wiping the seed with currentAvatar=null.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ChatViewModel` to preserve seeded avatar URL when binding room
> When binding a room, `currentAvatar` was hardcoded to `null`, discarding any avatar URL already loaded into the UI state. Now passes `_uiState.value.roomAvatarUrl` instead, so the existing avatar is retained.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 020595d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->