### PR TITLE
ui(navbar): stop bottom-nav from covering last list items

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.21.0" // x-release-please-version
+val appVersionName = "0.21.1" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -474,7 +474,9 @@ fun MainScreen(
     val tabNavController = rememberNavController()
     val navBackStackEntry by tabNavController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
-    val navBarHeight = 60.dp
+    // Bottom navbar Row: 16 top + 32 icon + 16 bottom = 64dp; +8dp breathing
+    // room so last list items don't visually crowd the navbar.
+    val navBarHeight = 72.dp
     val bottomInsets = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val topInsets = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     val safeTop = maxOf(topInsets, 16.dp)


### PR DESCRIPTION
Bumps navBarHeight from 60dp to 72dp so LocalNavBarPadding covers the real navbar (64dp) plus 8dp breathing room. Last items in events/poznaj/wiadomości no longer hide under the navbar.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bottom nav bar covering last list items by increasing height to 72dp
> Increases the bottom navigation bar height in `MainScreen` from 60dp to 72dp to prevent the bar from overlapping the last items in scrollable lists. Also bumps the app version to 0.21.1 in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/395/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65fdccc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->