### PR TITLE
fix(auth): style "nie pamiętam hasła" as a link

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/LoginScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/LoginScreen.kt
@@ -130,9 +130,9 @@ fun LoginScreen(
             Text(
                 text = "nie pami\u0119tam has\u0142a",
                 fontFamily = NunitoFamily,
-                fontWeight = FontWeight.Normal,
+                fontWeight = FontWeight.SemiBold,
                 fontSize = 13.sp,
-                color = TextMuted,
+                color = Primary,
             )
         }
 


### PR DESCRIPTION
The forgot-password label on the login screen was muted-gray and normal-weight, which read as a section label instead of an action. Restyle to match the existing "zarejestruj się" link below the sign-in button (Primary teal, SemiBold).

Surfaced by the e2e UX review (\`.maestro/UX_REVIEW.md\`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Style 'nie pamiętam hasła' as a link on the login screen
> Updates the forgot-password text in [LoginScreen.kt](https://github.com/poziomki-app/poziomki/pull/450/files#diff-d4b3243bfcbcb55d6a2d3d6935b2157c75a0f58675c340a358de4002409cceb6) to use `FontWeight.SemiBold` and the primary color instead of normal weight and muted color, making it visually identifiable as a tappable link.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2feba00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->