### PR TITLE
feat(feedback): welcome modal + in-app feedback for test phase

### DIFF
--- a/backend/migrations/2026-05-18-000000_user_feedback/down.sql
+++ b/backend/migrations/2026-05-18-000000_user_feedback/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.user_feedback;

--- a/backend/migrations/2026-05-18-000000_user_feedback/up.sql
+++ b/backend/migrations/2026-05-18-000000_user_feedback/up.sql
@@ -1,0 +1,23 @@
+-- Collects free-form test-phase feedback from real users: 1–5 star
+-- rating plus optional text. Indexed by created_at so we can scan
+-- the latest entries while triaging.
+
+CREATE TABLE public.user_feedback (
+    id UUID PRIMARY KEY,
+    user_id INT4 NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    rating SMALLINT NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    message TEXT,
+    app_version TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_user_feedback_created_at ON public.user_feedback (created_at DESC);
+CREATE INDEX idx_user_feedback_user_id ON public.user_feedback (user_id);
+
+-- Row-level security: a user can only insert/see their own feedback.
+ALTER TABLE public.user_feedback ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_feedback FORCE ROW LEVEL SECURITY;
+CREATE POLICY user_feedback_owner ON public.user_feedback
+    FOR ALL TO poziomki_api
+    USING (user_id = app.current_user_id())
+    WITH CHECK (user_id = app.current_user_id());

--- a/backend/src/api/feedback.rs
+++ b/backend/src/api/feedback.rs
@@ -1,0 +1,94 @@
+//! Test-phase feedback collection. Mobile clients POST a 1–5 star
+//! rating plus an optional free-form message; we persist it for triage
+//! during the closed test rollout.
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use chrono::Utc;
+use diesel_async::RunQueryDsl;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::state::DataResponse;
+use crate::api::common::{auth_or_respond, error_response, ErrorSpec};
+use crate::app::AppContext;
+use crate::db::models::user_feedback::NewUserFeedback;
+use crate::db::schema::user_feedback;
+
+type Result<T> = crate::error::AppResult<T>;
+
+const MAX_MESSAGE_LEN: usize = 4000;
+const MAX_APP_VERSION_LEN: usize = 64;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::api) struct CreateFeedbackBody {
+    pub rating: i16,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub app_version: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct CreateFeedbackResponse {
+    id: Uuid,
+}
+
+pub(super) async fn create(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Json(body): Json<CreateFeedbackBody>,
+) -> Result<Response> {
+    let (_session, user) = auth_or_respond!(headers);
+
+    if !(1..=5).contains(&body.rating) {
+        return Ok(error_response(
+            StatusCode::BAD_REQUEST,
+            &headers,
+            ErrorSpec {
+                error: "rating must be between 1 and 5".to_string(),
+                code: "BAD_REQUEST",
+                details: None,
+            },
+        ));
+    }
+
+    let message = body
+        .message
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.chars().take(MAX_MESSAGE_LEN).collect::<String>());
+
+    let app_version = body
+        .app_version
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.chars().take(MAX_APP_VERSION_LEN).collect::<String>());
+
+    let row = NewUserFeedback {
+        id: Uuid::new_v4(),
+        user_id: user.id,
+        rating: body.rating,
+        message,
+        app_version,
+        created_at: Utc::now(),
+    };
+
+    let mut conn = crate::db::conn().await?;
+    diesel::insert_into(user_feedback::table)
+        .values(&row)
+        .execute(&mut conn)
+        .await?;
+
+    Ok(Json(DataResponse {
+        data: CreateFeedbackResponse { id: row.id },
+    })
+    .into_response())
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -17,6 +17,7 @@ mod catalog;
 pub(crate) mod chat;
 mod common;
 mod events;
+mod feedback;
 pub(crate) mod imgproxy_signing;
 pub mod ip_rate_limit;
 mod matching;
@@ -170,6 +171,12 @@ fn routing_routes() -> Router<AppContext> {
         .layer(cache_layer("private, max-age=300"))
 }
 
