### PR TITLE
polish(event): drop attendees pill and fix back arrow padding

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -59,7 +59,6 @@ import com.adamglin.phosphoricons.bold.Trash
 import com.adamglin.phosphoricons.bold.UserPlus
 import com.adamglin.phosphoricons.fill.CalendarDots
 import com.adamglin.phosphoricons.fill.MapPin
-import com.adamglin.phosphoricons.fill.UsersThree
 import com.poziomki.app.network.Event
 import com.poziomki.app.network.EventAttendee
 import com.poziomki.app.ui.designsystem.Text
@@ -138,6 +137,7 @@ fun EventCoverImage(
 }
 
 @Composable
+@Suppress("UnusedParameter")
 fun EventMetaRows(
     event: Event,
     onParticipantsClick: (() -> Unit)? = null,
@@ -157,13 +157,6 @@ fun EventMetaRows(
                 onClick = onLocationClick,
             )
         }
-
-        MetaChip(
-            icon = PhosphorIcons.Fill.UsersThree,
-            text = event.attendeesCount.toString(),
-            onClick = onParticipantsClick,
-            accent = true,
-        )
 
         if (onInfoClick != null) {
             val infoShape = RoundedCornerShape(50)
@@ -605,7 +598,7 @@ private fun LocationMapDialog(
         ) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    text = locationName,
+                    text = formatEventLocation(locationName),
                     preserveCase = true,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.Bold,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -148,7 +148,6 @@ fun EventChatJoinRequiredView(
                 modifier =
                     Modifier
                         .align(Alignment.TopStart)
-                        .statusBarsPadding()
                         .padding(horizontal = 8.dp, vertical = 8.dp)
                         .size(40.dp),
                 shape = CircleShape,


### PR DESCRIPTION
- Removed the blue attendees count pill from event detail meta row (attendees re-surface in a follow-up via avatars next to dołącz).
- Back arrow on the join-required cover no longer double-pads above the status bar.
- Location dialog title now uses the trimmed location too.

- [ ] eyeball event detail (joined + join-required)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove attendees pill and fix back arrow padding in event chat header
> - Removes the attendees count `MetaChip` (with `UsersThree` icon) from `EventMetaRows` in [EventChatHeader.kt](https://github.com/poziomki-app/poziomki/pull/466/files#diff-03629e6d0d7bca288c6b50a0e665e404632270ff54760a7213758fdc94120d80); the participants click action is no longer accessible from this composable.
> - Fixes the location dialog title to display a formatted location string via `formatEventLocation()` instead of the raw `locationName`.
> - Removes `statusBarsPadding()` from the back arrow control in [EventChatStateViews.kt](https://github.com/poziomki-app/poziomki/pull/466/files#diff-dc77fa9f64ddb97ec56b309fbfe774d102483e0b8dbdce72772de14e65b0380a), moving it closer to the top of the screen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86b836e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->