### PR TITLE
fix(buttons): unify style, larger size, full-width in onboarding

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
@@ -51,8 +51,12 @@ private val DestructiveGradient =
 
 private fun contentColor(variant: ButtonVariant): Color =
     when (variant) {
-        ButtonVariant.PRIMARY, ButtonVariant.OUTLINE -> Primary
-        ButtonVariant.SECONDARY -> White
+        // OUTLINE is kept as an alias for SECONDARY to avoid touching every
+        // call site — both render as the simple grey style.
+        ButtonVariant.PRIMARY -> Primary
+
+        ButtonVariant.SECONDARY, ButtonVariant.OUTLINE -> White
+
         ButtonVariant.DESTRUCTIVE -> Error
     }
 
@@ -89,9 +93,9 @@ fun AppButton(
             .then(if (isEnabled) Modifier.clickable(onClick = onClick) else Modifier)
             .then(
                 if (isIconOnly) {
-                    Modifier.padding(14.dp)
+                    Modifier.padding(16.dp)
                 } else {
-                    Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+                    Modifier.padding(horizontal = 28.dp, vertical = 20.dp)
                 },
             )
 
@@ -200,7 +204,7 @@ private fun ButtonLabel(
         text = text,
         fontFamily = NunitoFamily,
         fontWeight = FontWeight.SemiBold,
-        fontSize = 15.sp,
+        fontSize = 17.sp,
         color = color,
     )
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/BasicInfoScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/BasicInfoScreen.kt
@@ -61,6 +61,7 @@ fun BasicInfoScreen(
                 text = "dalej",
                 onClick = onNext,
                 enabled = state.name.isNotBlank(),
+                modifier = Modifier.fillMaxWidth(),
             )
         },
     ) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/InterestsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/InterestsScreen.kt
@@ -87,17 +87,13 @@ fun InterestsScreen(
         showBack = true,
         onBack = onBack,
         footer = {
-            Row(
+            AppButton(
+                text = "dalej",
+                onClick = onNext,
+                enabled = ready,
+                variant = if (ready) ButtonVariant.PRIMARY else ButtonVariant.SECONDARY,
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-            ) {
-                AppButton(
-                    text = "dalej",
-                    onClick = onNext,
-                    enabled = ready,
-                    variant = if (ready) ButtonVariant.PRIMARY else ButtonVariant.OUTLINE,
-                )
-            }
+            )
         },
     ) {
         InterestsContent(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -110,17 +109,13 @@ fun ProfileSetupScreen(
                     modifier = Modifier.padding(bottom = AppTheme.spacing.sm),
                 )
             }
-            Row(
+            AppButton(
+                text = "potwierd\u017a",
+                onClick = { viewModel.createProfile(onComplete) },
+                loading = state.isLoading,
+                variant = ButtonVariant.PRIMARY,
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-            ) {
-                AppButton(
-                    text = "potwierd\u017a",
-                    onClick = { viewModel.createProfile(onComplete) },
-                    loading = state.isLoading,
-                    variant = ButtonVariant.PRIMARY,
-                )
-            }
+            )
         },
     ) {
         ProfileSetupContent(


### PR DESCRIPTION
Trzy rzeczy:
- "dalej" w onboardingu zamiast po lewej -> fillMaxWidth na footer button
- OUTLINE renderuje się tak samo jak SECONDARY (jeden szary styl, jak "dalej")
- Większy padding/font żeby przyciski były bardziej tappable

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify button styles with larger size and full-width layout in onboarding screens
> - Increases button padding (horizontal 24→28dp, vertical 16→20dp; icon-only 14→16dp) and label font size (15→17sp) across all `AppButton` instances.
> - Changes `OUTLINE` variant content color from Primary to White, treating it as an alias for `SECONDARY`.
> - Makes footer buttons in `BasicInfoScreen`, `InterestsScreen`, and `ProfileSetupScreen` full-width by replacing end-aligned `Row` wrappers with `Modifier.fillMaxWidth()` on the button directly.
> - In `InterestsScreen`, the "not ready" state button switches from `OUTLINE` to `SECONDARY` variant.
> - Behavioral Change: `OUTLINE` buttons now render with white content color instead of primary color.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1bd33e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->