### PR TITLE
perf(matching): cache tag-parent map with 60s TTL

### DIFF
--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -205,7 +205,7 @@ pub(super) async fn events_recommendations(
                     .iter()
                     .copied()
                     .map(|tag_id| (tag_id, 1.0)),
-                &tag_parent_map,
+                tag_parent_map.as_ref(),
             );
 
             let saved_event_ids: Vec<Uuid> = user_ctx.saved_event_ids.iter().copied().collect();
@@ -231,7 +231,7 @@ pub(super) async fn events_recommendations(
                         tags.iter().copied().map(move |tag_id| (tag_id, weight))
                     })
                 }),
-                &tag_parent_map,
+                tag_parent_map.as_ref(),
             );
 
             let user_geo = query.lat.zip(query.lng).map(|(lat, lng)| {
@@ -253,7 +253,7 @@ pub(super) async fn events_recommendations(
                         &event_tag_ids,
                         event,
                         user_geo,
-                        &tag_parent_map,
+                        tag_parent_map.as_ref(),
                     );
                     (s, event)
                 })

--- a/backend/src/api/matching/repo.rs
+++ b/backend/src/api/matching/repo.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
@@ -341,14 +343,53 @@ impl MatchingRepository {
     pub(super) async fn load_tag_parent_map(
         &self,
         conn: &mut diesel_async::AsyncPgConnection,
-    ) -> std::result::Result<HashMap<Uuid, Option<Uuid>>, crate::error::AppError> {
-        Ok(tags::table
+    ) -> std::result::Result<Arc<HashMap<Uuid, Option<Uuid>>>, crate::error::AppError> {
+        if let Some(map) = cached_tag_parent_map() {
+            return Ok(map);
+        }
+        let map: HashMap<Uuid, Option<Uuid>> = tags::table
             .select((tags::id, tags::parent_id))
             .load::<(Uuid, Option<Uuid>)>(conn)
             .await?
             .into_iter()
-            .collect())
+            .collect();
+        Ok(store_tag_parent_map(map))
     }
+}
+
+const TAG_PARENT_MAP_TTL: Duration = Duration::from_secs(60);
+
+struct TagParentMapCache {
+    map: Arc<HashMap<Uuid, Option<Uuid>>>,
+    refreshed_at: Instant,
+}
+
+fn cache_slot() -> &'static RwLock<Option<TagParentMapCache>> {
+    static CACHE: OnceLock<RwLock<Option<TagParentMapCache>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(None))
+}
+
+fn cached_tag_parent_map() -> Option<Arc<HashMap<Uuid, Option<Uuid>>>> {
+    let guard = cache_slot().read().ok()?;
+    let entry = guard.as_ref()?;
+    if entry.refreshed_at.elapsed() < TAG_PARENT_MAP_TTL {
+        let map = Arc::clone(&entry.map);
+        drop(guard);
+        Some(map)
+    } else {
+        None
+    }
+}
+
+fn store_tag_parent_map(map: HashMap<Uuid, Option<Uuid>>) -> Arc<HashMap<Uuid, Option<Uuid>>> {
+    let arc = Arc::new(map);
+    if let Ok(mut guard) = cache_slot().write() {
+        *guard = Some(TagParentMapCache {
+            map: Arc::clone(&arc),
+            refreshed_at: Instant::now(),
+        });
+    }
+    arc
 }
 
 fn scope_from_str(s: &str) -> TagScope {


### PR DESCRIPTION
Every `/api/v1/matching/events` request was hitting `SELECT * FROM tags` via `load_tag_parent_map`. Profiling counted 170k of these in 14 minutes. Cache the map for 60 s process-wide.

## Test plan
- [x] `cargo test -p poziomki-backend --lib api::matching::` — 11/11 pass
- [ ] Reset pg_stat_statements, hit `/matching/events` 50× with same auth, confirm tags SELECT count ≤ 1 per 60s window
- [ ] Existing affinity tests still pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache tag-parent map in `MatchingRepository.load_tag_parent_map` with a 60s TTL
> Adds an in-process read-through cache for the tag-parent map used during event matching. On a cache hit (within 60 seconds), the database query is skipped and the cached `Arc<HashMap<Uuid, Option<Uuid>>>` is returned directly. The cache is stored in a static `OnceLock<RwLock<Option<TagParentMapCache>>>` and the return type of `load_tag_parent_map` now wraps the map in an `Arc`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22c5947.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->