### PR TITLE
polish(profile): subtler testy badge

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
@@ -1,6 +1,7 @@
 package com.poziomki.app.ui.feature.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -53,11 +54,9 @@ import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.ProfileCard
 import com.poziomki.app.ui.designsystem.components.ScreenHeader
 import com.poziomki.app.ui.designsystem.components.rememberExternalLinkOpener
-import com.poziomki.app.ui.designsystem.theme.Black
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
-import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.navigation.LocalNavBarPadding
@@ -250,20 +249,20 @@ private fun SettingsMenuItem(
             color = TextPrimary,
         )
         if (badge != null) {
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(6.dp))
             Box(
                 modifier =
                     Modifier
-                        .clip(RoundedCornerShape(6.dp))
-                        .background(Primary)
-                        .padding(horizontal = 6.dp, vertical = 2.dp),
+                        .clip(RoundedCornerShape(4.dp))
+                        .border(1.dp, Border, RoundedCornerShape(4.dp))
+                        .padding(horizontal = 4.dp, vertical = 1.dp),
             ) {
                 Text(
                     text = badge,
                     fontFamily = NunitoFamily,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 10.sp,
-                    color = Black,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 8.sp,
+                    color = TextMuted,
                 )
             }
         }


### PR DESCRIPTION
Smaller outlined badge in muted text instead of bright filled chip.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restyle `SettingsMenuItem` badge to a subtler outlined pill with muted text
> Updates the badge in [ProfileScreen.kt](https://github.com/poziomki-app/poziomki/pull/477/files#diff-fc887268faeed367fe5f146e13ce4d6c7e27a2e86e7acb6aa3dca33b6623ac2d) from a solid Primary-filled pill with bold black text to a small outlined box with a Border stroke and muted text. Reduces corner radius (6dp→4dp), padding, spacing, and font size (10sp bold→8sp medium).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14e1b72.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->