### PR TITLE
events: recurring events via RRULE

### DIFF
--- a/backend/migrations/2026-05-09-100000_event_recurrence/down.sql
+++ b/backend/migrations/2026-05-09-100000_event_recurrence/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.events DROP COLUMN IF EXISTS recurrence_rule;

--- a/backend/migrations/2026-05-09-100000_event_recurrence/up.sql
+++ b/backend/migrations/2026-05-09-100000_event_recurrence/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.events
+    ADD COLUMN recurrence_rule VARCHAR(200);

--- a/backend/src/api/events/view.rs
+++ b/backend/src/api/events/view.rs
@@ -98,6 +98,7 @@ fn build_from_context(
         is_pending,
         requires_approval: event.requires_approval,
         conversation_id: event.conversation_id.clone(),
+        recurrence_rule: event.recurrence_rule.clone(),
         score: None,
     }
 }

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -200,6 +200,12 @@ fn build_new_event(
         created_at: now,
         updated_at: now,
         requires_approval: payload.requires_approval.unwrap_or(false),
+        recurrence_rule: payload
+            .recurrence_rule
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from),
     };
     (model, event_id)
 }

--- a/backend/src/api/events/write_service.rs
+++ b/backend/src/api/events/write_service.rs
@@ -148,6 +148,16 @@ fn build_update_changeset(payload: &UpdateEventBody, dates: EventDates) -> Event
     if let Some(limit) = &payload.max_attendees {
         changeset.max_attendees = Some(*limit);
     }
+    if let Some(rule) = &payload.recurrence_rule {
+        changeset.recurrence_rule = Some(rule.as_ref().and_then(|s| {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }));
+    }
 
     let (new_starts, new_ends) = dates;
     changeset.starts_at = Some(new_starts);

--- a/backend/src/api/matching/scoring.rs
+++ b/backend/src/api/matching/scoring.rs
@@ -315,6 +315,7 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
             requires_approval: false,
