### PR TITLE
feat(nav): move profile avatar to bottom nav, smaller icons

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -1,6 +1,7 @@
 package com.poziomki.app.ui.navigation
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -18,7 +19,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -71,7 +71,6 @@ import com.poziomki.app.ui.designsystem.components.OfflineBanner
 import com.poziomki.app.ui.designsystem.components.UserAvatar
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Primary
-import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.backSlide
 import com.poziomki.app.ui.designsystem.theme.backSlideExit
 import com.poziomki.app.ui.designsystem.theme.forwardSlide
@@ -525,12 +524,7 @@ fun MainScreen(
         }
     }
 
-    val profileAvatarAction: @Composable () -> Unit = {
-        ProfileAvatarButton(
-            profilePicture = profilePicture,
-            onClick = navigateToProfileTab,
-        )
-    }
+    val profileAvatarAction: @Composable () -> Unit = {}
 
     val immersive = remember { mutableStateOf(false) }
     val navBarPadding = if (immersive.value) 0.dp else navBarHeight + bottomInsets
@@ -651,8 +645,62 @@ fun MainScreen(
                                         Icon(
                                             if (selected) item.selectedIcon else item.icon,
                                             contentDescription = item.label,
-                                            modifier = Modifier.size(32.dp),
+                                            modifier = Modifier.size(26.dp),
                                             tint = tint,
+                                        )
+                                    }
+                                }
+                                val profileSelected =
+                                    currentDestination?.hasRoute(Route.ProfileTab::class) == true
+                                Column(
+                                    modifier =
+                                        Modifier
+                                            .weight(1f)
+                                            .clickable(
+                                                interactionSource = remember { MutableInteractionSource() },
+                                                indication = null,
+                                            ) {
+                                                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                                navigateToProfileTab()
+                                            },
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                ) {
+                                    if (profilePicture != null) {
+                                        Box(
+                                            modifier =
+                                                Modifier
+                                                    .size(28.dp)
+                                                    .then(
+                                                        if (profileSelected) {
+                                                            Modifier
+                                                                .border(
+                                                                    width = 1.5.dp,
+                                                                    color = MaterialTheme.colorScheme.onSurface,
+                                                                    shape = CircleShape,
+                                                                ).padding(3.dp)
+                                                        } else {
+                                                            Modifier
+                                                        },
+                                                    ),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            UserAvatar(
+                                                picture = profilePicture,
+                                                displayName = null,
+                                                size = if (profileSelected) 22.dp else 26.dp,
+                                            )
+                                        }
+                                    } else {
+                                        Icon(
+                                            PhosphorIcons.Bold.GearSix,
+                                            contentDescription = "Profil",
+                                            modifier = Modifier.size(26.dp),
+                                            tint =
+                                                if (profileSelected) {
+                                                    MaterialTheme.colorScheme.onSurface
+                                                } else {
+                                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                                },
                                         )
                                     }
                                 }
@@ -678,29 +726,5 @@ fun MainScreen(
             onSubmit = { feedbackViewModel.submit(appVersion = null) },
             onDismiss = { feedbackViewModel.closeDialog() },
         )
-    }
-}
-
-@Composable
-private fun ProfileAvatarButton(
-    profilePicture: String?,
-    onClick: () -> Unit,
-) {
-    val avatarSize = 28.dp
-    IconButton(onClick = onClick) {
-        if (profilePicture != null) {
-            UserAvatar(
-                picture = profilePicture,
-                displayName = null,
-                size = avatarSize,
-            )
-        } else {
-            Icon(
-                PhosphorIcons.Bold.GearSix,
-                contentDescription = "Profil",
-                modifier = Modifier.size(22.dp),
-                tint = TextMuted,
-            )
-        }
     }
 }


### PR DESCRIPTION
avatar becomes the 4th tab on the right; bottom nav icons sized 26dp; selected avatar gets a thin ring

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move profile avatar to bottom nav and reduce bottom nav icon size
> - Removes the top-bar `ProfileAvatarButton` and adds a Profile tab to the bottom navigation bar in [AppNavigation.kt](https://github.com/poziomki-app/poziomki/pull/465/files#diff-d0c4d4fb202ccaa45fc79b5e9a20b97727c5ae374c4bb3f074445da38252c7e8).
> - The Profile tab renders a `UserAvatar` or gear icon depending on whether a profile photo is set, with a circular border highlight and size change (22.dp vs 26.dp) when selected.
> - Tapping the Profile tab triggers haptic feedback (`TextHandleMove`) and navigates to `Route.ProfileTab`.
> - All other bottom nav icons shrink from 32.dp to 26.dp.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef42807.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->