### PR TITLE
ci: ignore RUSTSEC-2026-0138 (mysql-only, we use postgres)

### DIFF
--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -22,6 +22,13 @@ ignore = [
     # path. Re-evaluate when tokenizers or macro_rules_attribute migrates
     # off paste (likely to `pastey`).
     "RUSTSEC-2024-0436",
+    # RUSTSEC-2026-0138: diesel-async 0.8 unsoundness when serializing
+    # date/time values via the **Mysql** backend (cast over a `#[repr(C)]`
+    # struct exposes padding bytes). We only enable the Postgres backend
+    # (`diesel-async = { features = ["postgres", "deadpool"] }`), so the
+    # affected code path is not compiled. Drop this ignore when we bump
+    # diesel-async to >=0.9.
+    "RUSTSEC-2026-0138",
 ]
 
 [licenses]


### PR DESCRIPTION
diesel-async 0.8 unsoundness only affects the Mysql backend; we compile with `postgres` feature only, so the vulnerable code path isn't in our binary. Unblocks all PR CI.

Will revisit alongside a proper bump to diesel-async 0.9.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore RUSTSEC-2026-0138 in cargo-deny config for diesel-async Mysql unsoundness
> Adds `RUSTSEC-2026-0138` to the ignore list in [deny.toml](https://github.com/poziomki-app/poziomki/pull/421/files#diff-69d451b15b98b99acc2765158eecfbfd80089037eb487d1cdba9b2f1062eb982). The advisory covers a diesel-async 0.8 unsoundness issue specific to the Mysql backend, which is not enabled in this project (only Postgres is used). The ignore will be removed after upgrading to diesel-async >=0.9.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f53da67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->