### PR TITLE
fix(profile): hide kierunek on own profile when privacy toggle is off

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
@@ -72,9 +72,11 @@ fun ProfileViewScreen(
                 val bottomInsets =
                     WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
                 Box(modifier = Modifier.fillMaxSize()) {
+                    val displayedProgram =
+                        if (state.isOwnProfile && !state.showOwnProgram) null else p.program
                     ProfilePreview(
                         name = p.name,
-                        program = p.program,
+                        program = displayedProgram,
                         bio = p.bio,
                         tags = p.tags,
                         images = images,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.poziomki.app.data.repository.ProfileRepository
+import com.poziomki.app.data.repository.SettingsRepository
 import com.poziomki.app.network.ApiResult
 import com.poziomki.app.network.ApiService
 import com.poziomki.app.network.ProfileWithTags
@@ -22,12 +23,14 @@ data class ProfileViewState(
     val isLoading: Boolean = true,
     val isOwnProfile: Boolean = false,
     val isBookmarked: Boolean = false,
+    val showOwnProgram: Boolean = true,
 )
 
 class ProfileViewViewModel(
     savedStateHandle: SavedStateHandle,
     private val profileRepository: ProfileRepository,
     private val sessionManager: SessionManager,
+    private val settingsRepository: SettingsRepository,
     private val apiService: ApiService,
 ) : ViewModel() {
     private val route = savedStateHandle.toRoute<Route.ProfileView>()
@@ -49,6 +52,17 @@ class ProfileViewViewModel(
             val ownProfileId = sessionManager.profileId.first()
             if (ownProfileId == profileId) {
                 _state.update { it.copy(isOwnProfile = true) }
+                observeOwnPrivacy()
+            }
+        }
+    }
+
+    private fun observeOwnPrivacy() {
+        viewModelScope.launch {
+            val userId = sessionManager.userId.first() ?: return@launch
+            settingsRepository.observeSettings(userId).collect { settings ->
+                val show = settings?.privacy_show_program?.let { it != 0L } ?: true
+                _state.update { it.copy(showOwnProgram = show) }
             }
         }
     }


### PR DESCRIPTION
Backend zawsze zwraca program dla właściciela, więc toggle wyglądał jakby nie działał. Klient teraz ukrywa kierunek na podglądzie własnego profilu gdy toggle off.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide kierunek on own profile when privacy toggle is off
> - Adds `showOwnProgram` to `ProfileViewState`, populated by observing `privacy_show_program` from `SettingsRepository` when viewing own profile.
> - In `ProfileViewScreen`, passes `null` as the program to `ProfilePreview` when `showOwnProgram` is false, suppressing the field in the UI.
> - Behavioral Change: users viewing their own profile will no longer see their kierunek (program) if the privacy toggle is disabled; the field is shown by default if the setting is unset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b63c70d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->