### PR TITLE
fix(rls): materialise app.* GUCs via set_config (PG18 regression)

### DIFF
--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -34,9 +34,19 @@ pub async fn set_viewer_context(
     conn: &mut AsyncPgConnection,
     viewer: DbViewer,
 ) -> Result<(), diesel::result::Error> {
+    // Use set_config(..., is_local := true) instead of SET LOCAL because
+    // PostgreSQL 18 won't materialise a custom GUC set via SET LOCAL until
+    // something reads it — and RLS WITH CHECK clauses don't trigger that
+    // read in time, so app.current_user_id() returns NULL inside the policy
+    // and every INSERT/UPDATE bounces with "row violates row-level security
+    // policy". set_config materialises the GUC eagerly because the call
+    // itself returns the new value.
+    //
     // Safe interpolation: user_id is i32, is_review_stub is bool.
     let sql = format!(
-        "SET LOCAL app.user_id = '{}'; SET LOCAL app.is_stub = '{}'; SET LOCAL app.role = 'user'",
+        "SELECT set_config('app.user_id', '{}', true), \
+                set_config('app.is_stub', '{}', true), \
+                set_config('app.role', 'user', true)",
         viewer.user_id, viewer.is_review_stub
     );
     conn.batch_execute(&sql).await
@@ -44,8 +54,12 @@ pub async fn set_viewer_context(
 
 /// Anonymous / pre-auth context. `app.user_id = 0`, `app.role = 'anon'`.
 pub async fn set_anon_context(conn: &mut AsyncPgConnection) -> Result<(), diesel::result::Error> {
+    // See comment in set_viewer_context for why this uses set_config instead
+    // of SET LOCAL.
     conn.batch_execute(
-        "SET LOCAL app.user_id = '0'; SET LOCAL app.is_stub = 'false'; SET LOCAL app.role = 'anon'",
+        "SELECT set_config('app.user_id', '0', true), \
+                set_config('app.is_stub', 'false', true), \
+                set_config('app.role', 'anon', true)",
     )
     .await
 }


### PR DESCRIPTION
PostgreSQL 18 doesn't materialise custom GUCs set via `SET LOCAL` until something reads them. RLS WITH CHECK clauses don't trigger that read, so every INSERT/UPDATE on policy-protected tables bounced with row-level-security errors despite `app.user_id` being set.

Symptom on prod: profile creation in onboarding (POST /api/v1/profiles) returned 500 "You have asked diesel to rollback the transaction".

Fix: use `set_config(name, value, true)` — it materialises the GUC eagerly because the function returns the new value.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PG18 regression by materialising `app.*` GUCs via `set_config` in RLS viewer context
> PostgreSQL 18 changed how `SET LOCAL` interacts with GUCs in certain contexts, breaking row-level security. This fix replaces `SET LOCAL` statements in `set_viewer_context` and `set_anon_context` (in [viewer.rs](https://github.com/poziomki-app/poziomki/pull/385/files#diff-d986992a0bf9cdc6e2e73172ea9e9a9a3c4934b2571038ca252de8e298132526)) with `SELECT set_config(..., true)` calls, which reliably materialise the `app.user_id`, `app.is_stub`, and `app.role` GUCs as transaction-local values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bcd39a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->