### PR TITLE
fix: polish notification text + persist OSRM/FCM env in compose

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -155,6 +155,9 @@ services:
       # fails to boot instead of silently accepting everything. Override
       # to `false` only for a deliberate unmoderated rollout.
       MODERATION_REQUIRED: ${MODERATION_REQUIRED:-true}
+      OSRM_URL: ${OSRM_URL:-http://osrm-foot:5000}
+      FCM_PROJECT_ID: ${FCM_PROJECT_ID:-}
+      FCM_SERVICE_ACCOUNT_JSON: ${FCM_SERVICE_ACCOUNT_JSON:-}
     volumes:
       - ./ops/moderation/bielik-guard-onnx:/app/moderation:ro
     healthcheck:

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -14,7 +14,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.21.21" // x-release-please-version
+val appVersionName = "0.22.1" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
@@ -23,18 +23,18 @@ class NotificationHelper(
         val messagesChannel =
             NotificationChannel(
                 CHANNEL_MESSAGES,
-                "Messages",
+                "Wiadomości",
                 NotificationManager.IMPORTANCE_HIGH,
             ).apply {
-                description = "New message notifications"
+                description = "Powiadomienia o nowych wiadomościach"
             }
         val serviceChannel =
             NotificationChannel(
                 CHANNEL_SERVICE,
-                "Push Service",
+                "Usługa push",
                 NotificationManager.IMPORTANCE_MIN,
             ).apply {
-                description = "Background connection for push notifications"
+                description = "Połączenie w tle dla powiadomień push"
             }
         notificationManager.createNotificationChannel(messagesChannel)
         notificationManager.createNotificationChannel(serviceChannel)
@@ -56,8 +56,8 @@ class NotificationHelper(
         avatarUrl: String? = null,
         timestampMs: Long? = null,
     ) {
-        val title = sender ?: "New message"
-        val text = body ?: "You have a new message"
+        val title = sender ?: "Poziomki"
+        val text = body ?: "Nowa wiadomość"
         val groupKey = "poz_messages_${roomId ?: "unknown"}"
         val notificationTime = timestampMs ?: System.currentTimeMillis()
         val sortKey = notificationTime.toString().padStart(20, '0')


### PR DESCRIPTION
Closes the FCM rollout gaps:\n- Android push fallback was English ("New message"); now "Poziomki / Nowa wiadomość" matches the iOS APNs placeholder\n- `docker-compose.prod.yml` was missing OSRM_URL/FCM_* passthroughs, so every deploy wiped the live config. Now baked in.\n- Bumps appVersionName to 0.22.1.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish notification text and persist OSRM/FCM env vars in docker-compose
> - Updates `NotificationHelper` notification channel names and descriptions to Polish; default notification title changes from "New message" to "Poziomki" and body from "You have a new message" to "Nowa wiadomość".
> - Adds `OSRM_URL`, `FCM_PROJECT_ID`, and `FCM_SERVICE_ACCOUNT_JSON` environment variables to [docker-compose.prod.yml](https://github.com/poziomki-app/poziomki/pull/406/files#diff-2eeee385263c859a8fc9d0a455c48137ba77b00bde682f9a7208b0aad1d3f864) so they persist across deployments.
> - Bumps Android `appVersionName` to `0.22.1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51841eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->