### PR TITLE
feat(otp): add Resend HTTP fallback for OTP delivery

### DIFF
--- a/backend/src/api/auth/otp_email.rs
+++ b/backend/src/api/auth/otp_email.rs
@@ -329,33 +329,37 @@ pub(in crate::api) async fn send_otp_email(to: &str, code: &str) -> Result<(), S
         }
     }
 
-    // FALLBACK 1: direct-to-MX (works when port 25 outbound is open).
-    let domain = to
-        .rsplit_once('@')
-        .map(|(_, d)| d)
-        .ok_or_else(|| format!("No domain in {redacted}"))?;
-    let mx_err = match send_via_mx(&envelope, &body, domain).await {
-        Ok(mx_host) => {
-            tracing::info!("OTP email delivered to {redacted} via MX {mx_host}");
+    // FALLBACK 1: Resend HTTP API. Preferred over direct MX because Resend
+    // sends from warmed IPs with aligned SPF/DKIM/DMARC, so messages land in
+    // the inbox without "this message wasn't authenticated" banners. Free
+    // tier (100/day) is enough for our OTP volume; on quota exhaustion we
+    // fall through to direct MX. Skipped silently if RESEND_API_KEY is unset
+    // (local dev / staging).
+    let resend_err = match send_via_resend(to, code).await {
+        Ok(()) => {
+            tracing::info!("OTP email delivered to {redacted} via Resend");
             return Ok(());
         }
         Err(e) => {
-            tracing::warn!("OTP direct MX failed ({e}); falling back to Resend for {redacted}");
+            tracing::warn!("OTP Resend failed ({e}); falling back to direct MX for {redacted}");
             e
         }
     };
 
-    // FALLBACK 2: Resend HTTP API. Independent of SMTP/port 25, so it covers
-    // VPS network egress problems, MX greylisting, and IP reputation hits.
-    // Skipped silently if RESEND_API_KEY is unset — local dev and staging
-    // don't need Resend to test the chain.
-    match send_via_resend(to, code).await {
-        Ok(()) => {
-            tracing::info!("OTP email delivered to {redacted} via Resend");
+    // FALLBACK 2: direct-to-MX. Covers Resend outage / quota exhaustion. Will
+    // typically succeed but recipients may see Gmail's "untrusted sender"
+    // banner since our VPS IP isn't on warmed-up SES sending pools.
+    let domain = to
+        .rsplit_once('@')
+        .map(|(_, d)| d)
+        .ok_or_else(|| format!("No domain in {redacted}"))?;
+    match send_via_mx(&envelope, &body, domain).await {
+        Ok(mx_host) => {
+            tracing::info!("OTP email delivered to {redacted} via MX {mx_host}");
             Ok(())
         }
-        Err(resend_err) => Err(format!(
-            "OTP delivery failed for {redacted}: MX={mx_err}; resend={resend_err}"
+        Err(mx_err) => Err(format!(
+            "OTP delivery failed for {redacted}: resend={resend_err}; MX={mx_err}"
         )),
     }
 }

--- a/backend/src/api/auth/otp_email.rs
+++ b/backend/src/api/auth/otp_email.rs
@@ -222,6 +222,47 @@ async fn send_via_relay(
         .map_err(|e| format!("relay {relay_host}:{port}: {e}"))
 }
 
+async fn send_via_resend(to: &str, code: &str) -> Result<(), String> {
+    let api_key = env_nonempty("RESEND_API_KEY").ok_or_else(|| "no RESEND_API_KEY".to_string())?;
+    let from = env_nonempty("RESEND_FROM").unwrap_or_else(|| {
+        // Resend requires the From domain to match a verified domain in their
+        // dashboard. send.poziomki.app is the subdomain whose DNS records the
+        // dashboard provisioned.
+        "poziomki <noreply@send.poziomki.app>".into()
+    });
+
+    let body = serde_json::json!({
+        "from": from,
+        "to": [to],
+        "subject": format!("Twój kod logowania to {code}"),
+        "html": otp_email_html(code),
+        "text": format!(
+            "Twój kod logowania: {code}\n\nWpisz ten kod w aplikacji, aby potwierdzić swoje konto.\nKod wygasa za 10 minut.\n\n2026 poziomki 🩵"
+        ),
+    });
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("reqwest client: {e}"))?;
+
+    let response = client
+        .post("https://api.resend.com/emails")
+        .bearer_auth(api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("resend HTTP: {e}"))?;
+
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(format!("resend {status}: {text}"))
+    }
+}
+
 async fn send_via_mx(
     envelope: &lettre::address::Envelope,
     body: &[u8],
@@ -288,17 +329,34 @@ pub(in crate::api) async fn send_otp_email(to: &str, code: &str) -> Result<(), S
         }
     }
 
-    // FALLBACK: direct-to-MX (dev / when relay not configured or failing).
+    // FALLBACK 1: direct-to-MX (works when port 25 outbound is open).
     let domain = to
         .rsplit_once('@')
         .map(|(_, d)| d)
         .ok_or_else(|| format!("No domain in {redacted}"))?;
-    match send_via_mx(&envelope, &body, domain).await {
+    let mx_err = match send_via_mx(&envelope, &body, domain).await {
         Ok(mx_host) => {
             tracing::info!("OTP email delivered to {redacted} via MX {mx_host}");
+            return Ok(());
+        }
+        Err(e) => {
+            tracing::warn!("OTP direct MX failed ({e}); falling back to Resend for {redacted}");
+            e
+        }
+    };
+
+    // FALLBACK 2: Resend HTTP API. Independent of SMTP/port 25, so it covers
+    // VPS network egress problems, MX greylisting, and IP reputation hits.
+    // Skipped silently if RESEND_API_KEY is unset — local dev and staging
+    // don't need Resend to test the chain.
+    match send_via_resend(to, code).await {
+        Ok(()) => {
+            tracing::info!("OTP email delivered to {redacted} via Resend");
             Ok(())
         }
-        Err(e) => Err(format!("OTP delivery failed for {redacted}: {e}")),
+        Err(resend_err) => Err(format!(
+            "OTP delivery failed for {redacted}: MX={mx_err}; resend={resend_err}"
+        )),
     }
 }
 

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -139,6 +139,8 @@ services:
       NTFY_SERVER: ${NTFY_SERVER:-https://ntfy.poziomki.app}
       SMTP_ENABLE: ${SMTP_ENABLE:-true}
       SMTP_FROM: ${SMTP_FROM:-noreply@poziomki.app}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM: ${RESEND_FROM:-poziomki <noreply@send.poziomki.app>}
       OPS_STATUS_TOKEN: ${OPS_STATUS_TOKEN:-}
       ADMIN_TOKEN: ${ADMIN_TOKEN:-}
       IMGPROXY_HMAC_KEY: ${IMGPROXY_HMAC_KEY}
@@ -220,6 +222,8 @@ services:
       NTFY_SERVER: ${NTFY_SERVER:-https://ntfy.poziomki.app}
       SMTP_ENABLE: ${SMTP_ENABLE:-true}
       SMTP_FROM: ${SMTP_FROM:-noreply@poziomki.app}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM: ${RESEND_FROM:-poziomki <noreply@send.poziomki.app>}
       DKIM_DOMAIN: ${DKIM_DOMAIN:-poziomki.app}
       DKIM_SELECTOR: ${DKIM_SELECTOR:-mail}
       DKIM_PRIVATE_KEY_PATH: /etc/dkim/private.key


### PR DESCRIPTION
Direct-to-MX as primary, Resend HTTPS API as fallback. Skipped silently if RESEND_API_KEY is unset.

DNS dla `send.poziomki.app` (DKIM/SPF/MX) już dodane przez OVH API. Domain verified w Resend.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Resend HTTP API as OTP email fallback before direct MX delivery
> - Adds `send_via_resend` in [`otp_email.rs`](https://github.com/poziomki-app/poziomki/pull/382/files#diff-a1b3d79530f4be425d1d1f305c0c14b628d992bf48da9680087368f8fc94d491) that POSTs to `https://api.resend.com/emails` using a bearer token from `RESEND_API_KEY`, with a 15s timeout.
> - Updates `send_otp_email` to try Resend after SMTP relay failure, and only fall back to direct MX if Resend also fails; combined errors from both paths are surfaced on total failure.
> - Adds `RESEND_API_KEY` and `RESEND_FROM` env vars to the affected services in [`docker-compose.prod.yml`](https://github.com/poziomki-app/poziomki/pull/382/files#diff-2eeee385263c859a8fc9d0a455c48137ba77b00bde682f9a7208b0aad1d3f864).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b3dd8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->