### PR TITLE
fix(feed): keep joined events in polecane

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
@@ -62,9 +62,13 @@ class EventsViewModel(
                         _state.value = _state.value.copy(isLoading = false)
                     }
                 } else {
+                    val byId = events.associateBy { it.id }
+                    val syncedRecommended =
+                        _state.value.recommendedEvents.mapNotNull { byId[it.id] }
                     _state.value =
                         _state.value.copy(
                             allEvents = events,
+                            recommendedEvents = syncedRecommended,
                             isLoading = if (events.isNotEmpty()) false else _state.value.isLoading,
                         )
                     filterEvents()


### PR DESCRIPTION
joining an event was dropping it from polecane because recommendedEvents held stale references. now sync against allEvents on every observe update, so the joined event stays with isAttending=true.

## Test plan
- [ ] join a recommended event → stays in polecane with attending state

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix joined events being dropped from recommended events on reload
> When new events are loaded, `EventsViewModel` now syncs `recommendedEvents` against the updated `allEvents` list, removing any recommendations that no longer exist. Previously, stale recommended events could persist or joined events could be dropped incorrectly after a reload.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 80a5983. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->