### PR TITLE
feat(filters): pill style for messages + events filter tabs

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
@@ -11,25 +11,32 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 
+enum class FilterTabsStyle { Dot, Pill }
+
 @Composable
+@Suppress("LongParameterList")
 fun <T> FilterTabs(
     tabs: List<Pair<T, String>>,
     selected: T,
     onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
     horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(24.dp),
+    style: FilterTabsStyle = FilterTabsStyle.Dot,
 ) {
     Row(
         modifier =
@@ -41,30 +48,69 @@ fun <T> FilterTabs(
     ) {
         tabs.forEach { (value, label) ->
             val isSelected = value == selected
-            Row(
-                modifier =
-                    Modifier
-                        .clickable { onSelect(value) }
-                        .padding(vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (isSelected) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .size(6.dp)
-                                .background(Primary, CircleShape),
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
+            when (style) {
+                FilterTabsStyle.Dot -> {
+                    DotTab(label = label, isSelected = isSelected, onClick = { onSelect(value) })
                 }
-                Text(
-                    text = label,
-                    fontFamily = NunitoFamily,
-                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                    fontSize = 16.sp,
-                    color = if (isSelected) TextPrimary else TextMuted,
-                )
+
+                FilterTabsStyle.Pill -> {
+                    PillTab(label = label, isSelected = isSelected, onClick = { onSelect(value) })
+                }
             }
         }
     }
+}
+
+@Composable
+private fun DotTab(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .clickable(onClick = onClick)
+                .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (isSelected) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(6.dp)
+                        .background(Primary, CircleShape),
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+        }
+        Text(
+            text = label,
+            fontFamily = NunitoFamily,
+            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+            fontSize = 16.sp,
+            color = if (isSelected) TextPrimary else TextMuted,
+        )
+    }
+}
+
+@Composable
+private fun PillTab(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    Text(
+        text = label,
+        fontFamily = NunitoFamily,
+        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+        fontSize = 14.sp,
+        color = if (isSelected) TextPrimary else TextMuted,
+        modifier =
+            Modifier
+                .clickable(onClick = onClick)
+                .background(
+                    color = if (isSelected) Color(0xFF242424) else SurfaceElevated,
+                    shape = RoundedCornerShape(50),
+                ).padding(horizontal = 10.dp, vertical = 4.dp),
+    )
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -65,6 +65,7 @@ import com.poziomki.app.network.Event
 import com.poziomki.app.ui.designsystem.components.AppSnackbar
 import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.FilterTabs
+import com.poziomki.app.ui.designsystem.components.FilterTabsStyle
 import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.SearchableScreenHeader
 import com.poziomki.app.ui.designsystem.components.StackedAvatars
@@ -188,6 +189,8 @@ fun EventsScreen(
                     Modifier
                         .weight(1f)
                         .padding(end = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                style = FilterTabsStyle.Pill,
             )
             androidx.compose.material3.IconButton(
                 onClick = { viewModel.toggleShowTagFilter() },

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.FilterTabs
+import com.poziomki.app.ui.designsystem.components.FilterTabsStyle
 import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.SearchableScreenHeader
 import com.poziomki.app.ui.designsystem.theme.Background
@@ -74,7 +75,8 @@ fun MessagesScreen(
             selected = selectedFilter,
             onSelect = { selectedFilter = it },
             modifier = Modifier.padding(start = 24.dp, end = PoziomkiTheme.spacing.md),
-            horizontalArrangement = Arrangement.spacedBy(48.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            style = FilterTabsStyle.Pill,
         )
 
         when {


### PR DESCRIPTION
Pill-style filter tabs for wiadomości and wydarzenia. Selected = lighter grey pill, unselected = subtle pill. Saved screen unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pill style to `FilterTabs` and apply it to Messages and Events screens
> - Adds a `FilterTabsStyle` enum (`Dot`, `Pill`) to [`FilterTabs.kt`](https://github.com/poziomki-app/poziomki/pull/439/files#diff-f5198729d0bf11d336910127721ef939c870431b209c5f33f6150798e3a93cc5) with `Dot` as the default to preserve existing behavior.
> - The new `PillTab` renders a rounded pill shape with a highlighted background and `SemiBold` text on selection.
> - Updates [`MessagesScreen.kt`](https://github.com/poziomki-app/poziomki/pull/439/files#diff-849874d483b21c54bae240049e8968cbc3c3c8fcb8994e7358a647c2d4c448a7) and [`EventsScreen.kt`](https://github.com/poziomki-app/poziomki/pull/439/files#diff-b1aad26129722f5aa103f55ac1d883a2b472203a3df536f251798d2ab83260dd) to use `FilterTabsStyle.Pill` and reduces tab spacing to `12.dp`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14d8ebd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->