### PR TITLE
polish(ui): normalize modal backgrounds to dark grey

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ConfirmDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ConfirmDialog.kt
@@ -30,6 +30,7 @@ fun ConfirmDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(16.dp),
         containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
         title = {
             Text(
                 text = title,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ReportDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ReportDialog.kt
@@ -30,9 +30,9 @@ import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
-import com.poziomki.app.ui.designsystem.theme.Surface as SurfaceColor
 
 private val REPORT_REASONS =
     listOf(
@@ -61,7 +61,7 @@ fun ReportDialog(
     ) {
         Surface(
             shape = RoundedCornerShape(20.dp),
-            color = SurfaceColor,
+            color = SurfaceElevated,
             modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp),
         ) {
             Column(modifier = Modifier.padding(16.dp)) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
@@ -72,6 +72,7 @@ import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
 import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.feature.chat.model.ChatUiState
@@ -560,7 +561,8 @@ private fun ReactionBreakdownSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        containerColor = SurfaceColor,
+        containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
     ) {
         Column(
             modifier =
@@ -570,7 +572,7 @@ private fun ReactionBreakdownSheet(
         ) {
             ScrollableTabRow(
                 selectedTabIndex = selectedTab,
-                containerColor = SurfaceColor,
+                containerColor = SurfaceElevated,
                 contentColor = Primary,
                 edgePadding = 16.dp,
                 divider = {},

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -475,6 +475,7 @@ private fun AttendeesDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(16.dp),
         containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
         title = {
             Text(
                 text = "uczestnicy",
@@ -547,6 +548,7 @@ private fun EventInfoDialog(
         onDismissRequest = onDismiss,
         shape = RoundedCornerShape(16.dp),
         containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
         title = {
             Text(
                 text = "opis",

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackDialog.kt
@@ -26,6 +26,7 @@ import com.adamglin.phosphoricons.regular.Star
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 
@@ -43,6 +44,8 @@ fun FeedbackDialog(
 ) {
     AlertDialog(
         onDismissRequest = { if (!isSubmitting) onDismiss() },
+        containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
         title = {
             Text(
                 text = "Zostaw opinię",

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/WelcomeDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/WelcomeDialog.kt
@@ -14,12 +14,15 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 
 @Composable
 fun WelcomeDialog(onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
+        containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
         title = {
             Text(
                 text = "Witaj w Poziomkach!",

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ExploreScreen.kt
@@ -289,7 +289,7 @@ private fun ExploreTagFilterDialog(
     BasicAlertDialog(onDismissRequest = onDismiss) {
         Surface(
             shape = RoundedCornerShape(20.dp),
-            color = MaterialTheme.colorScheme.surface,
+            color = SurfaceElevated,
         ) {
             Column(modifier = Modifier.padding(20.dp)) {
                 Row(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
@@ -132,6 +132,7 @@ fun ProfileSetupScreen(
             onDismissRequest = { showAvatarPicker = false },
             sheetState = sheetState,
             containerColor = SurfaceElevated,
+            tonalElevation = 0.dp,
             dragHandle = {
                 Box(
                     modifier =

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangeEmailDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangeEmailDialog.kt
@@ -23,6 +23,7 @@ import com.poziomki.app.ui.designsystem.components.PoziomkiPasswordField
 import com.poziomki.app.ui.designsystem.components.PoziomkiTextField
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 
 @Composable
@@ -68,6 +69,8 @@ private fun EnterEmailStep(
 
     AlertDialog(
         onDismissRequest = { if (!isLoading) onDismiss() },
+        containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
         title = {
             Text(
                 text = "Zmień email",
@@ -149,6 +152,8 @@ private fun OtpStep(
 
     AlertDialog(
         onDismissRequest = { if (!isLoading) onDismiss() },
+        containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
         title = {
             Text(
                 text = "Potwierdź email",

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangePasswordDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangePasswordDialog.kt
@@ -17,9 +17,11 @@ import androidx.compose.ui.unit.sp
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.components.PoziomkiPasswordField
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 
 @Composable
+@Suppress("LongMethod")
 fun ChangePasswordDialog(
     isLoading: Boolean,
     error: String?,
@@ -32,6 +34,8 @@ fun ChangePasswordDialog(
 
     AlertDialog(
         onDismissRequest = { if (!isLoading) onDismiss() },
+        containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
         title = {
             Text(
                 text = "Zmień hasło",

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
@@ -44,6 +44,7 @@ import com.poziomki.app.ui.designsystem.components.ScreenHeader
 import com.poziomki.app.ui.designsystem.components.SectionLabel
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.shared.rememberExportFileSaver
@@ -418,6 +419,8 @@ private fun DeleteAccountDialog(
 
     AlertDialog(
         onDismissRequest = { if (!isLoading) onDismiss() },
+        containerColor = SurfaceElevated,
+        tonalElevation = 0.dp,
         title = {
             Text(
                 text = "Usunąć konto?",


### PR DESCRIPTION
Dialogs and bottom sheets now render at SurfaceElevated (#141414) without M3's tonal lightening overlay.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize modal and bottom sheet backgrounds to dark grey across the app
> Sets `containerColor = SurfaceElevated` and `tonalElevation = 0.dp` on all `AlertDialog` and `ModalBottomSheet` components to ensure consistent dark grey backgrounds. Affected screens include chat, event, feedback, onboarding, profile settings, and home explore dialogs. Behavioral Change: dialogs and sheets that previously used the default surface color or tonal elevation overlay will now render with the `SurfaceElevated` color and no tonal tinting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35c138b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->