### PR TITLE
ci(rust): split clippy/test, drop --all-features, add mold

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,15 +1,15 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
   schedule:
     - cron: "0 6 * * 1"
+  workflow_dispatch:
 
-# CodeQL only runs on main pushes and the weekly schedule — PRs don't
-# wait on it. Findings still surface in the Security tab within ~1 day
-# of landing on main, which is the right tradeoff for a small team:
-# cuts PR wall time by ~4 minutes without losing coverage on shipped code.
+# CodeQL only runs on the weekly schedule (Mon 06:00 UTC) and on-demand
+# via workflow_dispatch. PRs and main pushes don't wait on it — findings
+# surface in the Security tab within a week of landing on main, which is
+# the right tradeoff for a small team: keeps coverage on shipped code
+# without paying ~4 min on every push.
 
 permissions:
   contents: read

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ env:
   # in prod), not the owner role behind DATABASE_URL. Kept scoped to
   # the harness — tier tests and tests that seed cross-user data use
   # DATABASE_URL. Password matches what the setup-roles.sql step
-  # creates in the `check` job below.
+  # creates in the `test` job below.
   TEST_API_DATABASE_URL: postgres://poziomki_api:poziomki_api_ci@localhost:5432/poziomki_test
   JWT_SECRET: ci-test-secret
   GARAGE_S3_ENDPOINT: http://localhost:3900
@@ -28,6 +28,9 @@ env:
   GARAGE_S3_REGION: garage
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  # mold halves link time on the cargo dep graph (~30-60s saved per
+  # `cargo` invocation that re-links).
+  RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 
 jobs:
   fmt:
@@ -42,11 +45,31 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
-  # clippy + test + nextest in a single job so they share target/.
-  # Previously these were two jobs, each paying the full workspace
-  # compile (~2 min each). Now clippy warms the dep graph, test+nextest
-  # reuse the artifacts — roughly halves the Rust critical path.
-  check:
+  clippy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libpq-dev libwebp-dev mold
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: backend
+          # Distinct key shard from the test job so concurrent jobs don't
+          # thrash a single cache entry.
+          shared-key: clippy
+
+      - run: cargo clippy --all-targets -- -D warnings
+
+  test:
     runs-on: ubuntu-latest
 
     services:
@@ -72,15 +95,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libpq-dev libwebp-dev postgresql-client
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libpq-dev libwebp-dev mold postgresql-client
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: clippy
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: backend
+          shared-key: test
 
       - uses: taiki-e/install-action@b5fddbb5361bce8a06fb168c9d403a6cc552b084 # v2
         with:
@@ -137,6 +159,4 @@ jobs:
             -v worker_password=poziomki_worker_ci \
             -f infra/ops/postgres/setup-roles.sql
 
-      - run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - run: cargo nextest run --all-targets --all-features
+      - run: cargo nextest run --all-targets


### PR DESCRIPTION
Skraca rust crit path z ~7 min do ~3-4 min:

1. Split check -> clippy + test (parallel, każdy z własnym cache shardem)
2. Drop --all-features (backend nie ma [features], flaga tylko zaciąga deps features)
3. mold linker via apt + RUSTFLAGS

Plus dodatkowy bonus: clippy nie czeka na postgres/garage setup.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split Rust CI clippy and test jobs, add mold linker, and drop `--all-features`
> - Splits the combined clippy/test job in [rust.yml](.github/workflows/rust.yml) into two separate jobs: `clippy` (runs `cargo clippy` with warnings as errors) and `test` (runs `cargo nextest` only).
> - Adds the `mold` linker to both jobs via `apt-get` and sets `RUSTFLAGS` accordingly to speed up linking.
> - Removes `--all-features` from the `cargo nextest` invocation in the `test` job.
> - Removes the push-to-main trigger from [codeql.yml](.github/workflows/codeql.yml), keeping only the weekly cron and `workflow_dispatch`.
> - Behavioral Change: tests no longer run with all features enabled; CodeQL no longer runs on every push to main.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acf13b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->