### PR TITLE
style(button): make disabled state read clearly as off

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
@@ -61,8 +61,8 @@ private fun borderColor(
     enabled: Boolean,
 ): Color =
     when (variant) {
-        ButtonVariant.DESTRUCTIVE -> if (enabled) Error.copy(alpha = 0.5f) else Error.copy(alpha = 0.2f)
-        else -> if (enabled) Border else Border.copy(alpha = 0.5f)
+        ButtonVariant.DESTRUCTIVE -> if (enabled) Error.copy(alpha = 0.5f) else Error.copy(alpha = 0.15f)
+        else -> if (enabled) Border else Border.copy(alpha = 0.3f)
     }
 
 @Suppress("LongParameterList")
@@ -78,7 +78,10 @@ fun AppButton(
     icon: ImageVector? = null,
 ) {
     val isEnabled = enabled && !loading
-    val tint = contentColor(variant).let { if (isEnabled) it else it.copy(alpha = 0.4f) }
+    // Stronger disabled fade (was 0.4) so disabled buttons read clearly as
+    // off-state against the dark form backgrounds — previously they were
+    // nearly indistinguishable from the enabled state.
+    val tint = contentColor(variant).let { if (isEnabled) it else it.copy(alpha = 0.25f) }
     val isIconOnly = text.isEmpty() && icon != null
 
     val rowModifier =


### PR DESCRIPTION
Across login / register / forgot-password / onboarding the primary CTA looked broken on first paint: the disabled state shifted only the text alpha by 60 %, leaving the border + fill unchanged, so users couldn't tell whether the button was "off" or just hard to see.

Lowered disabled alpha:
- content tint: 0.40 → 0.25
- border (non-destructive): 0.50 → 0.30
- border (destructive): 0.20 → 0.15

Enabled state untouched.

Surfaced by the e2e UX review (\`.maestro/UX_REVIEW.md\`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce disabled-state opacity for `AppButton` content and borders
> Lowers alpha values in [`AppButton.kt`](https://github.com/poziomki-app/poziomki/pull/451/files#diff-37fe2ab8c56db3e0875e1c8e6619d97b409e8d8e26307952be43e980635367fd) so disabled buttons read more clearly as off. Content (text/icon) alpha drops from 0.4 to 0.25; border alpha drops from 0.5 to 0.3 for standard variants and from 0.2 to 0.15 for destructive variants.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff62b1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->