### PR TITLE
feat(ios): firebase crashlytics and performance

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.perf)
+    alias(libs.plugins.firebase.crashlytics)
     id("poziomki.detekt")
     id("poziomki.ktlint")
     id("poziomki.kotlin-warnings")
@@ -126,5 +127,6 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
     implementation(libs.firebase.perf)
+    implementation(libs.firebase.crashlytics)
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/mobile/androidApp/proguard-rules.pro
+++ b/mobile/androidApp/proguard-rules.pro
@@ -49,6 +49,10 @@
 -dontwarn com.google.errorprone.annotations.Immutable
 -dontwarn com.google.errorprone.annotations.RestrictedApi
 
+# Crashlytics — preserve file/line info so uploaded mapping symbolicates stack traces
+-keepattributes SourceFile,LineNumberTable
+-keep public class * extends java.lang.Exception
+
 # Repackage classes into unnamed package for smaller DEX (default in AGP 9.1)
 -repackageclasses
 

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlinxSerialization) apply false
     alias(libs.plugins.sqldelight) apply false
     alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.versions)
 }
 

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -27,8 +27,10 @@ sqldelight = "2.3.2"
 firebaseBom = "33.6.0"
 firebaseMessaging = "24.1.0"
 firebasePerf = "22.0.5"
+firebaseCrashlytics = "20.0.0"
 googleServices = "4.4.2"
 firebasePerfPlugin = "2.0.2"
+firebaseCrashlyticsPlugin = "3.0.7"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
@@ -72,6 +74,7 @@ sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", versi
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "firebaseMessaging" }
 firebase-perf = { module = "com.google.firebase:firebase-perf", version.ref = "firebasePerf" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebaseCrashlytics" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -86,3 +89,4 @@ kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }

--- a/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		F1B1A00000000000000000A1 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B1 /* FirebaseAnalytics */; };
+		F1B1A00000000000000000A2 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B2 /* FirebaseCrashlytics */; };
+		F1B1A00000000000000000A3 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B3 /* FirebasePerformance */; };
+		F1B1A00000000000000000A4 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F1B1A00000000000000000C1 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,6 +25,7 @@
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		F1B1A00000000000000000C1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -28,6 +33,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1B1A00000000000000000A1 /* FirebaseAnalytics in Frameworks */,
+				F1B1A00000000000000000A2 /* FirebaseCrashlytics in Frameworks */,
+				F1B1A00000000000000000A3 /* FirebasePerformance in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -73,6 +81,7 @@
 				058557BA273AAA24004C7B11 /* Assets.xcassets */,
 				7555FF82242A565900829871 /* ContentView.swift */,
 				7555FF8C242A565B00829871 /* Info.plist */,
+				F1B1A00000000000000000C1 /* GoogleService-Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
 			);
@@ -98,6 +107,7 @@
 				7555FF77242A565900829871 /* Sources */,
 				B92378962B6B1156000C7307 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
+				F1B1A00000000000000000D1 /* Upload Crashlytics dSYMs */,
 			);
 			buildRules = (
 			);
@@ -105,6 +115,9 @@
 			);
 			name = iosApp;
 			packageProductDependencies = (
+				F1B1A00000000000000000B1 /* FirebaseAnalytics */,
+				F1B1A00000000000000000B2 /* FirebaseCrashlytics */,
+				F1B1A00000000000000000B3 /* FirebasePerformance */,
 			);
 			productName = iosApp;
 			productReference = 7555FF7B242A565900829871 /* KMP App.app */;
@@ -136,6 +149,7 @@
 			);
 			mainGroup = 7555FF72242A565900829871;
 			packageReferences = (
+				F1B1A00000000000000000E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -153,6 +167,7 @@
 			files = (
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
+				F1B1A00000000000000000A4 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,6 +191,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\ncd \"$SRCROOT/..\"\n./gradlew :app-ui:embedAndSignAppleFrameworkForXcode\n";
+		};
+		F1B1A00000000000000000D1 /* Upload Crashlytics dSYMs */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "Upload Crashlytics dSYMs";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -388,6 +424,35 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		F1B1A00000000000000000E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 11.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F1B1A00000000000000000B1 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F1B1A00000000000000000E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		F1B1A00000000000000000B2 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F1B1A00000000000000000E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		F1B1A00000000000000000B3 /* FirebasePerformance */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F1B1A00000000000000000E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebasePerformance;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 7555FF73242A565900829871 /* Project object */;
 }

--- a/mobile/iosApp/iosApp/iOSApp.swift
+++ b/mobile/iosApp/iosApp/iOSApp.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 import ComposeApp
+import FirebaseCore
 
 @main
 struct iOSApp: App {
     init() {
+        FirebaseApp.configure()
         let versionCode = (Bundle.main.infoDictionary?["CFBundleVersion"] as? String).flatMap(Int32.init) ?? 0
         KoinKt.doInitKoin(versionCode: versionCode)
     }


### PR DESCRIPTION
Wire firebase-ios-sdk via SPM (Analytics, Crashlytics, Performance), call FirebaseApp.configure(), add dSYM upload script.

GoogleService-Info.plist must be added locally (gitignored).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Firebase Crashlytics and Performance monitoring to iOS and Android apps
> - Integrates FirebaseAnalytics, FirebaseCrashlytics, and FirebasePerformance into the iOS target via Swift Package Manager, bundles `GoogleService-Info.plist`, and calls `FirebaseApp.configure()` on startup in [iOSApp.swift](https://github.com/poziomki-app/poziomki/pull/479/files#diff-8bd9a9fa56e44f279e7d95d8fbd11d2fabda86ccc7473287f605de3bd145519c)
> - Adds a Crashlytics dSYM upload build phase to the iOS Xcode project so symbolicated crash reports are available in the Firebase console
> - Applies the Firebase Crashlytics Gradle plugin and SDK to the Android app module via version catalog entries in [libs.versions.toml](https://github.com/poziomki-app/poziomki/pull/479/files#diff-da7313e5ea25a5de4765d29946874ca6296d66b5d74c58c3589a6801eb595434)
> - Updates [proguard-rules.pro](https://github.com/poziomki-app/poziomki/pull/479/files#diff-56c87a804d775f758b491a1c9c9351191a19e1768aecfb4e67e14f26445b31df) to preserve `SourceFile`/`LineNumberTable` attributes and public `Exception` subclasses so Android crash stack traces remain readable
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b52ea89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->