### PR TITLE
perf: add :benchmark macrobenchmark module

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -77,6 +77,14 @@ android {
                 "proguard-rules.pro",
             )
         }
+        create("benchmark") {
+            initWith(getByName("release"))
+            isMinifyEnabled = false
+            isShrinkResources = false
+            isProfileable = true
+            signingConfig = signingConfigs.getByName("debug")
+            matchingFallbacks += listOf("release")
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/mobile/app-ui/build.gradle.kts
+++ b/mobile/app-ui/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
             implementation(libs.camerax.lifecycle)
             implementation(libs.camerax.view)
             implementation(libs.zxing.core)
+            implementation(libs.androidx.tracing)
         }
         commonMain.dependencies {
             implementation(projects.core)

--- a/mobile/app-ui/src/androidMain/kotlin/com/poziomki/app/ui/navigation/ScreenTrace.android.kt
+++ b/mobile/app-ui/src/androidMain/kotlin/com/poziomki/app/ui/navigation/ScreenTrace.android.kt
@@ -1,0 +1,10 @@
+package com.poziomki.app.ui.navigation
+
+import androidx.tracing.Trace
+
+actual fun emitScreenTrace(name: String) {
+    if (Trace.isEnabled()) {
+        Trace.beginSection("screen:$name")
+        Trace.endSection()
+    }
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -155,6 +155,14 @@ fun AppNavigation(
     val chatRoomRepository = koinInject<ChatRoomRepository>()
     val navigationScope = rememberCoroutineScope()
 
+    LaunchedEffect(navController) {
+        navController.currentBackStackEntryFlow.collect { entry ->
+            entry.destination.route?.substringAfterLast('.')?.substringBefore('/')?.let { name ->
+                emitScreenTrace(name)
+            }
+        }
+    }
+
     // Navigate to auth screen only on actual logout (true → false), not on initial composition.
     var wasLoggedIn by remember { mutableStateOf(isLoggedIn) }
     LaunchedEffect(isLoggedIn) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/ScreenTrace.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/ScreenTrace.kt
@@ -1,0 +1,3 @@
+package com.poziomki.app.ui.navigation
+
+expect fun emitScreenTrace(name: String)

--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/navigation/ScreenTrace.ios.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/navigation/ScreenTrace.ios.kt
@@ -1,0 +1,3 @@
+package com.poziomki.app.ui.navigation
+
+actual fun emitScreenTrace(name: String) = Unit

--- a/mobile/benchmark/build.gradle.kts
+++ b/mobile/benchmark/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    id("com.android.test")
+}
+
+android {
+    namespace = "com.poziomki.benchmark"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 28
+        targetSdk = 36
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        create("benchmark") {
+            isDebuggable = true
+            signingConfig = signingConfigs.getByName("debug")
+            matchingFallbacks += listOf("release")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    targetProjectPath = ":androidApp"
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+}
+
+dependencies {
+    implementation(libs.androidx.test.ext.junit)
+    implementation(libs.androidx.test.espresso.core)
+    implementation(libs.androidx.uiautomator)
+    implementation(libs.androidx.benchmark.macro.junit4)
+}

--- a/mobile/benchmark/src/main/AndroidManifest.xml
+++ b/mobile/benchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <package android:name="app.poziomki" />
+    </queries>
+</manifest>

--- a/mobile/benchmark/src/main/kotlin/com/poziomki/benchmark/ScreenTraceBenchmark.kt
+++ b/mobile/benchmark/src/main/kotlin/com/poziomki/benchmark/ScreenTraceBenchmark.kt
@@ -1,0 +1,32 @@
+@file:OptIn(androidx.benchmark.macro.ExperimentalMetricApi::class)
+
+package com.poziomki.benchmark
+
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.TraceSectionMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ScreenTraceBenchmark {
+    @get:Rule
+    val rule = MacrobenchmarkRule()
+
+    @Test
+    fun authScreenTrace() =
+        rule.measureRepeated(
+            packageName = "app.poziomki",
+            metrics = listOf(TraceSectionMetric("screen:Auth"), FrameTimingMetric()),
+            iterations = 5,
+            startupMode = StartupMode.COLD,
+        ) {
+            startActivityAndWait()
+            device.wait(Until.hasObject(By.pkg("app.poziomki").depth(0)), 5_000)
+        }
+}

--- a/mobile/benchmark/src/main/kotlin/com/poziomki/benchmark/StartupBenchmark.kt
+++ b/mobile/benchmark/src/main/kotlin/com/poziomki/benchmark/StartupBenchmark.kt
@@ -1,0 +1,35 @@
+package com.poziomki.benchmark
+
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StartupBenchmark {
+    @get:Rule
+    val rule = MacrobenchmarkRule()
+
+    @Test
+    fun startupCompilationNone() = startup(CompilationMode.None())
+
+    @Test
+    fun startupCompilationPartial() = startup(CompilationMode.Partial())
+
+    private fun startup(mode: CompilationMode) =
+        rule.measureRepeated(
+            packageName = "app.poziomki",
+            metrics = listOf(StartupTimingMetric(), FrameTimingMetric()),
+            iterations = 5,
+            startupMode = StartupMode.COLD,
+            compilationMode = mode,
+        ) {
+            pressHome()
+            startActivityAndWait()
+        }
+}

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -27,6 +27,11 @@ sqldelight = "2.3.2"
 firebaseBom = "33.6.0"
 firebaseMessaging = "24.1.0"
 googleServices = "4.4.2"
+androidxBenchmark = "1.3.4"
+androidxTestExtJunit = "1.2.1"
+androidxTestEspresso = "3.6.1"
+androidxUiautomator = "2.3.0"
+androidxTracing = "1.2.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
@@ -69,9 +74,15 @@ sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", ver
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "firebaseMessaging" }
+androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidxBenchmark" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxTestEspresso" }
+androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidxUiautomator" }
+androidx-tracing = { module = "androidx.tracing:tracing", version.ref = "androidxTracing" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
+androidTest = { id = "com.android.test", version.ref = "agp" }
 androidKmpLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }

--- a/mobile/settings.gradle.kts
+++ b/mobile/settings.gradle.kts
@@ -32,3 +32,4 @@ dependencyResolutionManagement {
 include(":core")
 include(":app-ui")
 include(":androidApp")
+include(":benchmark")


### PR DESCRIPTION
Adds an Android macrobenchmark module for startup + per-screen perf measurement.

- new :benchmark gradle module with startup and screen-trace tests
- benchmark build type on :androidApp (profileable, debug-signed)
- androidx.tracing screen markers in AppNavigation

Run: `./gradlew :benchmark:connectedBenchmarkAndroidTest` on a physical device.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `:benchmark` macrobenchmark module with screen trace instrumentation
> - Adds a new [`:benchmark`](https://github.com/poziomki-app/poziomki/pull/408/files#diff-79f8656db9c55cb305656ed292e9a924b148f716b21aae98de4a2e92428a7fad) Android test module configured for macrobenchmarking against the `:androidApp` target.
> - Adds `StartupBenchmark` measuring cold-start timing under `CompilationMode.None` and `CompilationMode.Partial`, and `ScreenTraceBenchmark` measuring `TraceSectionMetric("screen:Auth")` and frame timing across 5 iterations.
> - Introduces an `emitScreenTrace(name)` expect/actual in `app-ui`: the Android actual wraps navigation back stack entries in `Trace.beginSection/endSection` named `screen:<name>`; iOS is a no-op.
> - Hooks trace emission into `AppNavigation` via a `LaunchedEffect` that collects `currentBackStackEntryFlow` and parses the screen name from the destination route.
> - Adds a `benchmark` build type to `:androidApp` (non-minified, profileable, debug signing) to support profiling without obfuscation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b772615.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->