### PR TITLE
events: place voting backend

### DIFF
--- a/backend/migrations/2026-05-09-000000_event_place_polls/down.sql
+++ b/backend/migrations/2026-05-09-000000_event_place_polls/down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS public.event_place_votes;
+DROP TABLE IF EXISTS public.event_place_options;
+DROP TABLE IF EXISTS public.event_place_polls;

--- a/backend/migrations/2026-05-09-000000_event_place_polls/up.sql
+++ b/backend/migrations/2026-05-09-000000_event_place_polls/up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE public.event_place_polls (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_id UUID NOT NULL UNIQUE
+        REFERENCES public.events(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.event_place_options (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    poll_id UUID NOT NULL
+        REFERENCES public.event_place_polls(id) ON DELETE CASCADE,
+    label VARCHAR(120) NOT NULL,
+    latitude DOUBLE PRECISION,
+    longitude DOUBLE PRECISION,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX event_place_options_poll_id_idx
+    ON public.event_place_options(poll_id);
+
+CREATE TABLE public.event_place_votes (
+    poll_id UUID NOT NULL
+        REFERENCES public.event_place_polls(id) ON DELETE CASCADE,
+    profile_id UUID NOT NULL
+        REFERENCES public.profiles(id) ON DELETE CASCADE,
+    option_id UUID NOT NULL
+        REFERENCES public.event_place_options(id) ON DELETE CASCADE,
+    voted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (poll_id, profile_id)
+);
+
+CREATE INDEX event_place_votes_option_id_idx
+    ON public.event_place_votes(option_id);

--- a/backend/src/api/events/mod.rs
+++ b/backend/src/api/events/mod.rs
@@ -16,6 +16,7 @@ mod events_write_handler;
 mod events_write_repo;
 #[path = "write_service.rs"]
 mod events_write_service;
+mod place_poll;
 mod report_handler;
 mod report_repo;
 
@@ -46,6 +47,7 @@ pub(super) use events_write_handler::{
     event_approve_attendee, event_attend, event_create, event_delete, event_leave,
     event_reject_attendee, event_save, event_unsave, event_update,
 };
+pub(super) use place_poll::{place_poll_create, place_poll_get, place_poll_vote};
 pub(super) use report_handler::event_report;
 
 const PRIVATE_CACHE_SHORT: HeaderValue = HeaderValue::from_static("private, max-age=60");

--- a/backend/src/api/events/place_poll.rs
+++ b/backend/src/api/events/place_poll.rs
@@ -1,0 +1,459 @@
+type Result<T> = crate::error::AppResult<T>;
+
+use axum::response::Response;
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    response::IntoResponse,
+    Json,
+};
+use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api::common::{error_response, ErrorSpec};
+use crate::api::state::DataResponse;
+use crate::app::AppContext;
+use crate::db;
+use crate::db::models::event_place_polls::{
+    EventPlaceOption, EventPlaceVote, NewEventPlaceOption, NewEventPlacePoll,
+};
+use crate::db::schema::{event_place_options, event_place_polls, event_place_votes};
+
+use super::events_service::{
+    forbidden, load_event_by_id, load_profile_for_user, not_found_event, profile_not_found,
+    validation_error,
+};
+
+const MIN_OPTIONS: usize = 2;
+const MAX_OPTIONS: usize = 5;
+const MAX_LABEL_LEN: usize = 120;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::api) struct CreatePlacePollBody {
+    pub(in crate::api) options: Vec<CreatePlacePollOption>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::api) struct CreatePlacePollOption {
+    pub(in crate::api) label: String,
+    #[serde(default)]
+    pub(in crate::api) latitude: Option<f64>,
+    #[serde(default)]
+    pub(in crate::api) longitude: Option<f64>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::api) struct VotePlacePollBody {
+    pub(in crate::api) option_id: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::api) struct PlacePollResponse {
+    pub(in crate::api) id: String,
+    pub(in crate::api) options: Vec<PlacePollOptionResponse>,
+    pub(in crate::api) my_vote: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::api) struct PlacePollOptionResponse {
+    pub(in crate::api) id: String,
+    pub(in crate::api) label: String,
+    pub(in crate::api) latitude: Option<f64>,
+    pub(in crate::api) longitude: Option<f64>,
+    pub(in crate::api) vote_count: i64,
+}
+
+fn into_diesel(e: crate::error::AppError) -> diesel::result::Error {
+    match e {
+        crate::error::AppError::Message(_) | crate::error::AppError::Validation(_) => {
+            diesel::result::Error::QueryBuilderError(Box::new(e))
+        }
+        crate::error::AppError::Any(_) => diesel::result::Error::RollbackTransaction,
+    }
+}
+
+enum CreateOutcome {
+    NoProfile,
+    NotFound,
+    NotCreator,
+    AlreadyExists,
+    Created(PlacePollResponse),
+}
+
+enum GetOutcome {
+    NoProfile,
+    NotFound,
+    NoPoll,
+    Loaded(PlacePollResponse),
+}
+
+enum VoteOutcome {
+    NoProfile,
+    NotFound,
+    NoPoll,
+    InvalidOption,
+    Voted(PlacePollResponse),
+}
+
+async fn build_response(
+    conn: &mut AsyncPgConnection,
+    poll_id: Uuid,
+    profile_id: Uuid,
+) -> std::result::Result<PlacePollResponse, crate::error::AppError> {
+    let options: Vec<EventPlaceOption> = event_place_options::table
+        .filter(event_place_options::poll_id.eq(poll_id))
+        .order(event_place_options::created_at.asc())
+        .load(conn)
+        .await?;
+
+    let counts: Vec<(Uuid, i64)> = event_place_votes::table
+        .filter(event_place_votes::poll_id.eq(poll_id))
+        .group_by(event_place_votes::option_id)
+        .select((event_place_votes::option_id, diesel::dsl::count_star()))
+        .load(conn)
+        .await?;
+
+    let my_vote: Option<Uuid> = event_place_votes::table
+        .filter(event_place_votes::poll_id.eq(poll_id))
+        .filter(event_place_votes::profile_id.eq(profile_id))
+        .select(event_place_votes::option_id)
+        .first(conn)
+        .await
+        .optional()?;
+
+    Ok(PlacePollResponse {
+        id: poll_id.to_string(),
+        options: options
+            .into_iter()
+            .map(|opt| {
+                let count = counts
+                    .iter()
+                    .find(|(id, _)| *id == opt.id)
+                    .map_or(0, |(_, c)| *c);
+                PlacePollOptionResponse {
+                    id: opt.id.to_string(),
+                    label: opt.label,
+                    latitude: opt.latitude,
+                    longitude: opt.longitude,
+                    vote_count: count,
+                }
+            })
+            .collect(),
+        my_vote: my_vote.map(|id| id.to_string()),
+    })
+}
+
+pub(in crate::api) async fn place_poll_create(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<CreatePlacePollBody>,
+) -> Result<Response> {
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+
+    if body.options.len() < MIN_OPTIONS || body.options.len() > MAX_OPTIONS {
+        return Ok(validation_error(
+            &headers,
+            "Głosowanie musi mieć od 2 do 5 propozycji",
+        ));
+    }
+    let mut prepared: Vec<(String, Option<f64>, Option<f64>)> =
+        Vec::with_capacity(body.options.len());
+    for opt in &body.options {
+        let label = opt.label.trim().to_string();
+        if label.is_empty() || label.chars().count() > MAX_LABEL_LEN {
+            return Ok(validation_error(&headers, "Nieprawidłowa nazwa propozycji"));
+        }
+        prepared.push((label, opt.latitude, opt.longitude));
+    }
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<CreateOutcome, diesel::result::Error>(CreateOutcome::NoProfile);
+            };
+            let Some(event) = load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(CreateOutcome::NotFound);
+            };
+            if event.creator_id != profile.id {
+                return Ok(CreateOutcome::NotCreator);
+            }
+            let exists = event_place_polls::table
+                .filter(event_place_polls::event_id.eq(event_uuid))
+                .select(event_place_polls::id)
+                .first::<Uuid>(conn)
+                .await
+                .optional()
+                .map_err(|e| into_diesel(crate::error::AppError::from(e)))?;
+            if exists.is_some() {
+                return Ok(CreateOutcome::AlreadyExists);
+            }
+
+            let poll_id = Uuid::new_v4();
+            diesel::insert_into(event_place_polls::table)
+                .values(NewEventPlacePoll {
+                    id: poll_id,
+                    event_id: event_uuid,
+                })
+                .execute(conn)
+                .await
+                .map_err(|e| into_diesel(crate::error::AppError::from(e)))?;
+
+            let new_options: Vec<NewEventPlaceOption> = prepared
+                .iter()
+                .map(|(label, lat, lng)| NewEventPlaceOption {
+                    id: Uuid::new_v4(),
+                    poll_id,
+                    label: label.clone(),
+                    latitude: *lat,
+                    longitude: *lng,
+                })
+                .collect();
+            diesel::insert_into(event_place_options::table)
+                .values(&new_options)
+                .execute(conn)
+                .await
+                .map_err(|e| into_diesel(crate::error::AppError::from(e)))?;
+
+            let response = build_response(conn, poll_id, profile.id)
+                .await
+                .map_err(into_diesel)?;
+            Ok(CreateOutcome::Created(response))
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        CreateOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        CreateOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        CreateOutcome::NotCreator => Ok(forbidden(
+            &headers,
+            "Tylko organizator może utworzyć głosowanie",
+        )),
+        CreateOutcome::AlreadyExists => Ok(error_response(
+            axum::http::StatusCode::CONFLICT,
+            &headers,
+            ErrorSpec {
+                error: "Głosowanie już istnieje".to_string(),
+                code: "ALREADY_EXISTS",
+                details: None,
+            },
+        )),
+        CreateOutcome::Created(response) => {
+            Ok(Json(DataResponse { data: response }).into_response())
+        }
+    }
+}
+
+pub(in crate::api) async fn place_poll_get(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Response> {
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<GetOutcome, diesel::result::Error>(GetOutcome::NoProfile);
+            };
+            if load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+                .is_none()
+            {
+                return Ok(GetOutcome::NotFound);
+            }
+            let poll_id = event_place_polls::table
+                .filter(event_place_polls::event_id.eq(event_uuid))
+                .select(event_place_polls::id)
+                .first::<Uuid>(conn)
+                .await
+                .optional()
+                .map_err(|e| into_diesel(crate::error::AppError::from(e)))?;
+            let Some(poll_id) = poll_id else {
+                return Ok(GetOutcome::NoPoll);
+            };
+            let response = build_response(conn, poll_id, profile.id)
+                .await
+                .map_err(into_diesel)?;
+            Ok(GetOutcome::Loaded(response))
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        GetOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        GetOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        GetOutcome::NoPoll => Ok(error_response(
+            axum::http::StatusCode::NOT_FOUND,
+            &headers,
+            ErrorSpec {
+                error: "Brak głosowania dla tego wydarzenia".to_string(),
+                code: "NOT_FOUND",
+                details: None,
+            },
+        )),
+        GetOutcome::Loaded(response) => Ok(Json(DataResponse { data: response }).into_response()),
+    }
+}
+
+pub(in crate::api) async fn place_poll_vote(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<VotePlacePollBody>,
+) -> Result<Response> {
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+    let Ok(option_uuid) = Uuid::parse_str(&body.option_id) else {
+        return Ok(validation_error(
+            &headers,
+            "Nieprawidłowy identyfikator opcji",
+        ));
+    };
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<VoteOutcome, diesel::result::Error>(VoteOutcome::NoProfile);
+            };
+            if load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+                .is_none()
+            {
+                return Ok(VoteOutcome::NotFound);
+            }
+            let poll_id = event_place_polls::table
+                .filter(event_place_polls::event_id.eq(event_uuid))
+                .select(event_place_polls::id)
+                .first::<Uuid>(conn)
+                .await
+                .optional()
+                .map_err(|e| into_diesel(crate::error::AppError::from(e)))?;
+            let Some(poll_id) = poll_id else {
+                return Ok(VoteOutcome::NoPoll);
+            };
+
+            let option_belongs = event_place_options::table
+                .filter(event_place_options::id.eq(option_uuid))
+                .filter(event_place_options::poll_id.eq(poll_id))
+                .select(event_place_options::id)
+                .first::<Uuid>(conn)
+                .await
+                .optional()
+                .map_err(|e| into_diesel(crate::error::AppError::from(e)))?;
+            if option_belongs.is_none() {
+                return Ok(VoteOutcome::InvalidOption);
+            }
+
+            let vote = EventPlaceVote {
+                poll_id,
+                profile_id: profile.id,
+                option_id: option_uuid,
+                voted_at: chrono::Utc::now(),
+            };
+            diesel::insert_into(event_place_votes::table)
+                .values(&vote)
+                .on_conflict((event_place_votes::poll_id, event_place_votes::profile_id))
+                .do_update()
+                .set((
+                    event_place_votes::option_id.eq(option_uuid),
+                    event_place_votes::voted_at.eq(chrono::Utc::now()),
+                ))
+                .execute(conn)
+                .await
+                .map_err(|e| into_diesel(crate::error::AppError::from(e)))?;
+
+            let response = build_response(conn, poll_id, profile.id)
+                .await
+                .map_err(into_diesel)?;
+            Ok(VoteOutcome::Voted(response))
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        VoteOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        VoteOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        VoteOutcome::NoPoll => Ok(error_response(
+            axum::http::StatusCode::NOT_FOUND,
+            &headers,
+            ErrorSpec {
+                error: "Brak głosowania dla tego wydarzenia".to_string(),
+                code: "NOT_FOUND",
+                details: None,
+            },
+        )),
+        VoteOutcome::InvalidOption => Ok(validation_error(
+            &headers,
+            "Wybrana propozycja nie należy do tego głosowania",
+        )),
+        VoteOutcome::Voted(response) => Ok(Json(DataResponse { data: response }).into_response()),
+    }
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -137,6 +137,11 @@ fn events_routes() -> Router<AppContext> {
             post(events::event_reject_attendee),
         )
         .route("/{id}/report", post(events::event_report))
