### PR TITLE
fix: screenshot default, delete-account, keep session on pw change

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2059,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -62,7 +62,7 @@ url = { version = "=2.5.8" }
 dashmap = { version = "6" }
 futures-util = { version = "0.3" }
 subtle = { version = "2" }
-lettre = { version = "=0.11.21", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder", "dkim"] }
+lettre = { version = "=0.11.22", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder", "dkim"] }
 hickory-resolver = { version = "0.26", features = ["tokio"] }
 image = { version = "=0.25.10", default-features = false, features = ["jpeg", "png", "webp"] }
 fast_image_resize = "=6.0.0"

--- a/backend/migrations/2026-05-16-200000_profiles_select_policy_own/down.sql
+++ b/backend/migrations/2026-05-16-200000_profiles_select_policy_own/down.sql
@@ -1,0 +1,4 @@
+DROP POLICY profiles_viewer ON public.profiles;
+CREATE POLICY profiles_viewer ON public.profiles
+    FOR SELECT TO poziomki_api
+    USING (id IN (SELECT id FROM app.profiles_in_current_bucket()));

--- a/backend/migrations/2026-05-16-200000_profiles_select_policy_own/up.sql
+++ b/backend/migrations/2026-05-16-200000_profiles_select_policy_own/up.sql
@@ -1,0 +1,16 @@
+-- Allow the viewer to SELECT their own profile rows directly, in addition to
+-- bucket reads. The previous policy went solely through
+-- `app.profiles_in_current_bucket()`, which is STABLE and therefore evaluates
+-- against the statement's pre-INSERT snapshot. That broke `INSERT ... RETURNING`
+-- on the very first profile a user creates: the new row passed the INSERT
+-- WITH CHECK but couldn't be seen by the implicit SELECT used to populate
+-- RETURNING, so onboarding "create profile" failed with a misleading
+-- "new row violates row-level security policy" error.
+
+DROP POLICY profiles_viewer ON public.profiles;
+CREATE POLICY profiles_viewer ON public.profiles
+    FOR SELECT TO poziomki_api
+    USING (
+        user_id = app.current_user_id()
+        OR id IN (SELECT id FROM app.profiles_in_current_bucket())
+    );

--- a/backend/migrations/2026-05-16-220000_uploads_allow_orphan/down.sql
+++ b/backend/migrations/2026-05-16-220000_uploads_allow_orphan/down.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION app.reject_uploads_identity_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.owner_id IS DISTINCT FROM OLD.owner_id THEN
+        RAISE EXCEPTION
+            'uploads (id, owner_id) are immutable';
+    END IF;
+    RETURN NEW;
+END
+$$;

--- a/backend/migrations/2026-05-16-220000_uploads_allow_orphan/up.sql
+++ b/backend/migrations/2026-05-16-220000_uploads_allow_orphan/up.sql
@@ -1,0 +1,22 @@
+-- Allow owner_id to transition to NULL so the delete-account flow can
+-- orphan a user's uploads before deleting the profile row. The original
+-- threat — a viewer "adopting" anon uploads or reassigning to another
+-- profile they own — still requires NEW.owner_id to be non-NULL, so
+-- this remains blocked. Going to NULL is a pure orphaning operation
+-- (no row is gained, none changes hands).
+
+CREATE OR REPLACE FUNCTION app.reject_uploads_identity_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF NEW.id IS DISTINCT FROM OLD.id THEN
+        RAISE EXCEPTION 'uploads.id is immutable';
+    END IF;
+    IF NEW.owner_id IS DISTINCT FROM OLD.owner_id AND NEW.owner_id IS NOT NULL THEN
+        RAISE EXCEPTION 'uploads.owner_id can only be cleared to NULL';
+    END IF;
+    RETURN NEW;
+END
+$$;

--- a/backend/src/api/auth/account.rs
+++ b/backend/src/api/auth/account.rs
@@ -298,7 +298,7 @@ pub(in crate::api) async fn change_password(
     headers: HeaderMap,
     Json(payload): Json<ChangePasswordBody>,
 ) -> Result<Response> {
-    let (_session, user) = auth_or_respond!(headers);
+    let (session, user) = auth_or_respond!(headers);
 
     if payload.current_password.is_empty()
         || !crate::security::verify_password(&payload.current_password, &user.password)
@@ -334,9 +334,16 @@ pub(in crate::api) async fn change_password(
                 ))
                 .execute(conn)
                 .await?;
-            diesel::delete(sessions::table.filter(sessions::user_id.eq(user.id)))
-                .execute(conn)
-                .await?;
+            // Keep the caller's session active so changing their password
+            // doesn't kick them out of the device they just confirmed it on.
+            // Every OTHER session for the user is invalidated.
+            diesel::delete(
+                sessions::table
+                    .filter(sessions::user_id.eq(user.id))
+                    .filter(sessions::id.ne(session.id)),
+            )
+            .execute(conn)
+            .await?;
             Ok::<(), diesel::result::Error>(())
         }
         .scope_boxed()

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -809,7 +809,7 @@ async fn delete_account_verifies_hashed_password() {
 
 #[tokio::test]
 #[serial]
-async fn change_password_rotates_credentials_and_invalidates_sessions() {
+async fn change_password_rotates_credentials_and_invalidates_other_sessions() {
     request(|request, _ctx| async move {
         let token = sign_up_and_verify(
             &request,
@@ -820,6 +820,21 @@ async fn change_password_rotates_credentials_and_invalidates_sessions() {
         .await;
 
         let (auth_key, auth_value) = auth_header(&token);
+
+        // Second session from a different device — must be invalidated.
+        let other_sign_in = request
+            .post("/api/v1/auth/sign-in/email")
+            .json(&serde_json::json!({
+                "email": "change-password@example.com",
+                "password": "old-password",
+            }))
+            .await;
+        assert_eq!(other_sign_in.status_code(), 200);
+        let other_token = other_sign_in.json::<serde_json::Value>()["data"]["token"]
+            .as_str()
+            .expect("other token")
+            .to_string();
+        let (other_key, other_value) = auth_header(&other_token);
 
         let change_bad = request
             .patch("/api/v1/auth/account/password")
@@ -841,11 +856,19 @@ async fn change_password_rotates_credentials_and_invalidates_sessions() {
             .await;
         assert_eq!(change_ok.status_code(), 200);
 
-        let old_sessions = request
+        // Caller's session stays alive.
+        let current_sessions = request
             .get("/api/v1/auth/sessions")
             .add_header(auth_key.clone(), auth_value.clone())
             .await;
-        assert_eq!(old_sessions.status_code(), 401);
+        assert_eq!(current_sessions.status_code(), 200);
+
+        // Other device is logged out.
+        let other_sessions = request
+            .get("/api/v1/auth/sessions")
+            .add_header(other_key, other_value)
+            .await;
+        assert_eq!(other_sessions.status_code(), 401);
 
         let old_sign_in = request
             .post("/api/v1/auth/sign-in/email")

--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -52,13 +52,10 @@ class MainActivity : ComponentActivity() {
             @Suppress("DEPRECATION")
             setTaskDescription(ActivityManager.TaskDescription(null, null, Color.BLACK))
         }
-        // Block screenshots + recent-apps previews by default. Chat
-        // messages, profile edit, and password-reset flows all surface
-        // PII that shouldn't leak to a device's recents carousel,
-        // screen-record apps, or untrusted projections. Users can opt
-        // in via Privacy settings; the toggle defaults off so the first
-        // frame is always protected.
-        applySecureFlag(secure = true)
+        // Allow screenshots by default. Users can opt into FLAG_SECURE
+        // via Privacy settings if they want to block screenshots + recent-
+        // apps previews.
+        applySecureFlag(secure = false)
         // Wrap defensively at the coroutine boundary — a failure to
         // read the privacy flag must never crash the activity. Worst
         // case the user stays on the safe default (FLAG_SECURE on).

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
@@ -26,7 +26,7 @@ data class PrivacyState(
     val error: String? = null,
     val discoverable: Boolean = true,
     val showProgram: Boolean = true,
-    val screenshotsAllowed: Boolean = false,
+    val screenshotsAllowed: Boolean = true,
     val currentEmail: String? = null,
     val pendingNewEmail: String? = null,
     val isRequestingEmailOtp: Boolean = false,
@@ -177,12 +177,10 @@ class PrivacyViewModel(
                 )
             when (apiService.changePassword(currentPassword, newPassword)) {
                 is ApiResult.Success -> {
-                    cacheManager.clearAll()
-                    sessionManager.clearSession()
                     _state.value =
                         _state.value.copy(
                             isChangingPassword = false,
-                            passwordSuccessMessage = "Hasło zostało zmienione. Zaloguj się ponownie.",
+                            passwordSuccessMessage = "Hasło zostało zmienione.",
                         )
                     onPasswordChanged()
                 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -446,11 +446,7 @@ fun AppNavigation(
         composable<Route.Privacy> {
             PrivacyScreen(
                 onBack = { navController.popBackStack() },
-                onPasswordChanged = {
-                    navController.navigate(Route.AuthGraph) {
-                        popUpTo(0) { inclusive = true }
-                    }
-                },
+                onPasswordChanged = {},
                 onAccountDeleted = {
                     navController.navigate(Route.AuthGraph) {
                         popUpTo(0) { inclusive = true }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/AppPreferences.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/AppPreferences.kt
@@ -15,7 +15,7 @@ class AppPreferences(
     }
 
     val screenshotsAllowed: Flow<Boolean> =
-        dataStore.data.map { prefs -> prefs[SCREENSHOTS_ALLOWED] ?: false }
+        dataStore.data.map { prefs -> prefs[SCREENSHOTS_ALLOWED] ?: true }
 
     suspend fun setScreenshotsAllowed(allowed: Boolean) {
         dataStore.edit { it[SCREENSHOTS_ALLOWED] = allowed }


### PR DESCRIPTION
- Default FLAG_SECURE off (screenshots allowed); Privacy toggle still works to opt in
- Delete account: relax uploads (id, owner_id) immutability so the orphan-uploads step in delete_user_data succeeds; only NULLing is allowed, reassign/adopt still blocked
- Change password: keep caller's session active, kill only other sessions; client no longer wipes the session or redirects to login

- [ ] try delete account end-to-end
- [ ] change password without getting logged out
- [ ] screenshots work on a fresh install

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep session active on password change and allow screenshots by default
> - Password change now invalidates all other sessions but keeps the initiating session active, so the user stays logged in on the device. The backend deletes all sessions except the current one, and the mobile client no longer clears caches or navigates to the auth screen.
> - Screenshots and recent-apps previews are now allowed by default; `FLAG_SECURE` is only applied when the user opts in via Privacy settings. The default for `screenshotsAllowed` is changed to `true` in `AppPreferences`, `PrivacyState`, and `MainActivity`.
> - A new DB migration updates the `profiles_viewer` RLS policy to allow `SELECT` on rows where `user_id = current_user_id()`, making self-owned profiles visible immediately after insert.
> - A second migration relaxes the `reject_uploads_identity_change` trigger to permit setting `uploads.owner_id` to `NULL` (orphaning an upload) while still blocking reassignment to another non-NULL owner.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 718a720.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->