### PR TITLE
events: visibility (public/private) + invites

### DIFF
--- a/backend/migrations/2026-05-09-200000_event_visibility/down.sql
+++ b/backend/migrations/2026-05-09-200000_event_visibility/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS events_visibility_idx;
+ALTER TABLE public.events DROP COLUMN IF EXISTS visibility;

--- a/backend/migrations/2026-05-09-200000_event_visibility/up.sql
+++ b/backend/migrations/2026-05-09-200000_event_visibility/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.events
+    ADD COLUMN visibility VARCHAR(20) NOT NULL DEFAULT 'public';
+
+CREATE INDEX events_visibility_idx ON public.events(visibility);

--- a/backend/src/api/events/invite_handler.rs
+++ b/backend/src/api/events/invite_handler.rs
@@ -1,0 +1,204 @@
+type Result<T> = crate::error::AppResult<T>;
+
+use axum::response::Response;
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    response::IntoResponse,
+    Json,
+};
+use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+use crate::api::state::{InviteUsersBody, SuccessResponse};
+use crate::app::AppContext;
+use crate::db;
+use crate::db::models::event_attendees::EventAttendee;
+use crate::db::schema::event_attendees;
+
+use super::events_service::{
+    forbidden, load_event_by_id, load_profile_for_user, not_found_event, profile_not_found,
+    validation_error,
+};
+
+const INVITED_STATUS: &str = "invited";
+
+fn into_diesel(e: crate::error::AppError) -> diesel::result::Error {
+    match e {
+        crate::error::AppError::Message(_) | crate::error::AppError::Validation(_) => {
+            diesel::result::Error::QueryBuilderError(Box::new(e))
+        }
+        crate::error::AppError::Any(_) => diesel::result::Error::RollbackTransaction,
+    }
+}
+
+enum InviteOutcome {
+    NoProfile,
+    NotFound,
+    NotCreator,
+    Inserted,
+}
+
+enum UninviteOutcome {
+    NoProfile,
+    NotFound,
+    NotCreator,
+    Removed,
+}
+
+pub(in crate::api) async fn event_invite_users(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<InviteUsersBody>,
+) -> Result<Response> {
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+
+    if body.profile_ids.is_empty() {
+        return Ok(validation_error(&headers, "Lista zaproszonych jest pusta"));
+    }
+    let mut profile_uuids: Vec<Uuid> = Vec::with_capacity(body.profile_ids.len());
+    for raw in &body.profile_ids {
+        let Ok(uuid) = Uuid::parse_str(raw) else {
+            return Ok(validation_error(
+                &headers,
+                "Nieprawidłowy identyfikator profilu",
+            ));
+        };
+        profile_uuids.push(uuid);
+    }
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<InviteOutcome, diesel::result::Error>(InviteOutcome::NoProfile);
+            };
+            let Some(event) = load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(InviteOutcome::NotFound);
+            };
+            if event.creator_id != profile.id {
+                return Ok(InviteOutcome::NotCreator);
+            }
+
+            let rows: Vec<EventAttendee> = profile_uuids
+                .iter()
+                .map(|pid| EventAttendee {
+                    event_id: event_uuid,
+                    profile_id: *pid,
+                    status: INVITED_STATUS.to_string(),
+                })
+                .collect();
+
+            diesel::insert_into(event_attendees::table)
+                .values(&rows)
+                .on_conflict_do_nothing()
+                .execute(conn)
+                .await?;
+
+            Ok(InviteOutcome::Inserted)
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        InviteOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        InviteOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        InviteOutcome::NotCreator => Ok(forbidden(
+            &headers,
+            "Tylko organizator może zapraszać uczestników",
+        )),
+        InviteOutcome::Inserted => Ok(Json(SuccessResponse { success: true }).into_response()),
+    }
+}
+
+pub(in crate::api) async fn event_uninvite_user(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path((id, profile_id)): Path<(String, String)>,
+) -> Result<Response> {
+    let (_session, user) = match crate::api::state::require_auth_db(&headers).await {
+        Ok(pair) => pair,
+        Err(response) => return Ok(*response),
+    };
+    let event_uuid = match crate::api::parse_uuid_response(&id, "event", &headers) {
+        Ok(uuid) => uuid,
+        Err(response) => return Ok(*response),
+    };
+    let Ok(target_profile) = Uuid::parse_str(&profile_id) else {
+        return Ok(validation_error(
+            &headers,
+            "Nieprawidłowy identyfikator profilu",
+        ));
+    };
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(profile) = load_profile_for_user(conn, user_id)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok::<UninviteOutcome, diesel::result::Error>(UninviteOutcome::NoProfile);
+            };
+            let Some(event) = load_event_by_id(conn, event_uuid)
+                .await
+                .map_err(into_diesel)?
+            else {
+                return Ok(UninviteOutcome::NotFound);
+            };
+            if event.creator_id != profile.id {
+                return Ok(UninviteOutcome::NotCreator);
+            }
+            diesel::delete(
+                event_attendees::table
+                    .filter(event_attendees::event_id.eq(event_uuid))
+                    .filter(event_attendees::profile_id.eq(target_profile))
+                    .filter(event_attendees::status.eq(INVITED_STATUS)),
+            )
+            .execute(conn)
+            .await?;
+            Ok(UninviteOutcome::Removed)
+        }
+        .scope_boxed()
+    })
+    .await
+    .map_err(crate::error::AppError::from)?;
+
+    match outcome {
+        UninviteOutcome::NoProfile => Ok(profile_not_found(&headers)),
+        UninviteOutcome::NotFound => Ok(not_found_event(&headers, &id)),
+        UninviteOutcome::NotCreator => Ok(forbidden(
+            &headers,
+            "Tylko organizator może odwoływać zaproszenia",
+        )),
+        UninviteOutcome::Removed => Ok(Json(SuccessResponse { success: true }).into_response()),
+    }
+}

