### PR TITLE
perf: add Firebase Performance Monitoring

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.perf)
     id("poziomki.detekt")
     id("poziomki.ktlint")
     id("poziomki.kotlin-warnings")
@@ -124,5 +125,6 @@ dependencies {
     implementation(libs.koin.android)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
+    implementation(libs.firebase.perf)
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/mobile/app-ui/build.gradle.kts
+++ b/mobile/app-ui/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
             implementation(libs.camerax.lifecycle)
             implementation(libs.camerax.view)
             implementation(libs.zxing.core)
+            implementation(libs.firebase.perf)
         }
         commonMain.dependencies {
             implementation(projects.core)

--- a/mobile/app-ui/src/androidMain/kotlin/com/poziomki/app/ui/perf/ScreenTrace.android.kt
+++ b/mobile/app-ui/src/androidMain/kotlin/com/poziomki/app/ui/perf/ScreenTrace.android.kt
@@ -1,0 +1,16 @@
+package com.poziomki.app.ui.perf
+
+import com.google.firebase.perf.FirebasePerformance
+import com.google.firebase.perf.metrics.Trace
+
+private class FirebaseScreenTraceHandle(
+    private val trace: Trace,
+) : ScreenTraceHandle {
+    override fun stop() = trace.stop()
+}
+
+actual fun startScreenTrace(name: String): ScreenTraceHandle {
+    val trace = FirebasePerformance.getInstance().newTrace("screen_$name")
+    trace.start()
+    return FirebaseScreenTraceHandle(trace)
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -99,6 +99,8 @@ import com.poziomki.app.ui.feature.onboarding.ProfileSetupScreen
 import com.poziomki.app.ui.feature.profile.PrivacyScreen
 import com.poziomki.app.ui.feature.profile.ProfileEditScreen
 import com.poziomki.app.ui.feature.profile.ProfileViewScreen
+import com.poziomki.app.ui.perf.ScreenTraceHandle
+import com.poziomki.app.ui.perf.startScreenTrace
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -154,6 +156,16 @@ fun AppNavigation(
     val chatClient = koinInject<ChatClient>()
     val chatRoomRepository = koinInject<ChatRoomRepository>()
     val navigationScope = rememberCoroutineScope()
+
+    LaunchedEffect(navController) {
+        var current: ScreenTraceHandle? = null
+        navController.currentBackStackEntryFlow.collect { entry ->
+            current?.stop()
+            val route = entry.destination.route ?: "unknown"
+            val name = route.substringAfterLast('.').substringBefore('/')
+            current = startScreenTrace(name)
+        }
+    }
 
     // Navigate to auth screen only on actual logout (true → false), not on initial composition.
     var wasLoggedIn by remember { mutableStateOf(isLoggedIn) }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/perf/ScreenTraceHandle.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/perf/ScreenTraceHandle.kt
@@ -1,0 +1,7 @@
+package com.poziomki.app.ui.perf
+
+interface ScreenTraceHandle {
+    fun stop()
+}
+
+expect fun startScreenTrace(name: String): ScreenTraceHandle

--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/perf/ScreenTrace.ios.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/perf/ScreenTrace.ios.kt
@@ -1,0 +1,7 @@
+package com.poziomki.app.ui.perf
+
+private object NoopScreenTraceHandle : ScreenTraceHandle {
+    override fun stop() = Unit
+}
+
+actual fun startScreenTrace(name: String): ScreenTraceHandle = NoopScreenTraceHandle

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -26,7 +26,9 @@ zxingCore = "3.5.4"
 sqldelight = "2.3.2"
 firebaseBom = "33.6.0"
 firebaseMessaging = "24.1.0"
+firebasePerf = "22.0.5"
 googleServices = "4.4.2"
+firebasePerfPlugin = "2.0.2"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
@@ -69,6 +71,7 @@ sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", ver
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "firebaseMessaging" }
+firebase-perf = { module = "com.google.firebase:firebase-perf", version.ref = "firebasePerf" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -82,3 +85,4 @@ versions = { id = "com.github.ben-manes.versions", version = "0.54.0" }
 kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }


### PR DESCRIPTION
Adds Firebase Performance Monitoring for per-screen render telemetry.

- firebase-perf plugin + dependency on :androidApp
- ScreenTrace helper (Android: Firebase Perf custom trace; iOS: no-op for now)
- AppNavigation emits a screen trace per route entry

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Firebase Performance Monitoring screen traces to Android navigation
> - Introduces a `ScreenTraceHandle` interface and `startScreenTrace` expect function in the common module, with an Android actual that creates and starts a Firebase Performance trace named `screen_<route>` and an iOS no-op implementation.
> - Adds a `LaunchedEffect` in `AppNavigation` that stops the previous trace and starts a new one on each navigation destination change.
> - Adds the Firebase Performance Gradle plugin and `firebase-perf` dependency to the Android app and `app-ui` modules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be3f45b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->