### PR TITLE
feat: powiadomienia settings + per-conversation mute

### DIFF
--- a/backend/migrations/2026-05-12-200000_notification_prefs/down.sql
+++ b/backend/migrations/2026-05-12-200000_notification_prefs/down.sql
@@ -1,0 +1,8 @@
+DROP FUNCTION IF EXISTS app.push_targets_filtered(integer[], uuid);
+
+DROP TABLE IF EXISTS public.conversation_mutes;
+
+ALTER TABLE public.user_settings
+    DROP COLUMN IF EXISTS notify_tag_events,
+    DROP COLUMN IF EXISTS notify_event_chats,
+    DROP COLUMN IF EXISTS notify_dms;

--- a/backend/migrations/2026-05-12-200000_notification_prefs/up.sql
+++ b/backend/migrations/2026-05-12-200000_notification_prefs/up.sql
@@ -1,0 +1,77 @@
+-- Per-channel notification preferences + per-conversation mute.
+--
+-- Today `user_settings.notifications_enabled` is the only switch, and it
+-- isn't surfaced anywhere in the UI. This migration adds the granular
+-- channels the new Powiadomienia screen needs (DMs vs event chats vs
+-- tag-driven event recommendations), and a `conversation_mutes` table
+-- so users can silence individual chats from the chat header.
+--
+-- All new columns default TRUE so existing users keep getting pushes;
+-- the master `notifications_enabled` switch stays the kill-all.
+
+ALTER TABLE public.user_settings
+    ADD COLUMN notify_dms boolean NOT NULL DEFAULT true,
+    ADD COLUMN notify_event_chats boolean NOT NULL DEFAULT true,
+    ADD COLUMN notify_tag_events boolean NOT NULL DEFAULT true;
+
+CREATE TABLE public.conversation_mutes (
+    user_id integer NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    conversation_id uuid NOT NULL REFERENCES public.conversations(id) ON DELETE CASCADE,
+    muted_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, conversation_id)
+);
+
+CREATE INDEX conversation_mutes_user_id_idx ON public.conversation_mutes(user_id);
+
+ALTER TABLE public.conversation_mutes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.conversation_mutes FORCE ROW LEVEL SECURITY;
+CREATE POLICY conversation_mutes_viewer ON public.conversation_mutes
+    FOR ALL TO poziomki_api
+    USING (user_id = app.current_user_id())
+    WITH CHECK (user_id = app.current_user_id());
+
+-- Narrow SECURITY DEFINER helper: gate a list of recipient user_ids
+-- against their notification preferences for a specific conversation.
+-- Returns only the user_ids whose master switch is on, channel for the
+-- conversation kind is on, and who haven't muted this conversation.
+-- Server-side push delivery only; the API role doesn't need broad SELECT
+-- across user_settings or conversation_mutes.
+CREATE OR REPLACE FUNCTION app.push_targets_filtered(
+    p_user_ids integer[],
+    p_conversation_id uuid
+)
+RETURNS TABLE (user_id integer)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT u.uid
+    FROM unnest(p_user_ids) AS u(uid)
+    JOIN public.user_settings s ON s.user_id = u.uid
+    JOIN public.conversations c ON c.id = p_conversation_id
+    WHERE s.notifications_enabled
+      AND CASE c.kind
+            WHEN 'dm'    THEN s.notify_dms
+            WHEN 'event' THEN s.notify_event_chats
+            ELSE TRUE
+          END
+      AND NOT EXISTS (
+        SELECT 1 FROM public.conversation_mutes m
+        WHERE m.user_id = u.uid
+          AND m.conversation_id = p_conversation_id
+      )
+$$;
+
+COMMENT ON FUNCTION app.push_targets_filtered(integer[], uuid) IS
+    'Filter push recipients by per-channel preferences and per-conversation mute. Narrow projection; server-side push only.';
+
+REVOKE EXECUTE ON FUNCTION app.push_targets_filtered(integer[], uuid) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.push_targets_filtered(integer[], uuid) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/api/chat/conversations.rs
+++ b/backend/src/api/chat/conversations.rs
@@ -7,7 +7,9 @@ use uuid::Uuid;
 use crate::db;
 use crate::db::models::conversation_members::NewConversationMember;
 use crate::db::models::conversations::{Conversation, NewConversation};
-use crate::db::schema::{conversation_members, conversations, events, profile_blocks, profiles};
+use crate::db::schema::{
+    conversation_members, conversation_mutes, conversations, events, profile_blocks, profiles,
+};
 
 /// Fetch the canonical DM conversation for `(low, high)` via the
 /// SECURITY DEFINER helper installed in the Tier-B migration. Bypasses
@@ -399,6 +401,22 @@ pub async fn list_for_user(
             std::collections::HashSet::new()
         };
 
+    // Batch-load muted conversation ids for this user. RLS scopes the
+    // table to own rows, but we run via the API role anyway — no SD
+    // helper needed.
+    let muted_ids: std::collections::HashSet<Uuid> = if conv_ids.is_empty() {
+        std::collections::HashSet::new()
+    } else {
+        conversation_mutes::table
+            .filter(conversation_mutes::user_id.eq(user_id))
+            .filter(conversation_mutes::conversation_id.eq_any(&conv_ids))
+            .select(conversation_mutes::conversation_id)
+            .load::<Uuid>(conn)
+            .await?
+            .into_iter()
+            .collect()
+    };
+
     let mut payloads = Vec::with_capacity(convs.len());
     for conv in &convs {
         let latest = latest_map.get(&conv.id).copied();
@@ -481,6 +499,7 @@ pub async fn list_for_user(
             latest_message_is_mine: latest_is_mine,
             latest_sender_name,
             is_blocked,
+            muted: muted_ids.contains(&conv.id),
             latest_moderation_verdict: latest_verdict,
             latest_moderation_categories: latest_categories,
         });

--- a/backend/src/api/chat/mod.rs
+++ b/backend/src/api/chat/mod.rs
@@ -2,6 +2,7 @@ pub mod conversations;
 pub mod hub;
 pub mod message_report_handler;
 pub mod messages;
