### PR TITLE
fix(rls): allow NULL'ing own upload owner_id

### DIFF
--- a/backend/migrations/2026-05-17-000000_uploads_update_allow_orphan/down.sql
+++ b/backend/migrations/2026-05-17-000000_uploads_update_allow_orphan/down.sql
@@ -1,0 +1,5 @@
+DROP POLICY uploads_update ON public.uploads;
+CREATE POLICY uploads_update ON public.uploads
+    FOR UPDATE TO poziomki_api
+    USING (owner_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (owner_id IN (SELECT id FROM app.viewer_profile_ids()));

--- a/backend/migrations/2026-05-17-000000_uploads_update_allow_orphan/up.sql
+++ b/backend/migrations/2026-05-17-000000_uploads_update_allow_orphan/up.sql
@@ -1,0 +1,14 @@
+-- Allow the viewer to UPDATE one of their own uploads to owner_id = NULL.
+-- The delete-account flow needs this to orphan uploads before deleting the
+-- profile cascade (the immutability trigger already permits this transition).
+-- The USING clause still forces the old row to be the viewer's own; only
+-- WITH CHECK is relaxed to also accept a NULL'd new row.
+
+DROP POLICY uploads_update ON public.uploads;
+CREATE POLICY uploads_update ON public.uploads
+    FOR UPDATE TO poziomki_api
+    USING (owner_id IN (SELECT id FROM app.viewer_profile_ids()))
+    WITH CHECK (
+        owner_id IS NULL
+        OR owner_id IN (SELECT id FROM app.viewer_profile_ids())
+    );


### PR DESCRIPTION
Delete account still 500'd: the uploads_update WITH CHECK forbade owner_id IS NULL, so the orphan step in delete_user_data was blocked even after the immutability trigger fix. USING still gates by viewer; only WITH CHECK is relaxed to allow the NULL transition.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow NULL owner_id in RLS policy for uploads updates
> Updates the `uploads_update` RLS policy on `public.uploads` for role `poziomki_api` to permit setting `owner_id` to NULL (orphaning an upload). The `WITH CHECK` clause now allows either `owner_id IS NULL` or `owner_id` within `app.viewer_profile_ids()`; non-null values are still restricted to the viewer's profiles. The [down migration](https://github.com/poziomki-app/poziomki/pull/431/files#diff-4ac1b1f15151275d45591bb87c3377ef759ca674e1428e0bf28cae0f13e3f5af) restores the stricter policy that rejects NULL owner updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b79d72c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->