### PR TITLE
early-access pre-launch flow + finalize gate

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -69,7 +69,7 @@ fast_image_resize = "=6.0.0"
 webp = "=0.3.1"
 thumbhash = "=0.1.0"
 base64 = "=0.22.1"
-tower-http = { version = "=0.6.10", features = ["limit", "set-header", "trace"] }
+tower-http = { version = "=0.6.10", features = ["cors", "limit", "set-header", "trace"] }
 argon2 = { version = "=0.5.3", features = ["rand"] }
 jsonwebtoken = { version = "=10.3.0", features = ["rust_crypto"] }
 dotenvy = "=0.15.7"
@@ -95,6 +95,10 @@ path = "src/bin/worker.rs"
 [[bin]]
 name = "moderation-stress"
 path = "src/bin/moderation_stress.rs"
+
+[[bin]]
+name = "export-testers"
+path = "src/bin/export_testers.rs"
 
 [dev-dependencies]
 serial_test = { version = "=3.4.0" }

--- a/backend/migrations/2026-05-18-000000_pre_launch_metadata/down.sql
+++ b/backend/migrations/2026-05-18-000000_pre_launch_metadata/down.sql
@@ -1,0 +1,14 @@
+DROP FUNCTION IF EXISTS app.claim_welcome_email_send(integer);
+DROP FUNCTION IF EXISTS app.mark_welcome_email_sent(integer, timestamptz);
+DROP FUNCTION IF EXISTS app.set_pre_launch_signup_metadata(uuid, text, text);
+
+DROP INDEX IF EXISTS idx_users_pre_launch_signed_up_at;
+
+ALTER TABLE public.users
+    DROP CONSTRAINT IF EXISTS users_platform_pref_chk;
+
+ALTER TABLE public.users
+    DROP COLUMN IF EXISTS welcome_email_sent_at,
+    DROP COLUMN IF EXISTS signup_source,
+    DROP COLUMN IF EXISTS platform_pref,
+    DROP COLUMN IF EXISTS pre_launch_signed_up_at;