+pub mod mutes;
 pub mod protocol;
 pub mod report_handler;
 pub mod report_repo;

--- a/backend/src/api/chat/mutes.rs
+++ b/backend/src/api/chat/mutes.rs
@@ -1,0 +1,133 @@
+//! Per-conversation mute toggle. POST = mute, DELETE = unmute.
+//!
+//! Membership check is the gate: muting a conversation you don't belong
+//! to has no semantic meaning, so we 404 rather than silently insert a
+//! dangling row. RLS on `conversation_mutes` (own-row-only) is the second
+//! line of defence — a forged `user_id` would be rejected by the policy.
+
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+use crate::api::common::{auth_or_respond, error_response, parse_uuid_response, ErrorSpec};
+use crate::app::AppContext;
+use crate::db;
+
+type Result<T> = crate::error::AppResult<T>;
+
+async fn require_member(
+    conn: &mut diesel_async::AsyncPgConnection,
+    conversation_id: Uuid,
+    user_id: i32,
+) -> std::result::Result<bool, diesel::result::Error> {
+    use crate::db::schema::conversation_members;
+    let count: i64 = conversation_members::table
+        .filter(conversation_members::conversation_id.eq(conversation_id))
+        .filter(conversation_members::user_id.eq(user_id))
+        .count()
+        .get_result(conn)
+        .await?;
+    Ok(count > 0)
+}
+
+pub async fn mute_conversation(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(conversation_id): Path<String>,
+) -> Result<Response> {
+    use crate::db::schema::conversation_mutes;
+
+    let (_session, user) = auth_or_respond!(headers);
+
+    let conversation_id = match parse_uuid_response(&conversation_id, "conversation", &headers) {
+        Ok(id) => id,
+        Err(response) => return Ok(*response),
+    };
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let caller_user_id = user.id;
+
+    let outcome: bool = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            if !require_member(conn, conversation_id, caller_user_id).await? {
+                return Ok::<bool, diesel::result::Error>(false);
+            }
+            diesel::insert_into(conversation_mutes::table)
+                .values((
+                    conversation_mutes::user_id.eq(caller_user_id),
+                    conversation_mutes::conversation_id.eq(conversation_id),
+                    conversation_mutes::muted_at.eq(chrono::Utc::now()),
+                ))
+                .on_conflict((
+                    conversation_mutes::user_id,
+                    conversation_mutes::conversation_id,
+                ))
+                .do_nothing()
+                .execute(conn)
+                .await?;
+            Ok(true)
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    if !outcome {
+        return Ok(error_response(
+            StatusCode::NOT_FOUND,
+            &headers,
+            ErrorSpec {
+                error: "Conversation not found".to_string(),
+                code: "NOT_FOUND",
+                details: None,
+            },
+        ));
+    }
+
+    Ok((StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response())
+}
+
+pub async fn unmute_conversation(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(conversation_id): Path<String>,
+) -> Result<Response> {
+    use crate::db::schema::conversation_mutes;
+
+    let (_session, user) = auth_or_respond!(headers);
+
+    let conversation_id = match parse_uuid_response(&conversation_id, "conversation", &headers) {
+        Ok(id) => id,
+        Err(response) => return Ok(*response),
+    };
+
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let caller_user_id = user.id;
+
+    db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            diesel::delete(
+                conversation_mutes::table
+                    .filter(conversation_mutes::user_id.eq(caller_user_id))
+                    .filter(conversation_mutes::conversation_id.eq(conversation_id)),
+            )
+            .execute(conn)
+            .await?;
+            Ok::<(), diesel::result::Error>(())
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    Ok((StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response())
+}

--- a/backend/src/api/chat/protocol.rs
+++ b/backend/src/api/chat/protocol.rs
@@ -187,6 +187,7 @@ pub struct ReactionPayload {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::struct_excessive_bools)]
 pub struct ConversationPayload {
     pub id: Uuid,
     pub kind: String,
@@ -202,6 +203,7 @@ pub struct ConversationPayload {
     pub latest_message_is_mine: bool,
     pub latest_sender_name: Option<String>,
     pub is_blocked: bool,
+    pub muted: bool,
     /// Bielik-Guard verdict for the latest message body — `None` until
     /// scanned, `"allow"`/`"flag"`/`"block"` after. Clients render the
     /// blur overlay in the chat list using this field; the body is

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -212,6 +212,10 @@ fn chat_routes() -> Router<AppContext> {
         )
         .route("/push/register", post(chat::push_register))
         .route("/push/unregister", post(chat::push_unregister))
+        .route(
+            "/conversations/{id}/mute",
+            post(chat::mutes::mute_conversation).delete(chat::mutes::unmute_conversation),
+        )
         .layer(cache_layer("no-store"))
 }
 

--- a/backend/src/api/settings.rs
+++ b/backend/src/api/settings.rs
@@ -24,10 +24,17 @@ pub(in crate::api) struct UserSettingsResponse {
     pub(in crate::api) privacy_show_program: bool,
     #[serde(rename = "privacyDiscoverable")]
     pub(in crate::api) privacy_discoverable: bool,
+    #[serde(rename = "notifyDms")]
+    pub(in crate::api) notify_dms: bool,
+    #[serde(rename = "notifyEventChats")]
+    pub(in crate::api) notify_event_chats: bool,
+    #[serde(rename = "notifyTagEvents")]
+    pub(in crate::api) notify_tag_events: bool,
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::struct_excessive_bools)]
 pub(in crate::api) struct UpdateSettingsBody {
     #[serde(default)]
     pub(in crate::api) theme: Option<String>,
@@ -39,6 +46,12 @@ pub(in crate::api) struct UpdateSettingsBody {
     pub(in crate::api) privacy_show_program: Option<bool>,
     #[serde(default)]
     pub(in crate::api) privacy_discoverable: Option<bool>,
+    #[serde(default)]
+    pub(in crate::api) notify_dms: Option<bool>,
+    #[serde(default)]
+    pub(in crate::api) notify_event_chats: Option<bool>,
+    #[serde(default)]
+    pub(in crate::api) notify_tag_events: Option<bool>,
 }
 
 fn model_to_response(model: &UserSetting) -> UserSettingsResponse {
@@ -48,6 +61,9 @@ fn model_to_response(model: &UserSetting) -> UserSettingsResponse {
         notifications_enabled: model.notifications_enabled,
         privacy_show_program: model.privacy_show_program,
         privacy_discoverable: model.privacy_discoverable,
+        notify_dms: model.notify_dms,
+        notify_event_chats: model.notify_event_chats,
+        notify_tag_events: model.notify_tag_events,
     }
 }
 
@@ -58,6 +74,9 @@ fn default_response() -> UserSettingsResponse {
         notifications_enabled: true,
         privacy_show_program: true,
         privacy_discoverable: true,
+        notify_dms: true,
+        notify_event_chats: true,
+        notify_tag_events: true,
     }
 }
 
@@ -101,6 +120,9 @@ pub(super) async fn settings_update(
             notifications_enabled: body.notifications_enabled,
             privacy_show_program: body.privacy_show_program,
             privacy_discoverable: body.privacy_discoverable,
+            notify_dms: body.notify_dms,
+            notify_event_chats: body.notify_event_chats,
+            notify_tag_events: body.notify_tag_events,
             updated_at: Some(Utc::now()),
         };
         diesel::update(user_settings::table.find(record.id))
@@ -120,6 +142,9 @@ pub(super) async fn settings_update(
             notifications_enabled: body.notifications_enabled.unwrap_or(true),
             privacy_show_program: body.privacy_show_program.unwrap_or(true),
             privacy_discoverable: body.privacy_discoverable.unwrap_or(true),
+            notify_dms: body.notify_dms.unwrap_or(true),
+            notify_event_chats: body.notify_event_chats.unwrap_or(true),
+            notify_tag_events: body.notify_tag_events.unwrap_or(true),
             created_at: now,
             updated_at: now,
         };

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -4,12 +4,12 @@ pub mod viewer;
 
 pub use viewer::{
     complete_password_reset, create_session_for_user, create_user_for_signup,
-    delete_session_by_token, find_user_for_login, find_user_for_password_reset,
-    mark_email_verified, profile_owner_user_id, profile_program_visibility, push_tokens_for_users,
-    resolve_session, set_anon_context, set_password_reset_token, set_viewer_context,
-    user_id_for_pid, user_pid_for_id, user_pids_for_ids, user_review_stubs, with_anon_tx,
-    with_viewer_tx, AuthSessionRow, AuthUserRow, CreatedSessionRow, DbViewer, PasswordResetUserRow,
-    UserPidRow, UserReviewStubRow,
+    delete_session_by_token, filter_push_targets, find_user_for_login,
+    find_user_for_password_reset, mark_email_verified, profile_owner_user_id,
+    profile_program_visibility, push_tokens_for_users, resolve_session, set_anon_context,
+    set_password_reset_token, set_viewer_context, user_id_for_pid, user_pid_for_id,
+    user_pids_for_ids, user_review_stubs, with_anon_tx, with_viewer_tx, AuthSessionRow,
+    AuthUserRow, CreatedSessionRow, DbViewer, PasswordResetUserRow, UserPidRow, UserReviewStubRow,
 };
 
 use deadpool::managed::Timeouts;

--- a/backend/src/db/models/conversation_mutes.rs
+++ b/backend/src/db/models/conversation_mutes.rs
@@ -1,0 +1,21 @@
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use crate::db::schema::conversation_mutes;
+
+#[derive(Debug, Clone, Queryable, Selectable)]
+#[diesel(table_name = conversation_mutes)]
+pub struct ConversationMute {
+    pub user_id: i32,
+    pub conversation_id: Uuid,
+    pub muted_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = conversation_mutes)]
+pub struct NewConversationMute {
+    pub user_id: i32,
+    pub conversation_id: Uuid,
+    pub muted_at: DateTime<Utc>,
+}

