### PR TITLE
polish(ui): bigger pill filter tabs, reuse on saved screen

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
@@ -103,7 +103,7 @@ private fun PillTab(
         text = label,
         fontFamily = NunitoFamily,
         fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-        fontSize = 14.sp,
+        fontSize = 15.sp,
         color = if (isSelected) TextPrimary else TextMuted,
         modifier =
             Modifier
@@ -111,6 +111,6 @@ private fun PillTab(
                 .background(
                     color = if (isSelected) Color(0xFF242424) else SurfaceElevated,
                     shape = RoundedCornerShape(50),
-                ).padding(horizontal = 10.dp, vertical = 4.dp),
+                ).padding(horizontal = 12.dp, vertical = 5.dp),
     )
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -130,7 +130,7 @@ fun EventsScreen(
         listOf(
             TimeFilter.ALL to "polecane",
             TimeFilter.NEARBY to "w pobliżu",
-            TimeFilter.WEEK to "ten tydzień",
+            TimeFilter.WEEK to "weekend",
         )
 
     // The nearby tab gives the map the whole height (no navbar, no
@@ -192,7 +192,7 @@ fun EventsScreen(
                     Modifier
                         .weight(1f)
                         .padding(end = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
                 style = FilterTabsStyle.Pill,
             )
             androidx.compose.material3.IconButton(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -77,7 +77,7 @@ fun MessagesScreen(
             selected = selectedFilter,
             onSelect = { selectedFilter = it },
             modifier = Modifier.padding(start = 24.dp, end = PoziomkiTheme.spacing.md),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
             style = FilterTabsStyle.Pill,
         )
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/SavedScreen.kt
@@ -21,11 +21,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.FilterTabs
+import com.poziomki.app.ui.designsystem.components.FilterTabsStyle
 import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.ProfileCard
 import com.poziomki.app.ui.designsystem.components.ScreenHeader
@@ -62,7 +62,9 @@ fun SavedScreen(
             tabs = tabs,
             selected = selectedTab,
             onSelect = { selectedTab = it },
-            horizontalArrangement = Arrangement.spacedBy(40.dp, Alignment.CenterHorizontally),
+            modifier = Modifier.padding(start = 24.dp, end = PoziomkiTheme.spacing.md),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            style = FilterTabsStyle.Pill,
         )
 
         when {


### PR DESCRIPTION
bigger text on pill tabs; saved screen uses same style; weekend label replaces ten tydzień

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase pill filter tab size and apply pill style to SavedScreen
> - Increases `PillTab` font size from 14sp to 15sp and padding (horizontal 10→12dp, vertical 4→5dp) for a larger tap target
> - Updates `FilterTabs` spacing from 12dp to 16dp in `EventsScreen` and `MessagesScreen`
> - Switches `SavedScreen` to use `FilterTabsStyle.Pill` with consistent 16dp tab spacing and start/end padding, replacing the previous 40dp centered arrangement
> - Renames the `TimeFilter.WEEK` tab label from "ten tydzień" to "weekend" in `EventsScreen`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 305e829.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->