### PR TITLE
fix(rls): viewer can DELETE own DM conversations (account-delete)

### DIFF
--- a/backend/migrations/2026-05-17-010000_conversations_dm_delete_policy/down.sql
+++ b/backend/migrations/2026-05-17-010000_conversations_dm_delete_policy/down.sql
@@ -1,0 +1,1 @@
+DROP POLICY conversations_dm_delete ON public.conversations;

--- a/backend/migrations/2026-05-17-010000_conversations_dm_delete_policy/up.sql
+++ b/backend/migrations/2026-05-17-010000_conversations_dm_delete_policy/up.sql
@@ -1,0 +1,16 @@
+-- Account-delete needs to remove the user's DM conversations before the
+-- final users-row delete; the conversations_user_*_id_fkey has no CASCADE,
+-- so a leftover DM blocks the cascade. With FORCE RLS and no DELETE
+-- policy on conversations, the diesel::delete in delete_user_data was
+-- silently affecting zero rows.
+--
+-- This grants DELETE only on DMs where the caller is one of the two
+-- pinned participants — event conversations remain governed by event
+-- owner deletes (which cascade) and admin tooling.
+
+CREATE POLICY conversations_dm_delete ON public.conversations
+    FOR DELETE TO poziomki_api
+    USING (
+        kind = 'dm'
+        AND (user_low_id = app.current_user_id() OR user_high_id = app.current_user_id())
+    );


### PR DESCRIPTION
FORCE RLS + no DELETE policy meant diesel::delete in delete_user_data silently affected zero rows; the leftover DMs then blocked the final users-row delete with conversations_user_high_id_fkey. Grants DELETE only on DMs where the caller is a pinned participant.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLS policy to allow viewers to DELETE their own DM conversations
> Adds a new RLS policy `conversations_dm_delete` on `public.conversations` that permits the `poziomki_api` role to DELETE rows only where `kind = 'dm'` and the caller's ID (via `app.current_user_id()`) matches either `user_low_id` or `user_high_id`. This is needed to support account deletion flows where a user must be able to remove their own DM conversations. Migration files are at [`up.sql`](https://github.com/poziomki-app/poziomki/pull/432/files#diff-9027603cdb21919a7533513b2670663518c5c5c273abe906469f25c33494f2db) and [`down.sql`](https://github.com/poziomki-app/poziomki/pull/432/files#diff-d9ba09a030080626d9d3a7060af8efc7f6a0c204e89918a5e3d56f5ddfe4e2da).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8a4c4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->