### PR TITLE
fix(map): smoother user-location halo pulse

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
@@ -1,11 +1,11 @@
 package com.poziomki.app.ui.feature.home
 
-import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -75,7 +75,10 @@ private const val DEFAULT_LAT = 52.2297
 private const val DEFAULT_LNG = 21.0122
 private const val TAP_THRESHOLD_DEG = 0.005
 private const val USER_DOT_RADIUS_DP = 9f
-private const val USER_HALO_MAX_RADIUS_DP = 24f
+private const val USER_HALO_MAX_RADIUS_DP = 28f
+private const val USER_HALO_PEAK_ALPHA = 0.35f
+private const val USER_HALO_CYCLE_MS = 2_200
+private val UserHaloEasing = CubicBezierEasing(0.16f, 1f, 0.3f, 1f)
 
 // Warsaw metro bounding box, slightly padded so the city fits with breathing
 // room. Pan is clamped to this — outside of Warsaw the nearby tab makes no
@@ -287,23 +290,39 @@ internal fun NearbyEventsContent(
                         rememberGeoJsonSource(
                             data = pointGeoJson(userLat, userLng),
                         )
+                    // One shared cycle drives both radius and opacity. Alpha
+                    // starts and ends at 0 so the loop restart is invisible —
+                    // no flash, no perceptible redraw seam.
                     val pulse = rememberInfiniteTransition(label = "user-pulse")
                     val haloRadius by pulse.animateFloat(
                         initialValue = USER_DOT_RADIUS_DP,
-                        targetValue = USER_HALO_MAX_RADIUS_DP,
+                        targetValue = USER_DOT_RADIUS_DP,
                         animationSpec =
                             infiniteRepeatable(
-                                animation = tween(durationMillis = 1_400, easing = LinearEasing),
+                                animation =
+                                    keyframes {
+                                        durationMillis = USER_HALO_CYCLE_MS
+                                        USER_DOT_RADIUS_DP at 0 using UserHaloEasing
+                                        USER_HALO_MAX_RADIUS_DP at (USER_HALO_CYCLE_MS - 400)
+                                        USER_HALO_MAX_RADIUS_DP at USER_HALO_CYCLE_MS
+                                    },
                                 repeatMode = RepeatMode.Restart,
                             ),
                         label = "halo-radius",
                     )
                     val haloAlpha by pulse.animateFloat(
-                        initialValue = 0.45f,
+                        initialValue = 0f,
                         targetValue = 0f,
                         animationSpec =
                             infiniteRepeatable(
-                                animation = tween(durationMillis = 1_400, easing = LinearEasing),
+                                animation =
+                                    keyframes {
+                                        durationMillis = USER_HALO_CYCLE_MS
+                                        0f at 0
+                                        USER_HALO_PEAK_ALPHA at 180
+                                        0f at (USER_HALO_CYCLE_MS - 400)
+                                        0f at USER_HALO_CYCLE_MS
+                                    },
                                 repeatMode = RepeatMode.Restart,
                             ),
                         label = "halo-alpha",


### PR DESCRIPTION
Echo ripple now decelerates (cubic-bezier ease-out) and the loop seam is invisible — alpha starts and ends at 0, so no flash on restart.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Smooth user-location halo pulse animation on the map
> Replaces a tween/`LinearEasing` loop with a keyframe animation in [`NearbyEventsContent.kt`](https://github.com/poziomki-app/poziomki/pull/435/files#diff-4b254621a5c67acf73fc8f3619229de35cfcffe5ed1d64536e7e98375cc84e98) to eliminate the visible jump at loop boundaries.
>
> - Radius starts and ends at the dot size, expands to a new max of 28dp near the end of each 2200 ms cycle, and holds until the loop restarts.
> - Alpha starts at 0, peaks at 0.35 early in the cycle, and returns to 0 before the loop restarts, hiding the seam.
> - A cubic-bezier easing `(0.16, 1, 0.3, 1)` shapes the early expansion for a more natural feel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52415a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->