### PR TITLE
style(auth): promote register link on login to a real button

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/LoginScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/LoginScreen.kt
@@ -148,17 +148,13 @@ fun LoginScreen(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        TextButton(
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
+
+        AppButton(
+            text = "zarejestruj si\u0119",
             onClick = onNavigateToRegister,
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        ) {
-            Text(
-                text = "zarejestruj si\u0119",
-                fontFamily = NunitoFamily,
-                fontWeight = FontWeight.SemiBold,
-                fontSize = 14.sp,
-                color = Primary,
-            )
-        }
+            variant = ButtonVariant.SECONDARY,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }


### PR DESCRIPTION
"zarejestruj się" on the login screen was a teal text link — easy to miss as a primary alternative to signing in. Promoting it to a \`SECONDARY\` AppButton (same shape/border as the primary CTA, lower visual weight) makes the "or create an account" path discoverable without competing with sign-in.

Surfaced by user feedback on the UX review run.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace register `TextButton` with full-width secondary `AppButton` on login screen
> In [LoginScreen.kt](https://github.com/poziomki-app/poziomki/pull/452/files#diff-d4b3243bfcbcb55d6a2d3d6935b2157c75a0f58675c340a358de4002409cceb6), the "zarejestruj się" link-style `TextButton` is replaced with a full-width `AppButton` using `ButtonVariant.SECONDARY`, with a `PoziomkiTheme.spacing.md` spacer above it. Click behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a40b99.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->