### PR TITLE
fix(auth): wrong password on delete/change doesn't log out

### DIFF
--- a/backend/src/api/auth/account.rs
+++ b/backend/src/api/auth/account.rs
@@ -11,14 +11,29 @@ use diesel::prelude::*;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::RunQueryDsl;
 
-use crate::api::{auth_or_respond, error_response};
+use crate::api::{auth_or_respond, error_response, ErrorSpec};
 
 use super::super::state::{
     invalidate_auth_cache_for_user_id, ChangePasswordBody, DataResponse, DeleteAccountBody,
     SuccessResponse,
 };
-use super::auth_service::unauthorized_error;
 type Result<T> = crate::error::AppResult<T>;
+
+/// Password re-verification failed on a session-authenticated endpoint
+/// (change password, delete account). Returns 403 rather than 401 so the
+/// mobile client's generic 401 handler doesn't clear the session — the
+/// user is still authenticated; they just typed the wrong password.
+fn invalid_password_error(headers: &HeaderMap) -> Response {
+    error_response(
+        axum::http::StatusCode::FORBIDDEN,
+        headers,
+        ErrorSpec {
+            error: "Invalid password".to_string(),
+            code: "INVALID_PASSWORD",
+            details: None,
+        },
+    )
+}
 
 use crate::app::AppContext;
 use crate::db::models::profiles::Profile;
@@ -276,7 +291,7 @@ pub(in crate::api) async fn delete_account(
     if payload.password.is_empty()
         || !crate::security::verify_password(&payload.password, &user.password)
     {
-        return Ok(unauthorized_error(&headers, "Invalid password"));
+        return Ok(invalid_password_error(&headers));
     }
 
     let viewer = DbViewer {
@@ -303,7 +318,7 @@ pub(in crate::api) async fn change_password(
     if payload.current_password.is_empty()
         || !crate::security::verify_password(&payload.current_password, &user.password)
     {
-        return Ok(unauthorized_error(&headers, "Invalid password"));
+        return Ok(invalid_password_error(&headers));
     }
 
     if !(8..=128).contains(&payload.new_password.len()) {

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -794,7 +794,7 @@ async fn delete_account_verifies_hashed_password() {
             .add_header(auth_key.clone(), auth_value.clone())
             .json(&serde_json::json!({ "password": "wrong-password" }))
             .await;
-        assert_eq!(delete_bad.status_code(), 401);
+        assert_eq!(delete_bad.status_code(), 403);
 
         // delete with correct password succeeds
         let delete_ok = request
@@ -844,7 +844,7 @@ async fn change_password_rotates_credentials_and_invalidates_other_sessions() {
                 "newPassword": "new-password-123",
             }))
             .await;
-        assert_eq!(change_bad.status_code(), 401);
+        assert_eq!(change_bad.status_code(), 403);
 
         let change_ok = request
             .patch("/api/v1/auth/account/password")

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -15,7 +15,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.22.1" // x-release-please-version
+val appVersionName = "0.22.2" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -15,7 +15,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.22.2" // x-release-please-version
+val appVersionName = "0.22.3" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }


### PR DESCRIPTION
Wrong password in delete-account or change-password dialog used to return 401, which the mobile client treats as session invalid and clears the session. Now returns 403 with INVALID_PASSWORD so the dialog can show the error without kicking the user out. Data wipe in delete_user_data was already complete (verified table cascades + S3 cleanup).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix wrong password on account delete/change to return 403 instead of 401
> Returning 401 on a failed password check was causing clients to log the user out, since 401 is treated as an authentication failure. The fix changes both the `delete_account` and `change_password` handlers in [account.rs](https://github.com/poziomki-app/poziomki/pull/428/files#diff-bbdfd4575cacec32ca674d1d737611e5809c5d10e496ab08f3a49a6964cbe60a) to return 403 Forbidden with error code `INVALID_PASSWORD` instead of 401 Unauthorized. Behavioral Change: clients that key on 401 to trigger logout will no longer do so for wrong-password errors on these endpoints.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5c7a93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->