+            recurrence_rule: None,
         };
 
         let score = score_event(

--- a/backend/src/api/state/event_requests.rs
+++ b/backend/src/api/state/event_requests.rs
@@ -46,6 +46,8 @@ pub(in crate::api) struct CreateEventBody {
     pub(in crate::api) tag_ids: Option<Vec<String>>,
     #[serde(default)]
     pub(in crate::api) requires_approval: Option<bool>,
+    #[serde(default)]
+    pub(in crate::api) recurrence_rule: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -82,6 +84,8 @@ pub(in crate::api) struct UpdateEventBody {
     pub(in crate::api) tag_ids: Option<Vec<String>>,
     #[serde(default)]
     pub(in crate::api) requires_approval: Option<bool>,
+    #[serde(default, deserialize_with = "deserialize_some")]
+    pub(in crate::api) recurrence_rule: Option<Option<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/backend/src/api/state/event_responses.rs
+++ b/backend/src/api/state/event_responses.rs
@@ -42,6 +42,8 @@ pub(in crate::api) struct EventResponse {
     pub(in crate::api) requires_approval: bool,
     #[serde(rename = "conversationId")]
     pub(in crate::api) conversation_id: Option<String>,
+    #[serde(rename = "recurrenceRule", skip_serializing_if = "Option::is_none")]
+    pub(in crate::api) recurrence_rule: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(in crate::api) score: Option<f64>,
 }

--- a/backend/src/db/models/events.rs
+++ b/backend/src/db/models/events.rs
@@ -23,6 +23,7 @@ pub struct Event {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub requires_approval: bool,
+    pub recurrence_rule: Option<String>,
 }
 
 #[derive(Debug, Insertable)]
@@ -44,6 +45,7 @@ pub struct NewEvent {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub requires_approval: bool,
+    pub recurrence_rule: Option<String>,
 }
 
 #[derive(Debug, AsChangeset, Default)]
@@ -62,4 +64,5 @@ pub struct EventChangeset {
     pub max_attendees: Option<Option<i32>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub requires_approval: Option<bool>,
+    pub recurrence_rule: Option<Option<String>>,
 }

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -145,6 +145,7 @@ diesel::table! {
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
         requires_approval -> Bool,
+        recurrence_rule -> Nullable<Varchar>,
     }
 }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
@@ -626,6 +626,14 @@ fun EventCreateScreen(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
+            SectionLabel("powtarzaj")
+            RecurrencePicker(
+                selected = state.recurrenceRule,
+                onSelect = viewModel::updateRecurrenceRule,
+            )
+
+            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
+
             // Error
             state.error?.let { error ->
                 Text(
@@ -883,6 +891,46 @@ private fun EventTagChip(
                 tint = Primary,
                 modifier = Modifier.size(14.dp),
             )
+        }
+    }
+}
+
+private val RECURRENCE_OPTIONS: List<Pair<String?, String>> =
+    listOf(
+        null to "brak",
+        "FREQ=WEEKLY" to "co tydzień",
+        "FREQ=WEEKLY;INTERVAL=2" to "co 2 tyg.",
+        "FREQ=MONTHLY" to "co miesiąc",
+    )
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun RecurrencePicker(
+    selected: String?,
+    onSelect: (String?) -> Unit,
+) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        RECURRENCE_OPTIONS.forEach { (rule, label) ->
+            val isSelected = selected == rule
+            Surface(
+                shape = RoundedCornerShape(999.dp),
+                color = if (isSelected) PrimaryLight else SurfaceColor,
+                border = BorderStroke(1.dp, if (isSelected) Primary else Border),
+                modifier = Modifier.clickable { onSelect(rule) },
+            ) {
+                Text(
+                    text = label,
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 13.sp,
+                    color = if (isSelected) Primary else TextPrimary,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                )
+            }
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateViewModel.kt
@@ -30,6 +30,7 @@ data class EventCreateState(
     val latitude: Double? = null,
     val longitude: Double? = null,
     val requiresApproval: Boolean = false,
+    val recurrenceRule: String? = null,
     val selectedTags: List<Tag> = emptyList(),
     val tagSearchQuery: String = "",
     val tagSearchResults: List<Tag> = emptyList(),
@@ -76,6 +77,10 @@ class EventCreateViewModel(
 
     fun updateRequiresApproval(value: Boolean) {
         _state.value = _state.value.copy(requiresApproval = value)
+    }
+
+    fun updateRecurrenceRule(rule: String?) {
+        _state.value = _state.value.copy(recurrenceRule = rule)
     }
 
     fun updateAttendeeLimit(attendeeLimit: String) {
@@ -177,6 +182,7 @@ class EventCreateViewModel(
                         latitude = event.latitude,
                         longitude = event.longitude,
                         requiresApproval = event.requiresApproval,
+                        recurrenceRule = event.recurrenceRule,
                         selectedTags = event.tags,
                         isLoading = false,
                         eventId = eventId,
@@ -248,6 +254,7 @@ class EventCreateViewModel(
                 maxAttendees = UpdateEventRequest.maxAttendeesValue(maxAttendees),
                 tagIds = s.selectedTags.map { it.id },
                 requiresApproval = s.requiresApproval,
+                recurrenceRule = s.recurrenceRule,
             )
         when (val result = eventRepository.updateEvent(eventId, request)) {
             is ApiResult.Success -> {
@@ -282,6 +289,7 @@ class EventCreateViewModel(
                 maxAttendees = maxAttendees,
                 tagIds = s.selectedTags.map { it.id },
                 requiresApproval = if (s.requiresApproval) true else null,
+                recurrenceRule = s.recurrenceRule,
             )
         when (val result = eventRepository.createEvent(request)) {
             is ApiResult.Success -> {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -408,6 +408,17 @@ private fun EventCard(
                         }
                     }
 
+                    formatRecurrence(event.recurrenceRule)?.let { label ->
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = label,
+                            fontFamily = NunitoFamily,
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 13.sp,
+                            color = TextMuted,
+                        )
+                    }
+
                     Spacer(modifier = Modifier.height(6.dp))
 
                     // Attendees row
@@ -469,6 +480,25 @@ private fun BookmarkOverlay(
             tint = if (isSaved) Primary else TextPrimary,
         )
     }
+}
+
+private fun formatRecurrence(rule: String?): String? {
+    if (rule.isNullOrBlank()) return null
+    val parts = mutableMapOf<String, String>()
+    rule.split(';').forEach { segment ->
+        val kv = segment.split('=', limit = 2)
+        if (kv.size == 2) parts[kv[0]] = kv[1]
+    }
+    val freq = parts["FREQ"] ?: return null
+    val interval = parts["INTERVAL"]?.toIntOrNull() ?: 1
+    val base =
+        when (freq) {
+            "WEEKLY" -> if (interval == 1) "co tydzień" else "co $interval tyg."
+            "MONTHLY" -> if (interval == 1) "co miesiąc" else "co $interval mies."
+            "DAILY" -> if (interval == 1) "codziennie" else "co $interval dni"
+            else -> return null
+        }
+    return "🔁 $base"
 }
 
 private fun Event.attendeeUsageLabel(): String =

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/mapper/EventMapper.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/mapper/EventMapper.kt
@@ -38,6 +38,7 @@ fun com.poziomki.app.db.Event.toApiModel(): Event =
         attendeesPreview = parseAttendeesPreview(attendees_preview_json),
         tags = parseTags(tags_json),
         conversationId = conversation_id,
+        recurrenceRule = recurrence_rule,
         score = score,
     )
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventMutationRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventMutationRepository.kt
@@ -132,6 +132,7 @@ internal class EventMutationRepository(
                     is_dirty = 1L,
                     requires_approval = current.requires_approval,
                     is_pending = current.is_pending,
+                    recurrence_rule = request.recurrenceRule ?: current.recurrence_rule,
                 )
             }
 
@@ -389,6 +390,7 @@ internal class EventMutationRepository(
             is_dirty = if (isDirty) 1L else 0L,
             requires_approval = if (event.requiresApproval) 1L else 0L,
             is_pending = if (event.isPending) 1L else 0L,
+            recurrence_rule = event.recurrenceRule,
         )
     }
 
@@ -452,6 +454,7 @@ internal class EventMutationRepository(
             longitude = request.longitude ?: cached.longitude,
             startsAt = request.startsAt ?: cached.startsAt,
             endsAt = request.endsAt ?: cached.endsAt,
+            recurrenceRule = request.recurrenceRule ?: cached.recurrenceRule,
             tags = optimisticTags,
         )
     }
@@ -502,6 +505,7 @@ internal class EventMutationRepository(
             is_dirty = event.is_dirty,
             requires_approval = event.requires_approval,
             is_pending = event.is_pending,
+            recurrence_rule = event.recurrence_rule,
         )
     }
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRoomRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRoomRepository.kt
@@ -96,6 +96,7 @@ internal class EventRoomRepository(
             is_dirty = current.is_dirty,
             requires_approval = current.requires_approval,
             is_pending = current.is_pending,
+            recurrence_rule = current.recurrence_rule,
         )
     }
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
@@ -231,6 +231,7 @@ class SyncEngine(
             is_dirty = 0L,
             requires_approval = if (event.requiresApproval) 1L else 0L,
             is_pending = if (event.isPending) 1L else 0L,
+            recurrence_rule = event.recurrenceRule,
         )
     }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
