### PR TITLE
events: floating category chip on card cover

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -80,6 +80,7 @@ import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.feature.onboarding.INTEREST_CATEGORIES
+import com.poziomki.app.ui.feature.onboarding.InterestCategoryInfo
 import com.poziomki.app.ui.navigation.LocalImmersive
 import com.poziomki.app.ui.navigation.LocalNavBarPadding
 import com.poziomki.app.ui.shared.TimeFilter
@@ -346,6 +347,16 @@ private fun EventCard(
                                 .align(Alignment.TopEnd)
                                 .padding(PoziomkiTheme.spacing.sm),
                     )
+
+                    eventCategoryInfo(event.category)?.let { info ->
+                        CategoryFloatingChip(
+                            info = info,
+                            modifier =
+                                Modifier
+                                    .align(Alignment.TopStart)
+                                    .padding(PoziomkiTheme.spacing.sm),
+                        )
+                    }
                 }
             }
 
@@ -467,6 +478,41 @@ private fun BookmarkOverlay(
             contentDescription = if (isSaved) "Usuń z zapisanych" else "Zapisz",
             modifier = Modifier.size(22.dp),
             tint = if (isSaved) Primary else TextPrimary,
+        )
+    }
+}
+
+private fun eventCategoryInfo(category: String?): InterestCategoryInfo? {
+    if (category.isNullOrBlank()) return null
+    return INTEREST_CATEGORIES.firstOrNull { it.key == category }
+}
+
+@Composable
+private fun CategoryFloatingChip(
+    info: InterestCategoryInfo,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(999.dp))
+                .background(Overlay)
+                .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = info.icon,
+            contentDescription = null,
+            modifier = Modifier.size(14.dp),
+            tint = info.color,
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = info.displayName,
+            fontFamily = NunitoFamily,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 12.sp,
+            color = TextPrimary,
         )
     }
 }


### PR DESCRIPTION
Floating chip z ikoną + nazwą kategorii w lewym górnym rogu cover image karty eventu. Bez chipa gdy event nie ma kategorii.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add floating category chip to event card covers
> - Adds a `CategoryFloatingChip` composable that renders a rounded chip with the category icon and display name, positioned at the top-start of the card.
> - Introduces a private `eventCategoryInfo` helper that maps an event's category string to an `InterestCategoryInfo` from `INTEREST_CATEGORIES`, returning null for unknown or blank values.
> - The chip is only shown when the event's category matches a known interest category.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5303a85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->