### PR TITLE
polish(profile): inset close button, move message into header

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
@@ -238,13 +238,12 @@ fun ProfilePreview(
             // X on, so we render it here. ProfileViewScreen passes onClose=null
             // and renders its own sticky X outside the scrolling content.
             if (onClose != null) {
-                val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
                 IconButton(
                     onClick = onClose,
                     modifier =
                         Modifier
                             .align(Alignment.TopEnd)
-                            .padding(top = statusBarTop + 8.dp, end = 20.dp)
+                            .padding(top = 8.dp, end = 8.dp)
                             .size(40.dp)
                             .clip(CircleShape)
                             .background(Black.copy(alpha = 0.45f)),
@@ -340,12 +339,8 @@ fun ProfilePreview(
                 bottomContent()
             }
 
-            // Headroom for a sticky bottom-end overlay button (e.g. "Wiadomość"
-            // FAB on ProfileViewScreen) plus the system navigation bar inset,
-            // so the last bit of content can always be scrolled clear of the
-            // overlay. Harmless when no overlay is rendered.
             val navBars = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-            Spacer(modifier = Modifier.height(navBars + 96.dp))
+            Spacer(modifier = Modifier.height(navBars + PoziomkiTheme.spacing.lg))
         }
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -264,7 +264,7 @@ fun EventChatHeader(
                 Modifier
                     .fillMaxWidth()
                     .align(Alignment.TopStart)
-                    .padding(horizontal = 4.dp, vertical = 4.dp),
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Surface(

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
@@ -2,10 +2,10 @@ package com.poziomki.app.ui.feature.profile
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
@@ -34,8 +34,6 @@ import com.adamglin.phosphoricons.bold.X
 import com.adamglin.phosphoricons.fill.BookmarkSimple
 import com.adamglin.phosphoricons.fill.PaperPlaneRight
 import com.poziomki.app.ui.designsystem.Text
-import com.poziomki.app.ui.designsystem.components.AppButton
-import com.poziomki.app.ui.designsystem.components.ButtonVariant
 import com.poziomki.app.ui.designsystem.components.ProfileImage
 import com.poziomki.app.ui.designsystem.components.ProfilePreview
 import com.poziomki.app.ui.designsystem.theme.Background
@@ -69,8 +67,6 @@ fun ProfileViewScreen(
 
                 val statusBarTop =
                     WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-                val bottomInsets =
-                    WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
                 Box(modifier = Modifier.fillMaxSize()) {
                     val displayedProgram =
                         if (state.isOwnProfile && !state.showOwnProgram) null else p.program
@@ -91,23 +87,37 @@ fun ProfileViewScreen(
                         headerAction =
                             if (!state.isOwnProfile) {
                                 {
-                                    IconButton(onClick = { viewModel.toggleBookmark() }) {
-                                        Icon(
-                                            imageVector =
-                                                if (state.isBookmarked) {
-                                                    PhosphorIcons.Fill.BookmarkSimple
-                                                } else {
-                                                    PhosphorIcons.Bold.BookmarkSimple
-                                                },
-                                            contentDescription =
-                                                if (state.isBookmarked) {
-                                                    "Usuń zakładkę"
-                                                } else {
-                                                    "Dodaj zakładkę"
-                                                },
-                                            tint = if (state.isBookmarked) Primary else White,
-                                            modifier = Modifier.size(22.dp),
-                                        )
+                                    Row {
+                                        IconButton(
+                                            onClick = {
+                                                onNavigateToChat(p.userId, p.name, p.id)
+                                            },
+                                        ) {
+                                            Icon(
+                                                imageVector = PhosphorIcons.Fill.PaperPlaneRight,
+                                                contentDescription = "Napisz wiadomość",
+                                                tint = Primary,
+                                                modifier = Modifier.size(22.dp),
+                                            )
+                                        }
+                                        IconButton(onClick = { viewModel.toggleBookmark() }) {
+                                            Icon(
+                                                imageVector =
+                                                    if (state.isBookmarked) {
+                                                        PhosphorIcons.Fill.BookmarkSimple
+                                                    } else {
+                                                        PhosphorIcons.Bold.BookmarkSimple
+                                                    },
+                                                contentDescription =
+                                                    if (state.isBookmarked) {
+                                                        "Usuń zakładkę"
+                                                    } else {
+                                                        "Dodaj zakładkę"
+                                                    },
+                                                tint = if (state.isBookmarked) Primary else White,
+                                                modifier = Modifier.size(22.dp),
+                                            )
+                                        }
                                     }
                                 }
                             } else {
@@ -115,15 +125,16 @@ fun ProfileViewScreen(
                             },
                     )
 
-                    // Sticky X (close) — top-end, above status bar. Does NOT
-                    // scroll with the image carousel, so it's reachable at
-                    // every scroll position.
+                    // Sticky X (close) — top-end, inset from the image's
+                    // rounded corner so it never overlaps the curved edge.
+                    // Image: 12dp horizontal padding + 24dp corner radius,
+                    // top at statusBarTop + 8dp.
                     IconButton(
                         onClick = onBack,
                         modifier =
                             Modifier
                                 .align(Alignment.TopEnd)
-                                .padding(top = statusBarTop + 8.dp, end = 20.dp)
+                                .padding(top = statusBarTop + 16.dp, end = 20.dp)
                                 .size(40.dp)
                                 .clip(CircleShape)
                                 .background(Color.Black.copy(alpha = 0.45f)),
@@ -133,26 +144,6 @@ fun ProfileViewScreen(
                             contentDescription = "Zamknij",
                             tint = White,
                             modifier = Modifier.size(24.dp),
-                        )
-                    }
-
-                    // Sticky "Wiadomość" — bottom-end, above the system nav
-                    // bar. Same anchor on every screen of every profile so
-                    // the user always taps the same spot. ProfilePreview
-                    // adds bottom headroom so content scrolls clear of it.
-                    if (!state.isOwnProfile) {
-                        AppButton(
-                            text = "Wiadomość",
-                            onClick = { onNavigateToChat(p.userId, p.name, p.id) },
-                            variant = ButtonVariant.PRIMARY,
-                            icon = PhosphorIcons.Fill.PaperPlaneRight,
-                            modifier =
-                                Modifier
-                                    .align(Alignment.BottomEnd)
-                                    .padding(
-                                        end = 16.dp,
-                                        bottom = bottomInsets + 24.dp,
-                                    ),
                         )
                     }
                 }


### PR DESCRIPTION
- inset X close button so it sits inside the image's rounded corner (profile view, profile preview dialog, event chat header)
- replace floating wiadomość pill with paper-plane icon next to bookmark

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move message action into profile header and inset close button
> - Replaces the bottom-end 'Wiadomość' button in [ProfileViewScreen.kt](https://github.com/poziomki-app/poziomki/pull/471/files#diff-0f5e2d8316e1a1ac2aabcd891bc6dea7580fc2db838010570275cc5408aa7ee3) with a message icon (`PaperPlaneRight`) placed in the header row alongside the bookmark icon.
> - Increases the close button's top padding from `statusBarTop + 8.dp` to `statusBarTop + 16.dp` in `ProfileViewScreen`, and removes status bar inset from the close button padding in [ProfilePreview.kt](https://github.com/poziomki-app/poziomki/pull/471/files#diff-03afc31fe4d766b0d251f7d43acf05a0a107dbecf813c0df76fa96e5f4ae7de0) (now fixed at 8dp top/end).
> - Replaces the fixed 96dp bottom scroll spacer in `ProfilePreview` with `navBars + PoziomkiTheme.spacing.lg`.
> - Increases outer padding in [EventChatHeader.kt](https://github.com/poziomki-app/poziomki/pull/471/files#diff-03629e6d0d7bca288c6b50a0e665e404632270ff54760a7213758fdc94120d80) from 4dp to 8dp.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30b1921.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->