+        .route(
+            "/{id}/place-poll",
+            get(events::place_poll_get).post(events::place_poll_create),
+        )
+        .route("/{id}/place-poll/vote", post(events::place_poll_vote))
         .layer(cache_layer("private, max-age=60"));
 
     personal.merge(shared)

--- a/backend/src/db/models/event_place_polls.rs
+++ b/backend/src/db/models/event_place_polls.rs
@@ -1,0 +1,51 @@
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use crate::db::schema::{event_place_options, event_place_polls, event_place_votes};
+
+#[derive(Debug, Clone, Queryable, Selectable, Identifiable)]
+#[diesel(table_name = event_place_polls)]
+pub struct EventPlacePoll {
+    pub id: Uuid,
+    pub event_id: Uuid,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = event_place_polls)]
+pub struct NewEventPlacePoll {
+    pub id: Uuid,
+    pub event_id: Uuid,
+}
+
+#[derive(Debug, Clone, Queryable, Selectable, Identifiable)]
+#[diesel(table_name = event_place_options)]
+pub struct EventPlaceOption {
+    pub id: Uuid,
+    pub poll_id: Uuid,
+    pub label: String,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = event_place_options)]
+pub struct NewEventPlaceOption {
+    pub id: Uuid,
+    pub poll_id: Uuid,
+    pub label: String,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+}
+
+#[derive(Debug, Clone, Queryable, Selectable, Insertable)]
+#[diesel(table_name = event_place_votes)]
+#[diesel(primary_key(poll_id, profile_id))]
+pub struct EventPlaceVote {
+    pub poll_id: Uuid,
+    pub profile_id: Uuid,
+    pub option_id: Uuid,
+    pub voted_at: DateTime<Utc>,
+}

