### PR TITLE
polish(profile): confirm before opening buycoffee link

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -53,6 +52,7 @@ import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.ProfileCard
 import com.poziomki.app.ui.designsystem.components.ScreenHeader
+import com.poziomki.app.ui.designsystem.components.rememberExternalLinkOpener
 import com.poziomki.app.ui.designsystem.theme.Black
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
@@ -79,7 +79,7 @@ fun ProfileScreen(
 ) {
     val state by viewModel.state.collectAsState()
     var showLogoutDialog by remember { mutableStateOf(false) }
-    val uriHandler = LocalUriHandler.current
+    val openExternal = rememberExternalLinkOpener()
 
     Column(
         modifier =
@@ -156,7 +156,7 @@ fun ProfileScreen(
                                     SettingsMenuItem(
                                         icon = PhosphorIcons.Bold.Coffee,
                                         label = "postaw kawę",
-                                        onClick = { uriHandler.openUri("https://buycoffee.to/poziomki-app") },
+                                        onClick = { openExternal("https://buycoffee.to/poziomki-app") },
                                     )
                                 }
 


### PR DESCRIPTION
Reuses the external-link confirm dialog (same as events) for postaw kawę.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add confirmation dialog before opening the buycoffee external link in ProfileScreen
> Replaces `LocalUriHandler` with `rememberExternalLinkOpener` from the design system in [ProfileScreen.kt](https://github.com/poziomki-app/poziomki/pull/476/files#diff-fc887268faeed367fe5f146e13ce4d6c7e27a2e86e7acb6aa3dca33b6623ac2d). The new utility prompts the user for confirmation before opening the "postaw kawę" link in an external browser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d55e6d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->