### PR TITLE
fix(verify): require explicit tap to verify OTP

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
@@ -63,17 +63,6 @@ fun VerifyScreen(
         focusRequester.requestFocus()
     }
 
-    // Auto-submit when 6 digits entered (with guard against double-submit)
-    var hasSubmitted by remember { mutableStateOf(false) }
-    LaunchedEffect(otp) {
-        if (otp.length < 6) {
-            hasSubmitted = false
-        } else if (!hasSubmitted && !uiState.isLoading) {
-            hasSubmitted = true
-            submit()
-        }
-    }
-
     Column(
         modifier =
             Modifier


### PR DESCRIPTION
Removes the auto-submit-on-6th-digit in \`VerifyScreen\`. The "potwierdź" button is already enabled at length 6, so the auto-submit only hid the affordance and skipped any "is the code correct?" beat for the user. Also better for accessibility — a clear final tap is easier for screen-reader flows than an invisible state-change submission.

Surfaced by the e2e UX review (\`.maestro/UX_REVIEW.md\`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require explicit tap to verify OTP in `VerifyScreen`
> Removes the `LaunchedEffect` in [VerifyScreen.kt](https://github.com/poziomki-app/poziomki/pull/447/files#diff-57c2d29996eb02009a6c66508839dff1b1f0fa91bac775455f5444708dbe0a78) that auto-submitted the form when 6 digits were entered. Users must now explicitly tap a submit button to trigger OTP verification. Behavioral Change: any user flow that relied on auto-submission upon entering the 6th digit will now require an additional tap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b34042.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->