### PR TITLE
polish(events): trim location strings and ellipsize long titles

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -76,6 +77,7 @@ import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.feature.chat.ActionMenuItem
 import com.poziomki.app.ui.shared.formatEventDateCompact
+import com.poziomki.app.ui.shared.formatEventLocation
 import com.poziomki.app.ui.shared.resolveImageUrl
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.rememberCameraState
@@ -151,7 +153,7 @@ fun EventMetaRows(
         event.location?.let { location ->
             MetaChip(
                 icon = PhosphorIcons.Fill.MapPin,
-                text = shortenLocation(location),
+                text = formatEventLocation(location),
                 onClick = onLocationClick,
             )
         }
@@ -241,12 +243,6 @@ private fun ChipContent(
             maxLines = 1,
         )
     }
-}
-
-private fun shortenLocation(location: String): String {
-    val parts = location.split(",").map { it.trim() }
-    if (parts.size <= 2) return location
-    return parts.dropLast(1).joinToString(", ")
 }
 
 @Composable
@@ -379,6 +375,8 @@ fun EventChatHeader(
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.ExtraBold,
                 color = Color.White,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
             )
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xs))

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adamglin.PhosphorIcons
@@ -175,6 +176,8 @@ fun EventChatJoinRequiredView(
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.ExtraBold,
                     color = Color.White,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -89,6 +89,7 @@ import com.poziomki.app.ui.shared.TimeFilter
 import com.poziomki.app.ui.shared.dayLabel
 import com.poziomki.app.ui.shared.eventDateKey
 import com.poziomki.app.ui.shared.formatEventDate
+import com.poziomki.app.ui.shared.formatEventLocation
 import com.poziomki.app.ui.shared.pluralizePolish
 import com.poziomki.app.ui.shared.rememberLocationPermissionLauncher
 import com.poziomki.app.ui.shared.resolveImageUrl
@@ -401,6 +402,7 @@ private fun EventCard(
                         color = TextPrimary,
                         fontWeight = FontWeight.Bold,
                         maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
                     )
 
                     Spacer(modifier = Modifier.height(2.dp))
@@ -429,13 +431,14 @@ private fun EventCard(
                             )
                             Spacer(modifier = Modifier.width(2.dp))
                             Text(
-                                text = location,
+                                text = formatEventLocation(location),
                                 preserveCase = true,
                                 fontFamily = NunitoFamily,
                                 fontWeight = FontWeight.Normal,
                                 fontSize = 14.sp,
                                 color = TextMuted,
                                 maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                                 modifier = Modifier.weight(1f, fill = false),
                             )
                         }
@@ -696,6 +699,7 @@ private fun EventRowContent(
             fontSize = 18.sp,
             color = TextPrimary,
             maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
         Spacer(modifier = Modifier.height(2.dp))
         Text(
@@ -715,7 +719,7 @@ private fun EventRowContent(
                 )
                 Spacer(modifier = Modifier.width(3.dp))
                 Text(
-                    text = location,
+                    text = formatEventLocation(location),
                     preserveCase = true,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.Normal,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/shared/LocationFormat.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/shared/LocationFormat.kt
@@ -1,0 +1,32 @@
+package com.poziomki.app.ui.shared
+
+// Picks the first comma-separated segment that reads as a place name, falling
+// back to a street address with the "ul. " / "ulica " prefix stripped.
+// Examples:
+//   "Plaża Wilanów, Aleja..."          -> "Plaża Wilanów"
+//   "Elektrownia Powiśle, ul."         -> "Elektrownia Powiśle"
+//   "ul. Koszykowa 86"                 -> "Koszykowa 86"
+//   "pjatk, aula a1, ul. koszykowa 86" -> "pjatk"
+fun formatEventLocation(raw: String): String {
+    val segments = raw.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+    if (segments.isEmpty()) return raw.trim()
+    val descriptive = segments.firstOrNull { !it.startsWithStreetPrefix() }
+    if (descriptive != null) return descriptive
+    return segments.first().stripStreetPrefix()
+}
+
+private fun String.startsWithStreetPrefix(): Boolean {
+    val lower = lowercase()
+    return lower.startsWith("ul.") || lower.startsWith("ul ") || lower.startsWith("ulica ")
+}
+
+private fun String.stripStreetPrefix(): String {
+    val lower = lowercase()
+    return when {
+        lower.startsWith("ul. ") -> substring(4).trim()
+        lower.startsWith("ul.") -> substring(3).trim()
+        lower.startsWith("ul ") -> substring(3).trim()
+        lower.startsWith("ulica ") -> substring(6).trim()
+        else -> trim()
+    }
+}


### PR DESCRIPTION
- `formatEventLocation`: keeps first descriptive segment (e.g. "Plaża Wilanów, Aleja..." → "Plaża Wilanów"); falls back to street name minus "ul." prefix when no descriptive part.
- Event titles and the location pill on cards + detail header now ellipsize instead of overflowing.

- [ ] eyeball event list, event detail, join screen

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trim and ellipsize event location and title text across event UI components
> - Adds a shared `formatEventLocation(raw)` utility in [`LocationFormat.kt`](https://github.com/poziomki-app/poziomki/pull/462/files#diff-faf9c332b56e05295b76ba0d0322ba31e81079cb252e0ea785115770c249e4bc) that picks the first non-street comma-separated segment, stripping `ul.`/`ulica` prefixes as needed.
> - Replaces local `shortenLocation()` calls in `EventChatHeader`, `EventsScreen`, and related composables with the new shared utility.
> - Limits event title `Text` composables to 3 lines with ellipsis overflow in `EventChatHeader`, `EventChatStateViews`, and `EventsScreen`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a45b210.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->