### PR TITLE
fix(messages): remove placeholder dropdown menu

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -1,6 +1,7 @@
 package com.poziomki.app.ui.feature.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -72,7 +73,8 @@ fun MessagesScreen(
             tabs = roomFilterTabs,
             selected = selectedFilter,
             onSelect = { selectedFilter = it },
-            modifier = Modifier.padding(horizontal = 24.dp),
+            modifier = Modifier.padding(start = 24.dp, end = PoziomkiTheme.spacing.md),
+            horizontalArrangement = Arrangement.spacedBy(48.dp),
         )
 
         when {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -1,20 +1,13 @@
 package com.poziomki.app.ui.feature.home
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -22,23 +15,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.adamglin.PhosphorIcons
-import com.adamglin.phosphoricons.Bold
-import com.adamglin.phosphoricons.bold.Check
-import com.adamglin.phosphoricons.bold.DotsThreeVertical
-import com.adamglin.phosphoricons.bold.UsersThree
 import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.FilterTabs
 import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.SearchableScreenHeader
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
-import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
-import com.poziomki.app.ui.designsystem.theme.TextPrimary
-import com.poziomki.app.ui.feature.chat.ActionMenuItem
 import com.poziomki.app.ui.feature.home.messages.MessagesRoomFilter
 import com.poziomki.app.ui.feature.home.messages.RoomRow
 import com.poziomki.app.ui.feature.home.messages.filterMessagesRooms
@@ -59,7 +43,6 @@ fun MessagesScreen(
     val state by viewModel.state.collectAsState()
     var selectedFilter by remember { mutableStateOf(MessagesRoomFilter.All) }
     var searchActive by remember { mutableStateOf(false) }
-    var menuOpen by remember { mutableStateOf(false) }
 
     val filteredRooms =
         state.rooms.filterMessagesRooms(
@@ -85,51 +68,12 @@ fun MessagesScreen(
         ) {
             profileAvatarAction()
         }
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(start = 24.dp, end = PoziomkiTheme.spacing.md),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            FilterTabs(
-                tabs = roomFilterTabs,
-                selected = selectedFilter,
-                onSelect = { selectedFilter = it },
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .padding(end = 12.dp),
-            )
-            Box {
-                IconButton(onClick = { menuOpen = true }) {
-                    Icon(
-                        PhosphorIcons.Bold.DotsThreeVertical,
-                        contentDescription = "Menu",
-                        tint = TextPrimary,
-                    )
-                }
-                DropdownMenu(
-                    expanded = menuOpen,
-                    onDismissRequest = { menuOpen = false },
-                    shape = RoundedCornerShape(16.dp),
-                    containerColor = SurfaceElevated,
-                ) {
-                    Column(modifier = Modifier.padding(horizontal = 4.dp)) {
-                        ActionMenuItem(
-                            icon = PhosphorIcons.Bold.UsersThree,
-                            label = "nowa grupa",
-                            onClick = { menuOpen = false },
-                        )
-                        ActionMenuItem(
-                            icon = PhosphorIcons.Bold.Check,
-                            label = "przeczytaj wszystkie",
-                            onClick = { menuOpen = false },
-                        )
-                    }
-                }
-            }
-        }
+        FilterTabs(
+            tabs = roomFilterTabs,
+            selected = selectedFilter,
+            onSelect = { selectedFilter = it },
+            modifier = Modifier.padding(horizontal = 24.dp),
+        )
 
         when {
             state.isLoading && state.rooms.isEmpty() -> {


### PR DESCRIPTION
Drops the "nowa grupa" / "przeczytaj wszystkie" overflow menu — both items had no-op handlers.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove placeholder dropdown menu from MessagesScreen
> Removes the overflow menu (dots icon, dropdown with "nowa grupa" and "przeczytaj wszystkie" items) from the messages screen header. The surrounding `Row`/`Box` layout is replaced with a direct `FilterTabs` call using `start=24.dp` padding and `spacedBy(48.dp)` horizontal arrangement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 867ccfa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->