### PR TITLE
feat(privacy): change email with OTP

### DIFF
--- a/backend/src/api/auth/email_change.rs
+++ b/backend/src/api/auth/email_change.rs
@@ -28,6 +28,7 @@ pub(in crate::api) struct EmailChangeRequestBody {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(in crate::api) struct EmailChangeConfirmBody {
     pub(in crate::api) new_email: String,
     pub(in crate::api) code: String,

--- a/backend/src/api/auth/email_change.rs
+++ b/backend/src/api/auth/email_change.rs
@@ -1,0 +1,190 @@
+use axum::response::Response;
+use axum::{extract::State, http::HeaderMap, response::IntoResponse, Json};
+use chrono::Utc;
+use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::RunQueryDsl;
+use serde::{Deserialize, Serialize};
+
+use crate::api::{auth_or_respond, error_response, ErrorSpec};
+use crate::app::AppContext;
+use crate::db::schema::users;
+use crate::db::{self, DbViewer};
+
+use super::super::state::{
+    invalidate_auth_cache_for_user_id, is_valid_email, normalize_email, otp_in_cooldown,
+    upsert_otp, verify_otp_db, DataResponse, SuccessResponse,
+};
+use super::auth_service::{find_user_by_email, generate_otp_code, OTP_RESEND_COOLDOWN_SECS};
+use crate::jobs::enqueue_otp_email;
+
+type Result<T> = crate::error::AppResult<T>;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::api) struct EmailChangeRequestBody {
+    pub(in crate::api) new_email: String,
+    pub(in crate::api) current_password: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(in crate::api) struct EmailChangeConfirmBody {
+    pub(in crate::api) new_email: String,
+    pub(in crate::api) code: String,
+}
+
+#[derive(Serialize)]
+struct EmailChangeResponse {
+    success: bool,
+    email: String,
+}
+
+fn validation_error(headers: &HeaderMap, message: &str) -> Response {
+    error_response(
+        axum::http::StatusCode::BAD_REQUEST,
+        headers,
+        ErrorSpec {
+            error: message.to_string(),
+            code: "VALIDATION_ERROR",
+            details: None,
+        },
+    )
+}
+
+fn email_taken_error(headers: &HeaderMap) -> Response {
+    error_response(
+        axum::http::StatusCode::CONFLICT,
+        headers,
+        ErrorSpec {
+            error: "Email is already in use".to_string(),
+            code: "EMAIL_TAKEN",
+            details: None,
+        },
+    )
+}
+
+pub(in crate::api) async fn request_email_change(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Json(payload): Json<EmailChangeRequestBody>,
+) -> Result<Response> {
+    let (_session, user) = auth_or_respond!(headers);
+
+    if payload.current_password.is_empty()
+        || !crate::security::verify_password(&payload.current_password, &user.password)
+    {
+        return Ok(super::auth_service::unauthorized_error(
+            &headers,
+            "Invalid password",
+        ));
+    }
+
+    let new_email = normalize_email(&payload.new_email);
+    if new_email.is_empty() || !is_valid_email(&new_email) {
+        return Ok(validation_error(&headers, "Invalid email address"));
+    }
+    if new_email == user.email {
+        return Ok(validation_error(
+            &headers,
+            "New email must differ from current email",
+        ));
+    }
+    if find_user_by_email(&new_email).await?.is_some() {
+        return Ok(email_taken_error(&headers));
+    }
+    if otp_in_cooldown(&new_email, OTP_RESEND_COOLDOWN_SECS).await {
+        return Ok(error_response(
+            axum::http::StatusCode::TOO_MANY_REQUESTS,
+            &headers,
+            ErrorSpec {
+                error: "Please wait before requesting another code".to_string(),
+                code: "RATE_LIMITED",
+                details: None,
+            },
+        ));
+    }
+
+    let code = generate_otp_code();
+    upsert_otp(&new_email, &code).await?;
+    if let Err(error) = enqueue_otp_email(&new_email, &code).await {
+        tracing::error!(
+            %error,
+            email = %crate::api::redact_email(&new_email),
+            "failed to enqueue OTP email for email change"
+        );
+    }
+
+    Ok(Json(DataResponse {
+        data: SuccessResponse { success: true },
+    })
+    .into_response())
+}
+
+pub(in crate::api) async fn confirm_email_change(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Json(payload): Json<EmailChangeConfirmBody>,
+) -> Result<Response> {
+    let (_session, user) = auth_or_respond!(headers);
+
+    let new_email = normalize_email(&payload.new_email);
+    if new_email.is_empty() || !is_valid_email(&new_email) {
+        return Ok(validation_error(&headers, "Invalid email address"));
+    }
+    if new_email == user.email {
+        return Ok(validation_error(
+            &headers,
+            "New email must differ from current email",
+        ));
+    }
+
+    if !verify_otp_db(&new_email, &payload.code).await {
+        return Ok(error_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            &headers,
+            ErrorSpec {
+                error: "Invalid or expired verification code".to_string(),
+                code: "INVALID_OTP",
+                details: None,
+            },
+        ));
+    }
+
+    // Re-check inside the transaction — between request and confirm someone
+    // else may have signed up with this address.
+    if find_user_by_email(&new_email).await?.is_some() {
+        return Ok(email_taken_error(&headers));
+    }
+
+    let viewer = DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let new_email_for_tx = new_email.clone();
+    db::with_viewer_tx(viewer, |conn| {
+        async move {
+            let now = Utc::now();
+            diesel::update(users::table.find(user.id))
+                .set((
+                    users::email.eq(new_email_for_tx),
+                    users::email_verified_at.eq(Some(now)),
+                    users::updated_at.eq(now),
+                ))
+                .execute(conn)
+                .await?;
+            Ok::<(), diesel::result::Error>(())
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    invalidate_auth_cache_for_user_id(user.id).await;
+
+    Ok(Json(DataResponse {
+        data: EmailChangeResponse {
+            success: true,
+            email: new_email,
+        },
+    })
+    .into_response())
+}

--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -1,5 +1,7 @@
 #[path = "account.rs"]
 mod auth_account;
+#[path = "email_change.rs"]
+mod auth_email_change;
 #[path = "rate_limit.rs"]
 mod auth_rate_limit;
 #[path = "service.rs"]
@@ -39,6 +41,7 @@ use crate::db::schema::sessions;
 use crate::jobs::enqueue_otp_email;
 
 pub(super) use auth_account::{change_password, delete_account, export_data};
+pub(super) use auth_email_change::{confirm_email_change, request_email_change};
 pub(super) use auth_session::get_session;
 
 pub(super) async fn sign_up(

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -54,6 +54,8 @@ fn auth_routes() -> Router<AppContext> {
         .route("/sessions", get(auth::sessions))
         .route("/account", delete(auth::delete_account))
         .route("/account/password", patch(auth::change_password))
+        .route("/account/email/request", patch(auth::request_email_change))
+        .route("/account/email/confirm", patch(auth::confirm_email_change))
         .route("/export", get(auth::export_data))
         .route("/forgot-password", post(auth::forgot_password))
         .route(

--- a/backend/tests/requests/email_change.rs
+++ b/backend/tests/requests/email_change.rs
@@ -1,0 +1,146 @@
+use axum::http::{HeaderName, HeaderValue};
+use axum_test::TestServer;
+use serial_test::serial;
+use std::future::Future;
+
+fn auth_header(token: &str) -> (HeaderName, HeaderValue) {
+    let value = HeaderValue::from_str(&format!("Bearer {token}")).unwrap();
+    (HeaderName::from_static("authorization"), value)
+}
+
+async fn run<F, Fut>(f: F)
+where
+    F: FnOnce(TestServer) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let _ = dotenvy::dotenv();
+    let ctx = poziomki_backend::app::build_test_app_context().expect("build test app context");
+    poziomki_backend::app::reset_test_database()
+        .await
+        .expect("truncate test tables");
+    let server = TestServer::new(poziomki_backend::app::build_router_with_state(ctx));
+    f(server).await;
+}
+
+async fn get_otp_code(email: &str) -> String {
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+    use poziomki_backend::db::models::otp_codes::OtpCode;
+    use poziomki_backend::db::schema::otp_codes;
+
+    let mut conn = poziomki_backend::db::conn().await.expect("get DB conn");
+    otp_codes::table
+        .filter(otp_codes::email.eq(email))
+        .first::<OtpCode>(&mut conn)
+        .await
+        .expect("No OTP found for email")
+        .code
+}
+
+async fn sign_up_and_verify(server: &TestServer, email: &str, password: &str) -> String {
+    let sign_up = server
+        .post("/api/v1/auth/sign-up/email")
+        .json(&serde_json::json!({
+            "email": email,
+            "name": "Test User",
+            "password": password,
+        }))
+        .await;
+    assert_eq!(sign_up.status_code(), 200);
+
+    let otp = get_otp_code(email).await;
+    let verify = server
+        .post("/api/v1/auth/verify-otp")
+        .json(&serde_json::json!({ "email": email, "otp": otp }))
+        .await;
+    assert_eq!(verify.status_code(), 200);
+    let body: serde_json::Value = verify.json();
+    body["data"]["token"]
+        .as_str()
+        .map(ToOwned::to_owned)
+        .expect("verify-otp should return token")
+}
+
+#[tokio::test]
+#[serial]
+async fn email_change_happy_path() {
+    run(|server| async move {
+        let token = sign_up_and_verify(&server, "old@example.com", "secret123").await;
+        let (k, v) = auth_header(&token);
+
+        let request = server
+            .patch("/api/v1/auth/account/email/request")
+            .add_header(k.clone(), v.clone())
+            .json(&serde_json::json!({
+                "newEmail": "new@example.com",
+                "currentPassword": "secret123",
+            }))
+            .await;
+        assert_eq!(request.status_code(), 200);
+
+        let code = get_otp_code("new@example.com").await;
+        let confirm = server
+            .patch("/api/v1/auth/account/email/confirm")
+            .add_header(k, v)
+            .json(&serde_json::json!({
+                "newEmail": "new@example.com",
+                "code": code,
+            }))
+            .await;
+        assert_eq!(confirm.status_code(), 200);
+        let body: serde_json::Value = confirm.json();
+        assert_eq!(body["data"]["email"], "new@example.com");
+
+        // Sign-in with new email should now work
+        let sign_in = server
+            .post("/api/v1/auth/sign-in/email")
+            .json(&serde_json::json!({
+                "email": "new@example.com",
+                "password": "secret123",
+            }))
+            .await;
+        assert_eq!(sign_in.status_code(), 200);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn email_change_rejects_wrong_password() {
+    run(|server| async move {
+        let token = sign_up_and_verify(&server, "user@example.com", "secret123").await;
+        let (k, v) = auth_header(&token);
+
+        let response = server
+            .patch("/api/v1/auth/account/email/request")
+            .add_header(k, v)
+            .json(&serde_json::json!({
+                "newEmail": "other@example.com",
+                "currentPassword": "wrong-password",
+            }))
+            .await;
+        assert_eq!(response.status_code(), 401);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn email_change_rejects_taken_email() {
+    run(|server| async move {
+        let _other = sign_up_and_verify(&server, "taken@example.com", "secret123").await;
+        let token = sign_up_and_verify(&server, "me@example.com", "secret123").await;
+        let (k, v) = auth_header(&token);
+
+        let response = server
+            .patch("/api/v1/auth/account/email/request")
+            .add_header(k, v)
+            .json(&serde_json::json!({
+                "newEmail": "taken@example.com",
+                "currentPassword": "secret123",
+            }))
+            .await;
+        assert_eq!(response.status_code(), 409);
+    })
+    .await;
+}

--- a/backend/tests/requests/mod.rs
+++ b/backend/tests/requests/mod.rs
@@ -1,4 +1,5 @@
 mod db_viewer;
+mod email_change;
 mod migration_contract;
 mod rls_baseline;
 mod rls_harness;

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/OtpInput.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/OtpInput.kt
@@ -1,0 +1,79 @@
+package com.poziomki.app.ui.designsystem.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.poziomki.app.ui.designsystem.theme.Border
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.Surface
+import com.poziomki.app.ui.designsystem.theme.TextPrimary
+
+@Composable
+@Suppress("LongMethod")
+fun OtpInput(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = { input ->
+            if (input.length <= 6 && input.all { it.isDigit() }) onValueChange(input)
+        },
+        modifier = modifier,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        singleLine = true,
+        cursorBrush = SolidColor(TextPrimary),
+        decorationBox = { _ ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                repeat(6) { index ->
+                    val char = value.getOrNull(index)
+                    val isFocused = value.length == index
+                    val boxModifier =
+                        Modifier
+                            .weight(1f)
+                            .height(48.dp)
+                            .background(Surface, RoundedCornerShape(12.dp))
+                            .border(
+                                width = if (isFocused) 2.dp else 1.dp,
+                                color = if (isFocused) Primary else Border,
+                                shape = RoundedCornerShape(12.dp),
+                            )
+                    Box(
+                        modifier = boxModifier,
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = char?.toString() ?: "",
+                            fontFamily = NunitoFamily,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 24.sp,
+                            color = TextPrimary,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+            }
+        },
+    )
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
@@ -1,18 +1,11 @@
 package com.poziomki.app.ui.feature.auth
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -27,18 +20,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.poziomki.app.ui.designsystem.components.AppButton
-import com.poziomki.app.ui.designsystem.theme.Border
+import com.poziomki.app.ui.designsystem.components.OtpInput
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
 import com.poziomki.app.ui.designsystem.theme.Primary
-import com.poziomki.app.ui.designsystem.theme.Surface
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
@@ -136,7 +126,7 @@ fun VerifyScreen(
         // OTP input boxes
         OtpInput(
             value = otp,
-            onValueChange = { if (it.length <= 6 && it.all { c -> c.isDigit() }) otp = it },
+            onValueChange = { otp = it },
             modifier = Modifier.focusRequester(focusRequester),
         )
 
@@ -180,55 +170,4 @@ fun VerifyScreen(
             )
         }
     }
-}
-
-@Composable
-private fun OtpInput(
-    value: String,
-    onValueChange: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val nunito = NunitoFamily
-
-    BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
-        modifier = modifier,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-        singleLine = true,
-        cursorBrush = SolidColor(TextPrimary),
-        decorationBox = { _ ->
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                repeat(6) { index ->
-                    val char = value.getOrNull(index)
-                    val isFocused = value.length == index
-                    Box(
-                        modifier =
-                            Modifier
-                                .weight(1f)
-                                .height(48.dp)
-                                .background(Surface, RoundedCornerShape(12.dp))
-                                .border(
-                                    width = if (isFocused) 2.dp else 1.dp,
-                                    color = if (isFocused) Primary else Border,
-                                    shape = RoundedCornerShape(12.dp),
-                                ),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = char?.toString() ?: "",
-                            fontFamily = nunito,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 24.sp,
-                            color = TextPrimary,
-                            textAlign = TextAlign.Center,
-                        )
-                    }
-                }
-            }
-        },
-    )
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangeEmailDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangeEmailDialog.kt
@@ -1,0 +1,205 @@
+package com.poziomki.app.ui.feature.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.poziomki.app.ui.designsystem.components.OtpInput
+import com.poziomki.app.ui.designsystem.components.PoziomkiPasswordField
+import com.poziomki.app.ui.designsystem.components.PoziomkiTextField
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.TextSecondary
+
+@Composable
+@Suppress("LongParameterList")
+fun ChangeEmailDialog(
+    isRequesting: Boolean,
+    isConfirming: Boolean,
+    otpSent: Boolean,
+    pendingNewEmail: String?,
+    error: String?,
+    onDismiss: () -> Unit,
+    onRequestOtp: (newEmail: String, currentPassword: String) -> Unit,
+    onConfirmOtp: (code: String) -> Unit,
+) {
+    if (otpSent && pendingNewEmail != null) {
+        OtpStep(
+            newEmail = pendingNewEmail,
+            isLoading = isConfirming,
+            error = error,
+            onConfirm = onConfirmOtp,
+            onDismiss = onDismiss,
+        )
+    } else {
+        EnterEmailStep(
+            isLoading = isRequesting,
+            error = error,
+            onSubmit = onRequestOtp,
+            onDismiss = onDismiss,
+        )
+    }
+}
+
+@Composable
+@Suppress("LongMethod")
+private fun EnterEmailStep(
+    isLoading: Boolean,
+    error: String?,
+    onSubmit: (String, String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        title = {
+            Text(
+                text = "Zmień email",
+                fontFamily = NunitoFamily,
+                fontWeight = FontWeight.Bold,
+            )
+        },
+        text = {
+            Column {
+                Text(
+                    text = "Wpisz nowy adres email i aktualne hasło. Wyślemy kod weryfikacyjny na nowy adres.",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 14.sp,
+                    color = TextSecondary,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                PoziomkiTextField(
+                    value = email,
+                    onValueChange = { email = it.trim() },
+                    placeholder = "nowy email",
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                PoziomkiPasswordField(
+                    value = password,
+                    onValueChange = { password = it },
+                    placeholder = "Aktualne hasło",
+                )
+                error?.let {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = it,
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onSubmit(email, password) },
+                enabled = email.isNotBlank() && password.isNotBlank() && !isLoading,
+            ) {
+                Text("Wyślij kod", fontFamily = NunitoFamily, fontWeight = FontWeight.Bold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isLoading) {
+                Text("Anuluj", fontFamily = NunitoFamily)
+            }
+        },
+    )
+}
+
+@Composable
+@Suppress("LongMethod")
+private fun OtpStep(
+    newEmail: String,
+    isLoading: Boolean,
+    error: String?,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var code by remember { mutableStateOf("") }
+    var hasSubmitted by remember { mutableStateOf(false) }
+
+    LaunchedEffect(code) {
+        if (code.length < 6) {
+            hasSubmitted = false
+        } else if (!hasSubmitted && !isLoading) {
+            hasSubmitted = true
+            onConfirm(code)
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        title = {
+            Text(
+                text = "Potwierdź email",
+                fontFamily = NunitoFamily,
+                fontWeight = FontWeight.Bold,
+            )
+        },
+        text = {
+            Column {
+                Text(
+                    text = "Wpisz 6-cyfrowy kod wysłany na",
+                    fontFamily = NunitoFamily,
+                    fontSize = 14.sp,
+                    color = TextSecondary,
+                )
+                Text(
+                    text = newEmail,
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                    color = Primary,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                OtpInput(
+                    value = code,
+                    onValueChange = { code = it },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                error?.let {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = it,
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(code) },
+                enabled = code.length == 6 && !isLoading,
+            ) {
+                Text("Potwierdź", fontFamily = NunitoFamily, fontWeight = FontWeight.Bold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isLoading) {
+                Text("Anuluj", fontFamily = NunitoFamily)
+            }
+        },
+    )
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
@@ -62,6 +62,7 @@ fun PrivacyScreen(
     val navBarBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showPasswordDialog by remember { mutableStateOf(false) }
+    var showEmailDialog by remember { mutableStateOf(false) }
 
     val saveExport =
         rememberExportFileSaver(
@@ -93,12 +94,37 @@ fun PrivacyScreen(
             navBarBottom = navBarBottom,
             nunito = nunito,
             onOpenPasswordDialog = { showPasswordDialog = true },
+            onOpenEmailDialog = { showEmailDialog = true },
             onExport = { viewModel.exportData() },
             onDelete = { showDeleteDialog = true },
             onToggleDiscoverable = viewModel::toggleDiscoverable,
             onToggleShowProgram = viewModel::toggleShowProgram,
             onToggleScreenshots = viewModel::toggleScreenshotsAllowed,
         )
+    }
+
+    if (showEmailDialog) {
+        ChangeEmailDialog(
+            isRequesting = state.isRequestingEmailOtp,
+            isConfirming = state.isConfirmingEmail,
+            otpSent = state.emailOtpSent,
+            pendingNewEmail = state.pendingNewEmail,
+            error = state.emailChangeError,
+            onDismiss = {
+                showEmailDialog = false
+                viewModel.cancelEmailChange()
+            },
+            onRequestOtp = viewModel::requestEmailChange,
+            onConfirmOtp = viewModel::confirmEmailChange,
+        )
+    }
+
+    LaunchedEffect(state.emailChangeSuccess) {
+        if (state.emailChangeSuccess != null) {
+            showEmailDialog = false
+            kotlinx.coroutines.delay(2000)
+            viewModel.clearEmailChangeSuccess()
+        }
     }
 
     if (showPasswordDialog && state.error == null) {
@@ -128,13 +154,14 @@ fun PrivacyScreen(
     }
 }
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 @Composable
 private fun PrivacyContent(
     state: PrivacyState,
     navBarBottom: androidx.compose.ui.unit.Dp,
     nunito: androidx.compose.ui.text.font.FontFamily,
     onOpenPasswordDialog: () -> Unit,
+    onOpenEmailDialog: () -> Unit,
     onExport: () -> Unit,
     onDelete: () -> Unit,
     onToggleDiscoverable: (Boolean) -> Unit,
@@ -178,6 +205,42 @@ private fun PrivacyContent(
             checked = state.screenshotsAllowed,
             onCheckedChange = onToggleScreenshots,
             nunito = nunito,
+        )
+
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
+        SectionLabel("EMAIL", color = TextMuted)
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
+        Text(
+            text = state.currentEmail.orEmpty(),
+            fontFamily = nunito,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 15.sp,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xs))
+        Text(
+            text = "kończysz studia a chcesz zostać w apce? wolisz korzystać z innego maila niż studenckiego?",
+            fontFamily = nunito,
+            fontWeight = FontWeight.Normal,
+            fontSize = 13.sp,
+            color = TextSecondary,
+            lineHeight = 18.sp,
+        )
+        state.emailChangeSuccess?.let {
+            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
+            Text(
+                text = it,
+                fontFamily = nunito,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp,
+                color = TextSecondary,
+            )
+        }
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
+        AppButton(
+            text = "zmień email",
+            onClick = onOpenEmailDialog,
+            variant = ButtonVariant.OUTLINE,
         )
 
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
@@ -27,8 +27,16 @@ data class PrivacyState(
     val discoverable: Boolean = true,
     val showProgram: Boolean = true,
     val screenshotsAllowed: Boolean = false,
+    val currentEmail: String? = null,
+    val pendingNewEmail: String? = null,
+    val isRequestingEmailOtp: Boolean = false,
+    val isConfirmingEmail: Boolean = false,
+    val emailOtpSent: Boolean = false,
+    val emailChangeError: String? = null,
+    val emailChangeSuccess: String? = null,
 )
 
+@Suppress("TooManyFunctions")
 class PrivacyViewModel(
     private val apiService: ApiService,
     private val sessionManager: SessionManager,
@@ -52,6 +60,10 @@ class PrivacyViewModel(
                     )
             }
         }
+        sessionManager.email
+            .onEach { email ->
+                _state.value = _state.value.copy(currentEmail = email)
+            }.launchIn(viewModelScope)
         appPreferences.screenshotsAllowed
             .onEach { allowed ->
                 _state.value = _state.value.copy(screenshotsAllowed = allowed)
@@ -219,4 +231,104 @@ class PrivacyViewModel(
     fun clearPasswordSuccess() {
         _state.value = _state.value.copy(passwordSuccessMessage = null)
     }
+
+    fun requestEmailChange(
+        newEmail: String,
+        currentPassword: String,
+    ) {
+        val trimmed = newEmail.trim().lowercase()
+        if (trimmed.isBlank() || !trimmed.contains('@') || !trimmed.substringAfter('@').contains('.')) {
+            _state.value = _state.value.copy(emailChangeError = "Nieprawidłowy adres email")
+            return
+        }
+        if (currentPassword.isBlank()) {
+            _state.value = _state.value.copy(emailChangeError = "Wpisz aktualne hasło")
+            return
+        }
+        viewModelScope.launch {
+            _state.value =
+                _state.value.copy(
+                    isRequestingEmailOtp = true,
+                    emailChangeError = null,
+                    pendingNewEmail = trimmed,
+                )
+            when (val result = apiService.requestEmailChange(trimmed, currentPassword)) {
+                is ApiResult.Success -> {
+                    _state.value =
+                        _state.value.copy(
+                            isRequestingEmailOtp = false,
+                            emailOtpSent = true,
+                            emailChangeError = null,
+                        )
+                }
+
+                is ApiResult.Error -> {
+                    _state.value =
+                        _state.value.copy(
+                            isRequestingEmailOtp = false,
+                            emailOtpSent = false,
+                            pendingNewEmail = null,
+                            emailChangeError = mapEmailChangeError(result),
+                        )
+                }
+            }
+        }
+    }
+
+    fun confirmEmailChange(code: String) {
+        val newEmail = _state.value.pendingNewEmail ?: return
+        if (code.length != 6) {
+            _state.value = _state.value.copy(emailChangeError = "Wpisz 6-cyfrowy kod")
+            return
+        }
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isConfirmingEmail = true, emailChangeError = null)
+            when (val result = apiService.confirmEmailChange(newEmail, code)) {
+                is ApiResult.Success -> {
+                    sessionManager.updateEmail(result.data.email)
+                    _state.value =
+                        _state.value.copy(
+                            isConfirmingEmail = false,
+                            emailOtpSent = false,
+                            pendingNewEmail = null,
+                            emailChangeError = null,
+                            emailChangeSuccess = "email zmieniony",
+                        )
+                }
+
+                is ApiResult.Error -> {
+                    _state.value =
+                        _state.value.copy(
+                            isConfirmingEmail = false,
+                            emailChangeError = mapEmailChangeError(result),
+                        )
+                }
+            }
+        }
+    }
+
+    fun cancelEmailChange() {
+        _state.value =
+            _state.value.copy(
+                isRequestingEmailOtp = false,
+                isConfirmingEmail = false,
+                emailOtpSent = false,
+                pendingNewEmail = null,
+                emailChangeError = null,
+            )
+    }
+
+    fun clearEmailChangeSuccess() {
+        _state.value = _state.value.copy(emailChangeSuccess = null)
+    }
+
+    private fun mapEmailChangeError(error: ApiResult.Error): String =
+        when (error.code) {
+            "UNAUTHORIZED" -> "nieprawidłowe hasło"
+            "EMAIL_TAKEN" -> "ten email jest już zajęty"
+            "INVALID_OTP" -> "nieprawidłowy lub wygasły kod"
+            "VALIDATION_ERROR" -> "nieprawidłowy adres email"
+            "RATE_LIMITED" -> "poczekaj chwilę zanim spróbujesz ponownie"
+            else -> "nie udało się zmienić emaila"
+        }
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
@@ -66,6 +66,24 @@ class ApiService(
             ChangePasswordRequest(currentPassword = currentPassword, newPassword = newPassword),
         )
 
+    suspend fun requestEmailChange(
+        newEmail: String,
+        currentPassword: String,
+    ): ApiResult<SuccessResponse> =
+        client.patch(
+            "/api/v1/auth/account/email/request",
+            RequestEmailChangeRequest(newEmail = newEmail, currentPassword = currentPassword),
+        )
+
+    suspend fun confirmEmailChange(
+        newEmail: String,
+        code: String,
+    ): ApiResult<EmailChangeResponse> =
+        client.patch(
+            "/api/v1/auth/account/email/confirm",
+            ConfirmEmailChangeRequest(newEmail = newEmail, code = code),
+        )
+
     // Profiles
 
     suspend fun getMyProfile(): ApiResult<Profile> = client.get("/api/v1/profiles/me")

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
@@ -415,6 +415,24 @@ data class ChangePasswordRequest(
     val newPassword: String,
 )
 
+@Serializable
+data class RequestEmailChangeRequest(
+    val newEmail: String,
+    val currentPassword: String,
+)
+
+@Serializable
+data class ConfirmEmailChangeRequest(
+    val newEmail: String,
+    val code: String,
+)
+
+@Serializable
+data class EmailChangeResponse(
+    val success: Boolean,
+    val email: String,
+)
+
 // Forgot password models
 
 @Serializable

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/SessionManager.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/SessionManager.kt
@@ -79,6 +79,17 @@ class SessionManager(
         }
     }
 
+    val email: Flow<String?> =
+        dataStore.data.map { prefs ->
+            prefs[USER_EMAIL]
+        }
+
+    suspend fun updateEmail(email: String) {
+        dataStore.edit { prefs ->
+            prefs[USER_EMAIL] = email
+        }
+    }
+
     suspend fun saveProfileId(profileId: String) {
         dataStore.edit { prefs ->
             prefs[PROFILE_ID] = profileId


### PR DESCRIPTION
Pozwala zmienić email konta (np. po utracie dostępu do skrzynki studenckiej).

Flow: nowy email + hasło → OTP na nowy adres → potwierdzenie → users.email zaktualizowany.

Backend: 2 endpointy reużywające istniejącą OTP infra. Testy happy-path + wrong password + taken email.
Mobile: OtpInput wyciągnięty do designsystem (reuse z VerifyScreen). SessionManager.updateEmail zapisuje nowy adres.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OTP-based email change flow to account privacy settings
> - Adds two new backend endpoints: `PATCH /api/v1/auth/account/email/request` (validates password, sends OTP to new email) and `PATCH /api/v1/auth/account/email/confirm` (verifies OTP, updates email in DB, invalidates auth cache), implemented in [email_change.rs](https://github.com/poziomki-app/poziomki/pull/381/files#diff-51bd3ebb4280025ca985ec6a879e56265dc1e857c27c5f39279814877d94c023).
> - Adds `PrivacyViewModel` methods `requestEmailChange` and `confirmEmailChange` that call the new endpoints, update `SessionManager` with the new email on success, and expose loading/error/success state to the UI.
> - Introduces a `ChangeEmailDialog` composable with a two-step flow (email + password entry, then OTP entry) wired to the view model, and surfaces it from the Privacy screen alongside the current email and a success message.
> - Extracts a shared `OtpInput` composable into the design system and replaces the inline copy previously used in `VerifyScreen`.
> - `SessionManager` gains a persistent `email` flow and `updateEmail()` to keep the stored email in sync after a successful change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a68f169.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->