### PR TITLE
fix(notifications): shorten label, default to DMs only

### DIFF
--- a/backend/migrations/2026-05-17-020000_notification_prefs_opt_in_defaults/down.sql
+++ b/backend/migrations/2026-05-17-020000_notification_prefs_opt_in_defaults/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.user_settings
+    ALTER COLUMN notify_event_chats SET DEFAULT true,
+    ALTER COLUMN notify_tag_events SET DEFAULT true;

--- a/backend/migrations/2026-05-17-020000_notification_prefs_opt_in_defaults/up.sql
+++ b/backend/migrations/2026-05-17-020000_notification_prefs_opt_in_defaults/up.sql
@@ -1,0 +1,8 @@
+-- New users should default to DMs only. Event-chat and tag-event pushes
+-- are opt-in (the user can flip them on in Powiadomienia). Existing rows
+-- are intentionally left alone — anyone who already onboarded keeps the
+-- channels they were granted.
+
+ALTER TABLE public.user_settings
+    ALTER COLUMN notify_event_chats SET DEFAULT false,
+    ALTER COLUMN notify_tag_events SET DEFAULT false;

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -769,21 +769,20 @@ async fn event_conversation_insert_rejects_pending_attendee() {
 }
 
 // ---------------------------------------------------------------------------
-// API role must not be able to UPDATE or DELETE whole conversation
-// rows. A naive member-only UPDATE/DELETE policy would let any chat
-// participant nuke the room for everyone via ON DELETE CASCADE
-// through conversation_members / messages / message_reactions.
-// Legitimate event-chat cleanup routes through
-// app.delete_event_and_chat() instead.
+// The only DELETE policy on conversations is conversations_dm_delete,
+// scoped to the two pinned DM participants (added so the account-delete
+// path can drop a user's DM rows). Outsiders must still see DELETE as a
+// no-op, and event-chat conversations remain undeletable from the API
+// role (cleanup goes through app.delete_event_and_chat()).
 // ---------------------------------------------------------------------------
 #[tokio::test]
 #[serial]
-async fn conversations_member_cannot_delete() {
+async fn conversations_outsider_cannot_delete_dm() {
     let fx = setup_fixture().await;
-    let alice_id = fx.alice.id;
+    let carol_id = fx.carol.id;
     let dm_id = fx.dm_id;
 
-    let affected = rls_harness::with_api_viewer_tx(alice_id, false, move |conn| {
+    let affected = rls_harness::with_api_viewer_tx(carol_id, false, move |conn| {
         async move {
             let sql = format!("DELETE FROM public.conversations WHERE id = '{dm_id}'");
             Ok(execute_count(conn, &sql).await)
@@ -791,10 +790,10 @@ async fn conversations_member_cannot_delete() {
         .scope_boxed()
     })
     .await
-    .expect("alice tx");
+    .expect("carol tx");
     assert_eq!(
         affected, 0,
-        "no conversations_delete policy — member DELETE must be a no-op"
+        "conversations_dm_delete must reject non-participants"
     );
 
     let mut conn = db::conn().await.expect("pool");

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaScreen.kt
@@ -103,8 +103,8 @@ fun PowiadomieniaScreen(
             )
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
             NotificationToggleRow(
-                label = "nowe wydarzenia w obserwowanych tagach",
-                description = "Powiadomienia o nowych wydarzeniach pasujących do Twoich zainteresowań.",
+                label = "wydarzenia w tagach",
+                description = "Nowe wydarzenia pasujące do obserwowanych tagów.",
                 checked = state.tagEvents,
                 enabled = state.masterEnabled,
                 onCheckedChange = viewModel::toggleTagEvents,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaViewModel.kt
@@ -13,8 +13,8 @@ import kotlinx.coroutines.launch
 data class PowiadomieniaState(
     val masterEnabled: Boolean = true,
     val dms: Boolean = true,
-    val eventChats: Boolean = true,
-    val tagEvents: Boolean = true,
+    val eventChats: Boolean = false,
+    val tagEvents: Boolean = false,
 )
 
 class PowiadomieniaViewModel(

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/SettingsRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/SettingsRepository.kt
@@ -33,8 +33,8 @@ class SettingsRepository(
             privacy_show_program = 1L,
             privacy_discoverable = 1L,
             notify_dms = 1L,
-            notify_event_chats = 1L,
-            notify_tag_events = 1L,
+            notify_event_chats = 0L,
+            notify_tag_events = 0L,
             cached_at = Clock.System.now().toEpochMilliseconds(),
             is_dirty = 0L,
         )

--- a/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/UserSettings.sq
+++ b/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/UserSettings.sq
@@ -6,8 +6,8 @@ CREATE TABLE user_settings (
     privacy_show_program INTEGER NOT NULL DEFAULT 1,
     privacy_discoverable INTEGER NOT NULL DEFAULT 1,
     notify_dms INTEGER NOT NULL DEFAULT 1,
-    notify_event_chats INTEGER NOT NULL DEFAULT 1,
-    notify_tag_events INTEGER NOT NULL DEFAULT 1,
+    notify_event_chats INTEGER NOT NULL DEFAULT 0,
+    notify_tag_events INTEGER NOT NULL DEFAULT 0,
     cached_at INTEGER NOT NULL DEFAULT 0,
     is_dirty INTEGER NOT NULL DEFAULT 0
 );


### PR DESCRIPTION
- 'nowe wydarzenia w obserwowanych tagach' → 'wydarzenia w tagach' (wrapped onto two lines and pushed the wkrótce badge off-screen).
- New users now default to DMs on, event chats and tag events off. Existing users untouched.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default event chat and tag event notifications to off in user settings
> - Changes defaults for `notify_event_chats` and `notify_tag_events` to `false`/`0` across the backend DB schema, mobile SQLDelight schema, `SettingsRepository` seed values, and `PowiadomieniaState`.
> - Adds a backend migration ([up.sql](https://github.com/poziomki-app/poziomki/pull/436/files#diff-92de58f0c6a0fc3dc3c6444f6d3900045c287df6a41dfec10ed72bee5e625780)) to set column-level defaults to `false`; existing rows are not modified.
> - Updates the tag events toggle label in [PowiadomieniaScreen.kt](https://github.com/poziomki-app/poziomki/pull/436/files#diff-aa24282efe316e45922fdc29ec85aced1d2b95fa8ee47027ea7d3c7a75d655a7) from 'nowe wydarzenia w obserwowanych tagach' to 'wydarzenia w tagach'.
> - Behavioral Change: new users will have event chat and tag event notifications off by default instead of on.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7621a76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->