--- a/backend/src/db/models/mod.rs
+++ b/backend/src/db/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth_rate_limits;
 pub mod conversation_members;
+pub mod conversation_mutes;
 pub mod conversations;
 pub mod degrees;
 pub mod event_attendees;

--- a/backend/src/db/models/user_settings.rs
+++ b/backend/src/db/models/user_settings.rs
@@ -17,6 +17,9 @@ pub struct UserSetting {
     pub privacy_discoverable: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub notify_dms: bool,
+    pub notify_event_chats: bool,
+    pub notify_tag_events: bool,
 }
 
 #[derive(Debug, Insertable)]
@@ -32,6 +35,9 @@ pub struct NewUserSetting {
     pub privacy_discoverable: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub notify_dms: bool,
+    pub notify_event_chats: bool,
+    pub notify_tag_events: bool,
 }
 
 #[derive(Debug, AsChangeset)]
@@ -43,5 +49,8 @@ pub struct UserSettingChangeset {
     pub notifications_enabled: Option<bool>,
     pub privacy_show_program: Option<bool>,
     pub privacy_discoverable: Option<bool>,
+    pub notify_dms: Option<bool>,
+    pub notify_event_chats: Option<bool>,
+    pub notify_tag_events: Option<bool>,
     pub updated_at: Option<DateTime<Utc>>,
 }

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -24,6 +24,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    conversation_mutes (user_id, conversation_id) {
+        user_id -> Int4,
+        conversation_id -> Uuid,
+        muted_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     messages (id) {
         id -> Uuid,
         conversation_id -> Uuid,
@@ -293,6 +301,9 @@ diesel::table! {
         privacy_discoverable -> Bool,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        notify_dms -> Bool,
+        notify_event_chats -> Bool,
+        notify_tag_events -> Bool,
     }
 }
 
@@ -320,6 +331,8 @@ diesel::table! {
 }
 
 diesel::joinable!(conversation_members -> conversations (conversation_id));
+diesel::joinable!(conversation_mutes -> conversations (conversation_id));
+diesel::joinable!(conversation_mutes -> users (user_id));
 diesel::joinable!(conversations -> events (event_id));
 diesel::joinable!(messages -> conversations (conversation_id));
 diesel::joinable!(messages -> uploads (attachment_upload_id));
@@ -347,6 +360,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     chat_message_reports,
     chat_message_reveals,
     conversation_members,
+    conversation_mutes,
     conversations,
     degrees,
     event_attendees,

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -472,6 +472,33 @@ pub async fn push_tokens_for_users(
     Ok(rows)
 }
 
+#[derive(Debug, Clone, QueryableByName)]
+struct UserIdRow {
+    #[diesel(sql_type = Integer)]
+    user_id: i32,
+}
+
+/// Filter push recipients by notification preferences.
+///
+/// Returns only those whose master switch is on, channel for the
+/// conversation kind is on, and who haven't muted the conversation.
+/// Server-side delivery only.
+pub async fn filter_push_targets(
+    conn: &mut AsyncPgConnection,
+    user_ids: &[i32],
+    conversation_id: uuid::Uuid,
+) -> Result<Vec<i32>, diesel::result::Error> {
+    if user_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows = diesel::sql_query("SELECT * FROM app.push_targets_filtered($1, $2)")
+        .bind::<diesel::sql_types::Array<Integer>, _>(user_ids)
+        .bind::<diesel::sql_types::Uuid, _>(conversation_id)
+        .load::<UserIdRow>(conn)
+        .await?;
+    Ok(rows.into_iter().map(|r| r.user_id).collect())
+}
+
 // ---------------------------------------------------------------------------
 // Narrow public projections used by the events module.
 // ---------------------------------------------------------------------------

--- a/backend/src/push/fcm.rs
+++ b/backend/src/push/fcm.rs
@@ -259,7 +259,24 @@ pub async fn send_wake(user_ids: Vec<i32>, conversation_id: Uuid) {
                 return;
             }
         };
