### PR TITLE
feat(e2e): Maestro scaffold + per-PR CI + nightly device matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ backend/seed/
 # Python build cache
 __pycache__/
 *.pyc
+
+# Maestro e2e artifacts
+.maestro/artifacts/
+/0[0-9]_*.png

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,0 +1,3 @@
+appId: app.poziomki
+---
+- runFlow: flows/_helpers/launch.yaml

--- a/.maestro/flows/01_launch_smoke.yaml
+++ b/.maestro/flows/01_launch_smoke.yaml
@@ -1,0 +1,12 @@
+appId: app.poziomki
+name: Launch smoke — login screen renders
+---
+- launchApp
+- extendedWaitUntil:
+    visible: "zaloguj się"
+    timeout: 15000
+- assertVisible: "zarejestruj się"
+- assertVisible: "nie pamiętam hasła"
+- assertVisible: "email"
+- assertVisible: "hasło"
+- takeScreenshot: 01_login_screen

--- a/.maestro/flows/02_open_register.yaml
+++ b/.maestro/flows/02_open_register.yaml
@@ -1,0 +1,12 @@
+appId: app.poziomki
+name: Open register screen from login
+---
+- launchApp
+- extendedWaitUntil:
+    visible: "zarejestruj się"
+    timeout: 15000
+- tapOn: "zarejestruj się"
+- waitForAnimationToEnd
+- takeScreenshot: 02_register_screen
+- back
+- assertVisible: "zaloguj się"

--- a/.maestro/flows/03_forgot_password.yaml
+++ b/.maestro/flows/03_forgot_password.yaml
@@ -1,0 +1,12 @@
+appId: app.poziomki
+name: Open forgot-password flow
+---
+- launchApp
+- extendedWaitUntil:
+    visible: "nie pamiętam hasła"
+    timeout: 15000
+- tapOn: "nie pamiętam hasła"
+- waitForAnimationToEnd
+- takeScreenshot: 03_forgot_password
+- back
+- assertVisible: "zaloguj się"

--- a/.maestro/flows/04_login_invalid.yaml
+++ b/.maestro/flows/04_login_invalid.yaml
@@ -1,0 +1,17 @@
+appId: app.poziomki
+name: Login with invalid credentials shows error or stays on login
+---
+- launchApp
+- extendedWaitUntil:
+    visible: "email"
+    timeout: 15000
+- tapOn: "email"
+- inputText: "nope-not-real@example.invalid"
+- tapOn: "hasło"
+- inputText: "wrong-password-xxxxx"
+- hideKeyboard
+- takeScreenshot: 04a_filled_form
+- tapOn: "zaloguj się"
+- waitForAnimationToEnd
+- takeScreenshot: 04b_after_submit
+- assertVisible: "zaloguj się"

--- a/.maestro/flows/05_rotation_resilience.yaml
+++ b/.maestro/flows/05_rotation_resilience.yaml
@@ -1,0 +1,18 @@
+appId: app.poziomki
+name: Form state survives rotation
+---
+- launchApp
+- extendedWaitUntil:
+    visible: "email"
+    timeout: 15000
+- tapOn: "email"
+- inputText: "rotate-test@example.com"
+- hideKeyboard
+- setOrientation: LANDSCAPE_LEFT
+- waitForAnimationToEnd
+- takeScreenshot: 05a_landscape
+- assertVisible: "zaloguj się"
+- setOrientation: PORTRAIT
+- waitForAnimationToEnd
+- takeScreenshot: 05b_portrait
+- assertVisible: "zaloguj się"

--- a/.maestro/flows/_helpers/launch.yaml
+++ b/.maestro/flows/_helpers/launch.yaml
@@ -1,0 +1,4 @@
+appId: app.poziomki
+---
+- launchApp:
+    stopApp: true

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Run all Maestro flows on every poziomki AVD, sequentially.
+# Artifacts (screenshots, logs) go to .maestro/artifacts/<avd>/.
+set -uo pipefail
+
+ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"
+ADB="$ANDROID_HOME/platform-tools/adb"
+EMULATOR="$ANDROID_HOME/emulator/emulator"
+MAESTRO="${MAESTRO:-$HOME/.maestro/bin/maestro}"
+
+APK="mobile/androidApp/build/outputs/apk/debug/androidApp-x86_64-debug.apk"
+FLOWS=".maestro/flows"
+ARTIFACTS=".maestro/artifacts"
+AVDS=("${@:-poziomki poziomki_small poziomki_tablet}")
+# shellcheck disable=SC2206
+AVDS=( $AVDS )
+
+[[ -f "$APK" ]] || { echo "Missing $APK — run: gradle :androidApp:assembleDebug"; exit 1; }
+command -v "$MAESTRO" >/dev/null || { echo "Maestro not found at $MAESTRO"; exit 1; }
+
+mkdir -p "$ARTIFACTS"
+overall_rc=0
+
+for avd in "${AVDS[@]}"; do
+  echo "=== AVD: $avd ==="
+  out="$ARTIFACTS/$avd"
+  mkdir -p "$out"
+
+  # Boot
+  "$EMULATOR" -avd "$avd" -no-window -no-snapshot-save -no-boot-anim \
+    -gpu swiftshader_indirect -no-audio > "$out/emulator.log" 2>&1 &
+  emu_pid=$!
+
+  # Wait for boot
+  for _ in $(seq 1 120); do
+    state=$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
+    [[ "$state" == "1" ]] && break
+    sleep 2
+  done
+  if [[ "$state" != "1" ]]; then
+    echo "  ! $avd never booted; skipping"
+    kill -9 "$emu_pid" 2>/dev/null
+    overall_rc=1
+    continue
+  fi
+
+  "$ADB" install -r "$APK" > "$out/install.log" 2>&1
+
+  if "$MAESTRO" test "$FLOWS" --format junit --output "$out/report.xml" > "$out/maestro.log" 2>&1; then
+    echo "  ✓ $avd passed"
+  else
+    echo "  ✗ $avd failed — see $out/maestro.log"
+    overall_rc=1
+  fi
+
+  # Pull most recent Maestro screenshots
+  latest=$(ls -dt "$HOME/.maestro/tests"/*/ 2>/dev/null | head -1)
+  [[ -n "$latest" ]] && cp -r "$latest" "$out/screenshots" 2>/dev/null
+
+  # Stop emulator
+  "$ADB" -s emulator-5554 emu kill > /dev/null 2>&1
+  wait "$emu_pid" 2>/dev/null
+done
+
+echo
+echo "Done. Artifacts under $ARTIFACTS/."
+exit $overall_rc


### PR DESCRIPTION
Five Maestro flows, local runner, per-PR CI emulator, and a nightly matrix across 18 API/profile combos (API 26-35 × pixel_6 / pixel_tablet / Nexus 5).

- [ ] local: `gradle :androidApp:assembleDebug && scripts/run-e2e.sh`
- [ ] per-PR `E2E` job passes on this PR
- [ ] kick off `E2E nightly matrix` once via workflow_dispatch to validate before relying on the cron