### PR TITLE
ci(mobile): stub google-services.json for PR builds

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -35,6 +35,9 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
+      - name: Stub google-services.json for CI
+        run: cp androidApp/google-services.json.sample androidApp/google-services.json
+
       - run: ./gradlew :androidApp:assembleDebug
 
       # Upload debug APK on PR runs so the trusted pr-apk-comment workflow


### PR DESCRIPTION
Unblocks the `build` job that fails on every PR with `File google-services.json is missing`.

Copies the existing `.sample` in CI before `assembleDebug`. The file is gitignored so real Firebase config still has to be dropped in locally for production builds.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stub `google-services.json` for Android PR builds in CI
> The Android build was failing in CI because `androidApp/google-services.json` is not checked in. The build step in [mobile.yml](.github/workflows/mobile.yml) now copies `google-services.json.sample` to `google-services.json` before running `:androidApp:assembleDebug`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2881411.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->