### PR TITLE
fix(rls): split set_config into separate statements

### DIFF
--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -42,11 +42,16 @@ pub async fn set_viewer_context(
     // policy". set_config materialises the GUC eagerly because the call
     // itself returns the new value.
     //
+    // Each set_config has to be its own statement. Combining them as
+    // comma-separated targets in a single SELECT (verified empirically
+    // against PG18.3) leaves earlier GUCs unmaterialised when subsequent
+    // RLS WITH CHECK clauses run, so the first two reads still return NULL.
+    //
     // Safe interpolation: user_id is i32, is_review_stub is bool.
     let sql = format!(
-        "SELECT set_config('app.user_id', '{}', true), \
-                set_config('app.is_stub', '{}', true), \
-                set_config('app.role', 'user', true)",
+        "SELECT set_config('app.user_id', '{}', true); \
+         SELECT set_config('app.is_stub', '{}', true); \
+         SELECT set_config('app.role', 'user', true);",
         viewer.user_id, viewer.is_review_stub
     );
     conn.batch_execute(&sql).await
@@ -55,11 +60,11 @@ pub async fn set_viewer_context(
 /// Anonymous / pre-auth context. `app.user_id = 0`, `app.role = 'anon'`.
 pub async fn set_anon_context(conn: &mut AsyncPgConnection) -> Result<(), diesel::result::Error> {
     // See comment in set_viewer_context for why this uses set_config instead
-    // of SET LOCAL.
+    // of SET LOCAL and why each call is its own statement.
     conn.batch_execute(
-        "SELECT set_config('app.user_id', '0', true), \
-                set_config('app.is_stub', 'false', true), \
-                set_config('app.role', 'anon', true)",
+        "SELECT set_config('app.user_id', '0', true); \
+         SELECT set_config('app.is_stub', 'false', true); \
+         SELECT set_config('app.role', 'anon', true);",
     )
     .await
 }


### PR DESCRIPTION
Follow-up do #385. Łączenie 3× set_config przecinkiem w jednym SELECT pozostawia wcześniejsze GUC-i niematerializowane gdy potem działa RLS WITH CHECK. Każdy set_config musi być osobnym statementem.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLS `set_config` calls to execute as separate statements in viewer context
> In [viewer.rs](https://github.com/poziomki-app/poziomki/pull/387/files#diff-d986992a0bf9cdc6e2e73172ea9e9a9a3c4934b2571038ca252de8e298132526), both `set_viewer_context` and `set_anon_context` previously combined three `set_config` calls into a single `SELECT` statement. Each call is now issued as its own statement via `batch_execute`. This fixes a bug where the grouped form was not correctly applying all three config values (`app.user_id`, `app.is_stub`, `app.role`) for RLS policies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0da1509.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->