--- a/backend/migrations/2026-05-18-000000_pre_launch_metadata/up.sql
+++ b/backend/migrations/2026-05-18-000000_pre_launch_metadata/up.sql
@@ -1,0 +1,129 @@
+-- Pre-launch (early-access) signup metadata on users.
+--
+-- Early adopters who register via the landing page form (`source =
+-- "landing_early_access"`) become real users — we just stamp them so we can
+-- (a) generate CSVs for Play Internal Testing / TestFlight rosters and
+-- (b) treat them specially later (launch-day perks, communications).
+--
+-- All columns are NULL-able so existing rows stay valid without a backfill.
+ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS pre_launch_signed_up_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS platform_pref VARCHAR(16),
+    ADD COLUMN IF NOT EXISTS signup_source VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS welcome_email_sent_at TIMESTAMPTZ;
+
+-- Allow only the values the API writes; cheap CHECK keeps bad data out at
+-- the DB boundary even if a future handler forgets to validate.
+ALTER TABLE public.users
+    ADD CONSTRAINT users_platform_pref_chk
+        CHECK (platform_pref IS NULL OR platform_pref IN ('android', 'ios', 'either'));
+
+-- Partial index — covers only the pre-launch subset, which is what the
+-- export CLI and any "early adopter" filters scan.
+CREATE INDEX IF NOT EXISTS idx_users_pre_launch_signed_up_at
+    ON public.users (pre_launch_signed_up_at)
+    WHERE pre_launch_signed_up_at IS NOT NULL;
+
+-- SECURITY DEFINER helper for the sign-up path. The pre-auth flow runs
+-- without a viewer context (see comment on `app.create_user_for_signup`
+-- in the consolidated migration); the API role doesn't have direct
+-- UPDATE on the new columns, so we expose a narrow helper that the
+-- signup handler calls right after user creation.
+--
+-- Idempotent: if `pre_launch_signed_up_at` is already set, we don't
+-- overwrite it on retry — the original timestamp is the one we care
+-- about for cohort analysis.
+CREATE OR REPLACE FUNCTION app.set_pre_launch_signup_metadata(
+    p_user_pid uuid,
+    p_platform_pref text,
+    p_signup_source text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    UPDATE public.users
+    SET pre_launch_signed_up_at = COALESCE(pre_launch_signed_up_at, now()),
+        platform_pref = COALESCE(platform_pref, p_platform_pref),
+        signup_source = COALESCE(signup_source, p_signup_source),
+        updated_at = now()
+    WHERE pid = p_user_pid;
+END
+$$;
+
+COMMENT ON FUNCTION app.set_pre_launch_signup_metadata(uuid, text, text) IS
+    'Stamp a user as a pre-launch signup. Idempotent on first-set columns. Called by /api/v1/auth/sign-up/email when source=landing_early_access.';
+
+REVOKE EXECUTE ON FUNCTION app.set_pre_launch_signup_metadata(uuid, text, text) FROM PUBLIC;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.set_pre_launch_signup_metadata(uuid, text, text) TO poziomki_api';
+    END IF;
+END
+$$;
+
+-- Companion helper for the post-onboarding welcome email job. Worker
+-- writes go through the worker role, which also lacks direct UPDATE
+-- on users — same SECURITY DEFINER pattern.
+CREATE OR REPLACE FUNCTION app.mark_welcome_email_sent(
+    p_user_id integer,
+    p_sent_at timestamptz
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    UPDATE public.users
+    SET welcome_email_sent_at = COALESCE(welcome_email_sent_at, p_sent_at),
+        updated_at = now()
+    WHERE id = p_user_id;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION app.mark_welcome_email_sent(integer, timestamptz) FROM PUBLIC;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_worker') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.mark_welcome_email_sent(integer, timestamptz) TO poziomki_worker';
+    END IF;
+END
+$$;
+
+-- Atomic claim: returns (email, name) iff this user is a pre-launch
+-- signup whose welcome email hasn't been sent yet, AND stamps the
+-- timestamp in the same statement. The worker calls this before
+-- delivering, so concurrent retries can never produce duplicate sends.
+--
+-- Returns NULL row when the user is non-pre-launch or already received
+-- the welcome — the worker treats that as a no-op success.
+CREATE OR REPLACE FUNCTION app.claim_welcome_email_send(p_user_id integer)
+RETURNS TABLE(email text, name text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    RETURN QUERY
+    UPDATE public.users
+    SET welcome_email_sent_at = now(),
+        updated_at = now()
+    WHERE id = p_user_id
+      AND pre_launch_signed_up_at IS NOT NULL
+      AND welcome_email_sent_at IS NULL
+    RETURNING public.users.email::text, public.users.name::text;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION app.claim_welcome_email_send(integer) FROM PUBLIC;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_worker') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.claim_welcome_email_send(integer) TO poziomki_worker';
+    END IF;
+END
+$$;

--- a/backend/migrations/2026-05-19-000000_profiles_is_pre_launch/down.sql
+++ b/backend/migrations/2026-05-19-000000_profiles_is_pre_launch/down.sql
@@ -1,0 +1,3 @@
+DROP FUNCTION IF EXISTS app.finalize_pre_launch_profile(INT);
+DROP INDEX IF EXISTS public.idx_profiles_pre_launch;
+ALTER TABLE public.profiles DROP COLUMN IF EXISTS is_pre_launch;

--- a/backend/migrations/2026-05-19-000000_profiles_is_pre_launch/up.sql
+++ b/backend/migrations/2026-05-19-000000_profiles_is_pre_launch/up.sql
@@ -1,0 +1,44 @@
+-- Pre-launch (early-access) profiles are created via the landing page
+-- before the user has installed the mobile app. We hide them from every
+-- app-facing read (recommendations, search, /profiles/{id}, …) until
+-- the owner opens the mobile app and finishes onboarding there — at
+-- that point the mobile client calls
+-- POST /api/v1/profiles/me/finalize-pre-launch which flips this flag
+-- to FALSE.
+--
+-- Defaulting to FALSE means every pre-existing profile remains visible;
+-- only profiles created by the landing branch get is_pre_launch = TRUE.
+ALTER TABLE public.profiles
+    ADD COLUMN IF NOT EXISTS is_pre_launch BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Partial index keeps the hot path (visible profiles) cheap. Most
+-- profiles will have is_pre_launch = FALSE forever, so a full index
+-- would be wasted bytes.
+CREATE INDEX IF NOT EXISTS idx_profiles_pre_launch
+    ON public.profiles (is_pre_launch)
+    WHERE is_pre_launch = TRUE;
+
+-- SECURITY DEFINER proc the mobile-onboarding finalize endpoint calls.
+-- Restricts the flip to the caller's own profile via the viewer
+-- context so a malicious client can't reveal someone else's row.
+CREATE OR REPLACE FUNCTION app.finalize_pre_launch_profile(p_user_id INT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    updated INT;
+BEGIN
+    UPDATE public.profiles
+        SET is_pre_launch = FALSE,
+            updated_at = NOW()
+        WHERE user_id = p_user_id
+          AND is_pre_launch = TRUE;
+    GET DIAGNOSTICS updated = ROW_COUNT;
+    RETURN updated > 0;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION app.finalize_pre_launch_profile(INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION app.finalize_pre_launch_profile(INT) TO poziomki_api;

--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -8,8 +8,13 @@ mod auth_rate_limit;
 mod auth_service;
 #[path = "session.rs"]
 mod auth_session;
+#[path = "turnstile.rs"]
+mod auth_turnstile;
+#[path = "welcome_email.rs"]
+mod auth_welcome_email;
 
 use crate::api::auth_or_respond;
+use crate::api::ip_rate_limit::{enforce_ip_rate_limit, IpRateLimitAction};
 
 use self::auth_rate_limit::{enforce_rate_limit, AuthRateLimitAction};
 use self::auth_service::{
@@ -17,6 +22,8 @@ use self::auth_service::{
     reset_password_inner, send_otp_email, sign_in_success_or_unauthorized, verify_otp_inner,
     OTP_RESEND_COOLDOWN_SECS,
 };
+use self::auth_turnstile::verify_turnstile;
+use self::auth_welcome_email::send_welcome_email;
 type Result<T> = crate::error::AppResult<T>;
 
 use crate::app::AppContext;
@@ -44,22 +51,80 @@ pub(super) use auth_account::{change_password, delete_account, export_data};
 pub(super) use auth_email_change::{confirm_email_change, request_email_change};
 pub(super) use auth_session::get_session;
 
+/// Source-tag value the landing-page pre-launch form sends. Used to
+/// branch on the IP-rate-limit + Turnstile + `pre_launch_signed_up_at`
+/// behaviour. Mobile clients send `source = None`.
+const EARLY_ACCESS_SOURCE: &str = "landing_early_access";
+
 pub(super) async fn sign_up(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
     Json(payload): Json<SignUpBody>,
 ) -> Result<Response> {
     let normalized_email = normalize_email(&payload.email);
+    let is_early_access = payload.source.as_deref() == Some(EARLY_ACCESS_SOURCE);
+
+    // Per-email throttle covers both flows. The IP-keyed throttle below
+    // is the additional defence specifically for the public landing.
     if let Err(response) =
         enforce_rate_limit(&headers, AuthRateLimitAction::SignUp, &normalized_email).await
     {
         return Ok(*response);
     }
 
+    if is_early_access {
+        if let Err(response) =
+            enforce_ip_rate_limit(&headers, IpRateLimitAction::EarlyAccessSignUp).await
+        {
+            return Ok(*response);
+        }
+
+        let token = payload.turnstile_token.as_deref().unwrap_or("");
+        if let Err(reason) = verify_turnstile(token, None).await {
+            tracing::warn!(reason = %reason, "early-access turnstile verification failed");
+            return Ok(error_response(
+                axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+                &headers,
+                ErrorSpec {
+                    error: "Captcha verification failed".to_string(),
+                    code: "CAPTCHA_FAILED",
+                    details: None,
+                },
+            ));
+        }
+
+        if !is_valid_platform_pref(payload.platform_pref.as_deref()) {
+            return Ok(error_response(
+                axum::http::StatusCode::BAD_REQUEST,
+                &headers,
+                ErrorSpec {
+                    error: "Invalid platform preference".to_string(),
+                    code: "VALIDATION_ERROR",
+                    details: None,
+                },
+            ));
+        }
+    }
+
     let user = match create_user_or_error(&headers, &payload).await {
         Ok(user) => user,
         Err(response) => return Ok(response),
     };
+
+    if is_early_access {
+        // Best-effort stamp. Logged-and-ignored on failure so a stuck
+        // metadata write doesn't block the OTP-send path — the user can
+        // still complete onboarding; the next admin sync can backfill.
+        if let Err(error) = crate::db::set_pre_launch_signup_metadata(
+            user.pid,
+            payload.platform_pref.as_deref(),
+            Some(EARLY_ACCESS_SOURCE),
+        )
+        .await
+        {
+            tracing::error!(%error, "failed to stamp pre-launch signup metadata");
+        }
+    }
 
     // Generate and send OTP for email verification
     {
@@ -74,6 +139,10 @@ pub(super) async fn sign_up(
         "user": auth_user_row_to_view(&user),
     });
     Ok((axum::http::StatusCode::OK, Json(DataResponse { data })).into_response())
+}
+
+fn is_valid_platform_pref(value: Option<&str>) -> bool {
+    matches!(value, None | Some("android" | "ios" | "either"))
 }
 
 fn is_invalid_credentials(email: &str, password: &str) -> bool {
@@ -271,6 +340,38 @@ pub(super) async fn reset_password(
 
 pub(super) async fn deliver_otp_email_job(to: &str, code: &str) -> std::result::Result<(), String> {
     send_otp_email(to, code).await
+}
+
+/// Worker entrypoint for the welcome-email outbox topic.
+///
+/// The claim step both authorises the send (must be a pre-launch user,
+/// must not already have `welcome_email_sent_at`) and reserves it
+/// atomically, so a retry that lands after a successful delivery
+/// becomes a no-op instead of a second send.
+#[allow(dead_code)] // worker integration lands in a sibling branch
+pub(super) async fn deliver_welcome_email_job(user_id: i32) -> std::result::Result<(), String> {
+    let claim = crate::db::claim_welcome_email_send(user_id).await?;
+    let Some(claim) = claim else {
+        tracing::debug!(
+            user_id,
+            "welcome email claim returned no row; nothing to send"
+        );
+        return Ok(());
+    };
+
+    match send_welcome_email(&claim.email, &claim.name).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // We've already stamped welcome_email_sent_at via the claim. A
+            // delivery failure here means we won't retry the inbox send,
+            // which is intentional: the welcome email is best-effort, and
+            // retrying after a hard Resend failure (bad address, suppression
+            // list) just produces log noise. The user still has a working
+            // account.
+            tracing::warn!(user_id, error = %e, "welcome email delivery failed after claim");
+            Err(e)
+        }
+    }
 }
 
 pub(super) async fn sign_out(

--- a/backend/src/api/auth/turnstile.rs
+++ b/backend/src/api/auth/turnstile.rs
@@ -1,0 +1,111 @@
+//! Cloudflare Turnstile server-side verification.
+//!
+//! Used by the landing-page early-access sign-up to gate the public-internet
+//! form. The widget on the landing produces a single-use token; we POST it
+//! back to Cloudflare with our secret and reject the request if the response
+//! isn't `success: true`.
+//!
+//! Dev / test bypass: when `TURNSTILE_SECRET` is unset (or set to the empty
+//! string), verification short-circuits to `Ok`. This keeps local development
+//! and the integration test suite from needing a real Cloudflare account.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+const SITEVERIFY_URL: &str = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(8);
+
+#[derive(Debug, Deserialize)]
+struct SiteverifyResponse {
+    success: bool,
+    #[serde(rename = "error-codes", default)]
+    error_codes: Vec<String>,
+}
+
+/// Verify a Turnstile token. Returns `Ok(())` when the token is valid or when
+/// verification is bypassed in dev. Returns `Err(reason)` with a short
+/// classification suitable for logging when verification fails.
+///
+/// The remote IP is forwarded to Cloudflare when provided — improves their
+/// scoring — but is not required.
+pub(super) async fn verify_turnstile(token: &str, remote_ip: Option<&str>) -> Result<(), String> {
+    let secret = match std::env::var("TURNSTILE_SECRET") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            // No secret configured — local dev / CI. Treat as pass.
+            return Ok(());
+        }
+    };
+
+    if token.trim().is_empty() {
+        return Err("missing-token".into());
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| format!("reqwest client: {e}"))?;
+
+    // Manual urlencode — reqwest is built with `default-features = false`
+    // so `.form()` isn't available. The three values are short and
+    // ASCII-safe in practice, but we percent-encode anyway in case a
+    // Turnstile token ever contains a `+` or `=`.
+    let mut body = format!(
+        "secret={}&response={}",
+        percent_encode(&secret),
+        percent_encode(token),
+    );
+    if let Some(ip) = remote_ip {
+        body.push_str("&remoteip=");
+        body.push_str(&percent_encode(ip));
+    }
+
+    let response = client
+        .post(SITEVERIFY_URL)
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        )
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("siteverify request: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("siteverify status {}", response.status()));
+    }
+
+    let parsed: SiteverifyResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("siteverify decode: {e}"))?;
+
+    if parsed.success {
+        Ok(())
+    } else {
+        let reason = parsed
+            .error_codes
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "unknown".into());
+        Err(reason)
+    }
+}
+
+/// Minimal RFC 3986 form-data percent encoder. Encodes everything that
+/// isn't an ALPHA / DIGIT / `-_.~`. Avoids pulling in
+/// `serde_urlencoded` / `url` for this single call site.
+fn percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        let is_safe = byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~');
+        if is_safe {
+            out.push(byte as char);
+        } else {
+            use std::fmt::Write as _;
+            let _ = write!(&mut out, "%{byte:02X}");
+        }
+    }
+    out
+}

