### PR TITLE
feat(profile): allow editing name in profile editor

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
@@ -165,6 +165,18 @@ fun ProfileEditScreen(
 
                 Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
+                // --- imię ---
+                SectionLabel("imię")
+
+                PoziomkiTextField(
+                    value = state.name,
+                    onValueChange = { viewModel.updateName(it) },
+                    placeholder = "imię",
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
+
                 // --- bio ---
                 SectionLabel("bio")
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditViewModel.kt
@@ -143,6 +143,10 @@ class ProfileEditViewModel(
         }
     }
 
+    fun updateName(name: String) {
+        _state.value = _state.value.copy(name = name.take(60))
+    }
+
     fun updateBio(bio: String) {
         val visibleLength = bio.replace(Regex("""!\[\]\([^)]*\)"""), "").length
         if (visibleLength <= 1500) {
@@ -287,8 +291,19 @@ class ProfileEditViewModel(
         viewModelScope.launch {
             _state.value = _state.value.copy(isSaving = true)
             val s = _state.value
+            val trimmedName = s.name.trim()
+            if (trimmedName.isBlank()) {
+                _state.value =
+                    _state.value.copy(
+                        isSaving = false,
+                        snackbarMessage = "imię nie może być puste",
+                        snackbarType = SnackbarType.ERROR,
+                    )
+                return@launch
+            }
             val request =
                 UpdateProfileRequest(
+                    name = trimmedName,
                     bio = s.bio.ifBlank { null },
                     program = s.program.ifBlank { null },
                     profilePicture = s.images.firstOrNull()?.let { JsonPrimitive(it) } ?: JsonNull,


### PR DESCRIPTION
Adds an imię field to edytuj profil so users can change their display name. Empty value is rejected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add name editing field to profile editor screen
> - Adds a "imię" (name) text field to [`ProfileEditScreen`](https://github.com/poziomki-app/poziomki/pull/379/files#diff-765a0bfa960ac3d97ec00ad0eaefbb004cfc044f0cd7c99d27ef9ccbdedcc95a), bound to `state.name` and wired to `viewModel.updateName`.
> - `updateName` in [`ProfileEditViewModel`](https://github.com/poziomki-app/poziomki/pull/379/files#diff-a677feb6ddc9738e0c17138c4ab6cfb1a6ef09538184ea56fe225b88bcb9d83f) caps input at 60 characters via `name.take(60)`.
> - On save, the name is trimmed; a blank name aborts the save and shows an error snackbar ("imię nie może być puste"). A valid name is included in the `UpdateProfileRequest`.
> - Behavioral Change: saving a profile now requires a non-blank name — previously the save flow had no name field at all.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 848fe2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->