### PR TITLE
fix(register): show password mismatch only after submit

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/RegisterScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/RegisterScreen.kt
@@ -56,6 +56,7 @@ fun RegisterScreen(
     var confirmPassword by remember { mutableStateOf("") }
     var acceptedPolicy by remember { mutableStateOf(false) }
     var showPolicy by remember { mutableStateOf(false) }
+    var showPasswordMismatch by remember { mutableStateOf(false) }
 
     Column(
         modifier =
@@ -130,12 +131,13 @@ fun RegisterScreen(
             value = confirmPassword,
             onValueChange = {
                 confirmPassword = it
+                showPasswordMismatch = false
                 viewModel.clearError()
             },
             label = "potwierd\u017a has\u0142o",
             placeholder = "has\u0142o",
             error =
-                if (confirmPassword.isNotEmpty() && confirmPassword != password) {
+                if (showPasswordMismatch && confirmPassword != password) {
                     "has\u0142a nie s\u0105 takie same"
                 } else {
                     null
@@ -188,13 +190,17 @@ fun RegisterScreen(
         AppButton(
             text = "zarejestruj si\u0119",
             onClick = {
+                if (password != confirmPassword) {
+                    showPasswordMismatch = true
+                    return@AppButton
+                }
                 val placeholderName = email.substringBefore("@").ifBlank { "User" }
                 viewModel.signUp(email, password, placeholderName, onRegisterSuccess, onUserExists)
             },
             enabled =
                 email.isNotBlank() &&
                     password.length >= 8 &&
-                    password == confirmPassword &&
+                    confirmPassword.isNotBlank() &&
                     acceptedPolicy,
             loading = uiState.isLoading,
             loadingText = "tworzenie konta...",


### PR DESCRIPTION
Komunikat "hasła nie są takie same" pojawiał się na żywo przy każdym znaku w drugim polu. Teraz pokazuje się dopiero po kliknięciu "zarejestruj się".

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show password mismatch error in registration only after submit attempt
> - The confirm password error is no longer shown while typing; it only appears after the user clicks the register button with mismatched passwords.
> - The register button is enabled as soon as `confirmPassword` is non-blank, replacing the previous `password == confirmPassword` requirement.
> - Typing in the confirm password field resets the mismatch error state.
> - Behavioral Change: users can now attempt to submit with a non-empty but mismatched confirm password, whereas before the button was disabled until passwords matched.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a3673a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->