### PR TITLE
fix(rls): let viewer SELECT own profile so INSERT...RETURNING works

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2059,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -62,7 +62,7 @@ url = { version = "=2.5.8" }
 dashmap = { version = "6" }
 futures-util = { version = "0.3" }
 subtle = { version = "2" }
-lettre = { version = "=0.11.21", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder", "dkim"] }
+lettre = { version = "=0.11.22", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder", "dkim"] }
 hickory-resolver = { version = "0.26", features = ["tokio"] }
 image = { version = "=0.25.10", default-features = false, features = ["jpeg", "png", "webp"] }
 fast_image_resize = "=6.0.0"

--- a/backend/migrations/2026-05-16-200000_profiles_select_policy_own/down.sql
+++ b/backend/migrations/2026-05-16-200000_profiles_select_policy_own/down.sql
@@ -1,0 +1,4 @@
+DROP POLICY profiles_viewer ON public.profiles;
+CREATE POLICY profiles_viewer ON public.profiles
+    FOR SELECT TO poziomki_api
+    USING (id IN (SELECT id FROM app.profiles_in_current_bucket()));

--- a/backend/migrations/2026-05-16-200000_profiles_select_policy_own/up.sql
+++ b/backend/migrations/2026-05-16-200000_profiles_select_policy_own/up.sql
@@ -1,0 +1,16 @@
+-- Allow the viewer to SELECT their own profile rows directly, in addition to
+-- bucket reads. The previous policy went solely through
+-- `app.profiles_in_current_bucket()`, which is STABLE and therefore evaluates
+-- against the statement's pre-INSERT snapshot. That broke `INSERT ... RETURNING`
+-- on the very first profile a user creates: the new row passed the INSERT
+-- WITH CHECK but couldn't be seen by the implicit SELECT used to populate
+-- RETURNING, so onboarding "create profile" failed with a misleading
+-- "new row violates row-level security policy" error.
+
+DROP POLICY profiles_viewer ON public.profiles;
+CREATE POLICY profiles_viewer ON public.profiles
+    FOR SELECT TO poziomki_api
+    USING (
+        user_id = app.current_user_id()
+        OR id IN (SELECT id FROM app.profiles_in_current_bucket())
+    );


### PR DESCRIPTION
Onboarding "create profile" was failing with `Coś poszło nie tak`. Backend returns 500 because `INSERT INTO profiles ... RETURNING id` hits the SELECT policy on the new row before it's visible to the STABLE bucket function.

Adds `user_id = app.current_user_id()` to the SELECT policy. Security-equivalent (owner already saw their own row via the bucket).

- [ ] migration applies on staging
- [ ] new account onboarding succeeds end-to-end

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLS policy on `public.profiles` to allow viewers to SELECT their own profile
> The `profiles_viewer` RLS policy previously only allowed `poziomki_api` to SELECT rows in `public.profiles` returned by `app.profiles_in_current_bucket()`. This excluded the current user's own profile, causing `INSERT...RETURNING` to fail. The updated policy adds an `OR user_id = app.current_user_id()` condition so a user can always read back their own profile row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b2e564.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->