+fn feedback_routes() -> Router<AppContext> {
+    Router::new()
+        .route("/", post(feedback::create))
+        .layer(cache_layer("no-store"))
+}
+
 fn settings_routes() -> Router<AppContext> {
     Router::new().route(
         "/",
@@ -285,6 +292,7 @@ pub fn router() -> Router<AppContext> {
         .nest("/api/v1/matching", matching_routes())
         .nest("/api/v1/uploads", uploads_routes())
         .nest("/api/v1/settings", settings_routes())
+        .nest("/api/v1/feedback", feedback_routes())
         .nest("/api/v1", search_routes())
         .nest("/api/v1/chat", chat_routes())
         .nest("/api/v1/routing", routing_routes())

--- a/backend/src/db/models/mod.rs
+++ b/backend/src/db/models/mod.rs
@@ -22,5 +22,6 @@ pub mod sessions;
 pub mod tags;
 pub mod uploads;
 pub mod user_audit_log;
+pub mod user_feedback;
 pub mod user_settings;
 pub mod users;

--- a/backend/src/db/models/user_feedback.rs
+++ b/backend/src/db/models/user_feedback.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use crate::db::schema::user_feedback;
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = user_feedback)]
+pub struct NewUserFeedback {
+    pub id: Uuid,
+    pub user_id: i32,
+    pub rating: i16,
+    pub message: Option<String>,
+    pub app_version: Option<String>,
+    pub created_at: DateTime<Utc>,
+}

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -291,6 +291,17 @@ diesel::table! {
 }
 
 diesel::table! {
+    user_feedback (id) {
+        id -> Uuid,
+        user_id -> Int4,
+        rating -> Int2,
+        message -> Nullable<Text>,
+        app_version -> Nullable<Text>,
+        created_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     user_settings (id) {
         id -> Uuid,
         user_id -> Int4,
@@ -353,6 +364,7 @@ diesel::joinable!(profile_tags -> tags (tag_id));
 diesel::joinable!(reports -> profiles (reporter_id));
 diesel::joinable!(profiles -> users (user_id));
 diesel::joinable!(sessions -> users (user_id));
+diesel::joinable!(user_feedback -> users (user_id));
 diesel::joinable!(user_settings -> users (user_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
@@ -380,6 +392,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     sessions,
     tags,
     uploads,
+    user_feedback,
     user_settings,
     users,
     user_audit_log,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/di/AppModule.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/di/AppModule.kt
@@ -5,6 +5,7 @@ import com.poziomki.app.ui.feature.auth.AuthViewModel
 import com.poziomki.app.ui.feature.chat.ChatViewModel
 import com.poziomki.app.ui.feature.event.EventCreateViewModel
 import com.poziomki.app.ui.feature.event.EventDetailViewModel
+import com.poziomki.app.ui.feature.feedback.FeedbackViewModel
 import com.poziomki.app.ui.feature.home.EventsViewModel
 import com.poziomki.app.ui.feature.home.ExploreViewModel
 import com.poziomki.app.ui.feature.home.MessagesViewModel
@@ -35,4 +36,5 @@ val appModule =
         viewModelOf(::PrivacyViewModel)
         viewModelOf(::PowiadomieniaViewModel)
         viewModelOf(::SavedViewModel)
+        viewModelOf(::FeedbackViewModel)
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackBanner.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackBanner.kt
@@ -1,0 +1,77 @@
+package com.poziomki.app.ui.feature.feedback
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Bold
+import com.adamglin.phosphoricons.Regular
+import com.adamglin.phosphoricons.bold.X
+import com.adamglin.phosphoricons.regular.ChatTeardropText
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.TextPrimary
+import com.poziomki.app.ui.designsystem.theme.TextSecondary
+
+@Composable
+fun FeedbackBanner(
+    onClick: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val rowModifier =
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Primary.copy(alpha = 0.12f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+    Row(
+        modifier = rowModifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = PhosphorIcons.Regular.ChatTeardropText,
+            contentDescription = null,
+            tint = Primary,
+            modifier = Modifier.size(20.dp),
+        )
+        Column(
+            modifier = Modifier.weight(1f).padding(horizontal = 12.dp),
+        ) {
+            Text(
+                text = "Testujemy aplikację!",
+                fontFamily = NunitoFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                color = TextPrimary,
+            )
+            Text(
+                text = "Zostaw opinię — dotknij, aby otworzyć",
+                fontFamily = NunitoFamily,
+                fontSize = 12.sp,
+                color = TextSecondary,
+            )
+        }
+        Icon(
+            imageVector = PhosphorIcons.Bold.X,
+            contentDescription = "Zamknij",
+            tint = TextSecondary,
+            modifier = Modifier.size(20.dp).clickable(onClick = onDismiss),
+        )
+    }
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackDialog.kt
@@ -1,0 +1,121 @@
+package com.poziomki.app.ui.feature.feedback
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.adamglin.PhosphorIcons
+import com.adamglin.phosphoricons.Fill
+import com.adamglin.phosphoricons.Regular
+import com.adamglin.phosphoricons.fill.Star
+import com.adamglin.phosphoricons.regular.Star
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.TextMuted
+import com.poziomki.app.ui.designsystem.theme.TextSecondary
+
+@Suppress("LongMethod", "LongParameterList")
+@Composable
+fun FeedbackDialog(
+    rating: Int,
+    message: String,
+    isSubmitting: Boolean,
+    error: String?,
+    onRatingChange: (Int) -> Unit,
+    onMessageChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = { if (!isSubmitting) onDismiss() },
+        title = {
+            Text(
+                text = "Zostaw opinię",
+                fontFamily = NunitoFamily,
+                fontWeight = FontWeight.Bold,
+            )
+        },
+        text = {
+            Column {
+                Text(
+                    text = "Jak oceniasz aplikację?",
+                    fontFamily = NunitoFamily,
+                    fontSize = 14.sp,
+                    color = TextSecondary,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    for (i in 1..5) {
+                        val filled = i <= rating
+                        Icon(
+                            imageVector = if (filled) PhosphorIcons.Fill.Star else PhosphorIcons.Regular.Star,
+                            contentDescription = "$i",
+                            tint = if (filled) Primary else TextMuted,
+                            modifier = Modifier.size(36.dp).clickable(enabled = !isSubmitting) { onRatingChange(i) },
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                OutlinedTextField(
+                    value = message,
+                    onValueChange = onMessageChange,
+                    placeholder = {
+                        Text(
+                            text = "Co działa, co nie, co poprawić?",
+                            fontFamily = NunitoFamily,
+                            color = TextMuted,
+                        )
+                    },
+                    minLines = 3,
+                    maxLines = 6,
+                    enabled = !isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (error != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = error,
+                        fontFamily = NunitoFamily,
+                        fontSize = 13.sp,
+                        color = Color(0xFFD32F2F),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onSubmit,
+                enabled = rating in 1..5 && !isSubmitting,
+            ) {
+                Text(
+                    text = if (isSubmitting) "Wysyłanie…" else "Wyślij",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isSubmitting) {
+                Text("Anuluj", fontFamily = NunitoFamily)
+            }
+        },
+    )
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackViewModel.kt
@@ -1,0 +1,113 @@
+package com.poziomki.app.ui.feature.feedback
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.poziomki.app.network.ApiResult
+import com.poziomki.app.network.ApiService
+import com.poziomki.app.network.FeedbackRequest
+import com.poziomki.app.session.AppPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+data class FeedbackState(
+    val showWelcome: Boolean = false,
+    val bannerVisible: Boolean = false,
+    val dialogOpen: Boolean = false,
+    val rating: Int = 0,
+    val message: String = "",
+    val isSubmitting: Boolean = false,
+    val submitted: Boolean = false,
+    val error: String? = null,
+)
+
+class FeedbackViewModel(
+    private val apiService: ApiService,
+    private val appPreferences: AppPreferences,
+) : ViewModel() {
+    private val _state = MutableStateFlow(FeedbackState())
+    val state: StateFlow<FeedbackState> = _state.asStateFlow()
+
+    init {
+        appPreferences.welcomeSeen
+            .onEach { seen -> _state.value = _state.value.copy(showWelcome = !seen) }
+            .launchIn(viewModelScope)
+        appPreferences.feedbackBannerDismissed
+            .onEach { dismissed -> _state.value = _state.value.copy(bannerVisible = !dismissed) }
+            .launchIn(viewModelScope)
+    }
+
+    fun dismissWelcome() {
+        _state.value = _state.value.copy(showWelcome = false)
+        viewModelScope.launch { appPreferences.setWelcomeSeen(true) }
+    }
+
+    fun dismissBanner() {
+        _state.value = _state.value.copy(bannerVisible = false)
+        viewModelScope.launch { appPreferences.setFeedbackBannerDismissed(true) }
+    }
+
+    fun openDialog() {
+        _state.value =
+            _state.value.copy(
+                dialogOpen = true,
+                rating = 0,
+                message = "",
+                submitted = false,
+                error = null,
+            )
+    }
+
+    fun closeDialog() {
+        _state.value = _state.value.copy(dialogOpen = false)
+    }
+
+    fun setRating(value: Int) {
+        _state.value = _state.value.copy(rating = value, error = null)
+    }
+
+    fun setMessage(value: String) {
+        _state.value = _state.value.copy(message = value)
+    }
+
+    fun submit(appVersion: String?) {
+        val current = _state.value
+        if (current.rating !in 1..5 || current.isSubmitting) return
+        viewModelScope.launch {
+            _state.value = current.copy(isSubmitting = true, error = null)
+            val req =
+                FeedbackRequest(
+                    rating = current.rating,
+                    message = current.message.trim().takeIf { it.isNotEmpty() },
+                    appVersion = appVersion,
+                )
+            when (apiService.submitFeedback(req)) {
+                is ApiResult.Success -> {
+                    _state.value =
+                        _state.value.copy(
+                            isSubmitting = false,
+                            submitted = true,
+                            dialogOpen = false,
+                            bannerVisible = false,
+                        )
+                    appPreferences.setFeedbackBannerDismissed(true)
+                }
+
+                is ApiResult.Error -> {
+                    _state.value =
+                        _state.value.copy(
+                            isSubmitting = false,
+                            error = "Nie udało się wysłać opinii. Spróbuj ponownie.",
+                        )
+                }
+            }
+        }
+    }
+
+    fun clearSubmitted() {
+        _state.value = _state.value.copy(submitted = false)
+    }
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/WelcomeDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/WelcomeDialog.kt
@@ -1,0 +1,86 @@
+package com.poziomki.app.ui.feature.feedback
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.TextSecondary
+
+@Composable
+fun WelcomeDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = "Witaj w Poziomkach!",
+                fontFamily = NunitoFamily,
+                fontWeight = FontWeight.Bold,
+            )
+        },
+        text = {
+            Column {
+                WelcomeParagraph(
+                    "Dzięki, że pomagasz nam testować aplikację. To jeszcze wersja " +
+                        "rozwojowa — niektóre rzeczy mogą działać dziwnie.",
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                WelcomeBullet("Bądź miły — to społeczność studencka, nie aplikacja randkowa.")
+                WelcomeBullet("Nie udostępniaj swoich danych logowania innym.")
+                WelcomeBullet("Zgłaszaj nadużycia (długie przytrzymanie wiadomości lub menu profilu).")
+                WelcomeBullet("Daj nam znać, co działa, a co nie — kliknij „Zostaw opinię”.")
+                Spacer(modifier = Modifier.height(12.dp))
+                WelcomeParagraph(
+                    "Miłej zabawy i dzięki, że jesteś częścią pierwszego testu.",
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = "Rozumiem",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun WelcomeParagraph(text: String) {
+    Text(
+        text = text,
+        fontFamily = NunitoFamily,
+        fontSize = 14.sp,
+        color = TextSecondary,
+    )
+}
+
+@Composable
+private fun WelcomeBullet(text: String) {
+    Row {
+        Text(
+            text = "•",
+            fontFamily = NunitoFamily,
+            fontSize = 14.sp,
+            color = TextSecondary,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = text,
+            fontFamily = NunitoFamily,
+            fontSize = 14.sp,
+            color = TextSecondary,
+        )
+    }
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
@@ -39,6 +39,7 @@ import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.bold.Bell
 import com.adamglin.phosphoricons.bold.BookmarkSimple
 import com.adamglin.phosphoricons.bold.CaretRight
+import com.adamglin.phosphoricons.bold.ChatTeardropText
 import com.adamglin.phosphoricons.bold.PencilSimple
 import com.adamglin.phosphoricons.bold.Shield
 import com.adamglin.phosphoricons.bold.SignOut
@@ -66,6 +67,7 @@ fun ProfileScreen(
     onNavigateToPowiadomienia: () -> Unit,
     onNavigateToSaved: () -> Unit,
     onNavigateToProfileView: (String) -> Unit,
+    onOpenFeedback: () -> Unit,
     onSignOut: () -> Unit,
     viewModel: ProfileViewModel = koinViewModel(),
 ) {
@@ -135,6 +137,12 @@ fun ProfileScreen(
                                         icon = PhosphorIcons.Bold.BookmarkSimple,
                                         label = "zapisane",
                                         onClick = onNavigateToSaved,
+                                    )
+                                    HorizontalDivider(color = Border, thickness = 1.dp)
+                                    SettingsMenuItem(
+                                        icon = PhosphorIcons.Bold.ChatTeardropText,
+                                        label = "zostaw opinię",
+                                        onClick = onOpenFeedback,
                                     )
                                 }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -87,6 +87,10 @@ import com.poziomki.app.ui.feature.auth.VerifyScreen
 import com.poziomki.app.ui.feature.chat.ChatScreen
 import com.poziomki.app.ui.feature.event.EventChatScreen
 import com.poziomki.app.ui.feature.event.EventCreateScreen
+import com.poziomki.app.ui.feature.feedback.FeedbackBanner
+import com.poziomki.app.ui.feature.feedback.FeedbackDialog
+import com.poziomki.app.ui.feature.feedback.FeedbackViewModel
+import com.poziomki.app.ui.feature.feedback.WelcomeDialog
 import com.poziomki.app.ui.feature.home.EventsScreen
 import com.poziomki.app.ui.feature.home.ExploreScreen
 import com.poziomki.app.ui.feature.home.MessagesScreen
@@ -501,6 +505,9 @@ fun MainScreen(
     val profileState by profileViewModel.state.collectAsState()
     val profilePicture = profileState.profile?.profilePicture
 
+    val feedbackViewModel: FeedbackViewModel = koinViewModel()
+    val feedbackState by feedbackViewModel.state.collectAsState()
+
     val navigateToProfileTab: () -> Unit = {
         tabNavController.navigate(Route.ProfileTab) {
             popUpTo(tabNavController.graph.findStartDestination().id) {
@@ -532,6 +539,12 @@ fun MainScreen(
         ) {
             Column(modifier = Modifier.fillMaxSize().padding(top = safeTop)) {
                 OfflineBanner()
+                if (feedbackState.bannerVisible && !immersive.value) {
+                    FeedbackBanner(
+                        onClick = { feedbackViewModel.openDialog() },
+                        onDismiss = { feedbackViewModel.dismissBanner() },
+                    )
+                }
                 Box(modifier = Modifier.fillMaxSize().weight(1f)) {
                     NavHost(
                         navController = tabNavController,
@@ -571,6 +584,7 @@ fun MainScreen(
                                 onNavigateToPowiadomienia = onNavigateToPowiadomienia,
                                 onNavigateToSaved = onNavigateToSaved,
                                 onNavigateToProfileView = onNavigateToProfileView,
+                                onOpenFeedback = { feedbackViewModel.openDialog() },
                                 onSignOut = onSignOut,
                             )
                         }
@@ -641,6 +655,22 @@ fun MainScreen(
                 }
             }
         }
+    }
+
+    if (feedbackState.showWelcome) {
+        WelcomeDialog(onDismiss = { feedbackViewModel.dismissWelcome() })
+    }
+    if (feedbackState.dialogOpen) {
+        FeedbackDialog(
+            rating = feedbackState.rating,
+            message = feedbackState.message,
+            isSubmitting = feedbackState.isSubmitting,
+            error = feedbackState.error,
+            onRatingChange = { feedbackViewModel.setRating(it) },
+            onMessageChange = { feedbackViewModel.setMessage(it) },
+            onSubmit = { feedbackViewModel.submit(appVersion = null) },
+            onDismiss = { feedbackViewModel.closeDialog() },
+        )
     }
 }
 

--- a/mobile/core/detekt-baseline.xml
+++ b/mobile/core/detekt-baseline.xml
@@ -4,6 +4,7 @@
   <CurrentIssues>
     <ID>ArgumentListWrapping:ApiService.kt$ApiService$("/api/v1/auth/resend-otp", ResendOtpRequest(email))</ID>
     <ID>ArgumentListWrapping:ApiService.kt$ApiService$("/api/v1/events/$id/attendees")</ID>
+    <ID>ArgumentListWrapping:ApiService.kt$ApiService$("/api/v1/feedback", request)</ID>
     <ID>ArgumentListWrapping:ApiService.kt$ApiService$("/api/v1/profiles", request)</ID>
     <ID>ArgumentListWrapping:ApiService.kt$ApiService$("/api/v1/profiles/$id/bookmark")</ID>
     <ID>ArgumentListWrapping:ApiService.kt$ApiService$("/api/v1/settings", request)</ID>

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
@@ -240,6 +240,8 @@ class ApiService(
 
     suspend fun updateSettings(request: UpdateSettingsRequest): ApiResult<UserSettingsResponse> = client.patch("/api/v1/settings", request)
 
+    suspend fun submitFeedback(request: FeedbackRequest): ApiResult<SuccessResponse> = client.post("/api/v1/feedback", request)
+
     suspend fun walkingRoute(
         fromLat: Double,
         fromLng: Double,

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
@@ -493,6 +493,15 @@ data class UserSettingsResponse(
     val notifyTagEvents: Boolean = true,
 )
 
+// Feedback models
+
+@Serializable
+data class FeedbackRequest(
+    val rating: Int,
+    val message: String? = null,
+    val appVersion: String? = null,
+)
+
 // Routing models
 
 @Serializable

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/AppPreferences.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/AppPreferences.kt
@@ -12,6 +12,8 @@ class AppPreferences(
 ) {
     private companion object {
         val SCREENSHOTS_ALLOWED = booleanPreferencesKey("screenshots_allowed")
+        val WELCOME_SEEN = booleanPreferencesKey("welcome_seen_v1")
+        val FEEDBACK_BANNER_DISMISSED = booleanPreferencesKey("feedback_banner_dismissed_v1")
     }
 
     val screenshotsAllowed: Flow<Boolean> =
@@ -19,5 +21,19 @@ class AppPreferences(
 
     suspend fun setScreenshotsAllowed(allowed: Boolean) {
         dataStore.edit { it[SCREENSHOTS_ALLOWED] = allowed }
+    }
+
+    val welcomeSeen: Flow<Boolean> =
+        dataStore.data.map { prefs -> prefs[WELCOME_SEEN] ?: false }
+
+    suspend fun setWelcomeSeen(seen: Boolean) {
+        dataStore.edit { it[WELCOME_SEEN] = seen }
+    }
+
+    val feedbackBannerDismissed: Flow<Boolean> =
+        dataStore.data.map { prefs -> prefs[FEEDBACK_BANNER_DISMISSED] ?: false }
+
+    suspend fun setFeedbackBannerDismissed(dismissed: Boolean) {
+        dataStore.edit { it[FEEDBACK_BANNER_DISMISSED] = dismissed }
     }
 }


### PR DESCRIPTION
- one-time Polish welcome modal with test-phase rules (shown on first launch)
- dismissable feedback banner on home + entry in profile settings
- 1-5 star + free-text feedback dialog
- backend `POST /api/v1/feedback` persisting to `user_feedback` table with RLS

## Test plan
- [ ] run `diesel migration run` on staging
- [ ] sign in → welcome modal appears once, doesn't reappear after dismiss
- [ ] banner on home → tap → dialog opens → submit 4★ + text → row in `user_feedback`
- [ ] dismiss banner → stays hidden across app restarts
- [ ] profile → "zostaw opinię" opens dialog
- [ ] backend rejects rating outside 1..5

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-app feedback flow and welcome dialog for test phase
> - Adds a `WelcomeDialog` shown on first launch and a dismissible `FeedbackBanner` in the main screen, with visibility state persisted via two new `AppPreferences` keys (`welcome_seen_v1`, `feedback_banner_dismissed_v1`).
> - Adds a `FeedbackDialog` (star rating 1–5, optional message) accessible from the banner and a new 'zostaw opinię' entry in `ProfileScreen`; submission is handled by `FeedbackViewModel` via a new `ApiService.submitFeedback` POST to `/api/v1/feedback`.
> - Adds the backend `user_feedback` table with a 1–5 rating check constraint, RLS enforced per-user via `app.current_user_id()`, and a Rust handler that validates and persists feedback rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c904382.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->