### PR TITLE
fix(ux): inline error in delete/change-password dialogs

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -15,7 +15,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.22.4" // x-release-please-version
+val appVersionName = "0.22.5" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangePasswordDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangePasswordDialog.kt
@@ -22,6 +22,7 @@ import com.poziomki.app.ui.designsystem.theme.TextSecondary
 @Composable
 fun ChangePasswordDialog(
     isLoading: Boolean,
+    error: String?,
     onDismiss: () -> Unit,
     onSubmit: (currentPassword: String, newPassword: String, confirmPassword: String) -> Unit,
 ) {
@@ -65,6 +66,7 @@ fun ChangePasswordDialog(
                     onValueChange = { confirm = it },
                     placeholder = "Powtórz nowe hasło",
                 )
+                DialogInlineError(error)
             }
         },
         confirmButton = {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
@@ -127,10 +127,14 @@ fun PrivacyScreen(
         }
     }
 
-    if (showPasswordDialog && state.error == null) {
+    if (showPasswordDialog) {
         ChangePasswordDialog(
             isLoading = state.isChangingPassword,
-            onDismiss = { showPasswordDialog = false },
+            error = state.error,
+            onDismiss = {
+                viewModel.clearError()
+                showPasswordDialog = false
+            },
             onSubmit = { current, new, confirm ->
                 viewModel.changePassword(current, new, confirm) {
                     showPasswordDialog = false
@@ -140,10 +144,14 @@ fun PrivacyScreen(
         )
     }
 
-    if (showDeleteDialog && state.error == null) {
+    if (showDeleteDialog) {
         DeleteAccountDialog(
             isLoading = state.isDeleting,
-            onDismiss = { showDeleteDialog = false },
+            error = state.error,
+            onDismiss = {
+                viewModel.clearError()
+                showDeleteDialog = false
+            },
             onConfirm = { password ->
                 viewModel.deleteAccount(password) {
                     showDeleteDialog = false
@@ -401,6 +409,7 @@ private fun PrivacyToggleRow(
 @Composable
 private fun DeleteAccountDialog(
     isLoading: Boolean,
+    error: String?,
     onDismiss: () -> Unit,
     onConfirm: (String) -> Unit,
 ) {
@@ -430,6 +439,7 @@ private fun DeleteAccountDialog(
                     onValueChange = { password = it },
                     placeholder = "Hasło",
                 )
+                DialogInlineError(error)
             }
         },
         confirmButton = {
@@ -456,5 +466,18 @@ private fun DeleteAccountDialog(
                 )
             }
         },
+    )
+}
+
+@Composable
+internal fun DialogInlineError(message: String?) {
+    if (message == null) return
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+        text = message,
+        fontFamily = NunitoFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 13.sp,
+        color = MaterialTheme.colorScheme.error,
     )
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyViewModel.kt
@@ -219,7 +219,7 @@ class PrivacyViewModel(
                 is ApiResult.Error -> {
                     val message =
                         when (result.code) {
-                            "INVALID_PASSWORD" -> "Nieprawidłowe hasło."
+                            "INVALID_PASSWORD" -> "Nieprawidłowe hasło"
                             else -> "Nie udało się usunąć konta. Spróbuj ponownie."
                         }
                     _state.value =


### PR DESCRIPTION
Error stays inside the dialog (no auto-close), no trailing dot.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show inline errors in delete account and change password dialogs
> - Both dialogs now stay visible when an error occurs and display the error message inline beneath the password fields, replacing the previous behavior where dialogs were hidden on error.
> - A reusable `DialogInlineError` composable is added in [PrivacyScreen.kt](https://github.com/poziomki-app/poziomki/pull/430/files#diff-e10ce7b571ec968e2633b5f01d65183b9f5bac40d0bae88d29de94b15260e0fe) and used by both dialogs.
> - Dismissing either dialog now calls `viewModel.clearError()` to reset error state.
> - Bumps `versionName` to `0.22.5` in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/430/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1312335.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->