### PR TITLE
fix(metrics): bind exporter to 0.0.0.0 inside container

### DIFF
--- a/backend/src/telemetry.rs
+++ b/backend/src/telemetry.rs
@@ -40,7 +40,7 @@ pub fn init_metrics_exporter(kind: ProcessKind) -> AppResult<()> {
     let port = metrics_port(kind)?;
     PrometheusBuilder::new()
         .add_global_label("service", kind.as_str())
-        .with_http_listener(([127, 0, 0, 1], port))
+        .with_http_listener(([0, 0, 0, 0], port))
         .install()
         .map_err(|error| AppError::message(format!("metrics init: {error}")))?;
 


### PR DESCRIPTION
Exporter was bound to 127.0.0.1, so the Docker port forward couldn't reach it and `curl 127.0.0.1:9092/metrics` returned connection-reset. Compose still restricts the published port to host loopback.

## Test plan
- [ ] After deploy: `curl -s http://127.0.0.1:9092/metrics | head` returns Prometheus text (was: connection reset)
- [ ] Same for worker port 9093
- [ ] Grafana / Prometheus scrape recovers

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind Prometheus metrics exporter to `0.0.0.0` inside container
> Changes the listener address in `init_metrics_exporter` in [telemetry.rs](https://github.com/poziomki-app/poziomki/pull/411/files#diff-f5cc6ea1debb2a92c34cbdc5e62a2e2459a88b56001211adf4d2a166c8933b04) from `127.0.0.1` to `0.0.0.0` so the metrics endpoint is reachable from outside the container. Behavioral Change: the metrics port is now exposed on all network interfaces, not just localhost.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0a9e0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->