-        match db::push_tokens_for_users(&mut conn, &user_ids).await {
+        // Honour per-channel preferences and per-conversation mute. The
+        // event-approval call path passes Uuid::nil() (no conversation
+        // row to join against); fall through to the master switch only.
+        let targets = if conversation_id.is_nil() {
+            user_ids.clone()
+        } else {
+            match db::filter_push_targets(&mut conn, &user_ids, conversation_id).await {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!(error = %e, "fcm: filter targets failed");
+                    return;
+                }
+            }
+        };
+        if targets.is_empty() {
+            return;
+        }
+        match db::push_tokens_for_users(&mut conn, &targets).await {
             Ok(rows) => rows,
             Err(e) => {
                 tracing::warn!(error = %e, "fcm: token lookup failed");

--- a/backend/tests/requests/rls_baseline.rs
+++ b/backend/tests/requests/rls_baseline.rs
@@ -29,6 +29,7 @@ const EXPECTED_TIER_A_TABLES: &[&str] = &[
     "user_settings",
     "user_audit_log",
     "push_subscriptions",
+    "conversation_mutes",
     "profile_bookmarks",
     "profile_blocks",
     "event_interactions",
@@ -71,6 +72,7 @@ const EXPECTED_SD_HELPERS: &[&str] = &[
     // row sets and are SECURITY DEFINER so policy expressions that embed
     // them don't recursively self-filter against RLS.
     "profiles_in_current_bucket",
+    "push_targets_filtered",
     "push_tokens_for_users",
     "resolve_session",
     // Tier-C policy-support helpers.

--- a/mobile/app-ui/detekt-baseline.xml
+++ b/mobile/app-ui/detekt-baseline.xml
@@ -40,6 +40,7 @@
     <ID>Indentation:PoziomkiLogo.kt$ </ID>
     <ID>Indentation:PoziomkiSearchBar.kt$ </ID>
     <ID>Indentation:PoziomkiTextField.kt$ </ID>
+    <ID>Indentation:PowiadomieniaScreen.kt$ </ID>
     <ID>Indentation:PrivacyScreen.kt$ </ID>
     <ID>Indentation:ProfileCard.kt$ </ID>
     <ID>Indentation:ProfileEditScreen.kt$ </ID>

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/di/AppModule.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/di/AppModule.kt
@@ -11,6 +11,7 @@ import com.poziomki.app.ui.feature.home.MessagesViewModel
 import com.poziomki.app.ui.feature.home.ProfileViewModel
 import com.poziomki.app.ui.feature.home.SavedViewModel
 import com.poziomki.app.ui.feature.onboarding.OnboardingViewModel
+import com.poziomki.app.ui.feature.profile.PowiadomieniaViewModel
 import com.poziomki.app.ui.feature.profile.PrivacyViewModel
 import com.poziomki.app.ui.feature.profile.ProfileEditViewModel
 import com.poziomki.app.ui.feature.profile.ProfileViewViewModel
@@ -32,5 +33,6 @@ val appModule =
         viewModelOf(::ProfileEditViewModel)
         viewModelOf(::ProfileViewViewModel)
         viewModelOf(::PrivacyViewModel)
+        viewModelOf(::PowiadomieniaViewModel)
         viewModelOf(::SavedViewModel)
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -42,6 +42,8 @@ import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.Fill
 import com.adamglin.phosphoricons.bold.ArrowLeft
+import com.adamglin.phosphoricons.bold.Bell
+import com.adamglin.phosphoricons.bold.BellSlash
 import com.adamglin.phosphoricons.bold.CaretDown
 import com.adamglin.phosphoricons.bold.CaretUp
 import com.adamglin.phosphoricons.bold.DotsThreeVertical
@@ -136,6 +138,7 @@ fun ChatScreen(
                     avatarUrl = state.roomAvatarUrl,
                     isEvent = !state.isDirectRoom,
                     isBlocked = state.isBlocked,
+                    isMuted = state.isMuted,
                     onBack = onBack,
                     onSearchClick = viewModel::toggleSearch,
                     onProfileClick =
@@ -147,6 +150,7 @@ fun ChatScreen(
                         viewModel.removeConversation()
                         onBack()
                     },
+                    onToggleMute = viewModel::toggleMute,
                 )
             }
         },
@@ -223,6 +227,7 @@ private fun ChatTopBar(
     title: String,
     avatarUrl: String?,
     isBlocked: Boolean,
+    isMuted: Boolean = false,
     isEvent: Boolean = false,
     onBack: () -> Unit,
     onSearchClick: () -> Unit,
@@ -230,6 +235,7 @@ private fun ChatTopBar(
     onBlock: () -> Unit = {},
     onReport: () -> Unit = {},
     onRemove: () -> Unit = {},
+    onToggleMute: () -> Unit = {},
 ) {
     var showMenu by remember { mutableStateOf(false) }
     Surface(
@@ -305,6 +311,19 @@ private fun ChatTopBar(
                             },
                             iconTint = Error,
                             labelColor = Error,
+                        )
+                        ActionMenuItem(
+                            icon =
+                                if (isMuted) {
+                                    PhosphorIcons.Bold.Bell
+                                } else {
+                                    PhosphorIcons.Bold.BellSlash
+                                },
+                            label = if (isMuted) "Wyłącz wyciszenie" else "Wycisz czat",
+                            onClick = {
+                                showMenu = false
+                                onToggleMute()
+                            },
                         )
                         ActionMenuItem(
                             icon = PhosphorIcons.Bold.Flag,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -446,6 +446,29 @@ class ChatViewModel(
         }
     }
 
+    fun toggleMute() {
+        val roomId = boundRoomId ?: return
+        val wantMuted = !_uiState.value.isMuted
+        // Optimistic update — flip immediately, revert if the call fails.
+        _uiState.update { it.copy(isMuted = wantMuted) }
+        viewModelScope.launch {
+            val result =
+                if (wantMuted) {
+                    apiService.muteConversation(roomId)
+                } else {
+                    apiService.unmuteConversation(roomId)
+                }
+            if (result is ApiResult.Error) {
+                _uiState.update {
+                    it.copy(
+                        isMuted = !wantMuted,
+                        error = "Nie udało się zmienić wyciszenia",
+                    )
+                }
+            }
+        }
+    }
+
     fun toggleSearch() {
         _uiState.update {
             if (it.isSearchActive) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -458,12 +458,20 @@ class ChatViewModel(
                 } else {
                     apiService.unmuteConversation(roomId)
                 }
-            if (result is ApiResult.Error) {
-                _uiState.update {
-                    it.copy(
-                        isMuted = !wantMuted,
-                        error = "Nie udało się zmienić wyciszenia",
-                    )
+            when (result) {
+                is ApiResult.Success -> {
+                    // Refresh the room list so the new muted state is reflected
+                    // on the next chat reopen and in the conversations payload.
+                    runCatching { chatClient.refreshRooms() }
+                }
+
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isMuted = !wantMuted,
+                            error = "Nie udało się zmienić wyciszenia",
+                        )
+                    }
                 }
             }
         }
@@ -716,6 +724,7 @@ class ChatViewModel(
                 roomAvatarUrl = initialAvatar,
                 isDirectRoom = initialIsDirect,
                 isBlocked = initialSummary?.isBlocked ?: false,
+                isMuted = initialSummary?.isMuted ?: false,
                 timelineItems = cachedTimeline?.items ?: emptyList(),
                 isAwayFromLatest = false,
                 unreadBelowCount = 0,
@@ -792,6 +801,7 @@ class ChatViewModel(
                         current.copy(
                             roomDisplayName = resolvedName,
                             isDirectRoom = summary?.isDirect ?: current.isDirectRoom,
+                            isMuted = summary?.isMuted ?: current.isMuted,
                             directProfileId = current.directProfileId ?: activeDirectProfileId ?: activeDirectUserId,
                             roomAvatarUrl =
                                 resolveRoomAvatar(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/model/ChatUiModels.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/model/ChatUiModels.kt
@@ -54,5 +54,6 @@ data class ChatUiState(
     val searchMatchIndices: List<Int> = emptyList(),
     val currentSearchMatchIndex: Int = -1,
     val isBlocked: Boolean = false,
+    val isMuted: Boolean = false,
     val transientNotice: TransientNotice? = null,
 )

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
+import com.adamglin.phosphoricons.bold.Bell
 import com.adamglin.phosphoricons.bold.BookmarkSimple
 import com.adamglin.phosphoricons.bold.CaretRight
 import com.adamglin.phosphoricons.bold.PencilSimple
@@ -57,10 +58,12 @@ import kotlinx.coroutines.delay
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
+@Suppress("LongMethod", "LongParameterList")
 @Composable
 fun ProfileScreen(
     onNavigateToEdit: () -> Unit,
     onNavigateToPrivacy: () -> Unit,
+    onNavigateToPowiadomienia: () -> Unit,
     onNavigateToSaved: () -> Unit,
     onNavigateToProfileView: (String) -> Unit,
     onSignOut: () -> Unit,
@@ -114,6 +117,12 @@ fun ProfileScreen(
                                         icon = PhosphorIcons.Bold.PencilSimple,
                                         label = "edytuj profil",
                                         onClick = onNavigateToEdit,
+                                    )
+                                    HorizontalDivider(color = Border, thickness = 1.dp)
+                                    SettingsMenuItem(
+                                        icon = PhosphorIcons.Bold.Bell,
+                                        label = "powiadomienia",
+                                        onClick = onNavigateToPowiadomienia,
                                     )
                                     HorizontalDivider(color = Border, thickness = 1.dp)
                                     SettingsMenuItem(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaScreen.kt
@@ -1,0 +1,191 @@
+package com.poziomki.app.ui.feature.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.poziomki.app.ui.designsystem.components.ScreenHeader
+import com.poziomki.app.ui.designsystem.components.SectionLabel
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
+import com.poziomki.app.ui.designsystem.theme.TextMuted
+import com.poziomki.app.ui.designsystem.theme.TextSecondary
+import org.koin.compose.viewmodel.koinViewModel
+
+@Suppress("LongMethod")
+@Composable
+fun PowiadomieniaScreen(
+    onBack: () -> Unit,
+    viewModel: PowiadomieniaViewModel = koinViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    val nunito = NunitoFamily
+    val navBarBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+    ) {
+        val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+        ScreenHeader(
+            title = "powiadomienia",
+            onBack = onBack,
+            modifier = Modifier.padding(top = statusBarPadding),
+        )
+
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = PoziomkiTheme.spacing.lg),
+        ) {
+            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
+
+            NotificationToggleRow(
+                label = "powiadomienia",
+                description = "Główny włącznik. Wyłącz, aby nic nie wpadało.",
+                checked = state.masterEnabled,
+                enabled = true,
+                onCheckedChange = viewModel::toggleMaster,
+                nunito = nunito,
+            )
+
+            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
+            SectionLabel("KANAŁY", color = TextMuted)
+            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
+
+            NotificationToggleRow(
+                label = "wiadomości prywatne",
+                description = "Powiadomienia o nowych wiadomościach od osób.",
+                checked = state.dms,
+                enabled = state.masterEnabled,
+                onCheckedChange = viewModel::toggleDms,
+                nunito = nunito,
+            )
+            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
+            NotificationToggleRow(
+                label = "czaty wydarzeń",
+                description = "Powiadomienia o nowych wiadomościach w czatach wydarzeń.",
+                checked = state.eventChats,
+                enabled = state.masterEnabled,
+                onCheckedChange = viewModel::toggleEventChats,
+                nunito = nunito,
+            )
+            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
+            NotificationToggleRow(
+                label = "nowe wydarzenia w obserwowanych tagach",
+                description = "Powiadomienia o nowych wydarzeniach pasujących do Twoich zainteresowań.",
+                checked = state.tagEvents,
+                enabled = state.masterEnabled,
+                onCheckedChange = viewModel::toggleTagEvents,
+                nunito = nunito,
+                trailingBadge = "wkrótce",
+            )
+
+            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
+            Text(
+                text = "Wyciszysz pojedynczy czat w jego ustawieniach (przycisk w nagłówku).",
+                fontFamily = nunito,
+                fontWeight = FontWeight.Normal,
+                fontSize = 12.sp,
+                color = TextSecondary,
+                lineHeight = 16.sp,
+            )
+
+            Spacer(modifier = Modifier.height(navBarBottom + PoziomkiTheme.spacing.xl))
+        }
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun NotificationToggleRow(
+    label: String,
+    description: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    nunito: androidx.compose.ui.text.font.FontFamily,
+    trailingBadge: String? = null,
+) {
+    val alpha = if (enabled) 1f else 0.5f
+    Row(
+        modifier = Modifier.fillMaxWidth().alpha(alpha),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = label,
+                    fontFamily = nunito,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 15.sp,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                if (trailingBadge != null) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Box(
+                        modifier =
+                            Modifier
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(MaterialTheme.colorScheme.surfaceVariant)
+                                .padding(horizontal = 6.dp, vertical = 2.dp),
+                    ) {
+                        Text(
+                            text = trailingBadge,
+                            fontFamily = nunito,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 10.sp,
+                            color = TextSecondary,
+                        )
+                    }
+                }
+            }
+            Text(
+                text = description,
+                fontFamily = nunito,
+                fontWeight = FontWeight.Normal,
+                fontSize = 13.sp,
+                color = TextSecondary,
+                lineHeight = 18.sp,
+            )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled,
+        )
+    }
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaViewModel.kt
@@ -1,0 +1,75 @@
+package com.poziomki.app.ui.feature.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.poziomki.app.data.repository.SettingsRepository
+import com.poziomki.app.session.SessionManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+data class PowiadomieniaState(
+    val masterEnabled: Boolean = true,
+    val dms: Boolean = true,
+    val eventChats: Boolean = true,
+    val tagEvents: Boolean = true,
+)
+
+class PowiadomieniaViewModel(
+    private val sessionManager: SessionManager,
+    private val settingsRepository: SettingsRepository,
+) : ViewModel() {
+    private val _state = MutableStateFlow(PowiadomieniaState())
+    val state: StateFlow<PowiadomieniaState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val userId = sessionManager.userId.first() ?: return@launch
+            settingsRepository.ensureDefaults(userId)
+            val settings = settingsRepository.observeSettings(userId).first()
+            if (settings != null) {
+                _state.value =
+                    PowiadomieniaState(
+                        masterEnabled = settings.notifications_enabled != 0L,
+                        dms = settings.notify_dms != 0L,
+                        eventChats = settings.notify_event_chats != 0L,
+                        tagEvents = settings.notify_tag_events != 0L,
+                    )
+            }
+        }
+    }
+
+    fun toggleMaster(enabled: Boolean) {
+        _state.value = _state.value.copy(masterEnabled = enabled)
+        viewModelScope.launch {
+            val userId = sessionManager.userId.first() ?: return@launch
+            settingsRepository.updateNotifications(userId, enabled)
+        }
+    }
+
+    fun toggleDms(enabled: Boolean) {
+        _state.value = _state.value.copy(dms = enabled)
+        viewModelScope.launch {
+            val userId = sessionManager.userId.first() ?: return@launch
+            settingsRepository.updateNotifyDms(userId, enabled)
+        }
+    }
+
+    fun toggleEventChats(enabled: Boolean) {
+        _state.value = _state.value.copy(eventChats = enabled)
+        viewModelScope.launch {
+            val userId = sessionManager.userId.first() ?: return@launch
+            settingsRepository.updateNotifyEventChats(userId, enabled)
+        }
+    }
+
+    fun toggleTagEvents(enabled: Boolean) {
+        _state.value = _state.value.copy(tagEvents = enabled)
+        viewModelScope.launch {
+            val userId = sessionManager.userId.first() ?: return@launch
+            settingsRepository.updateNotifyTagEvents(userId, enabled)
+        }
+    }
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -96,6 +96,7 @@ import com.poziomki.app.ui.feature.home.SavedScreen
 import com.poziomki.app.ui.feature.onboarding.BasicInfoScreen
 import com.poziomki.app.ui.feature.onboarding.InterestsScreen
 import com.poziomki.app.ui.feature.onboarding.ProfileSetupScreen
+import com.poziomki.app.ui.feature.profile.PowiadomieniaScreen
 import com.poziomki.app.ui.feature.profile.PrivacyScreen
 import com.poziomki.app.ui.feature.profile.ProfileEditScreen
 import com.poziomki.app.ui.feature.profile.ProfileViewScreen
@@ -379,6 +380,7 @@ fun AppNavigation(
                 onNavigateToProfileView = { id -> navController.navigate(Route.ProfileView(id)) },
                 onNavigateToProfileEdit = { navController.navigate(Route.ProfileEdit) },
                 onNavigateToPrivacy = { navController.navigate(Route.Privacy) },
+                onNavigateToPowiadomienia = { navController.navigate(Route.Powiadomienia) },
                 onNavigateToSaved = { navController.navigate(Route.Saved) },
                 onNavigateToChat = navigateToChat,
                 onSignOut = {
@@ -444,6 +446,11 @@ fun AppNavigation(
                 },
             )
         }
+        composable<Route.Powiadomienia> {
+            PowiadomieniaScreen(
+                onBack = { navController.popBackStack() },
+            )
+        }
         composable<Route.Chat> { backStackEntry ->
             val chat = backStackEntry.toRoute<Route.Chat>()
             ChatScreen(
@@ -467,6 +474,7 @@ fun MainScreen(
     onNavigateToProfileView: (String) -> Unit,
     onNavigateToProfileEdit: () -> Unit,
     onNavigateToPrivacy: () -> Unit,
+    onNavigateToPowiadomienia: () -> Unit,
     onNavigateToSaved: () -> Unit,
     onNavigateToChat: (String, String?) -> Unit,
     onSignOut: () -> Unit,
@@ -552,6 +560,7 @@ fun MainScreen(
                             ProfileScreen(
                                 onNavigateToEdit = onNavigateToProfileEdit,
                                 onNavigateToPrivacy = onNavigateToPrivacy,
+                                onNavigateToPowiadomienia = onNavigateToPowiadomienia,
                                 onNavigateToSaved = onNavigateToSaved,
                                 onNavigateToProfileView = onNavigateToProfileView,
                                 onSignOut = onSignOut,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/Route.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/Route.kt
@@ -68,6 +68,8 @@ sealed interface Route {
 
     @Serializable data object Privacy : Route
 
+    @Serializable data object Powiadomienia : Route
+
     @Serializable data object Saved : Route
 
     @Serializable data class Chat(

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/api/ChatClient.kt
@@ -36,6 +36,7 @@ data class RoomSummary(
     val latestMessageSendStatus: EventSendStatus? = null,
     val latestMessageReadByCount: Int = 0,
     val isBlocked: Boolean = false,
+    val isMuted: Boolean = false,
     /** Bielik-Guard verdict for the latest message body, or null when unscanned / mine. */
     val latestModerationVerdict: String? = null,
     /** Categories that exceeded the flag threshold for the latest message. */

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -360,6 +360,7 @@ private fun WsConversationPayload.toRoomSummary(): RoomSummary =
         latestMessageIsMine = latestMessageIsMine,
         latestMessageSendStatus = if (latestMessage != null) EventSendStatus.Sent else null,
         isBlocked = isBlocked,
+        isMuted = muted,
         latestModerationVerdict = latestModerationVerdict,
         latestModerationCategories = latestModerationCategories,
     )

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsProtocol.kt
@@ -240,6 +240,7 @@ data class WsConversationPayload(
     val latestMessageIsMine: Boolean = false,
     val latestSenderName: String? = null,
     val isBlocked: Boolean = false,
+    val muted: Boolean = false,
     val latestModerationVerdict: String? = null,
     val latestModerationCategories: List<String> = emptyList(),
 )

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/SettingsRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/SettingsRepository.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.time.Clock
 
+@Suppress("TooManyFunctions")
 class SettingsRepository(
     private val db: PoziomkiDatabase,
     private val connectivityMonitor: ConnectivityMonitor,
@@ -31,6 +32,9 @@ class SettingsRepository(
             notifications_enabled = 1L,
             privacy_show_program = 1L,
             privacy_discoverable = 1L,
+            notify_dms = 1L,
+            notify_event_chats = 1L,
+            notify_tag_events = 1L,
             cached_at = Clock.System.now().toEpochMilliseconds(),
             is_dirty = 0L,
         )
@@ -43,6 +47,9 @@ class SettingsRepository(
             notifications_enabled = settings.notifications_enabled,
             privacy_show_program = settings.privacy_show_program,
             privacy_discoverable = settings.privacy_discoverable,
+            notify_dms = settings.notify_dms,
+            notify_event_chats = settings.notify_event_chats,
+            notify_tag_events = settings.notify_tag_events,
             cached_at = settings.cached_at,
             is_dirty = settings.is_dirty,
         )
@@ -109,6 +116,66 @@ class SettingsRepository(
                 ),
             )
             pendingOps.enqueue("update_settings", userId, json.encodeToString(UpdateSettingsRequest(notificationsEnabled = enabled)))
+        }
+    }
+
+    suspend fun updateNotifyDms(
+        userId: String,
+        enabled: Boolean,
+    ) {
+        withContext(Dispatchers.IO) {
+            val current = getOrCreateSettings(userId)
+            upsertSettings(
+                current.copy(
+                    notify_dms = if (enabled) 1L else 0L,
+                    is_dirty = 1L,
+                ),
+            )
+            pendingOps.enqueue(
+                "update_settings",
+                userId,
+                json.encodeToString(UpdateSettingsRequest(notifyDms = enabled)),
+            )
+        }
+    }
+
+    suspend fun updateNotifyEventChats(
+        userId: String,
+        enabled: Boolean,
+    ) {
+        withContext(Dispatchers.IO) {
+            val current = getOrCreateSettings(userId)
+            upsertSettings(
+                current.copy(
+                    notify_event_chats = if (enabled) 1L else 0L,
+                    is_dirty = 1L,
+                ),
+            )
+            pendingOps.enqueue(
+                "update_settings",
+                userId,
+                json.encodeToString(UpdateSettingsRequest(notifyEventChats = enabled)),
+            )
+        }
+    }
+
+    suspend fun updateNotifyTagEvents(
+        userId: String,
+        enabled: Boolean,
+    ) {
+        withContext(Dispatchers.IO) {
+            val current = getOrCreateSettings(userId)
+            upsertSettings(
+                current.copy(
+                    notify_tag_events = if (enabled) 1L else 0L,
+                    is_dirty = 1L,
+                ),
+            )
+            pendingOps.enqueue(
+                "update_settings",
+                userId,
+                json.encodeToString(UpdateSettingsRequest(notifyTagEvents = enabled)),
+            )
         }
     }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
@@ -283,6 +283,12 @@ class ApiService(
             ReportConversationRequest(reason = reason, description = description),
         )
 
+    suspend fun muteConversation(conversationId: String): ApiResult<SuccessResponse> =
+        client.post("/api/v1/chat/conversations/$conversationId/mute")
+
+    suspend fun unmuteConversation(conversationId: String): ApiResult<SuccessResponse> =
+        client.delete("/api/v1/chat/conversations/$conversationId/mute")
+
     // Audit a tap-to-reveal of a moderation-flagged chat message.
     @Suppress("ktlint:standard:function-signature")
     suspend fun revealChatMessage(messageId: String): ApiResult<SuccessResponse> =

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
@@ -476,6 +476,9 @@ data class UpdateSettingsRequest(
     val notificationsEnabled: Boolean? = null,
     val privacyShowProgram: Boolean? = null,
     val privacyDiscoverable: Boolean? = null,
+    val notifyDms: Boolean? = null,
+    val notifyEventChats: Boolean? = null,
+    val notifyTagEvents: Boolean? = null,
 )
 
 @Serializable
@@ -485,6 +488,9 @@ data class UserSettingsResponse(
     val notificationsEnabled: Boolean,
     val privacyShowProgram: Boolean,
     val privacyDiscoverable: Boolean,
+    val notifyDms: Boolean = true,
+    val notifyEventChats: Boolean = true,
+    val notifyTagEvents: Boolean = true,
 )
 
 // Routing models

--- a/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/UserSettings.sq
+++ b/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/UserSettings.sq
@@ -5,6 +5,9 @@ CREATE TABLE user_settings (
     notifications_enabled INTEGER NOT NULL DEFAULT 1,
     privacy_show_program INTEGER NOT NULL DEFAULT 1,
     privacy_discoverable INTEGER NOT NULL DEFAULT 1,
+    notify_dms INTEGER NOT NULL DEFAULT 1,
+    notify_event_chats INTEGER NOT NULL DEFAULT 1,
+    notify_tag_events INTEGER NOT NULL DEFAULT 1,
     cached_at INTEGER NOT NULL DEFAULT 0,
     is_dirty INTEGER NOT NULL DEFAULT 0
 );
@@ -18,8 +21,9 @@ upsert:
 INSERT OR REPLACE INTO user_settings(
     user_id, theme, language, notifications_enabled,
     privacy_show_program, privacy_discoverable,
+    notify_dms, notify_event_chats, notify_tag_events,
     cached_at, is_dirty
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 clearDirty:
 UPDATE user_settings SET is_dirty = 0 WHERE user_id = ?;

--- a/mobile/core/src/commonMain/sqldelight/migrations/14.sqm
+++ b/mobile/core/src/commonMain/sqldelight/migrations/14.sqm
@@ -1,0 +1,3 @@
+ALTER TABLE user_settings ADD COLUMN notify_dms INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE user_settings ADD COLUMN notify_event_chats INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE user_settings ADD COLUMN notify_tag_events INTEGER NOT NULL DEFAULT 1;


### PR DESCRIPTION
## What

New Profil → powiadomienia screen with a master switch and per-channel toggles (DMs / event chats / tag-driven events). Per-event mute lives in the chat header overflow.

All flags default ON so existing users see zero behavioural change. The "nowe wydarzenia w obserwowanych tagach" toggle ships with a "wkrótce" badge — the trigger lands in v2 (tag_follows table + event-create hook).

## Server-side gating

New SD helper `app.push_targets_filtered(user_ids, conversation_id)` joins `user_settings` and `conversation_mutes` to filter out recipients whose channel is off or who muted the conversation. Called from `send_wake` before resolving FCM tokens. Conversation kind drives which channel flag applies (`dm` vs `event`).

## Mute state plumbing

`muted: bool` rides on `ConversationPayload` end-to-end: server fills it from a batch query against `conversation_mutes`, mobile pipes it through `WsConversationPayload` → `RoomSummary.isMuted` → `ChatUiState.isMuted`. `toggleMute()` calls `chatClient.refreshRooms()` after a successful POST/DELETE so the rooms list reflects the new state immediately. Reopening a muted chat renders the right icon on first frame.

## Test plan
- [ ] `cargo test --lib push::fcm` + `cargo test rls_baseline`
- [ ] Install debug APK, toggle "Czaty wydarzeń" off, confirm no notification from event chat post
- [ ] Toggle mute on a specific event chat, confirm only that chat is silenced
- [ ] Close + reopen the muted chat — icon stays in muted state
- [ ] Master off → no notifications regardless of other state

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-conversation mute and per-channel notification preferences to chat
> - Adds `POST`/`DELETE /api/v1/chat/conversations/{id}/mute` endpoints backed by a new `conversation_mutes` table with RLS restricting access to own rows.
> - Adds `notify_dms`, `notify_event_chats`, and `notify_tag_events` boolean columns to `user_settings` (default `true`), exposed via the settings API and a new mobile notifications settings screen (`PowiadomieniaScreen`).
> - Filters FCM wake push targets through a new `app.push_targets_filtered` Postgres `SECURITY DEFINER` function that applies the master switch, per-channel flags, and per-conversation mutes before sending.
> - Conversation list payloads now include a `muted` boolean; the chat top bar gains a Bell/BellSlash toggle with optimistic UI and server sync.
> - Behavioral Change: push notifications are now suppressed for users who have muted a conversation or disabled the relevant per-channel preference; previously all members received pushes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62409e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->