### PR TITLE
perf: defer non-critical init off Application.onCreate

### DIFF
--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -15,13 +15,21 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.poziomki.app.chat.push.NotificationChatTarget
+import com.poziomki.app.chat.push.NotificationHelper
+import com.poziomki.app.chat.push.PushManager
 import com.poziomki.app.session.AppPreferences
+import com.poziomki.app.ui.cache.AppUpdateMigrator
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
     private val appPreferences: AppPreferences by inject()
+    private val notificationHelper: NotificationHelper by inject()
+    private val pushManager: PushManager by inject()
+    private val appUpdateMigrator: AppUpdateMigrator by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -65,6 +73,18 @@ class MainActivity : ComponentActivity() {
                 @Suppress("TooGenericExceptionCaught") t: Throwable,
             ) {
                 android.util.Log.e("MainActivity", "screenshotsAllowed observer crashed", t)
+            }
+        }
+        lifecycleScope.launch {
+            try {
+                withContext(Dispatchers.Default) { notificationHelper.createChannels() }
+                // PushManager observes caches the migrator may wipe — wait for readiness.
+                appUpdateMigrator.ready.await()
+                pushManager.startObserving()
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                android.util.Log.e("MainActivity", "deferred init failed", t)
             }
         }
         if (savedInstanceState == null) {

--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/PoziomkiApp.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/PoziomkiApp.kt
@@ -4,8 +4,6 @@ import android.app.Application
 import android.content.ComponentCallbacks2
 import coil3.imageLoader
 import com.poziomki.app.cache.ImageCacheCleaner
-import com.poziomki.app.chat.push.NotificationHelper
-import com.poziomki.app.chat.push.PushManager
 import com.poziomki.app.di.appModule
 import com.poziomki.app.di.platformModule
 import com.poziomki.app.di.sharedModule
@@ -13,7 +11,6 @@ import com.poziomki.app.ui.cache.AndroidImageCacheCleaner
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
-import org.koin.java.KoinJavaComponent.getKoin
 
 class PoziomkiApp : Application() {
     override fun onCreate() {
@@ -36,12 +33,6 @@ class PoziomkiApp : Application() {
                 },
             )
         }
-
-        getKoin().get<NotificationHelper>().createChannels()
-        // Note: PushManager.startObserving and other DataStore/SQL consumers
-        // are gated by AppUpdateMigrator.ready inside App.kt — the migrator
-        // must finish before anything writes to the caches it might wipe.
-        getKoin().get<PushManager>().startObserving()
     }
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
Moves notification-channel creation and push observer startup out of Application.onCreate
to MainActivity after first frame, reducing cold-start blocking work.

- NotificationHelper.createChannels runs on Dispatchers.Default after RESUMED
- PushManager.startObserving runs after AppUpdateMigrator readiness (same ordering as before)
- Application.onCreate only retains Koin init (required before Activity)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer notification channel setup and push manager init off `Application.onCreate`
> - Moves `notificationHelper.createChannels()` and `pushManager.startObserving()` out of `PoziomkiApp.onCreate` and into a `lifecycleScope.launch` block in `MainActivity.onCreate`.
> - Channel creation runs on `Dispatchers.Default`; push manager observation starts only after `appUpdateMigrator.ready` resolves.
> - Errors are caught and logged under the `"MainActivity"` tag rather than crashing the app.
> - Behavioral Change: these side effects now run during activity lifecycle instead of application startup, so they are deferred until the first activity is created.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 728228c. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->