### PR TITLE
fix(api): wrap delete_account response so client parses as Success

### DIFF
--- a/backend/src/api/auth/account.rs
+++ b/backend/src/api/auth/account.rs
@@ -305,7 +305,10 @@ pub(in crate::api) async fn delete_account(
     delete_user_data(viewer).await?;
     invalidate_auth_cache_for_user_id(user.id).await;
 
-    Ok(Json(SuccessResponse { success: true }).into_response())
+    Ok(Json(DataResponse {
+        data: SuccessResponse { success: true },
+    })
+    .into_response())
 }
 
 pub(in crate::api) async fn change_password(


### PR DESCRIPTION
Server returned bare {success: true} while every other endpoint returns {data: ...}. Client treated the missing data field as an error and showed 'Nie udało się usunąć konta' even though the account was actually deleted server-side. Wraps in DataResponse like change_password already does.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap `delete_account` response in `DataResponse` envelope so client parses as Success
> The `delete_account` handler in [account.rs](https://github.com/poziomki-app/poziomki/pull/433/files#diff-bbdfd4575cacec32ca674d1d737611e5809c5d10e496ab08f3a49a6964cbe60a) previously returned `{"success": true}` directly; it now returns `{"data": {"success": true}}` to match the `DataResponse` envelope the client expects. No other logic is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71b9d51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->