### PR TITLE
feat(events): doodle for weekly empty state

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -556,7 +556,7 @@ private fun WeekEventsContent(
     onEventClick: (String) -> Unit,
 ) {
     if (events.isEmpty()) {
-        EmptyView("brak wydarzeń w tym tygodniu")
+        EmptyView("brak wydarzeń w tym tygodniu", illustration = Res.drawable.doodle_meditating)
         return
     }
 


### PR DESCRIPTION
Apply the existing reading doodle to "brak wydarzeń w tym tygodniu" too.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add meditating doodle illustration to weekly empty state in EventsScreen
> Passes `Res.drawable.doodle_meditating` as the illustration parameter to `EmptyView` in [`EventsScreen.kt`](https://github.com/poziomki-app/poziomki/pull/460/files#diff-b1aad26129722f5aa103f55ac1d883a2b472203a3df536f251798d2ab83260dd) when the weekly events list is empty. Previously, the empty state displayed only a message with no illustration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 176ca09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->