### PR TITLE
fix: center saved-screen filter tabs

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
@@ -29,13 +29,14 @@ fun <T> FilterTabs(
     selected: T,
     onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(24.dp),
 ) {
     Row(
         modifier =
             modifier
                 .fillMaxWidth()
                 .padding(top = 12.dp, bottom = 16.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
+        horizontalArrangement = horizontalArrangement,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         tabs.forEach { (value, label) ->

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
@@ -21,7 +21,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.FilterTabs
 import com.poziomki.app.ui.designsystem.components.LoadingView
@@ -56,7 +58,12 @@ fun SavedScreen(
             modifier = Modifier.padding(top = statusBarPadding),
         )
 
-        FilterTabs(tabs = tabs, selected = selectedTab, onSelect = { selectedTab = it })
+        FilterTabs(
+            tabs = tabs,
+            selected = selectedTab,
+            onSelect = { selectedTab = it },
+            horizontalArrangement = Arrangement.spacedBy(40.dp, Alignment.CenterHorizontally),
+        )
 
         when {
             state.isLoading -> {


### PR DESCRIPTION
Tabs in zapisane were pushed to opposite edges, cutting off osoby.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Center filter tabs on the Saved screen
> Adds a `horizontalArrangement` parameter to the `FilterTabs` composable in [FilterTabs.kt](https://github.com/poziomki-app/poziomki/pull/407/files#diff-f5198729d0bf11d336910127721ef939c870431b209c5f33f6150798e3a93cc5), defaulting to `Arrangement.spacedBy(24.dp)` instead of the previous `SpaceBetween`. The `SavedScreen` passes `Arrangement.spacedBy(40.dp, Alignment.CenterHorizontally)` to center its tabs rather than stretching them across the full width.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e4e746.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->