### PR TITLE
fix(chat): mute works, muted icon in list, mute for events, block snackbar

### DIFF
--- a/backend/src/api/chat/mutes.rs
+++ b/backend/src/api/chat/mutes.rs
@@ -15,6 +15,7 @@ use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
 use crate::api::common::{auth_or_respond, error_response, parse_uuid_response, ErrorSpec};
+use crate::api::state::{DataResponse, SuccessResponse};
 use crate::app::AppContext;
 use crate::db;
 
@@ -91,7 +92,10 @@ pub async fn mute_conversation(
         ));
     }
 
-    Ok((StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response())
+    Ok(Json(DataResponse {
+        data: SuccessResponse { success: true },
+    })
+    .into_response())
 }
 
 pub async fn unmute_conversation(
@@ -129,5 +133,8 @@ pub async fn unmute_conversation(
     })
     .await?;
 
-    Ok((StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response())
+    Ok(Json(DataResponse {
+        data: SuccessResponse { success: true },
+    })
+    .into_response())
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -407,8 +407,30 @@ class ChatViewModel(
         val profileId = activeDirectProfileId ?: activeDirectUserId ?: return
         viewModelScope.launch {
             when (apiService.blockProfile(profileId)) {
-                is ApiResult.Success -> _uiState.update { it.copy(isBlocked = true) }
-                is ApiResult.Error -> _uiState.update { it.copy(error = "Nie udało się zablokować") }
+                is ApiResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isBlocked = true,
+                            transientNotice =
+                                TransientNotice(
+                                    message = "Zablokowano",
+                                    type = SnackbarType.SUCCESS,
+                                ),
+                        )
+                    }
+                }
+
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            transientNotice =
+                                TransientNotice(
+                                    message = "Nie udało się zablokować",
+                                    type = SnackbarType.ERROR,
+                                ),
+                        )
+                    }
+                }
             }
         }
     }
@@ -417,8 +439,30 @@ class ChatViewModel(
         val profileId = activeDirectProfileId ?: activeDirectUserId ?: return
         viewModelScope.launch {
             when (apiService.unblockProfile(profileId)) {
-                is ApiResult.Success -> _uiState.update { it.copy(isBlocked = false) }
-                is ApiResult.Error -> _uiState.update { it.copy(error = "Nie udało się odblokować") }
+                is ApiResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isBlocked = false,
+                            transientNotice =
+                                TransientNotice(
+                                    message = "Odblokowano",
+                                    type = SnackbarType.SUCCESS,
+                                ),
+                        )
+                    }
+                }
+
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            transientNotice =
+                                TransientNotice(
+                                    message = "Nie udało się odblokować",
+                                    type = SnackbarType.ERROR,
+                                ),
+                        )
+                    }
+                }
             }
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -49,6 +49,8 @@ import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.Fill
 import com.adamglin.phosphoricons.bold.ArrowLeft
+import com.adamglin.phosphoricons.bold.Bell
+import com.adamglin.phosphoricons.bold.BellSlash
 import com.adamglin.phosphoricons.bold.DotsThreeVertical
 import com.adamglin.phosphoricons.bold.Flag
 import com.adamglin.phosphoricons.bold.PencilSimple
@@ -259,6 +261,8 @@ fun EventChatHeader(
     onEdit: () -> Unit,
     onReport: () -> Unit = {},
     onRemove: () -> Unit = {},
+    isMuted: Boolean = false,
+    onToggleMute: () -> Unit = {},
 ) {
     var showMenu by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -352,6 +356,19 @@ fun EventChatHeader(
                                 },
                             )
                         }
+                        ActionMenuItem(
+                            icon =
+                                if (isMuted) {
+                                    PhosphorIcons.Bold.Bell
+                                } else {
+                                    PhosphorIcons.Bold.BellSlash
+                                },
+                            label = if (isMuted) "Wyłącz wyciszenie" else "Wycisz czat",
+                            onClick = {
+                                showMenu = false
+                                onToggleMute()
+                            },
+                        )
                         ActionMenuItem(
                             icon = PhosphorIcons.Bold.Flag,
                             label = "Zgłoś",

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
@@ -140,6 +140,8 @@ fun EventChatScreen(
                             chatViewModel.removeConversation()
                             onBack()
                         },
+                        isMuted = chatState.isMuted,
+                        onToggleMute = chatViewModel::toggleMute,
                     )
                     ChatContent(
                         modifier = Modifier.weight(1f),

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -22,8 +24,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.Fill
 import com.adamglin.phosphoricons.Regular
+import com.adamglin.phosphoricons.bold.BellSlash
 import com.adamglin.phosphoricons.fill.CalendarDots
 import com.adamglin.phosphoricons.regular.User
 import com.poziomki.app.chat.api.RoomSummary
@@ -84,8 +88,18 @@ fun RoomRow(
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f, fill = false),
                 )
+                if (room.isMuted) {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Icon(
+                        imageVector = PhosphorIcons.Bold.BellSlash,
+                        contentDescription = "Wyciszone",
+                        tint = TextSecondary,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
                 room.latestTimestampMillis?.let {
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(


### PR DESCRIPTION
- mute API returned `{ok: true}` instead of the standard `{data: {success: true}}` envelope, so the client treated success as error
- show BellSlash next to muted rooms in the rooms list
- add mute item to the event chat menu (uses the same conversation mute endpoint)
- block/unblock now shows a snackbar

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mute functionality in chat with muted icon in list, event chat mute action, and block/unblock snackbars
> - Mute/unmute API handlers now return `{"data":{"success":true}}` instead of `{"ok":true}` in [mutes.rs](https://github.com/poziomki-app/poziomki/pull/440/files#diff-8eb2d04dc5c8ee713cc0fc562e25ec1b88343da26c3f4ca1f0564606589e3bcf).
> - Muted rooms show a bell-slash icon next to the title in the message list ([RoomRow.kt](https://github.com/poziomki-app/poziomki/pull/440/files#diff-638303e155da802f51e452c8fad551f5d6f23cbe70f9b86990bf5cf49e95de0c)).
> - Event chat header gains a mute/unmute menu action with a dynamic bell icon, wired to the view model in [EventChatScreen.kt](https://github.com/poziomki-app/poziomki/pull/440/files#diff-d0544b3363155f226ef43e4d445a67fe344383aaa42bae4aae0dd2c640c8310b).
> - Block/unblock actions in `ChatViewModel` now show success and error snackbars via `transientNotice` instead of setting the `error` field.
> - Behavioral Change: the mute API response shape changes from `{"ok":true}` to `{"data":{"success":true}}`; any client relying on the old shape will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65051eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->