--- a/backend/src/db/models/mod.rs
+++ b/backend/src/db/models/mod.rs
@@ -4,6 +4,7 @@ pub mod conversations;
 pub mod degrees;
 pub mod event_attendees;
 pub mod event_interactions;
+pub mod event_place_polls;
 pub mod event_tags;
 pub mod events;
 pub mod job_outbox;

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -317,6 +317,39 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    event_place_polls (id) {
+        id -> Uuid,
+        event_id -> Uuid,
+        created_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    event_place_options (id) {
+        id -> Uuid,
+        poll_id -> Uuid,
+        label -> Varchar,
+        latitude -> Nullable<Float8>,
+        longitude -> Nullable<Float8>,
+        created_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    event_place_votes (poll_id, profile_id) {
+        poll_id -> Uuid,
+        profile_id -> Uuid,
+        option_id -> Uuid,
+        voted_at -> Timestamptz,
+    }
+}
+
+diesel::joinable!(event_place_polls -> events (event_id));
+diesel::joinable!(event_place_options -> event_place_polls (poll_id));
+diesel::joinable!(event_place_votes -> event_place_polls (poll_id));
+diesel::joinable!(event_place_votes -> event_place_options (option_id));
+diesel::joinable!(event_place_votes -> profiles (profile_id));
 diesel::joinable!(conversation_members -> conversations (conversation_id));
 diesel::joinable!(conversations -> events (event_id));
 diesel::joinable!(messages -> conversations (conversation_id));
@@ -349,6 +382,9 @@ diesel::allow_tables_to_appear_in_same_query!(
     degrees,
     event_attendees,
     event_interactions,
+    event_place_options,
+    event_place_polls,
+    event_place_votes,
     event_tags,
     events,
     job_outbox,


### PR DESCRIPTION
Backend dla głosowania nad miejscem wydarzenia.

Tabele: `event_place_polls`, `event_place_options`, `event_place_votes`.

Endpointy:
- `POST /api/v1/events/{id}/place-poll` — twórca eventu tworzy głosowanie z 2–5 propozycjami
- `GET /api/v1/events/{id}/place-poll` — opcje + countsy + mój głos
- `POST /api/v1/events/{id}/place-poll/vote` — oddaj/zmień głos

Mobile UI w osobnym PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add place voting backend for events
> - Adds three new database tables (`event_place_polls`, `event_place_options`, `event_place_votes`) via migration, with foreign keys and cascade deletes tied to events and profiles.
> - Adds `POST /events/{id}/place-poll` (creator only, 2–5 options with lat/lng), `GET /events/{id}/place-poll`, and `POST /events/{id}/place-poll/vote` endpoints.
> - Each response includes all options with vote counts and the caller's current vote; voting upserts on `(poll_id, profile_id)`.
> - Only one poll is allowed per event; attempting to create a second returns 409.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2b04a7a. 5 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->