### PR TITLE
fix: user-location dot on degoogled phones

### DIFF
--- a/mobile/androidApp/src/main/AndroidManifest.xml
+++ b/mobile/androidApp/src/main/AndroidManifest.xml
@@ -14,8 +14,8 @@
         android:name="android.hardware.camera"
         android:required="false" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <!-- Remove fine location auto-merged by MapLibre SDK — app only needs coarse -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove"/>
+    <!-- FINE required to read GPS_PROVIDER on degoogled devices without GMS/microG -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <application
         android:allowBackup="false"

--- a/mobile/app-ui/src/androidMain/kotlin/com/poziomki/app/ui/shared/PermissionRequest.android.kt
+++ b/mobile/app-ui/src/androidMain/kotlin/com/poziomki/app/ui/shared/PermissionRequest.android.kt
@@ -9,7 +9,19 @@ import androidx.compose.runtime.Composable
 actual fun rememberLocationPermissionLauncher(onResult: (Boolean) -> Unit): () -> Unit {
     val launcher =
         rememberLauncherForActivityResult(
-            ActivityResultContracts.RequestPermission(),
-        ) { granted -> onResult(granted) }
-    return { launcher.launch(Manifest.permission.ACCESS_COARSE_LOCATION) }
+            ActivityResultContracts.RequestMultiplePermissions(),
+        ) { grants ->
+            val granted =
+                grants[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+                    grants[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+            onResult(granted)
+        }
+    return {
+        launcher.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ),
+        )
+    }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
@@ -4,14 +4,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.poziomki.app.data.repository.EventRepository
 import com.poziomki.app.location.LocationProvider
+import com.poziomki.app.location.LocationResult
 import com.poziomki.app.network.ApiResult
 import com.poziomki.app.network.Event
 import com.poziomki.app.ui.shared.TimeFilter
 import com.poziomki.app.ui.shared.matchesTimeFilter
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 data class EventsState(
     val allEvents: List<Event> = emptyList(),
@@ -40,6 +43,8 @@ class EventsViewModel(
 ) : ViewModel() {
     private val _state = MutableStateFlow(EventsState())
     val state: StateFlow<EventsState> = _state.asStateFlow()
+
+    private var locationJob: Job? = null
 
     init {
         observeEvents()
@@ -129,15 +134,12 @@ class EventsViewModel(
             }
             loadRecommendedEvents(forceRefresh = true)
             if (_state.value.activeFilter == TimeFilter.NEARBY) {
-                fetchNearbyIfPermitted()
+                val lat = _state.value.userLat ?: FALLBACK_LAT
+                val lng = _state.value.userLng ?: FALLBACK_LNG
+                loadNearbyEvents(lat, lng)
             }
             _state.value = _state.value.copy(isRefreshing = false)
         }
-    }
-
-    fun retryNearby() {
-        _state.value = _state.value.copy(isLocationPermissionDenied = false)
-        fetchNearbyIfPermitted()
     }
 
     fun selectNearbyEvent(id: String) {
@@ -178,34 +180,72 @@ class EventsViewModel(
                             },
                     )
             }
-            if (_state.value.userLat == null) {
-                fetchNearbyIfPermitted()
-            }
+            startLocationTracking()
+        } else {
+            stopLocationTracking()
         }
         filterEvents()
     }
 
