### PR TITLE
fix(events): align day-header chevron with top-bar icons

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -579,6 +579,9 @@ private fun WeekEventsContent(
                             .clickable { collapsedDays[dateKey] = !isCollapsed }
                             .padding(
                                 start = PoziomkiTheme.spacing.sm,
+                                // Matches IconButton's 12dp icon inset so the chevron
+                                // aligns with +, avatar, and the filter icon above.
+                                end = 12.dp,
                                 top = PoziomkiTheme.spacing.sm,
                                 bottom = PoziomkiTheme.spacing.sm,
                             ),


### PR DESCRIPTION
Chevron was flush to the LazyColumn edge while +/avatar/filter icons sit 12dp in (IconButton inset). Add matching end padding so they line up.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add end padding to day-header chevron in `WeekEventsContent` to align with top-bar icons
> Adds `12.dp` end padding to the clickable day-header element in [EventsScreen.kt](https://github.com/poziomki-app/poziomki/pull/437/files#diff-b1aad26129722f5aa103f55ac1d883a2b472203a3df536f251798d2ab83260dd), where only start, top, and bottom padding were previously set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ec60ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->