@@ -176,6 +176,7 @@ data class Event(
     val attendeesPreview: List<EventAttendeePreview> = emptyList(),
     val tags: List<Tag> = emptyList(),
     val conversationId: String? = null,
+    val recurrenceRule: String? = null,
     val score: Double = 0.0,
 )
 
@@ -193,6 +194,7 @@ data class CreateEventRequest(
     val maxAttendees: Int? = null,
     val tagIds: List<String> = emptyList(),
     val requiresApproval: Boolean? = null,
+    val recurrenceRule: String? = null,
 )
 
 @Serializable
@@ -209,6 +211,7 @@ data class UpdateEventRequest(
     val tagIds: List<String>? = null,
     val maxAttendees: JsonElement = JsonNull,
     val requiresApproval: Boolean? = null,
+    val recurrenceRule: String? = null,
 ) {
     companion object {
         fun maxAttendeesValue(value: Int?): JsonElement = value?.let { JsonPrimitive(it) } ?: JsonNull

--- a/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/Event.sq
+++ b/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/Event.sq
@@ -25,7 +25,8 @@ CREATE TABLE event (
     latitude REAL,
     longitude REAL,
     requires_approval INTEGER NOT NULL DEFAULT 0,
-    is_pending INTEGER NOT NULL DEFAULT 0
+    is_pending INTEGER NOT NULL DEFAULT 0,
+    recurrence_rule TEXT
 );
 
 selectAll:
@@ -68,8 +69,8 @@ INSERT OR REPLACE INTO event(
     starts_at, ends_at, creator_id, creator_name, creator_profile_picture,
     attendees_count, max_attendees, is_attending, is_saved, attendees_preview_json, tags_json, created_at,
     conversation_id, score, cached_at, in_list_feed, is_recommended, is_dirty, latitude, longitude,
-    requires_approval, is_pending
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    requires_approval, is_pending, recurrence_rule
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 updateAttendance:
 UPDATE event

--- a/mobile/core/src/commonMain/sqldelight/migrations/14.sqm
+++ b/mobile/core/src/commonMain/sqldelight/migrations/14.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE event ADD COLUMN recurrence_rule TEXT;


### PR DESCRIPTION
Pole `recurrence_rule` (iCal RRULE string) na evencie. UI:
- picker w EventCreateScreen: brak / co tydzień / co 2 tyg. / co miesiąc
- badge "🔁 co tydzień" na karcie eventu

Bez generowania osobnych instancji w DB — sam event ma jeden `startsAt`, klient pokazuje regułę powtarzania.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add recurring event support via RRULE to events API and mobile UI
> - Adds a nullable `recurrence_rule` column to the `events` table via backend and SQLDelight migrations, propagated through the Diesel ORM models, API request/response structs, and network models.
> - Event create and update endpoints accept an RRULE string (e.g. `FREQ=WEEKLY`), trimming whitespace and coercing empty strings to `null`; updates support explicit `null` to clear the rule.
> - The mobile event creation screen gains a `RecurrencePicker` chip selector for daily/weekly/monthly options, stored in `EventCreateViewModel` state and sent on create/update.
> - Event cards on the home screen display a localized Polish recurrence label when a rule is present, via a new `formatRecurrence` helper.
> - Local caching (Room/SQLDelight), optimistic updates, and sync engine all persist and propagate `recurrence_rule` correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78107c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->