-    private fun fetchNearbyIfPermitted() {
+    private fun startLocationTracking() {
         if (!locationProvider.isPermissionGranted()) {
             _state.value = _state.value.copy(isLocationPermissionDenied = true)
+            // Seed map at Warsaw so it renders, but keep user dot hidden.
+            if (_state.value.nearbyEvents.isEmpty()) {
+                loadNearbyEvents(FALLBACK_LAT, FALLBACK_LNG)
+            }
             return
         }
         _state.value = _state.value.copy(isLocationPermissionDenied = false)
-        viewModelScope.launch {
-            val loc = locationProvider.getCurrentLocation()
-            if (loc == null) {
-                loadNearbyEvents(FALLBACK_LAT, FALLBACK_LNG)
-                return@launch
+        if (locationJob?.isActive == true) return
+        locationJob =
+            viewModelScope.launch {
+                // Best-effort one-shot first so the dot appears as soon as possible
+                // (cached fix, fused last-known, etc.).
+                val initial = locationProvider.getCurrentLocation()
+                if (initial != null) {
+                    onLocationFix(initial)
+                } else {
+                    // No initial fix — still load nearby around Warsaw so map isn't blank.
+                    if (_state.value.nearbyEvents.isEmpty()) {
+                        loadNearbyEvents(FALLBACK_LAT, FALLBACK_LNG)
+                    }
+                }
+                locationProvider.locationUpdates().collect { onLocationFix(it) }
             }
-            _state.value = _state.value.copy(userLat = loc.latitude, userLng = loc.longitude)
+    }
+
+    private fun stopLocationTracking() {
+        locationJob?.cancel()
+        locationJob = null
+    }
+
+    private fun onLocationFix(loc: LocationResult) {
+        val prevLat = _state.value.userLat
+        val prevLng = _state.value.userLng
+        _state.value = _state.value.copy(userLat = loc.latitude, userLng = loc.longitude)
+        val movedSignificantly =
+            prevLat == null ||
+                prevLng == null ||
+                abs(prevLat - loc.latitude) > RELOAD_DEG_THRESHOLD ||
+                abs(prevLng - loc.longitude) > RELOAD_DEG_THRESHOLD
+        if (movedSignificantly) {
             loadNearbyEvents(loc.latitude, loc.longitude)
         }
+    }
+
+    fun retryNearby() {
+        _state.value = _state.value.copy(isLocationPermissionDenied = false)
+        startLocationTracking()
     }
 
     private companion object {
         // Warsaw — used when device location can't be obtained despite permission.
         const val FALLBACK_LAT = 52.2297
         const val FALLBACK_LNG = 21.0122
+
+        // ~111 m at the equator — reload nearby events when user has moved this far.
+        const val RELOAD_DEG_THRESHOLD = 0.001
     }
 
     fun loadNearbyEvents(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
@@ -1,5 +1,11 @@
 package com.poziomki.app.ui.feature.home
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -35,6 +41,8 @@ import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.bold.MapPinLine
 import com.poziomki.app.network.Event
 import com.poziomki.app.network.GeocodingService
+import com.poziomki.app.network.RoutingService
+import com.poziomki.app.network.WalkingRoute
 import com.poziomki.app.ui.designsystem.components.StackedAvatars
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
@@ -52,6 +60,7 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.rememberCameraState
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.layers.LineLayer
 import org.maplibre.compose.map.MapOptions
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.OrnamentOptions
@@ -65,6 +74,8 @@ private const val DEFAULT_ZOOM = 14.0
 private const val DEFAULT_LAT = 52.2297
 private const val DEFAULT_LNG = 21.0122
 private const val TAP_THRESHOLD_DEG = 0.005
+private const val USER_DOT_RADIUS_DP = 9f
+private const val USER_HALO_MAX_RADIUS_DP = 24f
 
 // Warsaw metro bounding box, slightly padded so the city fits with breathing
 // room. Pan is clamped to this — outside of Warsaw the nearby tab makes no
@@ -134,6 +145,9 @@ internal fun NearbyEventsContent(
     val geocoding = koinInject<GeocodingService>()
     var geocodedLocation by remember { mutableStateOf<String?>(null) }
 
+    val routing = koinInject<RoutingService>()
+    var route by remember { mutableStateOf<WalkingRoute?>(null) }
+
     LaunchedEffect(selectedEventId) {
         geocodedLocation = null
         val event = events.find { it.id == selectedEventId } ?: return@LaunchedEffect
@@ -142,6 +156,15 @@ internal fun NearbyEventsContent(
         val lat = event.latitude ?: return@LaunchedEffect
         val lng = event.longitude ?: return@LaunchedEffect
         geocodedLocation = geocoding.reverse(lat, lng)
+    }
+
+    LaunchedEffect(selectedEventId, userLat, userLng) {
+        route = null
+        if (userLat == null || userLng == null) return@LaunchedEffect
+        val event = events.find { it.id == selectedEventId } ?: return@LaunchedEffect
+        val evLat = event.latitude ?: return@LaunchedEffect
+        val evLng = event.longitude ?: return@LaunchedEffect
+        route = routing.walkingRoute(userLat, userLng, evLat, evLng)
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
@@ -244,18 +267,60 @@ internal fun NearbyEventsContent(
                     )
                 }
 
-                // User location dot
+                // Walking route polyline — drawn underneath the user dot.
+                val routeJson = route?.geometryJson
+                if (routeJson != null) {
+                    val routeSource =
+                        rememberGeoJsonSource(data = GeoJsonData.JsonString(featureFromGeometry(routeJson)))
+                    LineLayer(
+                        id = "user-route",
+                        source = routeSource,
+                        color = const(Primary),
+                        width = const(4.dp),
+                        opacity = const(0.85f),
+                    )
+                }
+
+                // User location: animated halo + solid core dot.
                 if (userLat != null && userLng != null) {
                     val userSource =
                         rememberGeoJsonSource(
                             data = pointGeoJson(userLat, userLng),
                         )
+                    val pulse = rememberInfiniteTransition(label = "user-pulse")
+                    val haloRadius by pulse.animateFloat(
+                        initialValue = USER_DOT_RADIUS_DP,
+                        targetValue = USER_HALO_MAX_RADIUS_DP,
+                        animationSpec =
+                            infiniteRepeatable(
+                                animation = tween(durationMillis = 1_400, easing = LinearEasing),
+                                repeatMode = RepeatMode.Restart,
+                            ),
+                        label = "halo-radius",
+                    )
+                    val haloAlpha by pulse.animateFloat(
+                        initialValue = 0.45f,
+                        targetValue = 0f,
+                        animationSpec =
+                            infiniteRepeatable(
+                                animation = tween(durationMillis = 1_400, easing = LinearEasing),
+                                repeatMode = RepeatMode.Restart,
+                            ),
+                        label = "halo-alpha",
+                    )
+                    CircleLayer(
+                        id = "user-halo",
+                        source = userSource,
+                        radius = const(haloRadius.dp),
+                        color = const(Primary),
+                        opacity = const(haloAlpha),
+                    )
                     CircleLayer(
                         id = "user-location",
                         source = userSource,
-                        radius = const(8.dp),
-                        color = const(White),
-                        strokeColor = const(Primary),
+                        radius = const(USER_DOT_RADIUS_DP.dp),
+                        color = const(Primary),
+                        strokeColor = const(White),
                         strokeWidth = const(3.dp),
                     )
                 }
@@ -312,6 +377,22 @@ internal fun NearbyEventsContent(
                         fontSize = 13.sp,
                         color = TextSecondary,
                     )
+                    val distanceMeters = route?.distanceMeters
+                    if (distanceMeters != null) {
+                        Text(
+                            text = " · ",
+                            fontFamily = NunitoFamily,
+                            fontSize = 13.sp,
+                            color = TextMuted,
+                        )
+                        Text(
+                            text = formatDistance(distanceMeters),
+                            fontFamily = NunitoFamily,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 13.sp,
+                            color = Primary,
+                        )
+                    }
                     val displayLocation =
                         selectedEvent.location
                             ?.takeIf { !looksLikeCoordinates(it) }
@@ -389,6 +470,11 @@ internal fun NearbyEventsContent(
     }
 }
 
+// Wrap a raw GeoJSON geometry (e.g. OSRM LineString) into a FeatureCollection
+// so it can be fed to GeoJsonSource.
+private fun featureFromGeometry(geometryJson: String): String =
+    """{"type":"FeatureCollection","features":[{"type":"Feature","geometry":$geometryJson,"properties":{}}]}"""
+
 private fun pointGeoJson(
     lat: Double,
     lng: Double,
@@ -421,3 +507,12 @@ private fun distanceDeg(
 }
 
 private fun looksLikeCoordinates(s: String): Boolean = s.matches(Regex("""^-?\d+[.,]\d+\s*,\s*-?\d+[.,]\d+$"""))
+
+private fun formatDistance(meters: Double): String =
+    if (meters < 1_000) {
+        "${meters.toInt()} m"
+    } else {
+        val km = meters / 1_000.0
+        val rounded = (km * 10).toInt() / 10.0
+        "$rounded km"
+    }

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/location/LocationProvider.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/location/LocationProvider.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
 import android.os.Looper
+import android.os.SystemClock
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.location.LocationListenerCompat
@@ -13,9 +14,11 @@ import androidx.core.location.LocationManagerCompat
 import androidx.core.location.LocationRequestCompat
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
-import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
@@ -24,9 +27,13 @@ actual class LocationProvider(
     private val context: Context,
 ) {
     actual fun isPermissionGranted(): Boolean =
+        hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ||
+            hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+
+    private fun hasPermission(perm: String): Boolean =
         ContextCompat.checkSelfPermission(
             context,
-            Manifest.permission.ACCESS_COARSE_LOCATION,
+            perm,
         ) == PackageManager.PERMISSION_GRANTED
 
     actual suspend fun getCurrentLocation(): LocationResult? {
@@ -34,29 +41,98 @@ actual class LocationProvider(
             Log.w(TAG, "permission not granted")
             return null
         }
-        Log.i(TAG, "getCurrentLocation start")
-        // 1. Google Fused (FusedLocationProviderClient) — instant on Play Services,
-        //    routes through microG/UnifiedNlp on supported AOSP forks.
-        val fused = if (isFusedLikelyAvailable()) fusedLocation() else null
-        if (fused != null) {
-            Log.i(TAG, "fused fix=$fused")
-            return fused
+        Log.i(TAG, "getCurrentLocation start (fine=${hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)})")
+
+        // 1. Fused last-known — instant on GMS/microG devices.
+        if (isFusedLikelyAvailable()) {
+            fusedLastLocation()?.let {
+                Log.i(TAG, "fused last fix=$it")
+                return it
+            }
         }
-        // 2. Raw GPS one-shot — only useful outdoors. Skip if Fused already returned.
-        val gps = gpsLocation()
-        if (gps != null) {
-            Log.i(TAG, "gps fix=$gps")
-            return gps
+        // 2. Platform last-known — works on degoogled phones if GPS/NETWORK
+        //    has any cached fix. This is the "Organic Maps shows dot instantly" path.
+        platformLastKnownSync(context.getSystemService(LocationManager::class.java))?.let {
+            Log.i(TAG, "platform last fix=$it")
+            return it
         }
-        // 3. ViewModel falls back to Warsaw on null.
+        // 3. Fused current — requires GMS/microG, but worth it when it works.
+        if (isFusedLikelyAvailable()) {
+            fusedCurrentLocation()?.let {
+                Log.i(TAG, "fused current fix=$it")
+                return it
+            }
+        }
+        // 4. Platform one-shot — listen on GPS_PROVIDER (if fine) and
+        //    NETWORK_PROVIDER in parallel; first fix wins.
+        platformOneShot()?.let {
+            Log.i(TAG, "platform one-shot fix=$it")
+            return it
+        }
         Log.w(TAG, "no fix obtained")
         return null
     }
 
-    // True if the device exposes a Play Services-compatible location backend.
-    // Accepts both genuine GMS and microG (where the official check fails without
-    // signature spoofing but the package exists and Fused requests are routed
-    // through UnifiedNlp).
+    actual fun locationUpdates(): Flow<LocationResult> =
+        callbackFlow {
+            if (!isPermissionGranted()) {
+                close()
+                return@callbackFlow
+            }
+            val manager = context.getSystemService(LocationManager::class.java)
+            val listeners = mutableListOf<LocationListenerCompat>()
+
+            fun emit(location: Location) {
+                trySend(location.toLocationResult())
+            }
+
+            // Seed with last-known so UI gets a dot immediately, even before first fresh fix.
+            platformLastKnownSync(manager)?.let { trySend(it) }
+
+            if (manager != null) {
+                val request =
+                    LocationRequestCompat
+                        .Builder(UPDATE_INTERVAL_MS)
+                        .setMinUpdateIntervalMillis(UPDATE_INTERVAL_MS)
+                        .setMinUpdateDistanceMeters(UPDATE_MIN_DISTANCE_M)
+                        .setQuality(LocationRequestCompat.QUALITY_HIGH_ACCURACY)
+                        .build()
+                // Prefer GPS strictly when fine permission is granted — like
+                // Organic Maps. NETWORK_PROVIDER returns cell-tower triangulation
+                // (center of Warsaw / Marszałkowska on Polish networks), which is
+                // wrong if we have GPS. Only fall back to NETWORK if GPS is off.
+                val useGps =
+                    hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) &&
+                        manager.isProviderEnabledSafe(LocationManager.GPS_PROVIDER)
+                val providers = mutableListOf<String>()
+                if (useGps) {
+                    providers += LocationManager.GPS_PROVIDER
+                } else if (manager.isProviderEnabledSafe(LocationManager.NETWORK_PROVIDER)) {
+                    providers += LocationManager.NETWORK_PROVIDER
+                }
+                for (provider in providers) {
+                    val listener = LocationListenerCompat { emit(it) }
+                    listeners += listener
+                    runCatching {
+                        @Suppress("MissingPermission")
+                        LocationManagerCompat.requestLocationUpdates(
+                            manager,
+                            provider,
+                            request,
+                            listener,
+                            Looper.getMainLooper(),
+                        )
+                    }.onFailure { Log.w(TAG, "updates failed for $provider", it) }
+                }
+            }
+
+            awaitClose {
+                if (manager != null) {
+                    for (l in listeners) LocationManagerCompat.removeUpdates(manager, l)
+                }
+            }
+        }
+
     private fun isFusedLikelyAvailable(): Boolean {
         val official =
             GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) ==
@@ -69,89 +145,153 @@ actual class LocationProvider(
     }
 
     @Suppress("MissingPermission", "TooGenericExceptionCaught")
-    private suspend fun fusedLocation(): LocationResult? =
+    private suspend fun fusedLastLocation(): LocationResult? =
         try {
             val client = LocationServices.getFusedLocationProviderClient(context)
-            fusedLastLocation(client) ?: fusedCurrentLocation(client)
+            withTimeoutOrNull(FUSED_LAST_TIMEOUT_MS) {
+                suspendCancellableCoroutine { continuation ->
+                    client.lastLocation
+                        .addOnSuccessListener { loc ->
+                            if (continuation.isActive) continuation.resume(loc?.toLocationResult())
+                        }.addOnFailureListener {
+                            if (continuation.isActive) continuation.resume(null)
+                        }
+                }
+            }
         } catch (e: Exception) {
-            Log.e(TAG, "fused location threw", e)
+            Log.w(TAG, "fused last threw", e)
+            null
+        }
+
+    @Suppress("MissingPermission", "TooGenericExceptionCaught")
+    private suspend fun fusedCurrentLocation(): LocationResult? =
+        try {
+            val client = LocationServices.getFusedLocationProviderClient(context)
+            withTimeoutOrNull(FUSED_CURRENT_TIMEOUT_MS) {
+                suspendCancellableCoroutine { continuation ->
+                    client
+                        .getCurrentLocation(Priority.PRIORITY_BALANCED_POWER_ACCURACY, null)
+                        .addOnSuccessListener { loc ->
+                            if (continuation.isActive) continuation.resume(loc?.toLocationResult())
+                        }.addOnFailureListener { e ->
+                            Log.w(TAG, "fused current failed", e)
+                            if (continuation.isActive) continuation.resume(null)
+                        }
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "fused current threw", e)
             null
         }
 
     @Suppress("MissingPermission")
-    private suspend fun fusedLastLocation(client: FusedLocationProviderClient): LocationResult? =
-        withTimeoutOrNull(FUSED_LAST_TIMEOUT_MS) {
-            suspendCancellableCoroutine { continuation ->
-                client.lastLocation
-                    .addOnSuccessListener { location ->
-                        if (continuation.isActive) continuation.resume(location?.toLocationResult())
-                    }.addOnFailureListener {
-                        if (continuation.isActive) continuation.resume(null)
-                    }
+    private fun platformLastKnownSync(manager: LocationManager?): LocationResult? {
+        if (manager == null) return null
+        // Build provider list in trust order: GPS first, NETWORK only as last
+        // resort (it returns cell-tower triangulation, often wildly off).
+        // PASSIVE only as a tiebreaker if everything else is unavailable.
+        val providers = mutableListOf<String>()
+        if (hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)) providers += LocationManager.GPS_PROVIDER
+        val now = SystemClock.elapsedRealtimeNanos()
+
+        // Try preferred providers first — return the first fresh-enough fix.
+        for (p in providers) {
+            val loc =
+                runCatching {
+                    if (manager.isProviderEnabledSafe(p)) manager.getLastKnownLocation(p) else null
+                }.getOrNull() ?: continue
+            val ageNs = now - loc.elapsedRealtimeNanos
+            if (ageNs <= LAST_KNOWN_MAX_AGE_NS) return loc.toLocationResult()
+        }
+        // No GPS last-known — try NETWORK only if it's *very* fresh AND
+        // reasonably accurate (< 500 m), otherwise we'd pin the user to
+        // a cell-tower center.
+        runCatching {
+            if (manager.isProviderEnabledSafe(LocationManager.NETWORK_PROVIDER)) {
+                manager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)
+            } else {
+                null
+            }
+        }.getOrNull()?.let { loc ->
+            val ageNs = now - loc.elapsedRealtimeNanos
+            val accuracyOk = !loc.hasAccuracy() || loc.accuracy <= NETWORK_ACCURACY_MAX_M
+            if (ageNs <= NETWORK_LAST_KNOWN_MAX_AGE_NS && accuracyOk) {
+                return loc.toLocationResult()
             }
         }
+        return null
+    }
 
-    @Suppress("MissingPermission")
-    private suspend fun fusedCurrentLocation(client: FusedLocationProviderClient): LocationResult? =
-        withTimeoutOrNull(FUSED_CURRENT_TIMEOUT_MS) {
-            suspendCancellableCoroutine { continuation ->
-                client
-                    .getCurrentLocation(Priority.PRIORITY_BALANCED_POWER_ACCURACY, null)
-                    .addOnSuccessListener { location ->
-                        if (continuation.isActive) continuation.resume(location?.toLocationResult())
-                    }.addOnFailureListener { e ->
-                        Log.w(TAG, "fused getCurrentLocation failed", e)
-                        if (continuation.isActive) continuation.resume(null)
-                    }
-            }
-        }
-
-    @Suppress("MissingPermission")
-    private suspend fun gpsLocation(): LocationResult? {
+    private suspend fun platformOneShot(): LocationResult? {
         val manager = context.getSystemService(LocationManager::class.java) ?: return null
-        if (!runCatching { manager.isProviderEnabled(LocationManager.GPS_PROVIDER) }.getOrDefault(false)) {
-            return null
+        // Same trust order: GPS only when we have fine permission; NETWORK
+        // strictly as fallback when GPS is unavailable.
+        val useGps =
+            hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) &&
+                manager.isProviderEnabledSafe(LocationManager.GPS_PROVIDER)
+        val providers = mutableListOf<String>()
+        if (useGps) {
+            providers += LocationManager.GPS_PROVIDER
+        } else if (manager.isProviderEnabledSafe(LocationManager.NETWORK_PROVIDER)) {
+            providers += LocationManager.NETWORK_PROVIDER
         }
-        return withTimeoutOrNull(GPS_TIMEOUT_MS) {
+        if (providers.isEmpty()) return null
+
+        return withTimeoutOrNull(PLATFORM_TIMEOUT_MS) {
             suspendCancellableCoroutine { continuation ->
+                val listeners = mutableListOf<LocationListenerCompat>()
+
+                fun removeAll() {
+                    for (l in listeners) LocationManagerCompat.removeUpdates(manager, l)
+                }
                 val request =
                     LocationRequestCompat
-                        .Builder(GPS_TIMEOUT_MS)
+                        .Builder(PLATFORM_TIMEOUT_MS)
                         .setQuality(LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY)
                         .setMaxUpdates(1)
-                        .setDurationMillis(GPS_TIMEOUT_MS)
+                        .setDurationMillis(PLATFORM_TIMEOUT_MS)
                         .build()
-                val listener =
-                    object : LocationListenerCompat {
-                        override fun onLocationChanged(location: Location) {
-                            LocationManagerCompat.removeUpdates(manager, this)
-                            if (continuation.isActive) continuation.resume(location.toLocationResult())
+                for (p in providers) {
+                    val listener =
+                        object : LocationListenerCompat {
+                            override fun onLocationChanged(location: Location) {
+                                removeAll()
+                                if (continuation.isActive) {
+                                    continuation.resume(location.toLocationResult())
+                                }
+                            }
                         }
-                    }
-                continuation.invokeOnCancellation {
-                    LocationManagerCompat.removeUpdates(manager, listener)
+                    listeners += listener
+                    runCatching {
+                        @Suppress("MissingPermission")
+                        LocationManagerCompat.requestLocationUpdates(
+                            manager,
+                            p,
+                            request,
+                            listener,
+                            Looper.getMainLooper(),
+                        )
+                    }.onFailure { Log.w(TAG, "one-shot requestUpdates failed for $p", it) }
                 }
-                runCatching {
-                    LocationManagerCompat.requestLocationUpdates(
-                        manager,
-                        LocationManager.GPS_PROVIDER,
-                        request,
-                        listener,
-                        Looper.getMainLooper(),
-                    )
-                }.onFailure {
-                    if (continuation.isActive) continuation.resume(null)
-                }
+                continuation.invokeOnCancellation { removeAll() }
             }
         }
     }
+
+    private fun LocationManager.isProviderEnabledSafe(provider: String): Boolean =
+        runCatching { isProviderEnabled(provider) }.getOrDefault(false)
 
     private companion object {
         const val TAG = "PoziomkiLocation"
         const val GMS_PACKAGE = "com.google.android.gms"
         const val FUSED_LAST_TIMEOUT_MS = 1_500L
         const val FUSED_CURRENT_TIMEOUT_MS = 8_000L
-        const val GPS_TIMEOUT_MS = 8_000L
+        const val PLATFORM_TIMEOUT_MS = 15_000L
+        const val UPDATE_INTERVAL_MS = 5_000L
+        const val UPDATE_MIN_DISTANCE_M = 5f
+        const val LAST_KNOWN_MAX_AGE_NS = 5L * 60 * 1_000_000_000 // 5 minutes (GPS)
+        const val NETWORK_LAST_KNOWN_MAX_AGE_NS = 60L * 1_000_000_000 // 1 minute
+        const val NETWORK_ACCURACY_MAX_M = 500f
     }
 }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
@@ -19,6 +19,7 @@ import com.poziomki.app.db.PoziomkiDatabase
 import com.poziomki.app.network.ApiClient
 import com.poziomki.app.network.ApiService
 import com.poziomki.app.network.GeocodingService
+import com.poziomki.app.network.RoutingService
 import com.poziomki.app.session.AppPreferences
 import com.poziomki.app.session.SessionManager
 import kotlinx.coroutines.CoroutineScope
@@ -53,6 +54,7 @@ val sharedModule =
             )
         }
         single { GeocodingService(get()) }
+        single { RoutingService(get()) }
         single { PoziomkiDatabase(get()) }
         single { CacheManager(get()) }
         single { PendingOperationsManager(get()) }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/location/LocationProvider.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/location/LocationProvider.kt
@@ -1,5 +1,7 @@
 package com.poziomki.app.location
 
+import kotlinx.coroutines.flow.Flow
+
 data class LocationResult(
     val latitude: Double,
     val longitude: Double,
@@ -7,6 +9,8 @@ data class LocationResult(
 
 expect class LocationProvider {
     suspend fun getCurrentLocation(): LocationResult?
+
+    fun locationUpdates(): Flow<LocationResult>
 
     fun isPermissionGranted(): Boolean
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/RoutingService.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/RoutingService.kt
@@ -1,0 +1,84 @@
+package com.poziomki.app.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+private data class OsrmResponse(
+    val code: String,
+    val routes: List<OsrmRoute> = emptyList(),
+)
+
+@Serializable
+private data class OsrmRoute(
+    val geometry: JsonElement,
+    val distance: Double,
+    val duration: Double,
+)
+
+data class WalkingRoute(
+    val geometryJson: String,
+    val distanceMeters: Double,
+    val durationSeconds: Double,
+)
+
+class RoutingService(
+    engine: HttpClientEngine,
+) {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        }
+    private val client =
+        HttpClient(engine) {
+            install(ContentNegotiation) { json(json) }
+            defaultRequest {
+                url("https://router.project-osrm.org/")
+                header(HttpHeaders.UserAgent, "Poziomki/1.0")
+            }
+        }
+
+    private val cache = mutableMapOf<String, WalkingRoute>()
+
+    suspend fun walkingRoute(
+        fromLat: Double,
+        fromLng: Double,
+        toLat: Double,
+        toLng: Double,
+    ): WalkingRoute? {
+        val key = "$fromLat,$fromLng->$toLat,$toLng"
+        cache[key]?.let { return it }
+        return try {
+            val path = "route/v1/foot/$fromLng,$fromLat;$toLng,$toLat"
+            val resp: OsrmResponse =
+                client
+                    .get(path) {
+                        url { parameters.append("overview", "full") }
+                        url { parameters.append("geometries", "geojson") }
+                    }.body()
+            if (resp.code != "Ok") return null
+            val route = resp.routes.firstOrNull() ?: return null
+            val result =
+                WalkingRoute(
+                    geometryJson = json.encodeToString(JsonElement.serializer(), route.geometry),
+                    distanceMeters = route.distance,
+                    durationSeconds = route.duration,
+                )
+            cache[key] = result
+            result
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/mobile/core/src/iosMain/kotlin/com/poziomki/app/location/LocationProvider.kt
+++ b/mobile/core/src/iosMain/kotlin/com/poziomki/app/location/LocationProvider.kt
@@ -2,6 +2,9 @@ package com.poziomki.app.location
 
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import platform.CoreLocation.CLAuthorizationStatus
@@ -68,4 +71,37 @@ actual class LocationProvider {
             }
         }
     }
+
+    actual fun locationUpdates(): Flow<LocationResult> =
+        callbackFlow {
+            if (!isPermissionGranted()) {
+                close()
+                return@callbackFlow
+            }
+            val delegate =
+                object : NSObject(), CLLocationManagerDelegateProtocol {
+                    override fun locationManager(
+                        manager: CLLocationManager,
+                        didUpdateLocations: List<*>,
+                    ) {
+                        val location = didUpdateLocations.lastOrNull() as? CLLocation ?: return
+                        location.coordinate.useContents {
+                            trySend(LocationResult(latitude, longitude))
+                        }
+                    }
+
+                    override fun locationManager(
+                        manager: CLLocationManager,
+                        didFailWithError: NSError,
+                    ) {
+                        // Keep flow open; transient errors shouldn't kill subscription.
+                    }
+                }
+            manager.delegate = delegate
+            manager.startUpdatingLocation()
+            awaitClose {
+                manager.stopUpdatingLocation()
+                manager.delegate = null
+            }
+        }
 }


### PR DESCRIPTION
Manifest stripped `ACCESS_FINE_LOCATION`, so the GPS_PROVIDER fallback threw `SecurityException` (silently caught) and no fix was ever returned on devices without GMS/microG. Restores FINE, prefers GPS strictly to avoid cell-tower triangulation pinning users to Marszałkowska. Adds continuous tracking (live dot), pulse halo, and OSRM walking route + km label to the selected event.

## To-do
- [ ] Test on degoogled device — dot appears and tracks live
- [ ] Test on GMS device — Fused fast-path still hits
- [ ] Tap an event — route line + km label render

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix user-location dot on degoogled phones by adding continuous location tracking with GPS/network fallbacks
> - Expands location permission requests to accept either `ACCESS_FINE_LOCATION` or `ACCESS_COARSE_LOCATION`, fixing location on devices without Google Play Services
> - Reworks `LocationProvider` on Android to try fused last-known, platform GPS/network last-known, fused current, and platform one-shot in sequence, with configurable timeouts
> - Adds a `locationUpdates` Flow (Android and iOS) for continuous updates; `EventsViewModel` subscribes when NEARBY filter is active and reloads events only when movement exceeds `RELOAD_DEG_THRESHOLD`
> - Adds `RoutingService` querying the public OSRM API for walking routes, rendered as a polyline on the map with distance displayed in the event details panel
> - Behavioral Change: NEARBY events now seed from fallback Warsaw coordinates when permission is denied or no fix is available, rather than blocking on permission state
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c389f26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->