### PR TITLE
fix(auth): lift register form above the IME

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/RegisterScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/RegisterScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -63,6 +64,7 @@ fun RegisterScreen(
             Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = PoziomkiTheme.spacing.lg)
                 .padding(bottom = PoziomkiTheme.spacing.xl),


### PR DESCRIPTION
The keyboard covered the privacy checkbox + submit button on the register screen, with no scroll cue. Added \`Modifier.imePadding()\` to the scrollable form column so the focused field can be brought above the keyboard.

OnboardingLayout already uses \`WindowInsets.ime\` in its bottom bar — onboarding screens unaffected.

Surfaced by the e2e UX review (\`.maestro/UX_REVIEW.md\`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply IME padding to the register form so it lifts above the on-screen keyboard
> Adds `.imePadding()` to the root `Modifier` chain in [RegisterScreen.kt](https://github.com/poziomki-app/poziomki/pull/448/files#diff-4d46844c2ddd57e245e0702a86a87c89646563f430cdb7ebc13328aacad5bf21) so the form content adjusts its bottom padding when the soft keyboard is visible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3f57c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->