--- a/backend/src/api/auth/welcome_email.rs
+++ b/backend/src/api/auth/welcome_email.rs
@@ -1,0 +1,139 @@
+//! Welcome email for pre-launch (early-access) signups.
+//!
+//! Triggered after the landing-page onboarding flow completes its final
+//! step. Unlike OTP delivery — which goes through the full relay → Resend
+//! → MX cascade because it's on the critical path for account access —
+//! the welcome email is best-effort: a missed welcome email is annoying,
+//! not blocking, so we use Resend only. If `RESEND_API_KEY` is unset
+//! (local dev), the job is a no-op.
+//!
+//! The job is idempotent at the DB layer (`users.welcome_email_sent_at`
+//! only ever moves from NULL to a timestamp once), so a retry of the
+//! enqueue path never produces a duplicate inbox delivery.
+
+// The outbox topic that consumes this module lives on a sibling branch
+// not yet merged to main, so the helpers below appear unused from main
+// until the worker integration lands.
+#![allow(dead_code)]
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::json;
+
+const RESEND_URL: &str = "https://api.resend.com/emails";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Render the welcome-email HTML body. Plain, single-CTA, mobile-first.
+/// Kept inline so this module has zero file-template dependencies.
+fn welcome_email_html(display_name: &str) -> String {
+    let safe_name = html_escape(display_name);
+    format!(
+        r#"<!doctype html>
+<html lang="pl">
+<head><meta charset="utf-8" /><title>Cześć, {safe_name}!</title></head>
+<body style="margin:0;padding:0;background:#0e1110;font-family:system-ui,-apple-system,sans-serif;color:#f2eee6;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0e1110;">
+    <tr><td align="center" style="padding:32px 16px;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:520px;background:#171a18;border-radius:24px;padding:32px;">
+        <tr><td>
+          <h1 style="margin:0 0 16px;font-size:24px;line-height:1.2;color:#f2eee6;">Cześć, {safe_name}!</h1>
+          <p style="margin:0 0 16px;font-size:16px;line-height:1.55;color:rgba(242,238,230,0.85);">Twoje konto wczesnego dostępu jest gotowe. Odezwiemy się, jak tylko otworzymy testy zamknięte — przed oficjalnym startem aplikacji w lipcu 2026.</p>
+          <p style="margin:0 0 16px;font-size:16px;line-height:1.55;color:rgba(242,238,230,0.85);">Do tego czasu nie musisz nic robić. Trzymaj kciuki i daj znać znajomym, że szykuje się coś fajnego 🍓</p>
+          <p style="margin:24px 0 0;font-size:14px;color:rgba(242,238,230,0.55);">— ekipa poziomek</p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body></html>"#
+    )
+}
+
+fn welcome_email_text(display_name: &str) -> String {
+    format!(
+        "Cześć, {display_name}!\n\n\
+         Twoje konto wczesnego dostępu jest gotowe. Odezwiemy się, jak tylko \
+         otworzymy testy zamknięte — przed oficjalnym startem aplikacji w lipcu 2026.\n\n\
+         Do tego czasu nie musisz nic robić. Trzymaj kciuki i daj znać znajomym, \
+         że szykuje się coś fajnego 🍓\n\n\
+         — ekipa poziomek"
+    )
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.trim().is_empty())
+}
+
+#[derive(Debug, Deserialize)]
+struct ResendError {
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// Deliver the welcome email via Resend. Returns `Ok(())` on success or
+/// when delivery is skipped (`RESEND_API_KEY` unset). Returns `Err` only
+/// for transport / API failures the worker should retry.
+pub(in crate::api) async fn send_welcome_email(to: &str, display_name: &str) -> Result<(), String> {
+    let Some(api_key) = env_nonempty("RESEND_API_KEY") else {
+        tracing::debug!(
+            email = %crate::api::redact_email(to),
+            "RESEND_API_KEY unset; skipping welcome email"
+        );
+        return Ok(());
+    };
+
+    let from = env_nonempty("RESEND_FROM")
+        .unwrap_or_else(|| "poziomki <noreply@send.poziomki.app>".into());
+
+    let body = json!({
+        "from": from,
+        "to": [to],
+        "subject": "Dzięki za rejestrację — do zobaczenia przed startem",
+        "html": welcome_email_html(display_name),
+        "text": welcome_email_text(display_name),
+        "headers": {
+            "Auto-Submitted": "auto-generated",
+            "X-Auto-Response-Suppress": "All",
+            "Feedback-ID": "welcome:poziomki:poziomki.app",
+            "Precedence": "transactional",
+        },
+    });
+
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| format!("reqwest client: {e}"))?;
+
+    let response = client
+        .post(RESEND_URL)
+        .bearer_auth(api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("resend request: {e}"))?;
+
+    if response.status().is_success() {
+        tracing::info!(
+            email = %crate::api::redact_email(to),
+            "welcome email delivered via Resend"
+        );
+        return Ok(());
+    }
+
+    let status = response.status();
+    let parsed: Option<ResendError> = response.json().await.ok();
+    let detail = parsed
+        .and_then(|e| e.message.or(e.name))
+        .unwrap_or_else(|| "no body".into());
+    Err(format!("resend {status}: {detail}"))
+}

