### PR TITLE
fix(onboarding): footer lifts above keyboard

### DIFF
--- a/backend/src/api/auth/account.rs
+++ b/backend/src/api/auth/account.rs
@@ -305,7 +305,10 @@ pub(in crate::api) async fn delete_account(
     delete_user_data(viewer).await?;
     invalidate_auth_cache_for_user_id(user.id).await;
 
-    Ok(Json(SuccessResponse { success: true }).into_response())
+    Ok(Json(DataResponse {
+        data: SuccessResponse { success: true },
+    })
+    .into_response())
 }
 
 pub(in crate::api) async fn change_password(

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -15,7 +15,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.22.5" // x-release-please-version
+val appVersionName = "0.22.6" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/OnboardingLayout.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/OnboardingLayout.kt
@@ -11,9 +11,11 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -47,6 +49,14 @@ fun OnboardingLayout(
     Scaffold(
         containerColor = Background,
         bottomBar = {
+            // Union with IME so the footer lifts above the keyboard instead of
+            // being covered. Falls back to nav bar inset (or xl spacing,
+            // whichever is larger) when the keyboard is closed.
+            val bottomInset =
+                WindowInsets.navigationBars
+                    .union(WindowInsets.ime)
+                    .asPaddingValues()
+                    .calculateBottomPadding()
             Column(
                 modifier =
                     Modifier
@@ -55,11 +65,7 @@ fun OnboardingLayout(
                         .padding(horizontal = PoziomkiTheme.spacing.lg)
                         .padding(top = PoziomkiTheme.spacing.sm)
                         .padding(
-                            bottom =
-                                maxOf(
-                                    PoziomkiTheme.spacing.xl,
-                                    WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding(),
-                                ),
+                            bottom = maxOf(PoziomkiTheme.spacing.xl, bottomInset),
                         ),
             ) {
                 footer()


### PR DESCRIPTION
Union nav-bar + IME insets so the Potwierdź/Dalej footer follows the keyboard instead of being covered.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix onboarding footer to lift above the keyboard on mobile
> - Updates [`OnboardingLayout`](https://github.com/poziomki-app/poziomki/pull/434/files#diff-9004ee762b92e08e7a2180eb211b0ba88918eee19ce0b96bdb5f77c5292f9c95) to union `WindowInsets.navigationBars` and `WindowInsets.ime`, so the footer repositions above the on-screen keyboard when it appears.
> - When the keyboard is hidden, the footer still respects the larger of `xl` spacing or system navigation bar insets.
> - Also wraps the `delete_account` endpoint response in a `DataResponse` envelope, and bumps the Android version to `0.22.6`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14f91e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->