### PR TITLE
fix(app): install Coil singleton in Application.onCreate

### DIFF
--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/PoziomkiApp.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/PoziomkiApp.kt
@@ -33,6 +33,7 @@ class PoziomkiApp : Application() {
                 },
             )
         }
+        installCoilSingleton()
     }
 
     @Suppress("DEPRECATION")

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/App.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/App.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import coil3.ImageLoader
 import coil3.PlatformContext
+import coil3.SingletonImageLoader
 import coil3.annotation.ExperimentalCoilApi
-import coil3.compose.setSingletonImageLoaderFactory
 import coil3.disk.DiskCache
 import coil3.memory.MemoryCache
 import coil3.network.ktor3.KtorNetworkFetcherFactory
@@ -37,13 +37,7 @@ private const val COIL_DISK_CACHE_MAX_SIZE_BYTES = 48L * 1024L * 1024L
 @Composable
 @Suppress("LongMethod")
 fun App() {
-    val engine = koinInject<HttpClientEngine>()
     val chatClient = koinInject<ChatClient>()
-    val imageHttpClient = remember(engine) { HttpClient(engine) }
-    val imageLoaderFactory: (PlatformContext) -> ImageLoader =
-        remember(imageHttpClient) { buildImageLoaderFactory(imageHttpClient) }
-
-    setSingletonImageLoaderFactory(imageLoaderFactory)
 
     val sessionManager = koinInject<SessionManager>()
     val syncEngine = koinInject<SyncEngine>()
@@ -96,7 +90,6 @@ fun App() {
     DisposableEffect(Unit) {
         onDispose {
             syncEngine.stop()
-            imageHttpClient.close()
         }
     }
 
@@ -121,7 +114,24 @@ fun App() {
     }
 }
 
-private fun buildImageLoaderFactory(imageHttpClient: HttpClient): (PlatformContext) -> ImageLoader =
+/**
+ * Install the Coil singleton image loader. Must be called from
+ * `Application.onCreate` after Koin has started — installing it lazily inside
+ * an @Composable races with `Application.onTrimMemory` / activity recreation
+ * touching `imageLoader` first, which permanently breaks `setSafe`.
+ */
+fun installCoilSingleton() {
+    val engine: HttpClientEngine = KoinPlatform.getKoin().get()
+    val imageHttpClient = HttpClient(engine)
+    val factory = buildImageLoaderFactory(imageHttpClient)
+    SingletonImageLoader.setSafe(
+        object : SingletonImageLoader.Factory {
+            override fun newImageLoader(context: PlatformContext): ImageLoader = factory(context)
+        },
+    )
+}
+
+internal fun buildImageLoaderFactory(imageHttpClient: HttpClient): (PlatformContext) -> ImageLoader =
     { context: PlatformContext ->
         ImageLoader
             .Builder(context)


### PR DESCRIPTION
Fixes a crash that killed the activity on every rotation, `pm clear`, or force-stop relaunch:

`coil3.compose.setSingletonImageLoaderFactory` ran inside `App()`, but `Application.imageLoader` was already touched from `PoziomkiApp.onTrimMemory` first, so the factory install threw `IllegalStateException`.

Moved the install to `Application.onCreate` after `startKoin`.

## Test plan
- [x] App boots, login screen renders
- [x] Rotate device — no crash, login screen redraws
- [x] `adb shell pm clear app.poziomki` + relaunch — no crash
- [x] Maestro flow 05 (rotation resilience) passes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install Coil singleton in `Application.onCreate` instead of from a Composable
> - Moves Coil `ImageLoader` setup from the `App` composable into a new `installCoilSingleton()` function called in [`PoziomkiApp.onCreate`](https://github.com/poziomki-app/poziomki/pull/445/files#diff-edf8282b8f9d3773b561ec519570bb184a20112040fe822da9c4ba17fde62f9d).
> - `installCoilSingleton()` obtains an `HttpClientEngine` from Koin, builds an `HttpClient`, and registers the loader via `SingletonImageLoader.setSafe` — ensuring one-time, safe initialization.
> - The `App` composable no longer creates an image `HttpClient`, installs a Coil singleton, or manages its lifecycle via `DisposableEffect`.
> - `buildImageLoaderFactory` is promoted from `private` to `internal` so it can be shared by `installCoilSingleton`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0b747d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->