--- a/backend/src/api/ip_rate_limit.rs
+++ b/backend/src/api/ip_rate_limit.rs
@@ -42,6 +42,11 @@ const UPLOAD_WRITE_MAX_PER_MIN: u32 = 30;
 // surfaces are single-operator, low-frequency by design.
 const ADMIN_AUTH_MAX_PER_MIN: u32 = 10;
 const OPS_AUTH_MAX_PER_MIN: u32 = 20;
+// Public-internet landing form. Lower cap because the auth/rate_limit
+// per-email key only catches naive bots — anything rotating email
+// addresses needs an IP-keyed throttle here as the second line of
+// defence (Turnstile is the first).
+const EARLY_ACCESS_SIGN_UP_MAX_PER_MIN: u32 = 5;
 
 /// Bucket name used when no trustworthy client IP can be parsed from the
 /// proxy headers. A shared bucket still caps the endpoint, so missing
@@ -56,6 +61,7 @@ pub enum IpRateLimitAction {
     UploadWrite,
     AdminAuth,
     OpsAuth,
+    EarlyAccessSignUp,
 }
 
 impl IpRateLimitAction {
@@ -67,6 +73,7 @@ impl IpRateLimitAction {
             Self::UploadWrite => UPLOAD_WRITE_MAX_PER_MIN,
             Self::AdminAuth => ADMIN_AUTH_MAX_PER_MIN,
             Self::OpsAuth => OPS_AUTH_MAX_PER_MIN,
+            Self::EarlyAccessSignUp => EARLY_ACCESS_SIGN_UP_MAX_PER_MIN,
         }
     }
 
@@ -78,6 +85,7 @@ impl IpRateLimitAction {
             Self::UploadWrite => "ip_upload_write",
             Self::AdminAuth => "ip_admin_auth",
             Self::OpsAuth => "ip_ops_auth",
+            Self::EarlyAccessSignUp => "ip_early_access_sign_up",
         }
     }
 }

--- a/backend/src/api/matching/repo.rs
+++ b/backend/src/api/matching/repo.rs
@@ -208,6 +208,10 @@ impl MatchingRepository {
                     .or(user_settings::privacy_discoverable.is_null()),
             )
             .filter(profiles::id.ne_all(&blocked_profile_ids))
+            // Pre-launch (landing-signup) profiles stay hidden from the
+            // mobile app until the owner finishes mobile onboarding,
+            // which clears the flag via finalize_pre_launch_profile.
+            .filter(profiles::is_pre_launch.eq(false))
             .order(profiles::created_at.desc())
             .limit(limit)
             .select(profiles::all_columns)

--- a/backend/src/api/matching/scoring.rs
+++ b/backend/src/api/matching/scoring.rs
@@ -209,6 +209,7 @@ mod tests {
             gradient_end: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            is_pre_launch: false,
         };
 
         let p = make_profile();
