### PR TITLE
fix(events): remove duplicate Usuń from header menu

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -15,7 +15,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.22.6" // x-release-please-version
+val appVersionName = "0.22.7" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -55,7 +55,6 @@ import com.adamglin.phosphoricons.bold.PencilSimple
 import com.adamglin.phosphoricons.bold.SignOut
 import com.adamglin.phosphoricons.bold.Trash
 import com.adamglin.phosphoricons.bold.UserPlus
-import com.adamglin.phosphoricons.bold.X
 import com.adamglin.phosphoricons.fill.CalendarDots
 import com.adamglin.phosphoricons.fill.MapPin
 import com.adamglin.phosphoricons.fill.UsersThree
@@ -258,7 +257,6 @@ fun EventChatHeader(
     onDelete: () -> Unit,
     onEdit: () -> Unit,
     onReport: () -> Unit = {},
-    onRemove: () -> Unit = {},
 ) {
     var showMenu by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -358,14 +356,6 @@ fun EventChatHeader(
                             onClick = {
                                 showMenu = false
                                 onReport()
-                            },
-                        )
-                        ActionMenuItem(
-                            icon = PhosphorIcons.Bold.X,
-                            label = "Usuń",
-                            onClick = {
-                                showMenu = false
-                                onRemove()
                             },
                         )
                     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatScreen.kt
@@ -136,10 +136,6 @@ fun EventChatScreen(
                         onDelete = { eventDetailViewModel.deleteEvent(onBack) },
                         onEdit = { onNavigateToEditEvent(event.id) },
                         onReport = { showReportDialog = true },
-                        onRemove = {
-                            chatViewModel.removeConversation()
-                            onBack()
-                        },
                     )
                     ChatContent(
                         modifier = Modifier.weight(1f),


### PR DESCRIPTION
Removes the redundant Usuń entry from the event header dropdown — leaves only the organizer's Usuń wydarzenie.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicate 'Usuń' delete action from event chat header menu
> Removes the `onRemove` parameter from `EventChatHeader` and deletes the corresponding "Usuń" menu item, which was a duplicate of an existing delete action. `EventChatScreen` no longer triggers `chatViewModel.removeConversation()` or back navigation via this header action. Also bumps `appVersionName` to `0.22.7`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5268643.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->