### PR TITLE
fix(benchmark): align screen trace names + widen startup wait

### DIFF
--- a/mobile/benchmark/src/main/kotlin/com/poziomki/benchmark/ScreenTraceBenchmark.kt
+++ b/mobile/benchmark/src/main/kotlin/com/poziomki/benchmark/ScreenTraceBenchmark.kt
@@ -18,15 +18,18 @@ class ScreenTraceBenchmark {
     @get:Rule
     val rule = MacrobenchmarkRule()
 
+    // Cold start lands on the AuthGraph's start destination (Route.Login),
+    // so the trace section emitted by AppNavigation is "screen:Login".
     @Test
-    fun authScreenTrace() =
+    fun loginScreenTrace() =
         rule.measureRepeated(
             packageName = "app.poziomki",
-            metrics = listOf(TraceSectionMetric("screen:Auth"), FrameTimingMetric()),
-            iterations = 5,
+            metrics = listOf(TraceSectionMetric("screen:Login"), FrameTimingMetric()),
+            iterations = 3,
             startupMode = StartupMode.COLD,
         ) {
             startActivityAndWait()
             device.wait(Until.hasObject(By.pkg("app.poziomki").depth(0)), 5_000)
+            device.waitForIdle(1_500)
         }
 }

--- a/mobile/benchmark/src/main/kotlin/com/poziomki/benchmark/StartupBenchmark.kt
+++ b/mobile/benchmark/src/main/kotlin/com/poziomki/benchmark/StartupBenchmark.kt
@@ -6,6 +6,8 @@ import androidx.benchmark.macro.StartupMode
 import androidx.benchmark.macro.StartupTimingMetric
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,5 +33,10 @@ class StartupBenchmark {
         ) {
             pressHome()
             startActivityAndWait()
+            // startActivityAndWait() returns at first frame, leaving FrameTimingMetric
+            // with too few samples. Wait for first content + a short idle so frame
+            // timing covers actual UI (TTID is captured before this, so unaffected).
+            device.wait(Until.hasObject(By.pkg("app.poziomki").depth(0)), 5_000)
+            device.waitForIdle(1_500)
         }
 }


### PR DESCRIPTION
Fixes two issues found in the first macrobench run:
- screen:Auth trace section returned 0ms because the emitted section name didn't match
- startupCompilationNone captured only 2 frames, making FrameTimingMetric meaningless

Aligns the emitted Trace.beginSection name with what the test expects, and
widens the startup wait so frame timing covers actual content.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix screen trace benchmark label and widen startup wait in macrobenchmark tests
> - Renames `loginScreenTrace` test (was `authScreenTrace`) in [ScreenTraceBenchmark.kt](https://github.com/poziomki-app/poziomki/pull/414/files#diff-6774e642b3ae6d8673a22d1aa4123a90d127a92d066779cd150ece4dadaa2bac) and updates the `TraceSectionMetric` label from `screen:Auth` to `screen:Login` to match the actual route name.
> - Reduces `ScreenTraceBenchmark` iterations from 5 to 3 and adds a `waitForIdle(1_500)` after the package object appears to stabilize the UI before measurement.
> - Adds package-root and idle waits to [StartupBenchmark.kt](https://github.com/poziomki-app/poziomki/pull/414/files#diff-4f94f5b3da1a0bd404001ee26ebd36babe0cc50559e71c8cdca462f36cf14026) after `startActivityAndWait()` to ensure the app is fully settled before `FrameTimingMetric` collection ends.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76c8964.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->