### PR TITLE
ops(db): warn on boot if postgres max_connections drifts below 60

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -221,7 +221,51 @@ async fn assert_pool_role(role: PoolRole) -> crate::error::AppResult<()> {
         )));
     }
     tracing::info!(db_user = %row.current_user, "pool role verified");
+    assert_pg_max_connections(&mut conn).await;
     Ok(())
+}
+
+// Pgdog is sized for 20 connections per role × 3 roles = 60. If postgres
+// `max_connections` drifts below that (e.g. an old ALTER SYSTEM override in
+// `postgresql.auto.conf` that survives a conf-file bump), pgdog can't realize
+// its configured pool and the API silently runs with a tighter cap. Profiling
+// in 2026-05 caught a 30-vs-60 drift this way. Warn loudly on boot so it's
+// visible in logs without failing startup.
+#[derive(diesel::deserialize::QueryableByName)]
+struct MaxConnectionsRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    setting: String,
+}
+
+const PG_MIN_MAX_CONNECTIONS: i32 = 60;
+
+async fn assert_pg_max_connections(conn: &mut crate::db::DbConn) {
+    use diesel_async::RunQueryDsl;
+
+    let row: Result<MaxConnectionsRow, _> =
+        diesel::sql_query("SELECT setting FROM pg_settings WHERE name = 'max_connections'")
+            .get_result(conn)
+            .await;
+    match row.map(|r| r.setting.parse::<i32>()) {
+        Ok(Ok(value)) if value < PG_MIN_MAX_CONNECTIONS => {
+            tracing::warn!(
+                max_connections = value,
+                expected_min = PG_MIN_MAX_CONNECTIONS,
+                "postgres max_connections below pgdog pool ceiling — \
+                 pool will be capped below configured size; check \
+                 postgresql.auto.conf for an ALTER SYSTEM override"
+            );
+        }
+        Ok(Ok(value)) => {
+            tracing::info!(max_connections = value, "postgres max_connections verified");
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(%error, "could not parse max_connections setting");
+        }
+        Err(error) => {
+            tracing::warn!(%error, "max_connections probe failed");
+        }
+    }
 }
 
 fn build_app_context(role: PoolRole) -> crate::error::AppResult<AppContext> {


### PR DESCRIPTION
Pgdog is sized for 60 connections; profiling caught a runtime drift to 30 caused by an ALTER SYSTEM override in postgresql.auto.conf outliving a postgresql.conf bump. Log a warn at API/worker boot so future drift is visible.

## Test plan
- [ ] On healthy prod: log line `postgres max_connections verified` with value 60
- [ ] Force-drift via `ALTER SYSTEM SET max_connections = 30` + restart, confirm warn line appears
- [ ] Restore via `ALTER SYSTEM RESET max_connections` + restart

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn on boot if PostgreSQL `max_connections` drops below 60
> Adds `assert_pg_max_connections` in [app.rs](https://github.com/poziomki-app/poziomki/pull/419/files#diff-b702b9211732f0e35064d2bc6290fe5f2f607f79ce8acc6c8caa211fa89d2b1c), called during `assert_pool_role` at startup. It queries `pg_settings` for `max_connections`, parses the value, and logs a warning if it falls below the `PG_MIN_MAX_CONNECTIONS` threshold of 60. Errors during query or parse also emit warnings. The check never affects the return value or control flow of `assert_pool_role`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 579935e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->