### PR TITLE
fix(chat): keep rooms list during ws reconnects

### DIFF
--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -192,29 +192,22 @@ class WsChatClient(
 
         _state.value = ChatClientState.Connecting
 
-        openedRoomsMutex.withLock {
-            openedRooms.values.forEach {
-                it.close()
-                it.liveTimeline.close()
-            }
-            openedRooms.clear()
-        }
-        latestConversations = emptyList()
-        _rooms.value = emptyList()
+        // Don't wipe _rooms / latestConversations / openedRooms here.
+        // ensureStarted runs on every chat open and pull-to-refresh, and
+        // a transient reconnect would otherwise blank the rooms list
+        // (MessagesScreen shows LoadingView while rooms is empty). The
+        // server resends Conversations after auth, and the reconnect
+        // handler in init backfills opened rooms. Sign-out goes through
+        // stop(), which is where the wholesale clear belongs.
 
         wsConnection.connect()
 
-        // Wait for connected state
         val connected =
             withTimeoutOrNull(15_000L) {
                 wsConnection.isConnected.first { it }
             }
 
         return if (connected == true) {
-            // Don't clear the persistent timeline cache here — server
-            // snapshots overwrite stale entries as they arrive, and
-            // wiping on every cold start defeats the offline-open path
-            // (UI reads the cache first in ChatViewModel.openRoom).
             Result.success(Unit)
         } else {
             _state.value = ChatClientState.Error("Connection timeout")


### PR DESCRIPTION
ensureStarted was wiping rooms on every non-Ready call, blanking the messages list during transient WS reconnects. Sign-out already clears via stop().

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve rooms list across WebSocket reconnects in chat client
> Previously, `WsChatClient.ensureStarted` cleared `openedRooms`, `latestConversations`, and `_rooms` on every (re)connect attempt, causing the rooms list to reset during reconnections. This removes that teardown logic so existing room state is retained across reconnects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2d832d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->