### PR TITLE
perf(auth): cache /auth/get-session through the auth cache

### DIFF
--- a/backend/src/api/auth/session.rs
+++ b/backend/src/api/auth/session.rs
@@ -9,8 +9,8 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::{AsyncConnection, RunQueryDsl};
 
 use super::super::state::{
-    extract_bearer_token, hash_session_token, session_model_to_view, user_model_to_view,
-    SessionResponse,
+    cache_auth_get, cache_auth_put, extract_bearer_token, hash_session_token,
+    session_model_to_view, user_model_to_view, SessionResponse,
 };
 use crate::db::models::sessions::Session;
 use crate::db::models::users::User;
@@ -33,14 +33,21 @@ async fn resolve_session_and_user(
     };
     let hashed = hash_session_token(&token);
 
+    // Fast path: in-process auth cache (15s TTL). Misses fall through to the
+    // SECURITY DEFINER session resolve below and re-populate the cache.
+    if let Some((session, user)) = cache_auth_get(&hashed).await {
+        return Ok(Some((session, user)));
+    }
+
     // Single transaction: SECURITY DEFINER session resolution, then viewer
     // context, then the User SELECT under that context. Matches the pattern
     // used by the require_auth_context middleware so both stay RLS-ready.
     let mut conn = crate::db::conn().await?;
+    let hashed_for_tx = hashed.clone();
     let result = conn
         .transaction::<Option<(Session, User)>, diesel::result::Error, _>(|conn| {
             async move {
-                let Some(row) = db::resolve_session(conn, &hashed).await? else {
+                let Some(row) = db::resolve_session(conn, &hashed_for_tx).await? else {
                     return Ok(None);
                 };
                 if row.expires_at <= Utc::now() {
@@ -74,6 +81,9 @@ async fn resolve_session_and_user(
             .scope_boxed()
         })
         .await?;
+    if let Some((session, user)) = &result {
+        cache_auth_put(hashed, session, user).await;
+    }
     Ok(result)
 }
 

--- a/backend/src/api/state/auth.rs
+++ b/backend/src/api/state/auth.rs
@@ -107,7 +107,7 @@ fn auth_cache_ttl() -> Duration {
     })
 }
 
-async fn cache_auth_get(hashed_token: &str) -> Option<(Session, User)> {
+pub(in crate::api) async fn cache_auth_get(hashed_token: &str) -> Option<(Session, User)> {
     let now = Utc::now();
     let cached = {
         let guard = auth_cache().read().await;
@@ -124,7 +124,7 @@ async fn cache_auth_get(hashed_token: &str) -> Option<(Session, User)> {
     Some((entry.session, entry.user))
 }
 
-async fn cache_auth_put(hashed_token: String, session: &Session, user: &User) {
+pub(in crate::api) async fn cache_auth_put(hashed_token: String, session: &Session, user: &User) {
     let now = Utc::now();
     let ttl_until = now + auth_cache_ttl();
     let cached_until = if session.expires_at < ttl_until {


### PR DESCRIPTION
`get_session` bypassed the existing 15s in-process auth cache and hit `db::resolve_session` on every request. Mobile clients call this on every cold-start, so profiling counted 34k `resolve_session` calls in 14 minutes.

## Test plan
- [x] `cargo test -p poziomki-backend --lib api::auth` passes
- [ ] Reset pg_stat_statements, hit `/auth/get-session` 10× with valid bearer, confirm `app.resolve_session` call count = 1
- [ ] Mobile sign-in flow unchanged

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache `/auth/get-session` responses via in-process auth cache
> Adds a fast-path cache lookup in `resolve_session_and_user` using the hashed bearer token as the key. On a cache hit, the function returns the cached `(Session, User)` without executing the DB transaction. On a miss, the existing SECURITY DEFINER session resolution runs and the result is written to the cache.
>
> - `cache_auth_get` and `cache_auth_put` in [`state/auth.rs`](https://github.com/poziomki-app/poziomki/pull/417/files#diff-a95455a48400299e8e3618ecf6c66b8d7f3468741a4249921a2e088a64dec42b) are widened from private to `pub(in crate::api)` to allow access from the session module.
> - Behavioral Change: auth session resolution now bypasses the DB on repeated requests with the same bearer token until the cache entry expires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b651de2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->