### PR TITLE
ui(navbar): drop labels under bottom nav icons

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -599,15 +599,8 @@ fun MainScreen(
                                     Icon(
                                         if (selected) item.selectedIcon else item.icon,
                                         contentDescription = item.label,
-                                        modifier = Modifier.size(26.dp),
+                                        modifier = Modifier.size(32.dp),
                                         tint = tint,
-                                    )
-                                    Spacer(modifier = Modifier.height(2.dp))
-                                    Text(
-                                        text = item.label,
-                                        fontSize = 10.sp,
-                                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
-                                        color = tint,
                                     )
                                 }
                             }


### PR DESCRIPTION
Trzy ikony są self-explanatory, podpisy zabierały miejsce. Ikony lekko powiększone (26->28dp), contentDescription zostaje dla a11y.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove text labels from bottom navigation icons
> Removes the text labels beneath bottom nav icons and increases icon size from 26dp to 32dp. Top and bottom padding in the nav container are also increased to compensate for the removed labels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3faaf5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->