### PR TITLE
fix(chat): remove mute button from chat header

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -42,8 +42,6 @@ import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.Fill
 import com.adamglin.phosphoricons.bold.ArrowLeft
-import com.adamglin.phosphoricons.bold.Bell
-import com.adamglin.phosphoricons.bold.BellSlash
 import com.adamglin.phosphoricons.bold.CaretDown
 import com.adamglin.phosphoricons.bold.CaretUp
 import com.adamglin.phosphoricons.bold.DotsThreeVertical
@@ -138,7 +136,6 @@ fun ChatScreen(
                     avatarUrl = state.roomAvatarUrl,
                     isEvent = !state.isDirectRoom,
                     isBlocked = state.isBlocked,
-                    isMuted = state.isMuted,
                     onBack = onBack,
                     onSearchClick = viewModel::toggleSearch,
                     onProfileClick =
@@ -150,7 +147,6 @@ fun ChatScreen(
                         viewModel.removeConversation()
                         onBack()
                     },
-                    onToggleMute = viewModel::toggleMute,
                 )
             }
         },
@@ -227,7 +223,6 @@ private fun ChatTopBar(
     title: String,
     avatarUrl: String?,
     isBlocked: Boolean,
-    isMuted: Boolean = false,
     isEvent: Boolean = false,
     onBack: () -> Unit,
     onSearchClick: () -> Unit,
@@ -235,7 +230,6 @@ private fun ChatTopBar(
     onBlock: () -> Unit = {},
     onReport: () -> Unit = {},
     onRemove: () -> Unit = {},
-    onToggleMute: () -> Unit = {},
 ) {
     var showMenu by remember { mutableStateOf(false) }
     Surface(
@@ -311,19 +305,6 @@ private fun ChatTopBar(
                             },
                             iconTint = Error,
                             labelColor = Error,
-                        )
-                        ActionMenuItem(
-                            icon =
-                                if (isMuted) {
-                                    PhosphorIcons.Bold.Bell
-                                } else {
-                                    PhosphorIcons.Bold.BellSlash
-                                },
-                            label = if (isMuted) "Wyłącz wyciszenie" else "Wycisz czat",
-                            onClick = {
-                                showMenu = false
-                                onToggleMute()
-                            },
                         )
                         ActionMenuItem(
                             icon = PhosphorIcons.Bold.Flag,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PowiadomieniaScreen.kt
@@ -112,16 +112,6 @@ fun PowiadomieniaScreen(
                 trailingBadge = "wkrótce",
             )
 
-            Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
-            Text(
-                text = "Wyciszysz pojedynczy czat w jego ustawieniach (przycisk w nagłówku).",
-                fontFamily = nunito,
-                fontWeight = FontWeight.Normal,
-                fontSize = 12.sp,
-                color = TextSecondary,
-                lineHeight = 16.sp,
-            )
-
             Spacer(modifier = Modifier.height(navBarBottom + PoziomkiTheme.spacing.xl))
         }
     }


### PR DESCRIPTION
Removes the Wycisz czat option from the chat header dropdown and the related helper text in notification settings.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove mute button from chat header and related notification hint
> Removes the mute/unmute action from the `ChatTopBar` overflow menu and drops the `isMuted`/`onToggleMute` parameters from both `ChatTopBar` and `ChatScreen`. Also removes the informational text in `PowiadomieniaScreen` that directed users to mute individual chats from the header menu.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e84950d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->