### PR TITLE
polish: event chat header, external link confirm, onboarding & chat tweaks

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -15,7 +15,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.22.1" // x-release-please-version
+val appVersionName = "0.22.2" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ExternalLink.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ExternalLink.kt
@@ -1,0 +1,105 @@
+package com.poziomki.app.ui.designsystem.components
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.poziomki.app.ui.designsystem.Text
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
+import com.poziomki.app.ui.designsystem.theme.TextMuted
+import com.poziomki.app.ui.designsystem.theme.TextPrimary
+import com.poziomki.app.ui.designsystem.theme.TextSecondary
+
+/**
+ * Returns an `(url) -> Unit` that confirms with the user before opening an external link.
+ * Place the call site high enough in the tree that the confirm dialog renders over the screen.
+ */
+@Composable
+fun rememberExternalLinkOpener(): (String) -> Unit {
+    val uriHandler = LocalUriHandler.current
+    var pending by remember { mutableStateOf<String?>(null) }
+
+    pending?.let { url ->
+        val isMaps = url.startsWith("geo:")
+        AlertDialog(
+            onDismissRequest = { pending = null },
+            shape = RoundedCornerShape(16.dp),
+            containerColor = SurfaceElevated,
+            tonalElevation = 0.dp,
+            title = {
+                Text(
+                    text = if (isMaps) "otworzyć w mapach?" else "otworzyć link zewnętrzny?",
+                    preserveCase = false,
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                    color = TextPrimary,
+                )
+            },
+            text = {
+                Text(
+                    text = humanReadable(url),
+                    preserveCase = true,
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 13.sp,
+                    color = TextSecondary,
+                    lineHeight = 18.sp,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val toOpen = url
+                    pending = null
+                    runCatching { uriHandler.openUri(toOpen) }
+                }) {
+                    Text(
+                        text = "otwórz",
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Primary,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pending = null }) {
+                    Text(
+                        text = "anuluj",
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.SemiBold,
+                        color = TextMuted,
+                    )
+                }
+            },
+        )
+    }
+
+    return { url -> pending = url }
+}
+
+/** Builds a Maps deeplink that prefers the device Maps app. */
+fun mapsDeeplink(
+    latitude: Double,
+    longitude: Double,
+    label: String? = null,
+): String {
+    val q = if (label.isNullOrBlank()) "$latitude,$longitude" else "$latitude,$longitude($label)"
+    return "geo:$latitude,$longitude?q=$q"
+}
+
+private fun humanReadable(url: String): String {
+    if (!url.startsWith("geo:")) return url
+    val labelInParens = url.substringAfter('(', "").substringBeforeLast(')', "")
+    if (labelInParens.isNotBlank()) return labelInParens
+    return url.removePrefix("geo:").substringBefore("?").replace(",", ", ")
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -136,7 +136,7 @@ internal fun MessageEventRow(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(top = if (groupedWithPrevious) 2.dp else 10.dp),
+                .padding(top = if (groupedWithPrevious) 4.dp else 12.dp),
         horizontalAlignment = horizontalAlignment,
     ) {
         Box(modifier = Modifier.fillMaxWidth()) {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -69,6 +69,7 @@ import com.poziomki.app.ui.designsystem.components.UserAvatar
 import com.poziomki.app.ui.designsystem.components.pointGeoJson
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Error
+import com.poziomki.app.ui.designsystem.theme.MontserratFamily
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
 import com.poziomki.app.ui.designsystem.theme.Primary
@@ -94,6 +95,7 @@ import org.maplibre.spatialk.geojson.Position
 @Composable
 fun EventCoverImage(
     event: Event,
+    strongOverlay: Boolean = false,
     content: @Composable BoxScope.() -> Unit,
 ) {
     val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
@@ -102,7 +104,7 @@ fun EventCoverImage(
             Modifier
                 .fillMaxWidth()
                 .padding(start = 12.dp, end = 12.dp, top = statusBarTop + 8.dp)
-                .aspectRatio(16f / 10f)
+                .aspectRatio(16f / 9f)
                 .clip(RoundedCornerShape(24.dp)),
     ) {
         val coverImage = event.coverImage
@@ -115,24 +117,33 @@ fun EventCoverImage(
             )
         }
 
+        val gradientStops =
+            if (strongOverlay) {
+                arrayOf(
+                    0f to Color.Black.copy(alpha = 0.2f),
+                    0.12f to Color.Transparent,
+                    0.25f to Background.copy(alpha = 0.18f),
+                    0.38f to Background.copy(alpha = 0.65f),
+                    0.48f to Background,
+                    1f to Background,
+                )
+            } else {
+                arrayOf(
+                    0f to Color.Black.copy(alpha = 0.18f),
+                    0.15f to Color.Transparent,
+                    0.55f to Color.Transparent,
+                    0.72f to Background.copy(alpha = 0.55f),
+                    0.88f to Background,
+                    1f to Background,
+                )
+            }
+        val solidBottomFraction = if (strongOverlay) 0.55f else 0.15f
+
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(
-                        Brush.verticalGradient(
-                            colorStops =
-                                arrayOf(
-                                    0f to Color.Black.copy(alpha = 0.45f),
-                                    0.08f to Color.Black.copy(alpha = 0.22f),
-                                    0.18f to Color.Black.copy(alpha = 0.08f),
-                                    0.28f to Background.copy(alpha = 0.2f),
-                                    0.40f to Background.copy(alpha = 0.7f),
-                                    0.50f to Background,
-                                    1f to Background,
-                                ),
-                        ),
-                    ),
+                    .background(Brush.verticalGradient(colorStops = gradientStops)),
         )
 
         Box(
@@ -140,7 +151,7 @@ fun EventCoverImage(
                 Modifier
                     .align(Alignment.BottomStart)
                     .fillMaxWidth()
-                    .fillMaxHeight(0.5f)
+                    .fillMaxHeight(solidBottomFraction)
                     .background(Background),
         )
 
@@ -269,7 +280,7 @@ fun EventChatHeader(
     var showLocationDialog by remember { mutableStateOf(false) }
     var showInfoDialog by remember { mutableStateOf(false) }
 
-    EventCoverImage(event = event) {
+    EventCoverImage(event = event, strongOverlay = true) {
         Row(
             modifier =
                 Modifier
@@ -371,15 +382,28 @@ fun EventChatHeader(
             modifier =
                 Modifier
                     .align(Alignment.BottomStart)
-                    .padding(horizontal = PoziomkiTheme.spacing.md, vertical = PoziomkiTheme.spacing.sm),
+                    .padding(
+                        start = PoziomkiTheme.spacing.md,
+                        end = PoziomkiTheme.spacing.md,
+                        top = PoziomkiTheme.spacing.sm,
+                        bottom = PoziomkiTheme.spacing.lg,
+                    ),
         ) {
+            val titleFontSize =
+                when {
+                    event.title.length > 40 -> 18.sp
+                    event.title.length > 28 -> 22.sp
+                    else -> 26.sp
+                }
             Text(
                 text = event.title,
                 preserveCase = true,
-                style = MaterialTheme.typography.headlineMedium,
+                fontFamily = MontserratFamily,
+                fontSize = titleFontSize,
+                lineHeight = titleFontSize * 1.15f,
                 fontWeight = FontWeight.ExtraBold,
                 color = Color.White,
-                maxLines = 3,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -41,12 +41,17 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import coil3.compose.AsyncImage
 import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
@@ -66,7 +71,8 @@ import com.poziomki.app.network.EventAttendee
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.components.ConfirmDialog
 import com.poziomki.app.ui.designsystem.components.UserAvatar
-import com.poziomki.app.ui.designsystem.components.pointGeoJson
+import com.poziomki.app.ui.designsystem.components.mapsDeeplink
+import com.poziomki.app.ui.designsystem.components.rememberExternalLinkOpener
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Error
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
@@ -81,16 +87,6 @@ import com.poziomki.app.ui.feature.chat.ActionMenuItem
 import com.poziomki.app.ui.shared.formatEventDateCompact
 import com.poziomki.app.ui.shared.formatEventLocation
 import com.poziomki.app.ui.shared.resolveImageUrl
-import org.maplibre.compose.camera.CameraPosition
-import org.maplibre.compose.camera.rememberCameraState
-import org.maplibre.compose.expressions.dsl.const
-import org.maplibre.compose.layers.CircleLayer
-import org.maplibre.compose.map.MapOptions
-import org.maplibre.compose.map.MaplibreMap
-import org.maplibre.compose.map.OrnamentOptions
-import org.maplibre.compose.sources.rememberGeoJsonSource
-import org.maplibre.compose.style.BaseStyle
-import org.maplibre.spatialk.geojson.Position
 
 @Composable
 fun EventCoverImage(
@@ -179,6 +175,7 @@ fun EventMetaRows(
                 text = formatEventLocation(location),
                 onClick = onLocationClick,
                 preserveCase = true,
+                modifier = Modifier.weight(1f, fill = false),
             )
         }
 
@@ -205,23 +202,25 @@ fun EventMetaRows(
 }
 
 @Composable
+@Suppress("LongParameterList")
 private fun MetaChip(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     text: String,
     onClick: (() -> Unit)? = null,
     accent: Boolean = false,
     preserveCase: Boolean = false,
+    modifier: Modifier = Modifier,
 ) {
     val shape = RoundedCornerShape(50)
     val bgColor = if (accent) Primary.copy(alpha = 0.18f) else Color.White.copy(alpha = 0.12f)
     val contentColor = if (accent) Primary else Color.White
 
     if (onClick != null) {
-        Surface(onClick = onClick, shape = shape, color = bgColor) {
+        Surface(onClick = onClick, shape = shape, color = bgColor, modifier = modifier) {
             ChipContent(icon = icon, text = text, tint = contentColor, preserveCase = preserveCase)
         }
     } else {
-        Surface(shape = shape, color = bgColor) {
+        Surface(shape = shape, color = bgColor, modifier = modifier) {
             ChipContent(icon = icon, text = text, tint = contentColor, preserveCase = preserveCase)
         }
     }
@@ -255,6 +254,7 @@ private fun ChipContent(
             fontSize = 12.sp,
             color = tint,
             maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             preserveCase = preserveCase,
         )
     }
@@ -277,8 +277,8 @@ fun EventChatHeader(
     var showMenu by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showAttendeesDialog by remember { mutableStateOf(false) }
-    var showLocationDialog by remember { mutableStateOf(false) }
     var showInfoDialog by remember { mutableStateOf(false) }
+    val openLink = rememberExternalLinkOpener()
 
     EventCoverImage(event = event, strongOverlay = true) {
         Row(
@@ -435,10 +435,12 @@ fun EventChatHeader(
                 event = event,
                 onParticipantsClick = { showAttendeesDialog = true },
                 onLocationClick =
-                    if (event.latitude != null && event.longitude != null) {
-                        { showLocationDialog = true }
-                    } else {
-                        null
+                    event.latitude?.let { lat ->
+                        event.longitude?.let { lng ->
+                            {
+                                openLink(mapsDeeplink(lat, lng, event.location))
+                            }
+                        }
                     },
                 onInfoClick =
                     if (!event.description.isNullOrBlank()) {
@@ -475,24 +477,11 @@ fun EventChatHeader(
         )
     }
 
-    if (showLocationDialog) {
-        val lat = event.latitude
-        val lng = event.longitude
-        val loc = event.location
-        if (lat != null && lng != null && loc != null) {
-            LocationMapDialog(
-                locationName = loc,
-                latitude = lat,
-                longitude = lng,
-                onDismiss = { showLocationDialog = false },
-            )
-        }
-    }
-
     if (showInfoDialog) {
         event.description?.let { description ->
             EventInfoDialog(
                 description = description,
+                onLinkClick = openLink,
                 onDismiss = { showInfoDialog = false },
             )
         }
@@ -577,6 +566,7 @@ private fun AttendeesDialog(
 @Composable
 private fun EventInfoDialog(
     description: String,
+    onLinkClick: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
     AlertDialog(
@@ -595,8 +585,7 @@ private fun EventInfoDialog(
         },
         text = {
             Text(
-                text = description,
-                preserveCase = true,
+                text = linkifiedText(description, onLinkClick),
                 fontFamily = NunitoFamily,
                 fontWeight = FontWeight.Normal,
                 fontSize = 14.sp,
@@ -617,104 +606,34 @@ private fun EventInfoDialog(
     )
 }
 
-@Composable
-@Suppress("LongMethod")
-private fun LocationMapDialog(
-    locationName: String,
-    latitude: Double,
-    longitude: Double,
-    onDismiss: () -> Unit,
-) {
-    val uriHandler = LocalUriHandler.current
-    val mapsUrl = "https://www.google.com/maps/search/?api=1&query=$latitude,$longitude"
+private val urlRegex = Regex("https?://[\\w./?=&#%~_+\\-:@!$']+")
 
-    Dialog(onDismissRequest = onDismiss) {
-        Surface(
-            shape = RoundedCornerShape(16.dp),
-            color = SurfaceElevated,
-        ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text(
-                    text = formatEventLocation(locationName),
-                    preserveCase = true,
-                    fontFamily = NunitoFamily,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 16.sp,
-                    color = TextPrimary,
-                    maxLines = 2,
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .height(220.dp)
-                            .clip(RoundedCornerShape(12.dp)),
-                ) {
-                    MaplibreMap(
-                        modifier = Modifier.fillMaxSize(),
-                        baseStyle =
-                            BaseStyle.Uri("https://tiles.openfreemap.org/styles/positron"),
-                        cameraState =
-                            rememberCameraState(
-                                firstPosition =
-                                    CameraPosition(
-                                        target = Position(latitude = latitude, longitude = longitude),
-                                        zoom = 14.0,
-                                    ),
-                            ),
-                        options =
-                            MapOptions(
-                                ornamentOptions =
-                                    OrnamentOptions(
-                                        isLogoEnabled = false,
-                                        isCompassEnabled = false,
-                                        isScaleBarEnabled = false,
-                                    ),
-                            ),
-                    ) {
-                        val source = rememberGeoJsonSource(data = pointGeoJson(latitude, longitude))
-                        CircleLayer(
-                            id = "location-marker",
-                            source = source,
-                            radius = const(8.dp),
-                            color = const(Primary),
-                            strokeColor = const(Color.White),
-                            strokeWidth = const(2.dp),
-                        )
-                    }
-                }
-                Spacer(modifier = Modifier.height(12.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    TextButton(onClick = { uriHandler.openUri(mapsUrl) }) {
-                        Icon(
-                            imageVector = PhosphorIcons.Fill.MapPin,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp),
-                            tint = Primary,
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = "otwórz w mapach",
-                            fontFamily = NunitoFamily,
-                            fontWeight = FontWeight.SemiBold,
-                            color = Primary,
-                        )
-                    }
-                    TextButton(onClick = onDismiss) {
-                        Text(
-                            text = "zamknij",
-                            fontFamily = NunitoFamily,
-                            fontWeight = FontWeight.SemiBold,
-                            color = TextMuted,
-                        )
-                    }
-                }
+@Composable
+private fun linkifiedText(
+    text: String,
+    onLinkClick: (String) -> Unit,
+): AnnotatedString =
+    buildAnnotatedString {
+        var cursor = 0
+        for (match in urlRegex.findAll(text)) {
+            if (match.range.first > cursor) {
+                append(text.substring(cursor, match.range.first))
             }
+            val url = match.value
+            val link =
+                LinkAnnotation.Clickable(
+                    tag = url,
+                    styles =
+                        TextLinkStyles(
+                            style =
+                                SpanStyle(
+                                    color = Primary,
+                                    textDecoration = TextDecoration.Underline,
+                                ),
+                        ),
+                ) { onLinkClick(url) }
+            withLink(link) { append(url) }
+            cursor = match.range.last + 1
         }
+        if (cursor < text.length) append(text.substring(cursor))
     }
-}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -53,6 +54,7 @@ import com.adamglin.phosphoricons.Fill
 import com.adamglin.phosphoricons.bold.ArrowLeft
 import com.adamglin.phosphoricons.bold.DotsThreeVertical
 import com.adamglin.phosphoricons.bold.Flag
+import com.adamglin.phosphoricons.bold.Info
 import com.adamglin.phosphoricons.bold.PencilSimple
 import com.adamglin.phosphoricons.bold.SignOut
 import com.adamglin.phosphoricons.bold.Trash
@@ -121,15 +123,25 @@ fun EventCoverImage(
                         Brush.verticalGradient(
                             colorStops =
                                 arrayOf(
-                                    0f to Color.Black.copy(alpha = 0.3f),
-                                    0.2f to Color.Transparent,
-                                    0.45f to Background.copy(alpha = 0.3f),
-                                    0.65f to Background.copy(alpha = 0.65f),
-                                    0.8f to Background.copy(alpha = 0.85f),
+                                    0f to Color.Black.copy(alpha = 0.45f),
+                                    0.08f to Color.Black.copy(alpha = 0.22f),
+                                    0.18f to Color.Black.copy(alpha = 0.08f),
+                                    0.28f to Background.copy(alpha = 0.2f),
+                                    0.40f to Background.copy(alpha = 0.7f),
+                                    0.50f to Background,
                                     1f to Background,
                                 ),
                         ),
                     ),
+        )
+
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.BottomStart)
+                    .fillMaxWidth()
+                    .fillMaxHeight(0.5f)
+                    .background(Background),
         )
 
         content()
@@ -155,29 +167,25 @@ fun EventMetaRows(
                 icon = PhosphorIcons.Fill.MapPin,
                 text = formatEventLocation(location),
                 onClick = onLocationClick,
+                preserveCase = true,
             )
         }
 
         if (onInfoClick != null) {
-            val infoShape = RoundedCornerShape(50)
             Surface(
                 onClick = onInfoClick,
-                shape = infoShape,
-                color = Primary.copy(alpha = 0.18f),
+                shape = CircleShape,
+                color = Color.White.copy(alpha = 0.12f),
             ) {
                 Box(
                     contentAlignment = Alignment.Center,
-                    modifier =
-                        Modifier
-                            .height(32.dp)
-                            .padding(horizontal = 12.dp),
+                    modifier = Modifier.size(32.dp),
                 ) {
-                    Text(
-                        text = "i",
-                        fontFamily = NunitoFamily,
-                        fontWeight = FontWeight.ExtraBold,
-                        fontSize = 14.sp,
-                        color = Primary,
+                    Icon(
+                        imageVector = PhosphorIcons.Bold.Info,
+                        contentDescription = "informacje",
+                        modifier = Modifier.size(18.dp),
+                        tint = Color.White.copy(alpha = 0.85f),
                     )
                 }
             }
@@ -191,6 +199,7 @@ private fun MetaChip(
     text: String,
     onClick: (() -> Unit)? = null,
     accent: Boolean = false,
+    preserveCase: Boolean = false,
 ) {
     val shape = RoundedCornerShape(50)
     val bgColor = if (accent) Primary.copy(alpha = 0.18f) else Color.White.copy(alpha = 0.12f)
@@ -198,11 +207,11 @@ private fun MetaChip(
 
     if (onClick != null) {
         Surface(onClick = onClick, shape = shape, color = bgColor) {
-            ChipContent(icon = icon, text = text, tint = contentColor)
+            ChipContent(icon = icon, text = text, tint = contentColor, preserveCase = preserveCase)
         }
     } else {
         Surface(shape = shape, color = bgColor) {
-            ChipContent(icon = icon, text = text, tint = contentColor)
+            ChipContent(icon = icon, text = text, tint = contentColor, preserveCase = preserveCase)
         }
     }
 }
@@ -212,6 +221,7 @@ private fun ChipContent(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     text: String,
     tint: Color,
+    preserveCase: Boolean = false,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -234,6 +244,7 @@ private fun ChipContent(
             fontSize = 12.sp,
             color = tint,
             maxLines = 1,
+            preserveCase = preserveCase,
         )
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -33,6 +33,8 @@ import com.poziomki.app.network.Event
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.components.AppButton
 import com.poziomki.app.ui.designsystem.components.ButtonVariant
+import com.poziomki.app.ui.designsystem.components.mapsDeeplink
+import com.poziomki.app.ui.designsystem.components.rememberExternalLinkOpener
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
 import com.poziomki.app.ui.designsystem.theme.Primary
@@ -137,6 +139,7 @@ fun EventChatJoinRequiredView(
     onJoin: () -> Unit,
     onBack: () -> Unit,
 ) {
+    val openLink = rememberExternalLinkOpener()
     Column(
         modifier =
             Modifier
@@ -189,7 +192,17 @@ fun EventChatJoinRequiredView(
         ) {
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
 
-            EventMetaRows(event = event)
+            EventMetaRows(
+                event = event,
+                onLocationClick =
+                    event.latitude?.let { lat ->
+                        event.longitude?.let { lng ->
+                            {
+                                openLink(mapsDeeplink(lat, lng, event.location))
+                            }
+                        }
+                    },
+            )
 
             if (event.requiresApproval) {
                 Spacer(modifier = Modifier.height(4.dp))

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
@@ -303,12 +303,12 @@ private fun EditableAvatar(
             Image(
                 bitmap = bitmap,
                 contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize().clip(CircleShape),
                 contentScale = ContentScale.Crop,
             )
         } else {
             Box(
-                modifier = Modifier.fillMaxSize().background(Surface),
+                modifier = Modifier.fillMaxSize().clip(CircleShape).background(Surface),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
@@ -323,7 +323,6 @@ private fun EditableAvatar(
             modifier =
                 Modifier
                     .align(Alignment.BottomEnd)
-                    .padding(10.dp)
                     .size(26.dp)
                     .clip(CircleShape)
                     .background(Primary)

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -616,7 +616,7 @@ fun MainScreen(
                                         if (selected) {
                                             MaterialTheme.colorScheme.onSurface
                                         } else {
-                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
                                         }
                                     Column(
                                         modifier =
@@ -694,7 +694,7 @@ fun MainScreen(
                                                 if (profileSelected) {
                                                     MaterialTheme.colorScheme.onSurface
                                                 } else {
-                                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
                                                 },
                                         )
                                     }


### PR DESCRIPTION
- nav inactive tabs dimmed
- event chat header: stronger cover gradient, montserrat title with autosize + ellipsis, neutral info icon, location chip preserves case + ellipses long names
- external links go through a confirm dialog; location uses geo: deeplink to prefer the device maps app
- event description detects http(s) urls and renders them as tappable links via the same confirm flow
- onboarding avatar clipped to circle with pen badge flush at corner
- chat messages spacing +2px

## Test plan
- [ ] open event chat, verify cover gradient + title sizes (short/long)
- [ ] tap location chip in chat and overview → confirm dialog shows label (not raw geo:) → opens maps app
- [ ] open info dialog with a url in description → link is underlined and triggers confirm
- [ ] onboarding avatar shows pen badge at bottom-right of circular avatar

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace in-app location map dialog with external maps app via geo: deeplink confirmation
> - Adds `rememberExternalLinkOpener` in [ExternalLink.kt](https://github.com/poziomki-app/poziomki/pull/474/files#diff-eeb2ba9755ad276160b3c8bffc49c528d15cc57988dc13c1a3f9e0b6c2d2ef15), a composable that shows a confirmation `AlertDialog` before opening any external URL, with geo: links displaying a human-readable label.
> - Removes the embedded `LocationMapDialog` (MapLibre map); tapping a location chip now triggers the confirmation dialog and opens the device maps app via a `geo:` deeplink built by `mapsDeeplink()`.
> - URLs in the event info dialog body are now rendered as clickable links via a new `linkifiedText` util, delegating opens to the same external link opener.
> - Updates `EventCoverImage` to 16:9 aspect ratio with a stronger gradient overlay option, adjusts event title typography (dynamic font size, max 2 lines, Montserrat), and refreshes the info button to use a circular icon style.
> - Dims unselected bottom nav items to 55% opacity and fixes the onboarding avatar to clip strictly to `CircleShape`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1c16212. 6 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->