### PR TITLE
fix(onboarding): hide back arrow on first step

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/BasicInfoScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/BasicInfoScreen.kt
@@ -54,7 +54,10 @@ fun BasicInfoScreen(
     OnboardingLayout(
         currentStep = 1,
         totalSteps = 3,
-        showBack = true,
+        // First onboarding step — pressing back from here would silently
+        // leave the user logged in but without a profile, which is a worse
+        // dead end than just staying on the form. Hide the affordance.
+        showBack = false,
         onBack = onBack,
         footer = {
             AppButton(


### PR DESCRIPTION
Pressing back from \`BasicInfoScreen\` would leave the user logged in but without a profile — silently stranding them. Hide \`showBack\` on the first step. Subsequent onboarding steps keep it.

Surfaced by the e2e UX review (\`.maestro/UX_REVIEW.md\`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide back arrow on the first onboarding step in `BasicInfoScreen`
> Passes `showBack=false` to `OnboardingLayout` in `BasicInfoScreen` so the back affordance is not shown on the first step of onboarding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e7e4e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->