### PR TITLE
ui(chat): show inline date dividers in timeline

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
@@ -79,6 +79,7 @@ import com.poziomki.app.ui.feature.chat.model.ComposerMode
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
@@ -158,7 +159,9 @@ fun ChatContent(
         }
 
         run {
-            val reversedItems = state.timelineItems.asReversed()
+            val itemsWithDividers =
+                remember(state.timelineItems) { withDateDividers(state.timelineItems) }
+            val reversedItems = itemsWithDividers.asReversed()
             val topTimelineLabel by remember(reversedItems, timelineListState) {
                 derivedStateOf {
                     val topVisibleIndex = timelineListState.layoutInfo.visibleItemsInfo.maxOfOrNull { it.index }
@@ -200,7 +203,7 @@ fun ChatContent(
                         Box(modifier = itemPadding) {
                             when (item) {
                                 is TimelineItem.DateDivider -> {
-                                    Spacer(modifier = Modifier.height(2.dp))
+                                    DateDivider(item.timestampMillis)
                                 }
 
                                 is TimelineItem.Event -> {
@@ -810,6 +813,24 @@ internal fun shouldGroupWithPrevious(
     if (previous.isMine != current.isMine) return false
     val delta = current.timestampMillis - previous.timestampMillis
     return delta in 0..(5 * 60 * 1000)
+}
+
+internal fun withDateDividers(items: List<TimelineItem>): List<TimelineItem> {
+    if (items.isEmpty()) return items
+    val zone = TimeZone.currentSystemDefault()
+    val out = ArrayList<TimelineItem>(items.size + 4)
+    var lastDate: LocalDate? = null
+    for (item in items) {
+        if (item is TimelineItem.Event) {
+            val date = Instant.fromEpochMilliseconds(item.timestampMillis).toLocalDateTime(zone).date
+            if (date != lastDate) {
+                out.add(TimelineItem.DateDivider(item.timestampMillis))
+                lastDate = date
+            }
+        }
+        out.add(item)
+    }
+    return out
 }
 
 internal fun formatDate(timestampMillis: Long): String {


### PR DESCRIPTION
Old chats showed only HH:MM with no date. Inserts a date label between messages from different days, reusing the existing `DateDivider` model and `formatDate()` helper.

- [ ] check messages spanning multiple days
- [ ] check single-day chat (one divider at top)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show inline date dividers between days in the chat timeline
> Adds a `withDateDividers` function in [ChatContent.kt](https://github.com/poziomki-app/poziomki/pull/400/files#diff-6f863f38c1b21e3ce2537ab3ef577f834352a02dfd2c9b0c6acf90ec9d80a581) that inserts `TimelineItem.DateDivider` entries at day boundaries before rendering. The `ChatContent` composable preprocesses the timeline with `remember` and passes the augmented list to the `LazyColumn`, replacing the previous 2dp spacer placeholder with a real `DateDivider` component.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f44578a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->