### PR TITLE
perf(api): raise CPU cap from 1.0 to 3.0

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -180,7 +180,7 @@ services:
           # the previous 512 MB would have been borderline once moderation
           # loaded. See scripts/guard-bench/Dockerfile.bench.
           memory: 768m
-          cpus: '1.0'
+          cpus: '3.0'
           pids: 256
     logging: *default-logging
     networks: [app]


### PR DESCRIPTION
API container pegs at 100% CPU above c=100 on the 4-core host, capping throughput at ~4.5k RPS. Raise cap to 3.0, leaving 1 core for postgres/pgdog/OSRM.

## Test plan
- [ ] After deploy: `docker inspect poziomki-rs-api-1 --format '{{.HostConfig.NanoCpus}}'` reports 3000000000
- [ ] Re-run oha c=10000 against `/api/v1/tags?q=`, expect RPS > 10000 (was 4592)
- [ ] `docker stats` shows API ≤ 290% under load, postgres unaffected

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise API container CPU cap from 1.0 to 3.0
> Updates the `cpus` limit in [docker-compose.prod.yml](https://github.com/poziomki-app/poziomki/pull/410/files#diff-2eeee385263c859a8fc9d0a455c48137ba77b00bde682f9a7208b0aad1d3f864) for the API service. The container can now use up to 3 CPU cores instead of 1 when deployed via Compose or Swarm.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 411cc6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->