### PR TITLE
fix(ux): distinct 'Nieprawidłowe hasło' message on delete/change

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -15,7 +15,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.22.3" // x-release-please-version
+val appVersionName = "0.22.4" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
@@ -175,7 +175,7 @@ class PrivacyViewModel(
                     error = null,
                     passwordSuccessMessage = null,
                 )
-            when (apiService.changePassword(currentPassword, newPassword)) {
+            when (val result = apiService.changePassword(currentPassword, newPassword)) {
                 is ApiResult.Success -> {
                     _state.value =
                         _state.value.copy(
@@ -186,10 +186,15 @@ class PrivacyViewModel(
                 }
 
                 is ApiResult.Error -> {
+                    val message =
+                        when (result.code) {
+                            "INVALID_PASSWORD" -> "Nieprawidłowe aktualne hasło."
+                            else -> "Nie udało się zmienić hasła. Spróbuj ponownie."
+                        }
                     _state.value =
                         _state.value.copy(
                             isChangingPassword = false,
-                            error = "Nie udało się zmienić hasła. Sprawdź aktualne hasło.",
+                            error = message,
                         )
                 }
             }
@@ -203,7 +208,7 @@ class PrivacyViewModel(
         if (password.isBlank()) return
         viewModelScope.launch {
             _state.value = _state.value.copy(isDeleting = true, error = null)
-            when (apiService.deleteAccount(password)) {
+            when (val result = apiService.deleteAccount(password)) {
                 is ApiResult.Success -> {
                     cacheManager.clearAll()
                     sessionManager.clearSession()
@@ -212,10 +217,15 @@ class PrivacyViewModel(
                 }
 
                 is ApiResult.Error -> {
+                    val message =
+                        when (result.code) {
+                            "INVALID_PASSWORD" -> "Nieprawidłowe hasło."
+                            else -> "Nie udało się usunąć konta. Spróbuj ponownie."
+                        }
                     _state.value =
                         _state.value.copy(
                             isDeleting = false,
-                            error = "Nie udało się usunąć konta. Sprawdź hasło.",
+                            error = message,
                         )
                 }
             }


### PR DESCRIPTION
Distinguish INVALID_PASSWORD (403) from other errors in the dialog text so wrong password is unambiguous.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show distinct 'Nieprawidłowe hasło' error on invalid password in delete/change flows
> In `PrivacyViewModel`, the `changePassword` and `deleteAccount` methods now inspect the API error code on failure. When the code is `INVALID_PASSWORD`, a specific message is shown (
>
> #### 🖇️ Linked Issues
> respectively); otherwise a generic retry message is displayed instead of a single fixed error string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d73ded5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->