### PR TITLE
fix(ui): soften top edge of profile and event cover images

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -15,7 +15,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.22.7" // x-release-please-version
+val appVersionName = "0.22.8" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
@@ -111,12 +111,14 @@ fun ProfilePreview(
                 .then(pageBackground)
                 .verticalScroll(rememberScrollState()),
     ) {
+        val imageTopInset =
+            WindowInsets.statusBars.asPaddingValues().calculateTopPadding() + 8.dp
         // Image carousel or avatar placeholder — rounded card with margin
         Box(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(start = 12.dp, end = 12.dp, top = 8.dp)
+                    .padding(start = 12.dp, end = 12.dp, top = imageTopInset)
                     .aspectRatio(0.75f)
                     .clip(RoundedCornerShape(24.dp)),
         ) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -8,13 +8,15 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -91,11 +93,14 @@ fun EventCoverImage(
     event: Event,
     content: @Composable BoxScope.() -> Unit,
 ) {
+    val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     Box(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .aspectRatio(16f / 10f),
+                .padding(start = 12.dp, end = 12.dp, top = statusBarTop + 8.dp)
+                .aspectRatio(16f / 10f)
+                .clip(RoundedCornerShape(24.dp)),
     ) {
         val coverImage = event.coverImage
         if (coverImage != null) {
@@ -270,7 +275,6 @@ fun EventChatHeader(
                 Modifier
                     .fillMaxWidth()
                     .align(Alignment.TopStart)
-                    .statusBarsPadding()
                     .padding(horizontal = 4.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {


### PR DESCRIPTION
Inset both images below the status bar and clip the top corners so the hero image reads as a floating card instead of a hard rectangle against the status bar.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Soften top edge of profile and event cover images with status bar insets and rounded corners
> - `EventCoverImage` now adds status bar top inset + 8dp padding, 12dp horizontal margins, and clips the image to a `RoundedCornerShape(24.dp)`.
> - `ProfilePreview` replaces the fixed 8dp top padding with a dynamic value derived from the status bar inset + 8dp.
> - `EventChatHeader` removes `.statusBarsPadding()` from its top Row since the cover image now handles that spacing.
> - Bumps Android `appVersionName` to 0.22.8 in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/443/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4734021. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->