--- a/backend/src/api/events/mod.rs
+++ b/backend/src/api/events/mod.rs
@@ -16,6 +16,7 @@ mod events_write_handler;
 mod events_write_repo;
 #[path = "write_service.rs"]
 mod events_write_service;
+mod invite_handler;
 mod report_handler;
 mod report_repo;
 
@@ -46,6 +47,7 @@ pub(super) use events_write_handler::{
     event_approve_attendee, event_attend, event_create, event_delete, event_leave,
     event_reject_attendee, event_save, event_unsave, event_update,
 };
+pub(super) use invite_handler::{event_invite_users, event_uninvite_user};
 pub(super) use report_handler::event_report;
 
 const PRIVATE_CACHE_SHORT: HeaderValue = HeaderValue::from_static("private, max-age=60");
@@ -132,8 +134,10 @@ pub(super) async fn events_list(
 ) -> Result<Response> {
     let limit = i64::from(query.limit.unwrap_or(20).clamp(1, 100));
     let now = Utc::now();
-    list_events_with_viewer(&headers, move |conn, _profile_id| {
-        Box::pin(async move { events_repo::list_upcoming_events(conn, now, limit).await })
+    list_events_with_viewer(&headers, move |conn, profile_id| {
+        Box::pin(
+            async move { events_repo::list_upcoming_events(conn, now, limit, profile_id).await },
+        )
     })
     .await
 }
@@ -197,6 +201,15 @@ pub(super) async fn event_get(
             else {
                 return Ok(EventGetOutcome::NotFound);
             };
+
+            if event.visibility == "private" && event.creator_id != profile.id {
+                let invited = events_repo::is_invited(conn, event_uuid, profile.id)
+                    .await
+                    .map_err(into_diesel)?;
+                if !invited {
+                    return Ok(EventGetOutcome::NotFound);
+                }
+            }
 
             let response = build_event_response_raw(conn, &event, &profile.id)
                 .await

--- a/backend/src/api/events/repo.rs
+++ b/backend/src/api/events/repo.rs
@@ -4,19 +4,30 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::db::models::events::Event;
-use crate::db::schema::{event_interactions, events};
+use crate::db::schema::{event_attendees, event_interactions, events};
 
 pub(in crate::api) async fn list_upcoming_events(
     conn: &mut AsyncPgConnection,
     now: DateTime<Utc>,
     limit: i64,
+    viewer_profile_id: Uuid,
 ) -> std::result::Result<Vec<Event>, crate::error::AppError> {
+    use diesel::dsl::exists;
+    let invited_subquery = event_attendees::table
+        .filter(event_attendees::event_id.eq(events::id))
+        .filter(event_attendees::profile_id.eq(viewer_profile_id));
     let models = events::table
         .filter(
             events::ends_at
                 .is_null()
                 .and(events::starts_at.ge(now))
                 .or(events::ends_at.ge(now)),
+        )
+        .filter(
+            events::visibility
+                .eq("public")
+                .or(events::creator_id.eq(viewer_profile_id))
+                .or(exists(invited_subquery)),
         )
         .order(events::starts_at.asc())
         .limit(limit)
@@ -65,4 +76,19 @@ pub(in crate::api) async fn find_event(
         .await
         .optional()?;
     Ok(model)
+}
+
+pub(in crate::api) async fn is_invited(
+    conn: &mut AsyncPgConnection,
+    event_id: Uuid,
+    profile_id: Uuid,
+) -> std::result::Result<bool, crate::error::AppError> {
+    let exists = event_attendees::table
+        .filter(event_attendees::event_id.eq(event_id))
+        .filter(event_attendees::profile_id.eq(profile_id))
+        .select(event_attendees::profile_id)
+        .first::<Uuid>(conn)
+        .await
+        .optional()?;
+    Ok(exists.is_some())
 }

--- a/backend/src/api/events/view.rs
+++ b/backend/src/api/events/view.rs
@@ -98,6 +98,7 @@ fn build_from_context(
         is_pending,
         requires_approval: event.requires_approval,
         conversation_id: event.conversation_id.clone(),
+        visibility: event.visibility.clone(),
         score: None,
     }
 }

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -200,8 +200,16 @@ fn build_new_event(
         created_at: now,
         updated_at: now,
         requires_approval: payload.requires_approval.unwrap_or(false),
+        visibility: normalize_visibility(payload.visibility.as_deref()),
     };
     (model, event_id)
+}
+
+fn normalize_visibility(value: Option<&str>) -> String {
+    match value.map(str::trim) {
+        Some("private") => "private".to_string(),
+        _ => "public".to_string(),
+    }
 }
 
 enum CreateOutcome {

--- a/backend/src/api/events/write_service.rs
+++ b/backend/src/api/events/write_service.rs
@@ -148,6 +148,12 @@ fn build_update_changeset(payload: &UpdateEventBody, dates: EventDates) -> Event
     if let Some(limit) = &payload.max_attendees {
         changeset.max_attendees = Some(*limit);
     }
+    if let Some(vis) = &payload.visibility {
+        changeset.visibility = Some(match vis.trim() {
+            "private" => "private".to_string(),
+            _ => "public".to_string(),
+        });
+    }
 
     let (new_starts, new_ends) = dates;
     changeset.starts_at = Some(new_starts);

--- a/backend/src/api/matching/scoring.rs
+++ b/backend/src/api/matching/scoring.rs
@@ -315,6 +315,7 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
             requires_approval: false,
+            visibility: "public".to_string(),
         };
 
         let score = score_event(

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -137,6 +137,11 @@ fn events_routes() -> Router<AppContext> {
             post(events::event_reject_attendee),
         )
         .route("/{id}/report", post(events::event_report))
+        .route("/{id}/invites", post(events::event_invite_users))
+        .route(
+            "/{id}/invites/{profile_id}",
+            delete(events::event_uninvite_user),
+        )
         .layer(cache_layer("private, max-age=60"));
 
     personal.merge(shared)

--- a/backend/src/api/state/event_requests.rs
+++ b/backend/src/api/state/event_requests.rs
@@ -46,6 +46,8 @@ pub(in crate::api) struct CreateEventBody {
     pub(in crate::api) tag_ids: Option<Vec<String>>,
     #[serde(default)]
     pub(in crate::api) requires_approval: Option<bool>,
+    #[serde(default)]
+    pub(in crate::api) visibility: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -82,6 +84,14 @@ pub(in crate::api) struct UpdateEventBody {
     pub(in crate::api) tag_ids: Option<Vec<String>>,
     #[serde(default)]
     pub(in crate::api) requires_approval: Option<bool>,
+    #[serde(default)]
+    pub(in crate::api) visibility: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::api) struct InviteUsersBody {
+    pub(in crate::api) profile_ids: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/backend/src/api/state/event_responses.rs
+++ b/backend/src/api/state/event_responses.rs
@@ -42,6 +42,7 @@ pub(in crate::api) struct EventResponse {
     pub(in crate::api) requires_approval: bool,
     #[serde(rename = "conversationId")]
     pub(in crate::api) conversation_id: Option<String>,
+    pub(in crate::api) visibility: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(in crate::api) score: Option<f64>,
 }

--- a/backend/src/db/models/events.rs
+++ b/backend/src/db/models/events.rs
@@ -23,6 +23,7 @@ pub struct Event {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub requires_approval: bool,
+    pub visibility: String,
 }
 
 #[derive(Debug, Insertable)]
@@ -44,6 +45,7 @@ pub struct NewEvent {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub requires_approval: bool,
+    pub visibility: String,
 }
 
 #[derive(Debug, AsChangeset, Default)]
@@ -62,4 +64,5 @@ pub struct EventChangeset {
     pub max_attendees: Option<Option<i32>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub requires_approval: Option<bool>,
+    pub visibility: Option<String>,
 }

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -145,6 +145,7 @@ diesel::table! {
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
         requires_approval -> Bool,
+        visibility -> Varchar,
     }
 }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
@@ -626,6 +626,14 @@ fun EventCreateScreen(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
+            SectionLabel("widoczność")
+            VisibilityPicker(
+                selected = state.visibility,
+                onSelect = viewModel::updateVisibility,
+            )
+
+            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
+
             // Error
             state.error?.let { error ->
                 Text(
@@ -883,6 +891,44 @@ private fun EventTagChip(
                 tint = Primary,
                 modifier = Modifier.size(14.dp),
             )
+        }
+    }
+}
+
+private val VISIBILITY_OPTIONS: List<Pair<String, String>> =
+    listOf(
+        "public" to "publiczne",
+        "private" to "prywatne (tylko zaproszeni)",
+    )
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun VisibilityPicker(
+    selected: String,
+    onSelect: (String) -> Unit,
+) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        VISIBILITY_OPTIONS.forEach { (value, label) ->
+            val isSelected = selected == value
+            Surface(
+                shape = RoundedCornerShape(999.dp),
+                color = if (isSelected) PrimaryLight else SurfaceColor,
+                border = BorderStroke(1.dp, if (isSelected) Primary else Border),
+                modifier = Modifier.clickable { onSelect(value) },
+            ) {
+                Text(
+                    text = label,
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 13.sp,
+                    color = if (isSelected) Primary else TextPrimary,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                )
+            }
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateViewModel.kt
@@ -30,6 +30,7 @@ data class EventCreateState(
     val latitude: Double? = null,
     val longitude: Double? = null,
     val requiresApproval: Boolean = false,
+    val visibility: String = "public",
     val selectedTags: List<Tag> = emptyList(),
     val tagSearchQuery: String = "",
     val tagSearchResults: List<Tag> = emptyList(),
@@ -76,6 +77,10 @@ class EventCreateViewModel(
 
     fun updateRequiresApproval(value: Boolean) {
         _state.value = _state.value.copy(requiresApproval = value)
+    }
+
+    fun updateVisibility(value: String) {
+        _state.value = _state.value.copy(visibility = value)
     }
 
     fun updateAttendeeLimit(attendeeLimit: String) {
@@ -177,6 +182,7 @@ class EventCreateViewModel(
                         latitude = event.latitude,
                         longitude = event.longitude,
                         requiresApproval = event.requiresApproval,
+                        visibility = event.visibility,
                         selectedTags = event.tags,
                         isLoading = false,
                         eventId = eventId,
@@ -248,6 +254,7 @@ class EventCreateViewModel(
                 maxAttendees = UpdateEventRequest.maxAttendeesValue(maxAttendees),
                 tagIds = s.selectedTags.map { it.id },
                 requiresApproval = s.requiresApproval,
+                visibility = s.visibility,
             )
         when (val result = eventRepository.updateEvent(eventId, request)) {
             is ApiResult.Success -> {
@@ -282,6 +289,7 @@ class EventCreateViewModel(
                 maxAttendees = maxAttendees,
                 tagIds = s.selectedTags.map { it.id },
                 requiresApproval = if (s.requiresApproval) true else null,
+                visibility = if (s.visibility != "public") s.visibility else null,
             )
         when (val result = eventRepository.createEvent(request)) {
             is ApiResult.Success -> {

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/mapper/EventMapper.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/mapper/EventMapper.kt
@@ -38,6 +38,7 @@ fun com.poziomki.app.db.Event.toApiModel(): Event =
         attendeesPreview = parseAttendeesPreview(attendees_preview_json),
         tags = parseTags(tags_json),
         conversationId = conversation_id,
+        visibility = visibility,
         score = score,
     )
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventMutationRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventMutationRepository.kt
@@ -132,6 +132,7 @@ internal class EventMutationRepository(
                     is_dirty = 1L,
                     requires_approval = current.requires_approval,
                     is_pending = current.is_pending,
+                    visibility = request.visibility ?: current.visibility,
                 )
             }
 
@@ -389,6 +390,7 @@ internal class EventMutationRepository(
             is_dirty = if (isDirty) 1L else 0L,
             requires_approval = if (event.requiresApproval) 1L else 0L,
             is_pending = if (event.isPending) 1L else 0L,
+            visibility = event.visibility,
         )
     }
 
@@ -452,6 +454,7 @@ internal class EventMutationRepository(
             longitude = request.longitude ?: cached.longitude,
             startsAt = request.startsAt ?: cached.startsAt,
             endsAt = request.endsAt ?: cached.endsAt,
+            visibility = request.visibility ?: cached.visibility,
             tags = optimisticTags,
         )
     }
@@ -502,6 +505,7 @@ internal class EventMutationRepository(
             is_dirty = event.is_dirty,
             requires_approval = event.requires_approval,
             is_pending = event.is_pending,
+            visibility = event.visibility,
         )
     }
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRoomRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRoomRepository.kt
@@ -96,6 +96,7 @@ internal class EventRoomRepository(
             is_dirty = current.is_dirty,
             requires_approval = current.requires_approval,
             is_pending = current.is_pending,
+            visibility = current.visibility,
         )
     }
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/sync/SyncEngine.kt
@@ -231,6 +231,7 @@ class SyncEngine(
             is_dirty = 0L,
             requires_approval = if (event.requiresApproval) 1L else 0L,
             is_pending = if (event.isPending) 1L else 0L,
+            visibility = event.visibility,
         )
     }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
@@ -176,6 +176,7 @@ data class Event(
     val attendeesPreview: List<EventAttendeePreview> = emptyList(),
     val tags: List<Tag> = emptyList(),
     val conversationId: String? = null,
+    val visibility: String = "public",
     val score: Double = 0.0,
 )
 
@@ -193,6 +194,7 @@ data class CreateEventRequest(
     val maxAttendees: Int? = null,
     val tagIds: List<String> = emptyList(),
     val requiresApproval: Boolean? = null,
+    val visibility: String? = null,
 )
 
 @Serializable
@@ -209,6 +211,7 @@ data class UpdateEventRequest(
     val tagIds: List<String>? = null,
     val maxAttendees: JsonElement = JsonNull,
     val requiresApproval: Boolean? = null,
+    val visibility: String? = null,
 ) {
     companion object {
         fun maxAttendeesValue(value: Int?): JsonElement = value?.let { JsonPrimitive(it) } ?: JsonNull

--- a/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/Event.sq
+++ b/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/Event.sq
@@ -25,7 +25,8 @@ CREATE TABLE event (
     latitude REAL,
     longitude REAL,
     requires_approval INTEGER NOT NULL DEFAULT 0,
-    is_pending INTEGER NOT NULL DEFAULT 0
+    is_pending INTEGER NOT NULL DEFAULT 0,
+    visibility TEXT NOT NULL DEFAULT 'public'
 );
 
 selectAll:
@@ -68,8 +69,8 @@ INSERT OR REPLACE INTO event(
     starts_at, ends_at, creator_id, creator_name, creator_profile_picture,
     attendees_count, max_attendees, is_attending, is_saved, attendees_preview_json, tags_json, created_at,
     conversation_id, score, cached_at, in_list_feed, is_recommended, is_dirty, latitude, longitude,
-    requires_approval, is_pending
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    requires_approval, is_pending, visibility
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 updateAttendance:
 UPDATE event

--- a/mobile/core/src/commonMain/sqldelight/migrations/14.sqm
+++ b/mobile/core/src/commonMain/sqldelight/migrations/14.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE event ADD COLUMN visibility TEXT NOT NULL DEFAULT 'public';


### PR DESCRIPTION
Pole `visibility` (public|private) na evencie:
- prywatne nie pojawiają się w feedzie ani szczegółach dla nie-zaproszonych
- twórca i osoby z `event_attendees` (status='invited' lub inne) widzą event

Endpointy:
- `POST /api/v1/events/{id}/invites` — body `{ profileIds: [] }`
- `DELETE /api/v1/events/{id}/invites/{profileId}`

UI: radio public/prywatne w EventCreateScreen.

Picker zapraszania (z DM/wyszukiwarki) w osobnym PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add event visibility (public/private) and creator-managed invites to events
> - Adds a `visibility` field (`'public'` or `'private'`) to events on the backend (DB migration, ORM models, API request/response) and mobile (network DTOs, local SQLDelight schema, cache/sync layer).
> - Private events are hidden from listing and detail endpoints unless the viewer is the event creator or has an `'invited'` attendee row.
> - Adds `POST /{id}/invites` and `DELETE /{id}/invites/{profile_id}` endpoints so event creators can invite or uninvite specific profiles.
> - Adds a `VisibilityPicker` UI component to the event create/edit screen and wires it through the `EventCreateViewModel`.
> - Behavioral Change: unauthenticated or uninvited users requesting a private event receive a 404 rather than the event data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24cbda7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->