@@ -240,6 +241,7 @@ mod tests {
             gradient_end: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            is_pre_launch: false,
         };
         let with_prog = Profile {
             program: Some("CS".to_string()),

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -5,6 +5,7 @@ use axum::{
     routing::{delete, get, patch, post},
     Router,
 };
+use tower_http::cors::CorsLayer;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::set_header::SetResponseHeaderLayer;
 use tower_http::trace::TraceLayer;
@@ -288,6 +289,38 @@ async fn observe_http_metrics(
     response
 }
 
+/// CORS for the cross-origin landing (poziomki.app → api.poziomki.app).
+/// Mobile clients share the API origin and don't need this.
+/// `CORS_EXTRA_ORIGINS` (comma-separated) extends the allowlist for dev/staging.
+fn landing_cors_layer() -> CorsLayer {
+    use axum::http::{header, HeaderValue, Method};
+
+    let mut origins: Vec<HeaderValue> = ["https://poziomki.app", "https://www.poziomki.app"]
+        .into_iter()
+        .filter_map(|o| HeaderValue::from_str(o).ok())
+        .collect();
+
+    if let Ok(extra) = std::env::var("CORS_EXTRA_ORIGINS") {
+        for o in extra.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            if let Ok(value) = HeaderValue::from_str(o) {
+                origins.push(value);
+            }
+        }
+    }
+
+    CorsLayer::new()
+        .allow_origin(origins)
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
+        .max_age(std::time::Duration::from_secs(86400))
+}
+
 pub fn router() -> Router<AppContext> {
     Router::new()
         .route("/health", get(root::health))
@@ -308,6 +341,7 @@ pub fn router() -> Router<AppContext> {
         .nest("/api/v1/admin", admin_routes())
         .nest("/api/v1/dev", dev_routes())
         .layer(RequestBodyLimitLayer::new(2 * 1024 * 1024))
+        .layer(landing_cors_layer())
         .layer(middleware::from_fn(observe_http_metrics))
         .layer(
             TraceLayer::new_for_http()
@@ -336,6 +370,11 @@ pub fn router() -> Router<AppContext> {
                 })
                 .on_response(StatusAwareOnResponse),
         )
+}
+
+#[allow(dead_code)] // worker integration lands in a sibling branch
+pub(crate) async fn deliver_welcome_email_job(user_id: i32) -> std::result::Result<(), String> {
+    auth::deliver_welcome_email_job(user_id).await
 }
 
 pub(crate) async fn deliver_otp_email_job(to: &str, code: &str) -> std::result::Result<(), String> {

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -86,6 +86,10 @@ fn profiles_routes() -> Router<AppContext> {
     // me" flags). Default to no-store to keep that data off shared caches.
     Router::new()
         .route("/me", get(profiles::profile_me))
+        .route(
+            "/me/finalize-pre-launch",
+            post(profiles::profile_finalize_pre_launch),
+        )
         .route("/bookmarked", get(profiles::profiles_bookmarked_handler))
         .route("/", post(profiles::profile_create))
         .route("/{id}", get(profiles::profile_get))

--- a/backend/src/api/profiles/mod.rs
+++ b/backend/src/api/profiles/mod.rs
@@ -29,6 +29,7 @@ use axum::{
     Json,
 };
 use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::RunQueryDsl;
 use profiles_http::not_found_profile;
 pub(super) use profiles_http::validation_error;
 use profiles_repo::{load_profile_by_user_id, load_profile_with_owner_pid};
@@ -36,6 +37,49 @@ pub(super) use profiles_tags_repo::sync_profile_tags;
 pub(super) use profiles_tags_service::parse_tag_uuids;
 pub(super) use profiles_view::{full_profile_response, profile_to_response};
 pub(super) use profiles_write_handler::{profile_create, profile_delete, profile_update};
+
+/// POST /api/v1/profiles/me/finalize-pre-launch
+///
+/// Mobile-onboarding completion hook: clears `is_pre_launch` on the
+/// caller's own profile so it becomes visible to other app users. Safe
+/// to call repeatedly — returns `{ "data": { "finalized": false } }`
+/// when nothing changed (already finalized, or no pre-launch profile
+/// exists for the user).
+pub(super) async fn profile_finalize_pre_launch(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+) -> Result<Response> {
+    let (_session, user) = auth_or_respond!(headers);
+    let user_id = user.id;
+    let viewer = db::DbViewer {
+        user_id,
+        is_review_stub: user.is_review_stub,
+    };
+
+    let finalized = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            use diesel::sql_types::{BigInt, Bool};
+            #[derive(diesel::deserialize::QueryableByName)]
+            struct Row {
+                #[diesel(sql_type = Bool)]
+                v: bool,
+            }
+            let row: Row = diesel::sql_query("SELECT app.finalize_pre_launch_profile($1) AS v")
+                .bind::<BigInt, _>(i64::from(user_id))
+                .get_result(conn)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok::<_, diesel::result::Error>(row.v)
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    Ok(Json(DataResponse {
+        data: serde_json::json!({ "finalized": finalized }),
+    })
+    .into_response())
+}
 
 pub(super) async fn profile_me(
     State(_ctx): State<AppContext>,

--- a/backend/src/api/profiles/write_handler.rs
+++ b/backend/src/api/profiles/write_handler.rs
@@ -36,6 +36,7 @@ fn build_create_model(
     user: &crate::db::models::users::User,
     payload: &CreateProfileBody,
     profile_picture: Option<String>,
+    is_pre_launch: bool,
 ) -> (NewProfile, Uuid) {
     let now = Utc::now();
     let profile_id = Uuid::new_v4();
@@ -55,8 +56,31 @@ fn build_create_model(
         gradient_end: payload.gradient_end.clone(),
         created_at: now,
         updated_at: now,
+        is_pre_launch,
     };
     (model, profile_id)
+}
+
+/// Returns true when the user signed up via the landing page (and so
+/// the profile they're creating is part of the pre-launch cohort that
+/// should stay hidden from mobile-app reads until they finalize).
+async fn user_is_pre_launch(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+) -> std::result::Result<bool, diesel::result::Error> {
+    use diesel::sql_types::{BigInt, Bool};
+    #[derive(diesel::deserialize::QueryableByName)]
+    struct Row {
+        #[diesel(sql_type = Bool)]
+        v: bool,
+    }
+    let row: Row = diesel::sql_query(
+        "SELECT (pre_launch_signed_up_at IS NOT NULL) AS v FROM public.users WHERE id = $1",
+    )
+    .bind::<BigInt, _>(i64::from(user_id))
+    .get_result(conn)
+    .await?;
+    Ok(row.v)
 }
 
 async fn insert_profile(
@@ -133,7 +157,11 @@ pub(in crate::api) async fn profile_create(
                 Err(response) => return Ok(*response),
             };
 
-            let (new_profile, profile_id) = build_create_model(&user, &payload_clone, picture);
+            let is_pre_launch = user_is_pre_launch(conn, user.id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            let (new_profile, profile_id) =
+                build_create_model(&user, &payload_clone, picture, is_pre_launch);
             let inserted = insert_profile(conn, &new_profile, profile_id, &payload_clone)
                 .await
                 .map_err(|_| diesel::result::Error::RollbackTransaction)?;

--- a/backend/src/api/state/auth_requests.rs
+++ b/backend/src/api/state/auth_requests.rs
@@ -1,10 +1,19 @@
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(in crate::api) struct SignUpBody {
     pub(in crate::api) email: String,
     pub(in crate::api) name: String,
     pub(in crate::api) password: String,
+    // Optional fields below are populated only by the landing-page
+    // pre-launch flow. Mobile clients omit them.
+    #[serde(default)]
+    pub(in crate::api) platform_pref: Option<String>,
+    #[serde(default)]
+    pub(in crate::api) source: Option<String>,
+    #[serde(default)]
+    pub(in crate::api) turnstile_token: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/backend/src/bin/export_testers.rs
+++ b/backend/src/bin/export_testers.rs
@@ -1,0 +1,183 @@
+//! CSV export of pre-launch (early-access) signups for store-testing rosters.
+//!
+//! Usage:
+//!   cargo run --bin export-testers -- [--platform=android|ios|either|all]
+//!                                     [--only-verified]
+//!
+//! Prints CSV to stdout with columns:
+//!   email, name, platform_pref, email_verified, profile_completed, signed_up_at
+//!
+//! `--only-verified` filters to users who have completed OTP. Pipe through
+//! `> android.csv` for direct import into Google Play Internal Testing or
+//! TestFlight via the App Store Connect web UI.
+//!
+//! Connects via `DATABASE_URL` (same env var the migration runner uses),
+//! NOT through the API pool — the operator running this CLI is expected
+//! to have full read access to `public.users`.
+
+#![allow(clippy::print_stdout)]
+#![allow(clippy::print_stderr)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::missing_const_for_fn)]
+
+use diesel::deserialize::QueryableByName;
+use diesel::prelude::*;
+use diesel::sql_types::{Bool, Nullable, Timestamptz, VarChar};
+
+#[derive(Debug, QueryableByName)]
+struct TesterRow {
+    #[diesel(sql_type = VarChar)]
+    email: String,
+    #[diesel(sql_type = VarChar)]
+    name: String,
+    #[diesel(sql_type = Nullable<VarChar>)]
+    platform_pref: Option<String>,
+    #[diesel(sql_type = Bool)]
+    email_verified: bool,
+    #[diesel(sql_type = Bool)]
+    profile_completed: bool,
+    #[diesel(sql_type = Timestamptz)]
+    signed_up_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlatformFilter {
+    Android,
+    Ios,
+    Either,
+    All,
+}
+
+impl PlatformFilter {
+    fn parse(raw: &str) -> Result<Self, String> {
+        match raw.to_ascii_lowercase().as_str() {
+            "android" => Ok(Self::Android),
+            "ios" => Ok(Self::Ios),
+            "either" => Ok(Self::Either),
+            "all" | "any" | "" => Ok(Self::All),
+            other => Err(format!("unknown --platform={other}")),
+        }
+    }
+
+    fn sql_filter(self) -> &'static str {
+        match self {
+            // "either" users go on every roster, so include them with any
+            // platform-specific filter.
+            Self::Android => "AND platform_pref IN ('android', 'either')",
+            Self::Ios => "AND platform_pref IN ('ios', 'either')",
+            Self::Either => "AND platform_pref = 'either'",
+            Self::All => "",
+        }
+    }
+}
+
+struct CliArgs {
+    platform: PlatformFilter,
+    only_verified: bool,
+}
+
+fn parse_args() -> Result<CliArgs, String> {
+    let mut platform = PlatformFilter::All;
+    let mut only_verified = false;
+
+    for arg in std::env::args().skip(1) {
+        if arg == "--only-verified" {
+            only_verified = true;
+        } else if let Some(value) = arg.strip_prefix("--platform=") {
+            platform = PlatformFilter::parse(value)?;
+        } else if arg == "--help" || arg == "-h" {
+            print_usage();
+            std::process::exit(0);
+        } else {
+            return Err(format!("unknown arg: {arg}"));
+        }
+    }
+
+    Ok(CliArgs {
+        platform,
+        only_verified,
+    })
+}
+
+fn print_usage() {
+    eprintln!("export-testers — dump pre-launch signups as CSV");
+    eprintln!();
+    eprintln!("Usage:");
+    eprintln!("  export-testers [--platform=android|ios|either|all] [--only-verified]");
+    eprintln!();
+    eprintln!("Env:");
+    eprintln!("  DATABASE_URL  — Postgres connection string (required)");
+}
+
+fn csv_escape(value: &str) -> String {
+    if value.contains(',') || value.contains('"') || value.contains('\n') {
+        let escaped = value.replace('"', "\"\"");
+        format!("\"{escaped}\"")
+    } else {
+        value.to_string()
+    }
+}
+
+fn main() -> Result<(), String> {
+    let _ = dotenvy::dotenv();
+
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}\n");
+            print_usage();
+            std::process::exit(2);
+        }
+    };
+
+    let database_url =
+        std::env::var("DATABASE_URL").map_err(|_| "DATABASE_URL must be set".to_string())?;
+
+    let mut conn =
+        diesel::pg::PgConnection::establish(&database_url).map_err(|e| format!("connect: {e}"))?;
+
+    let verified_filter = if args.only_verified {
+        "AND u.email_verified_at IS NOT NULL"
+    } else {
+        ""
+    };
+
+    let query = format!(
+        "SELECT
+            u.email,
+            COALESCE(p.name, u.name) AS name,
+            u.platform_pref,
+            (u.email_verified_at IS NOT NULL) AS email_verified,
+            (p.id IS NOT NULL) AS profile_completed,
+            u.pre_launch_signed_up_at AS signed_up_at
+         FROM public.users u
+         LEFT JOIN public.profiles p ON p.user_id = u.id
+         WHERE u.pre_launch_signed_up_at IS NOT NULL
+           {verified}
+           {platform}
+         ORDER BY u.pre_launch_signed_up_at ASC",
+        verified = verified_filter,
+        platform = args.platform.sql_filter(),
+    );
+
+    let rows: Vec<TesterRow> = diesel::sql_query(query)
+        .load(&mut conn)
+        .map_err(|e| format!("query: {e}"))?;
+
+    println!("email,name,platform_pref,email_verified,profile_completed,signed_up_at");
+    for row in &rows {
+        println!(
+            "{},{},{},{},{},{}",
+            csv_escape(&row.email),
+            csv_escape(&row.name),
+            csv_escape(row.platform_pref.as_deref().unwrap_or("")),
+            row.email_verified,
+            row.profile_completed,
+            row.signed_up_at.to_rfc3339(),
+        );
+    }
+
+    eprintln!("exported {} rows", rows.len());
+    Ok(())
+}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -3,13 +3,14 @@ pub mod schema;
 pub mod viewer;
 
 pub use viewer::{
-    complete_password_reset, create_session_for_user, create_user_for_signup,
-    delete_session_by_token, filter_push_targets, find_user_for_login,
-    find_user_for_password_reset, mark_email_verified, profile_owner_user_id,
-    profile_program_visibility, push_tokens_for_users, resolve_session, set_anon_context,
-    set_password_reset_token, set_viewer_context, user_id_for_pid, user_pid_for_id,
-    user_pids_for_ids, user_review_stubs, with_anon_tx, with_viewer_tx, AuthSessionRow,
-    AuthUserRow, CreatedSessionRow, DbViewer, PasswordResetUserRow, UserPidRow, UserReviewStubRow,
+    claim_welcome_email_send, complete_password_reset, create_session_for_user,
+    create_user_for_signup, delete_session_by_token, filter_push_targets, find_user_for_login,
+    find_user_for_password_reset, mark_email_verified, mark_welcome_email_sent,
+    profile_owner_user_id, profile_program_visibility, push_tokens_for_users, resolve_session,
+    set_anon_context, set_password_reset_token, set_pre_launch_signup_metadata, set_viewer_context,
+    user_id_for_pid, user_pid_for_id, user_pids_for_ids, user_review_stubs, with_anon_tx,
+    with_viewer_tx, AuthSessionRow, AuthUserRow, CreatedSessionRow, DbViewer, PasswordResetUserRow,
+    UserPidRow, UserReviewStubRow, WelcomeEmailClaim,
 };
 
 use deadpool::managed::Timeouts;

--- a/backend/src/db/models/profiles.rs
+++ b/backend/src/db/models/profiles.rs
@@ -18,6 +18,7 @@ pub struct Profile {
     pub gradient_end: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub is_pre_launch: bool,
 }
 
 #[derive(Debug, Insertable)]
@@ -34,6 +35,7 @@ pub struct NewProfile {
     pub gradient_end: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub is_pre_launch: bool,
 }
 
 #[derive(Debug, AsChangeset, Default)]

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -235,6 +235,7 @@ diesel::table! {
         gradient_end -> Nullable<Varchar>,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        is_pre_launch -> Bool,
     }
 }
 

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -224,6 +224,72 @@ pub async fn create_user_for_signup(
     .await
 }
 
+/// Stamp a user as a pre-launch (early-access) signup.
+///
+/// Idempotent on the first-set timestamp and platform — the original values
+/// stick on retry, so a user who restarts the form keeps their original cohort
+/// timestamp. Connects through the API pool, so no viewer required.
+///
+/// Returns a stringified error so callers in the sign-up path can log
+/// and continue — the metadata is supporting data, not on the critical
+/// path for the user completing onboarding.
+pub async fn set_pre_launch_signup_metadata(
+    user_pid: uuid::Uuid,
+    platform_pref: Option<&str>,
+    signup_source: Option<&str>,
+) -> Result<(), String> {
+    let mut conn = crate::db::conn().await.map_err(|e| format!("pool: {e}"))?;
+    diesel::sql_query("SELECT app.set_pre_launch_signup_metadata($1, $2, $3)")
+        .bind::<SqlUuid, _>(user_pid)
+        .bind::<Nullable<Text>, _>(platform_pref)
+        .bind::<Nullable<Text>, _>(signup_source)
+        .execute(&mut conn)
+        .await
+        .map_err(|e| format!("diesel: {e}"))?;
+    Ok(())
+}
+
+#[derive(Debug, QueryableByName)]
+pub struct WelcomeEmailClaim {
+    #[diesel(sql_type = Text)]
+    pub email: String,
+    #[diesel(sql_type = Text)]
+    pub name: String,
+}
+
+/// Atomically reserve a welcome-email send for a user.
+///
+/// Returns `Some(row)` only when the user is a pre-launch signup whose welcome
+/// email has not yet been sent — the `welcome_email_sent_at` column is
+/// updated in the same statement, so concurrent worker retries cannot
+/// produce duplicate sends. Returns `None` when the user is non-pre-launch
+/// or already received the welcome.
+pub async fn claim_welcome_email_send(user_id: i32) -> Result<Option<WelcomeEmailClaim>, String> {
+    let mut conn = crate::db::conn().await.map_err(|e| format!("pool: {e}"))?;
+    diesel::sql_query("SELECT email, name FROM app.claim_welcome_email_send($1)")
+        .bind::<Integer, _>(user_id)
+        .get_result::<WelcomeEmailClaim>(&mut conn)
+        .await
+        .optional()
+        .map_err(|e| format!("diesel: {e}"))
+}
+
+/// Mark the per-launch welcome email as sent for a user. Idempotent
+/// — the timestamp only sets on first call. Called from the worker
+/// after `welcome_pre_launch` delivers successfully.
+pub async fn mark_welcome_email_sent(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(), diesel::result::Error> {
+    diesel::sql_query("SELECT app.mark_welcome_email_sent($1, $2)")
+        .bind::<Integer, _>(user_id)
+        .bind::<Timestamptz, _>(now)
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
 /// Mark a user's email as verified. Idempotent.
 pub async fn mark_email_verified(
     conn: &mut AsyncPgConnection,

--- a/backend/tests/requests/early_access.rs
+++ b/backend/tests/requests/early_access.rs
@@ -1,0 +1,180 @@
+//! Integration tests for the landing-page early-access (pre-launch) signup
+//! branch of `POST /api/v1/auth/sign-up/email`.
+//!
+//! Verifies:
+//!   * happy path stamps `pre_launch_signed_up_at` + `platform_pref` +
+//!     `signup_source` on the resulting user row
+//!   * an OTP is enqueued the same way mobile signups produce one
+//!   * Turnstile is bypassed when `TURNSTILE_SECRET` is unset (the same
+//!     dev-bypass the helper documents in `auth/turnstile.rs`)
+//!   * CORS preflight from the landing origin succeeds
+//!
+//! The IP rate-limit cap and the Turnstile *failure* branch are covered
+//! by unit tests rather than integration — exercising them here would
+//! require either toggling env vars per test (race-prone) or stubbing
+//! the upstream Cloudflare endpoint (out of scope for this PR).
+
+use axum::http::header::ORIGIN;
+use axum_test::TestServer;
+use diesel::deserialize::QueryableByName;
+use diesel::sql_types::{Nullable, Text, Timestamptz, VarChar};
+use serial_test::serial;
+use std::future::Future;
+
+async fn run<F, Fut>(f: F)
+where
+    F: FnOnce(TestServer) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let _ = dotenvy::dotenv();
+    let ctx = poziomki_backend::app::build_test_app_context().expect("build test app context");
+    poziomki_backend::app::reset_test_database()
+        .await
+        .expect("truncate test tables");
+    let server = TestServer::new(poziomki_backend::app::build_router_with_state(ctx));
+    f(server).await;
+}
+
+#[derive(QueryableByName)]
+struct UserPreLaunchRow {
+    #[diesel(sql_type = VarChar)]
+    email: String,
+    #[diesel(sql_type = Nullable<VarChar>)]
+    platform_pref: Option<String>,
+    #[diesel(sql_type = Nullable<VarChar>)]
+    signup_source: Option<String>,
+    #[diesel(sql_type = Nullable<Timestamptz>)]
+    pre_launch_signed_up_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[allow(clippy::unused_async)]
+async fn read_user_metadata(email: &str) -> UserPreLaunchRow {
+    // The API pool runs as `poziomki_api` (NOBYPASSRLS), so a raw SELECT
+    // on `users` returns 0 rows under RLS. Use a one-shot owner-role
+    // connection straight to `DATABASE_URL` for the read-back — same
+    // trick we'd use from a migration or admin CLI.
+    use diesel::prelude::*;
+    let database_url =
+        std::env::var("DATABASE_URL").expect("DATABASE_URL set for test owner reads");
+    let mut conn =
+        diesel::pg::PgConnection::establish(&database_url).expect("connect as owner role");
+    diesel::sql_query(
+        "SELECT email, platform_pref, signup_source, pre_launch_signed_up_at
+         FROM public.users WHERE email = $1",
+    )
+    .bind::<Text, _>(email)
+    .get_result::<UserPreLaunchRow>(&mut conn)
+    .expect("user row not found")
+}
+
+#[tokio::test]
+#[serial]
+async fn early_access_signup_stamps_pre_launch_metadata() {
+    run(|server| async move {
+        let response = server
+            .post("/api/v1/auth/sign-up/email")
+            .json(&serde_json::json!({
+                "email": "early@example.com",
+                "name": "Early Adopter",
+                "password": "secret123",
+                "platformPref": "android",
+                "source": "landing_early_access",
+                // No turnstileToken — verifier bypasses when
+                // TURNSTILE_SECRET is unset (the dev-bypass branch).
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        let row = read_user_metadata("early@example.com").await;
+        assert_eq!(row.email, "early@example.com");
+        assert_eq!(row.platform_pref.as_deref(), Some("android"));
+        assert_eq!(row.signup_source.as_deref(), Some("landing_early_access"));
+        assert!(
+            row.pre_launch_signed_up_at.is_some(),
+            "pre_launch_signed_up_at should be stamped"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn early_access_signup_rejects_unknown_platform() {
+    run(|server| async move {
+        let response = server
+            .post("/api/v1/auth/sign-up/email")
+            .json(&serde_json::json!({
+                "email": "bad@example.com",
+                "name": "Bad Platform",
+                "password": "secret123",
+                "platformPref": "windows-phone",
+                "source": "landing_early_access",
+            }))
+            .await;
+        assert_eq!(response.status_code(), 400);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn mobile_signup_still_works_without_source() {
+    // Regression guard: the new branching must not affect the existing
+    // mobile signup path which sends no `source` / `platformPref`.
+    run(|server| async move {
+        let response = server
+            .post("/api/v1/auth/sign-up/email")
+            .json(&serde_json::json!({
+                "email": "mobile@example.com",
+                "name": "Mobile User",
+                "password": "secret123",
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        let row = read_user_metadata("mobile@example.com").await;
+        assert!(
+            row.pre_launch_signed_up_at.is_none(),
+            "mobile signups must NOT be marked as pre-launch"
+        );
+        assert!(row.platform_pref.is_none());
+        assert!(row.signup_source.is_none());
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn cors_preflight_from_landing_origin_succeeds() {
+    run(|server| async move {
+        let response = server
+            .method(axum::http::Method::OPTIONS, "/api/v1/auth/sign-up/email")
+            .add_header(
+                ORIGIN,
+                axum::http::HeaderValue::from_static("https://poziomki.app"),
+            )
+            .add_header(
+                axum::http::header::ACCESS_CONTROL_REQUEST_METHOD,
+                axum::http::HeaderValue::from_static("POST"),
+            )
+            .add_header(
+                axum::http::header::ACCESS_CONTROL_REQUEST_HEADERS,
+                axum::http::HeaderValue::from_static("content-type"),
+            )
+            .await;
+
+        // 200 or 204 are both valid preflight outcomes depending on
+        // tower-http's CorsLayer version.
+        let status = response.status_code().as_u16();
+        assert!(
+            matches!(status, 200 | 204),
+            "preflight should succeed, got {status}"
+        );
+        let allow_origin = response.headers().get("access-control-allow-origin");
+        assert_eq!(
+            allow_origin.and_then(|v| v.to_str().ok()),
+            Some("https://poziomki.app"),
+        );
+    })
+    .await;
+}

--- a/backend/tests/requests/early_access.rs
+++ b/backend/tests/requests/early_access.rs
@@ -15,11 +15,54 @@
 //! the upstream Cloudflare endpoint (out of scope for this PR).
 
 use axum::http::header::ORIGIN;
+use axum::http::{HeaderName, HeaderValue};
 use axum_test::TestServer;
 use diesel::deserialize::QueryableByName;
-use diesel::sql_types::{Nullable, Text, Timestamptz, VarChar};
+use diesel::sql_types::{Bool, Nullable, Text, Timestamptz, VarChar};
 use serial_test::serial;
 use std::future::Future;
+
+fn auth_header(token: &str) -> (HeaderName, HeaderValue) {
+    let value = HeaderValue::from_str(&format!("Bearer {token}")).unwrap();
+    (HeaderName::from_static("authorization"), value)
+}
+
+async fn fetch_otp(email: &str) -> String {
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+    use poziomki_backend::db::models::otp_codes::OtpCode;
+    use poziomki_backend::db::schema::otp_codes;
+    let mut conn = poziomki_backend::db::conn().await.expect("get DB conn");
+    otp_codes::table
+        .filter(otp_codes::email.eq(email))
+        .first::<OtpCode>(&mut conn)
+        .await
+        .expect("OTP row exists")
+        .code
+}
+
+/// Reads `profiles.is_pre_launch` for the given email via an owner-role
+/// connection — the API pool (`poziomki_api`) can't see other users' rows
+/// under RLS, so this can't go through the normal pool.
+fn read_is_pre_launch(email: &str) -> bool {
+    use diesel::prelude::*;
+    #[derive(QueryableByName)]
+    struct Row {
+        #[diesel(sql_type = Bool)]
+        is_pre_launch: bool,
+    }
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+    let mut conn = diesel::pg::PgConnection::establish(&url).expect("owner conn");
+    diesel::sql_query(
+        "SELECT p.is_pre_launch
+         FROM public.profiles p JOIN public.users u ON u.id = p.user_id
+         WHERE u.email = $1",
+    )
+    .bind::<Text, _>(email)
+    .get_result::<Row>(&mut conn)
+    .expect("profile row")
+    .is_pre_launch
+}
 
 async fn run<F, Fut>(f: F)
 where
@@ -139,6 +182,95 @@ async fn mobile_signup_still_works_without_source() {
         );
         assert!(row.platform_pref.is_none());
         assert!(row.signup_source.is_none());
+    })
+    .await;
+}
+
+/// Full end-to-end flow that the landing page drives the user through:
+///
+///   sign-up (source=`landing_early_access`)
+///   → verify-otp
+///   → POST /profiles with name + program + bio + tagIds
+///   → assert `profile.is_pre_launch` = TRUE  (hidden from mobile)
+///   → POST /profiles/me/finalize-pre-launch
+///   → assert `profile.is_pre_launch` = FALSE (now visible)
+#[tokio::test]
+#[serial]
+async fn early_access_full_flow_to_finalize() {
+    run(|server| async move {
+        let email = "e2e@example.com";
+
+        // 1. landing-page signup
+        let signup = server
+            .post("/api/v1/auth/sign-up/email")
+            .json(&serde_json::json!({
+                "email": email,
+                "name": "E2E",
+                "password": "secret123",
+                "platformPref": "android",
+                "source": "landing_early_access",
+            }))
+            .await;
+        assert_eq!(signup.status_code(), 200);
+
+        // 2. verify OTP → bearer token
+        let otp = fetch_otp(email).await;
+        let verify = server
+            .post("/api/v1/auth/verify-otp")
+            .json(&serde_json::json!({ "email": email, "otp": otp }))
+            .await;
+        assert_eq!(verify.status_code(), 200);
+        let body: serde_json::Value = verify.json();
+        let token = body["data"]["token"].as_str().expect("token").to_owned();
+        let (k, v) = auth_header(&token);
+
+        // 3. create the profile with the full payload — what the
+        //    landing's "potwierdź" click sends in one shot.
+        let create = server
+            .post("/api/v1/profiles")
+            .add_header(k.clone(), v.clone())
+            .json(&serde_json::json!({
+                "name": "Ada",
+                "program": "informatyka",
+                "bio": "hej",
+            }))
+            .await;
+        assert!(
+            matches!(create.status_code().as_u16(), 200 | 201),
+            "profile create should succeed, got {}",
+            create.status_code()
+        );
+
+        // 4. profile must be flagged is_pre_launch = TRUE (invisible
+        //    to mobile reads).
+        assert!(
+            read_is_pre_launch(email),
+            "landing-created profile should start hidden (is_pre_launch=true)"
+        );
+
+        // 5. mobile finishes its own onboarding → finalize endpoint
+        let finalize = server
+            .post("/api/v1/profiles/me/finalize-pre-launch")
+            .add_header(k.clone(), v.clone())
+            .await;
+        assert_eq!(finalize.status_code(), 200);
+        let body: serde_json::Value = finalize.json();
+        assert_eq!(body["data"]["finalized"], serde_json::json!(true));
+
+        // 6. flag flipped → profile now visible to the app
+        assert!(
+            !read_is_pre_launch(email),
+            "after finalize, is_pre_launch should be FALSE"
+        );
+
+        // 7. second finalize is a no-op (idempotent)
+        let again = server
+            .post("/api/v1/profiles/me/finalize-pre-launch")
+            .add_header(k, v)
+            .await;
+        assert_eq!(again.status_code(), 200);
+        let body: serde_json::Value = again.json();
+        assert_eq!(body["data"]["finalized"], serde_json::json!(false));
     })
     .await;
 }

--- a/backend/tests/requests/mod.rs
+++ b/backend/tests/requests/mod.rs
@@ -1,4 +1,5 @@
 mod db_viewer;
+mod early_access;
 mod email_change;
 mod migration_contract;
 mod rls_baseline;

--- a/backend/tests/requests/rls_tier_a.rs
+++ b/backend/tests/requests/rls_tier_a.rs
@@ -85,6 +85,7 @@ async fn insert_profile(user: &User, name: &str) -> Uuid {
         gradient_end: None,
         created_at: now,
         updated_at: now,
+        is_pre_launch: false,
     };
     diesel::insert_into(profiles::table)
         .values(&new_profile)

--- a/backend/tests/requests/rls_tier_b.rs
+++ b/backend/tests/requests/rls_tier_b.rs
@@ -103,6 +103,7 @@ async fn insert_profile(user: &User, name: &str) -> Uuid {
         gradient_end: None,
         created_at: now,
         updated_at: now,
+        is_pre_launch: false,
     };
     diesel::insert_into(profiles::table)
         .values(&new_profile)

--- a/backend/tests/requests/rls_tier_c.rs
+++ b/backend/tests/requests/rls_tier_c.rs
@@ -97,6 +97,7 @@ async fn insert_profile(user: &User, name: &str) -> Uuid {
         gradient_end: None,
         created_at: now,
         updated_at: now,
+        is_pre_launch: false,
     };
     diesel::insert_into(profiles::table)
         .values(&new_profile)


### PR DESCRIPTION
Restores the early-access (landing pre-launch) backend work currently running on prod and adds the visibility gate that keeps these accounts hidden from the mobile app until the user finishes mobile onboarding.

Two commits, can be split if preferred:
1. Restoration (no behavior change vs prod): migration, sign-up branch, Turnstile, CORS, welcome email, export CLI, existing tests
2. New gate: \`profiles.is_pre_launch\` flag + filter on matching + \`POST /profiles/me/finalize-pre-launch\` + e2e test covering signup → OTP → profile create → assert hidden → finalize → assert visible

## Test plan
- [ ] cargo test -p poziomki-backend early_access against a local DB
- [ ] apply both migrations to prod, deploy, smoke-test full flow
- [ ] mobile: call finalize endpoint at end of mobile onboarding

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add early-access pre-launch signup flow with finalize gate and welcome email
> - Adds an early-access branch to `POST /api/v1/auth/sign-up/email` (triggered by `source='landing_early_access'`) that enforces IP rate limiting (5/min), validates a Cloudflare Turnstile token, and stamps `pre_launch_signed_up_at`, `platform_pref`, and `signup_source` on the user row.
> - Profiles created by pre-launch users are inserted with `is_pre_launch = TRUE`, hiding them from matching candidates until finalized via the new `POST /api/v1/profiles/me/finalize-pre-launch` endpoint.
> - Adds a claim-and-send welcome email worker using Resend, with an atomic DB claim via `app.claim_welcome_email_send` to prevent duplicate sends.
> - Adds a CORS layer permitting `https://poziomki.app` and `https://www.poziomki.app` (plus `CORS_EXTRA_ORIGINS`) across all routes.
> - Adds an `export-testers` CLI binary that queries pre-launch signups and outputs CSV with optional platform and verified filters.
> - Behavioral Change: existing mobile signups without `source='landing_early_access'` are unaffected; pre-launch profiles are excluded from `load_recent_profiles` until finalized.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b5166e8. 18 files reviewed, 3 issues evaluated, 1 issue filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>backend/src/api/matching/repo.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 214](https://github.com/poziomki-app/poziomki/blob/b5166e8403df7aa21c1159fefa131a9d18be8608/backend/src/api/matching/repo.rs#L214): The new filter `.filter(profiles::is_pre_launch.eq(false))` will exclude profiles where `is_pre_launch` is `NULL`, since SQL `column = false` does not match NULL values. This contrasts with the handling of `privacy_discoverable` earlier in the same function which uses `.eq(true).or(...is_null())` to explicitly handle NULLs. If `is_pre_launch` is a nullable column (common for columns added via migration), legitimate non-pre-launch profiles with NULL values would be incorrectly filtered out of recommendations. Consider using `.filter(profiles::is_pre_launch.eq(false).or(profiles::is_pre_launch.is_null()))` to match the existing pattern. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->