### PR TITLE
feat(profile): add postaw kawę link and testy badge on feedback

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -29,7 +30,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,6 +42,7 @@ import com.adamglin.phosphoricons.bold.Bell
 import com.adamglin.phosphoricons.bold.BookmarkSimple
 import com.adamglin.phosphoricons.bold.CaretRight
 import com.adamglin.phosphoricons.bold.ChatTeardropText
+import com.adamglin.phosphoricons.bold.Coffee
 import com.adamglin.phosphoricons.bold.PencilSimple
 import com.adamglin.phosphoricons.bold.Shield
 import com.adamglin.phosphoricons.bold.SignOut
@@ -49,9 +53,11 @@ import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.ProfileCard
 import com.poziomki.app.ui.designsystem.components.ScreenHeader
+import com.poziomki.app.ui.designsystem.theme.Black
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
+import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.navigation.LocalNavBarPadding
@@ -73,6 +79,7 @@ fun ProfileScreen(
 ) {
     val state by viewModel.state.collectAsState()
     var showLogoutDialog by remember { mutableStateOf(false) }
+    val uriHandler = LocalUriHandler.current
 
     Column(
         modifier =
@@ -143,6 +150,13 @@ fun ProfileScreen(
                                         icon = PhosphorIcons.Bold.ChatTeardropText,
                                         label = "zostaw opinię",
                                         onClick = onOpenFeedback,
+                                        badge = "testy",
+                                    )
+                                    HorizontalDivider(color = Border, thickness = 1.dp)
+                                    SettingsMenuItem(
+                                        icon = PhosphorIcons.Bold.Coffee,
+                                        label = "postaw kawę",
+                                        onClick = { uriHandler.openUri("https://buycoffee.to/poziomki-app") },
                                     )
                                 }
 
@@ -211,6 +225,7 @@ private fun SettingsMenuItem(
     icon: ImageVector,
     label: String,
     onClick: () -> Unit,
+    badge: String? = null,
 ) {
     Row(
         modifier =
@@ -233,8 +248,26 @@ private fun SettingsMenuItem(
             fontWeight = FontWeight.Medium,
             fontSize = 16.sp,
             color = TextPrimary,
-            modifier = Modifier.weight(1f),
         )
+        if (badge != null) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(
+                modifier =
+                    Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(Primary)
+                        .padding(horizontal = 6.dp, vertical = 2.dp),
+            ) {
+                Text(
+                    text = badge,
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 10.sp,
+                    color = Black,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.weight(1f))
         Icon(
             imageVector = PhosphorIcons.Bold.CaretRight,
             contentDescription = null,


### PR DESCRIPTION
- adds postaw kawę menu item linking to buycoffee.to/poziomki-app
- adds small cyan testy badge on zostaw opinię

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'postaw kawę' link and 'testy' badge to profile feedback menu
> - Adds a new 'postaw kawę' menu item to [ProfileScreen](https://github.com/poziomki-app/poziomki/pull/473/files#diff-fc887268faeed367fe5f146e13ce4d6c7e27a2e86e7acb6aa3dca33b6623ac2d) that opens `https://buycoffee.to/poziomki-app` via the platform URI handler.
> - Adds an optional `badge` parameter to `SettingsMenuItem` and displays a rounded pill with Primary background when provided; the 'zostaw opinię' item uses this to show a `"testy"` badge.
> - Layout spacing in `SettingsMenuItem` is adjusted by moving the `weight(1f)` modifier from the label `Text` to a trailing `Spacer`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b00ac84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->