### PR TITLE
ui: unified tag chips, filter tabs, messages menu

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -13,7 +13,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.21.1" // x-release-please-version
+val appVersionName = "0.21.21" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
@@ -35,16 +35,16 @@ fun <T> FilterTabs(
             modifier
                 .fillMaxWidth()
                 .padding(top = 12.dp, bottom = 16.dp),
-        horizontalArrangement = Arrangement.Center,
+        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        tabs.forEachIndexed { index, (value, label) ->
+        tabs.forEach { (value, label) ->
             val isSelected = value == selected
             Row(
                 modifier =
                     Modifier
                         .clickable { onSelect(value) }
-                        .padding(horizontal = 12.dp, vertical = 4.dp),
+                        .padding(vertical = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (isSelected) {
@@ -63,9 +63,6 @@ fun <T> FilterTabs(
                     fontSize = 16.sp,
                     color = if (isSelected) TextPrimary else TextMuted,
                 )
-            }
-            if (index < tabs.lastIndex) {
-                Spacer(modifier = Modifier.width(8.dp))
             }
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -36,8 +36,6 @@ import com.poziomki.app.network.Tag
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
-import com.poziomki.app.ui.designsystem.theme.Primary
-import com.poziomki.app.ui.designsystem.theme.PrimaryMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.shared.resolveImageUrl
@@ -152,25 +150,10 @@ fun ProfileCard(
                         verticalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
                         orderedTags.forEach { tag ->
-                            val isActivity = tag.scope == "activity"
-                            Text(
-                                text = tag.name.lowercase(),
-                                fontFamily = NunitoFamily,
-                                fontWeight = if (isActivity) FontWeight.SemiBold else FontWeight.Medium,
-                                fontSize = 11.sp,
-                                lineHeight = 12.sp,
-                                color = if (isActivity) PrimaryMuted else TextSecondary,
-                                modifier =
-                                    Modifier
-                                        .clip(RoundedCornerShape(50))
-                                        .background(
-                                            if (isActivity) {
-                                                Primary.copy(alpha = 0.18f)
-                                            } else {
-                                                Color.White.copy(alpha = 0.06f)
-                                            },
-                                        ).padding(horizontal = 7.dp, vertical = 1.dp),
-                            )
+                            // All tags here are shared with the viewer
+                            // (matchingTags is already filtered), so always
+                            // highlight blue.
+                            TagChip(tag = tag, matching = true, size = TagChipSize.SMALL)
                         }
                     }
                 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
@@ -2,7 +2,6 @@ package com.poziomki.app.ui.designsystem.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -49,7 +48,6 @@ import com.adamglin.phosphoricons.bold.X
 import com.poziomki.app.network.Tag
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Black
-import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
@@ -83,6 +81,7 @@ fun ProfilePreview(
     emojiAvatar: String? = null,
     gradientStart: String? = null,
     gradientEnd: String? = null,
+    ownTagIds: Set<String> = emptySet(),
     onClose: (() -> Unit)? = null,
     bottomContent: @Composable (() -> Unit)? = null,
     headerAction: @Composable (() -> Unit)? = null,
@@ -303,8 +302,11 @@ fun ProfilePreview(
                 RichBio(bio = bio)
             }
 
-            // Tags — compact
-            if (tags.isNotEmpty()) {
+            // Tags — split into interests + activities, same chip style;
+            // shared tags (own user has them too) get the blue highlight.
+            val interestTags = tags.filter { it.scope == "interest" }
+            val activityTags = tags.filter { it.scope == "activity" }
+            if (interestTags.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
                 Text(
                     text = "zainteresowania",
@@ -314,24 +316,19 @@ fun ProfilePreview(
                     color = TextPrimary,
                 )
                 Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    tags.forEach { tag ->
-                        Text(
-                            text = tag.name.lowercase(),
-                            fontFamily = nunito,
-                            fontWeight = FontWeight.Medium,
-                            fontSize = 13.sp,
-                            color = TextSecondary,
-                            modifier =
-                                Modifier
-                                    .border(1.dp, Border, RoundedCornerShape(50))
-                                    .padding(horizontal = 8.dp, vertical = 3.dp),
-                        )
-                    }
-                }
+                TagFlowRow(tags = interestTags, ownTagIds = ownTagIds)
+            }
+            if (activityTags.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
+                Text(
+                    text = "aktywności",
+                    fontFamily = montserrat,
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 16.sp,
+                    color = TextPrimary,
+                )
+                Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
+                TagFlowRow(tags = activityTags, ownTagIds = ownTagIds)
             }
 
             // Bottom content slot (e.g. "send message" button)
@@ -397,6 +394,22 @@ private fun RichBio(bio: String) {
                     )
                 }
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun TagFlowRow(
+    tags: List<Tag>,
+    ownTagIds: Set<String>,
+) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        tags.forEach { tag ->
+            TagChip(tag = tag, matching = tag.id in ownTagIds)
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/SearchableScreenHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/SearchableScreenHeader.kt
@@ -62,7 +62,7 @@ fun SearchableScreenHeader(
     val rowModifier =
         modifier
             .fillMaxWidth()
-            .padding(PoziomkiTheme.spacing.md)
+            .padding(horizontal = PoziomkiTheme.spacing.md, vertical = PoziomkiTheme.spacing.xs)
             .height(48.dp)
     Row(
         modifier = rowModifier,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/TagChip.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/TagChip.kt
@@ -1,0 +1,51 @@
+package com.poziomki.app.ui.designsystem.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.poziomki.app.network.Tag
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.PrimaryMuted
+import com.poziomki.app.ui.designsystem.theme.TextSecondary
+
+enum class TagChipSize { SMALL, REGULAR }
+
+@Composable
+fun TagChip(
+    tag: Tag,
+    matching: Boolean = false,
+    size: TagChipSize = TagChipSize.REGULAR,
+    modifier: Modifier = Modifier,
+) {
+    val fontSize = if (size == TagChipSize.SMALL) 11.sp else 13.sp
+    val lineHeight = if (size == TagChipSize.SMALL) 12.sp else 16.sp
+    val hPad = if (size == TagChipSize.SMALL) 8.dp else 10.dp
+    val vPad = if (size == TagChipSize.SMALL) 2.dp else 4.dp
+
+    val bg = if (matching) Primary.copy(alpha = 0.18f) else Color.White.copy(alpha = 0.06f)
+    val fg = if (matching) PrimaryMuted else TextSecondary
+    val textModifier =
+        modifier
+            .clip(RoundedCornerShape(50))
+            .background(bg)
+            .padding(horizontal = hPad, vertical = vPad)
+
+    Text(
+        text = tag.name.lowercase(),
+        fontFamily = NunitoFamily,
+        fontWeight = if (matching) FontWeight.SemiBold else FontWeight.Medium,
+        fontSize = fontSize,
+        lineHeight = lineHeight,
+        color = fg,
+        modifier = textModifier,
+    )
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -58,6 +58,7 @@ import com.adamglin.phosphoricons.bold.BookmarkSimple
 import com.adamglin.phosphoricons.bold.CaretDown
 import com.adamglin.phosphoricons.bold.CaretUp
 import com.adamglin.phosphoricons.bold.Plus
+import com.adamglin.phosphoricons.bold.SlidersHorizontal
 import com.adamglin.phosphoricons.fill.BookmarkSimple
 import com.adamglin.phosphoricons.fill.MapPin
 import com.poziomki.app.network.Event
@@ -151,13 +152,6 @@ fun EventsScreen(
             },
             searchActive = searchActive,
             onSearchActiveChange = { searchActive = it },
-            filterActive = state.selectedCategories.isNotEmpty(),
-            onFilterClick =
-                if (!isNearby) {
-                    { viewModel.toggleShowTagFilter() }
-                } else {
-                    null
-                },
         ) {
             androidx.compose.material3.IconButton(onClick = onNavigateToEventCreate) {
                 Icon(
@@ -178,11 +172,32 @@ fun EventsScreen(
             )
         }
 
-        FilterTabs(
-            tabs = timeFilterTabs,
-            selected = state.activeFilter,
-            onSelect = { viewModel.setTimeFilter(it) },
-        )
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 24.dp, end = PoziomkiTheme.spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilterTabs(
+                tabs = timeFilterTabs,
+                selected = state.activeFilter,
+                onSelect = { viewModel.setTimeFilter(it) },
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(end = 12.dp),
+            )
+            androidx.compose.material3.IconButton(
+                onClick = { viewModel.toggleShowTagFilter() },
+            ) {
+                Icon(
+                    PhosphorIcons.Bold.SlidersHorizontal,
+                    contentDescription = "Filtruj",
+                    tint = if (state.selectedCategories.isNotEmpty()) Primary else TextPrimary,
+                )
+            }
+        }
 
         // Content
         Box(modifier = Modifier.fillMaxSize()) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -69,9 +69,10 @@ import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 fun ExploreScreen(
     onNavigateToProfile: (String) -> Unit,
-    onNavigateToEventDetail: (String) -> Unit = {},
+    @Suppress("UnusedParameter") onNavigateToEventDetail: (String) -> Unit = {},
     profileAvatarAction: @Composable () -> Unit = {},
     viewModel: ExploreViewModel = koinViewModel(),
 ) {
@@ -119,7 +120,7 @@ fun ExploreScreen(
             )
         }
 
-        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
 
         val isFilterOnlyMode = !isSearchActive && state.isFilterActive
         Box(modifier = Modifier.fillMaxSize()) {
@@ -167,20 +168,14 @@ fun ExploreScreen(
                     state.searchResults != null -> {
                         val raw = state.searchResults!!
                         val selectedIds = state.selectedTagIds
-                        val results =
+                        val profiles =
                             if (selectedIds.isEmpty()) {
-                                raw
+                                raw.profiles
                             } else {
-                                raw.copy(
-                                    profiles = raw.profiles.filter { p -> p.tags.any { it in selectedIds } },
-                                )
+                                raw.profiles.filter { p -> p.tags.any { it in selectedIds } }
                             }
-                        val hasResults =
-                            results.profiles.isNotEmpty() ||
-                                results.events.isNotEmpty() ||
-                                results.tags.isNotEmpty()
 
-                        if (!hasResults) {
+                        if (profiles.isEmpty()) {
                             EmptyView("brak wynik\u00f3w")
                         } else {
                             LazyColumn(
@@ -191,102 +186,14 @@ fun ExploreScreen(
                                 contentPadding = PaddingValues(bottom = LocalNavBarPadding.current),
                                 verticalArrangement = Arrangement.spacedBy(PoziomkiTheme.spacing.sm),
                             ) {
-                                // Tags section
-                                if (results.tags.isNotEmpty()) {
-                                    item {
-                                        Text(
-                                            text = "tagi",
-                                            style = MaterialTheme.typography.titleSmall,
-                                            color = TextSecondary,
-                                            modifier = Modifier.padding(vertical = 4.dp),
-                                        )
-                                        FlowRow(
-                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                                        ) {
-                                            results.tags.forEach { tag ->
-                                                Surface(
-                                                    shape = RoundedCornerShape(16.dp),
-                                                    color = SurfaceElevated,
-                                                ) {
-                                                    Text(
-                                                        text = "${tag.emoji ?: ""} ${tag.name}".trim(),
-                                                        fontFamily = NunitoFamily,
-                                                        color = TextPrimary,
-                                                        fontSize = 13.sp,
-                                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                                                    )
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                // Profiles section
-                                if (results.profiles.isNotEmpty()) {
-                                    item {
-                                        Text(
-                                            text = "osoby",
-                                            style = MaterialTheme.typography.titleSmall,
-                                            color = TextSecondary,
-                                            modifier = Modifier.padding(vertical = 4.dp),
-                                        )
-                                    }
-                                    items(results.profiles, key = { "p-${it.id}" }) { profile ->
-                                        ProfileCard(
-                                            name = profile.name,
-                                            profilePicture = profile.profilePicture,
-                                            matchingTags = state.ownTags.filter { it.id in profile.tags },
-                                            program = profile.program,
-                                            onClick = { onNavigateToProfile(profile.id) },
-                                        )
-                                    }
-                                }
-
-                                // Events section
-                                if (results.events.isNotEmpty()) {
-                                    item {
-                                        Text(
-                                            text = "wydarzenia",
-                                            style = MaterialTheme.typography.titleSmall,
-                                            color = TextSecondary,
-                                            modifier = Modifier.padding(vertical = 4.dp),
-                                        )
-                                    }
-                                    items(results.events, key = { "e-${it.id}" }) { event ->
-                                        Surface(
-                                            modifier =
-                                                Modifier
-                                                    .fillMaxWidth()
-                                                    .clickable { onNavigateToEventDetail(event.id) },
-                                            shape = RoundedCornerShape(12.dp),
-                                            color = SurfaceElevated,
-                                        ) {
-                                            Column(modifier = Modifier.padding(12.dp)) {
-                                                Text(
-                                                    text = event.title,
-                                                    style = MaterialTheme.typography.titleSmall,
-                                                    color = TextPrimary,
-                                                    fontFamily = NunitoFamily,
-                                                )
-                                                val loc = event.location
-                                                if (loc != null) {
-                                                    Text(
-                                                        text = loc,
-                                                        fontSize = 13.sp,
-                                                        color = TextSecondary,
-                                                        fontFamily = NunitoFamily,
-                                                    )
-                                                }
-                                                Text(
-                                                    text = event.creatorName,
-                                                    fontSize = 12.sp,
-                                                    color = TextMuted,
-                                                    fontFamily = NunitoFamily,
-                                                )
-                                            }
-                                        }
-                                    }
+                                items(profiles, key = { "p-${it.id}" }) { profile ->
+                                    ProfileCard(
+                                        name = profile.name,
+                                        profilePicture = profile.profilePicture,
+                                        matchingTags = state.ownTags.filter { it.id in profile.tags },
+                                        program = profile.program,
+                                        onClick = { onNavigateToProfile(profile.id) },
+                                    )
                                 }
                             }
                         }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -1,13 +1,20 @@
 package com.poziomki.app.ui.feature.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -15,13 +22,23 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Bold
+import com.adamglin.phosphoricons.bold.Check
+import com.adamglin.phosphoricons.bold.DotsThreeVertical
+import com.adamglin.phosphoricons.bold.UsersThree
 import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.FilterTabs
 import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.SearchableScreenHeader
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
+import com.poziomki.app.ui.designsystem.theme.TextPrimary
+import com.poziomki.app.ui.feature.chat.ActionMenuItem
 import com.poziomki.app.ui.feature.home.messages.MessagesRoomFilter
 import com.poziomki.app.ui.feature.home.messages.RoomRow
 import com.poziomki.app.ui.feature.home.messages.filterMessagesRooms
@@ -42,6 +59,7 @@ fun MessagesScreen(
     val state by viewModel.state.collectAsState()
     var selectedFilter by remember { mutableStateOf(MessagesRoomFilter.All) }
     var searchActive by remember { mutableStateOf(false) }
+    var menuOpen by remember { mutableStateOf(false) }
 
     val filteredRooms =
         state.rooms.filterMessagesRooms(
@@ -67,11 +85,51 @@ fun MessagesScreen(
         ) {
             profileAvatarAction()
         }
-        FilterTabs(
-            tabs = roomFilterTabs,
-            selected = selectedFilter,
-            onSelect = { selectedFilter = it },
-        )
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 24.dp, end = PoziomkiTheme.spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilterTabs(
+                tabs = roomFilterTabs,
+                selected = selectedFilter,
+                onSelect = { selectedFilter = it },
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(end = 12.dp),
+            )
+            Box {
+                IconButton(onClick = { menuOpen = true }) {
+                    Icon(
+                        PhosphorIcons.Bold.DotsThreeVertical,
+                        contentDescription = "Menu",
+                        tint = TextPrimary,
+                    )
+                }
+                DropdownMenu(
+                    expanded = menuOpen,
+                    onDismissRequest = { menuOpen = false },
+                    shape = RoundedCornerShape(16.dp),
+                    containerColor = SurfaceElevated,
+                ) {
+                    Column(modifier = Modifier.padding(horizontal = 4.dp)) {
+                        ActionMenuItem(
+                            icon = PhosphorIcons.Bold.UsersThree,
+                            label = "nowa grupa",
+                            onClick = { menuOpen = false },
+                        )
+                        ActionMenuItem(
+                            icon = PhosphorIcons.Bold.Check,
+                            label = "przeczytaj wszystkie",
+                            onClick = { menuOpen = false },
+                        )
+                    }
+                }
+            }
+        }
 
         when {
             state.isLoading && state.rooms.isEmpty() -> {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
@@ -87,7 +87,7 @@ import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Overlay
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
 import com.poziomki.app.ui.designsystem.theme.Primary
-import com.poziomki.app.ui.designsystem.theme.PrimaryLight
+import com.poziomki.app.ui.designsystem.theme.PrimaryMuted
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
@@ -1184,29 +1184,27 @@ private fun TagChip(
     selected: Boolean,
     onClick: () -> Unit,
 ) {
-    val nunito = NunitoFamily
-    val bgColor = if (selected) PrimaryLight else Color.Transparent
-    val borderColor = if (selected) Primary else Border
-    val textColor = if (selected) Primary else TextSecondary
-    val shape = RoundedCornerShape(8.dp)
+    val shape = RoundedCornerShape(50)
+    val bgColor =
+        if (selected) Primary.copy(alpha = 0.18f) else Color.White.copy(alpha = 0.06f)
+    val textColor = if (selected) PrimaryMuted else TextSecondary
 
     Row(
         modifier =
             Modifier
-                .background(bgColor, shape)
-                .border(1.dp, borderColor, shape)
                 .clip(shape)
+                .background(bgColor)
                 .clickable(onClick = onClick)
-                .padding(horizontal = 10.dp, vertical = 5.dp),
+                .padding(horizontal = 10.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = "${tag.emoji ?: ""} ${tag.name}".trim(),
-            fontFamily = nunito,
-            fontWeight = FontWeight.Medium,
-            fontSize = 12.sp,
+            text = "${tag.emoji ?: ""} ${tag.name}".trim().lowercase(),
+            fontFamily = NunitoFamily,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+            fontSize = 13.sp,
             color = textColor,
-            lineHeight = 14.sp,
+            lineHeight = 16.sp,
         )
         if (selected) {
             Spacer(modifier = Modifier.width(4.dp))

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
@@ -83,6 +83,7 @@ fun ProfileViewScreen(
                         emojiAvatar = emoji,
                         gradientStart = p.gradientStart,
                         gradientEnd = p.gradientEnd,
+                        ownTagIds = if (state.isOwnProfile) emptySet() else state.ownTagIds,
                         // X is rendered as a sticky overlay below; tell
                         // ProfilePreview not to draw its own (which would
                         // scroll with the image carousel).

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewViewModel.kt
@@ -24,6 +24,7 @@ data class ProfileViewState(
     val isOwnProfile: Boolean = false,
     val isBookmarked: Boolean = false,
     val showOwnProgram: Boolean = true,
+    val ownTagIds: Set<String> = emptySet(),
 )
 
 class ProfileViewViewModel(
@@ -45,6 +46,20 @@ class ProfileViewViewModel(
         observeProfile()
         refreshProfile()
         checkOwnProfile()
+        observeOwnTags()
+    }
+
+    private fun observeOwnTags() {
+        viewModelScope.launch {
+            val ownProfileId = sessionManager.profileId.first() ?: return@launch
+            profileRepository.observeProfile(ownProfileId).collect { ownProfile ->
+                if (ownProfile != null) {
+                    _state.update {
+                        it.copy(ownTagIds = ownProfile.tags.mapTo(mutableSetOf()) { t -> t.id })
+                    }
+                }
+            }
+        }
     }
 
     private fun checkOwnProfile() {


### PR DESCRIPTION
- shared TagChip; ProfilePreview split into interests/activities
- FilterTabs span from title to end icon
- events filter moved to tab row (also w pobliżu)
- messages 3-dot menu (nowa grupa, przeczytaj wszystkie)
- poznaj search: profiles only

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify tag chips, filter tabs layout, and messages overflow menu across UI
> - Introduces a reusable `TagChip` composable with `SMALL`/`REGULAR` sizes and matching/non-matching color states, replacing ad-hoc tag rendering in `ProfileCard` and `ProfileEditScreen`.
> - `ProfilePreview` now splits tags into interests and activities sections, highlighting tags shared with the viewer via `ownTagIds` (populated by a new `observeOwnTags()` call in `ProfileViewViewModel`).
> - `FilterTabs` layout switches to `SpaceBetween` arrangement, removing explicit spacers and horizontal per-tab padding.
> - `MessagesScreen` adds an overflow `DropdownMenu` beside the filter tabs with 'new group' and 'mark all read' actions (UI-only, no backend wiring yet).
> - `EventsScreen` moves the tag filter toggle out of the header into a tinted icon beside the filter tabs, reflecting active filter state via icon color.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67b21e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->