### PR TITLE
polish(feedback): swipe-dismissible minimal banner

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackBanner.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackBanner.kt
@@ -2,14 +2,19 @@ package com.poziomki.app.ui.feature.feedback
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -17,61 +22,54 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adamglin.PhosphorIcons
-import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.Regular
-import com.adamglin.phosphoricons.bold.X
 import com.adamglin.phosphoricons.regular.ChatTeardropText
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
-import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FeedbackBanner(
     onClick: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val rowModifier =
-        Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .clip(RoundedCornerShape(12.dp))
-            .background(Primary.copy(alpha = 0.12f))
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 10.dp)
-    Row(
-        modifier = rowModifier,
-        verticalAlignment = Alignment.CenterVertically,
+    val dismissState = rememberSwipeToDismissBoxState()
+
+    LaunchedEffect(dismissState.currentValue) {
+        if (dismissState.currentValue != SwipeToDismissBoxValue.Settled) {
+            onDismiss()
+        }
+    }
+
+    SwipeToDismissBox(
+        state = dismissState,
+        backgroundContent = {},
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
     ) {
-        Icon(
-            imageVector = PhosphorIcons.Regular.ChatTeardropText,
-            contentDescription = null,
-            tint = Primary,
-            modifier = Modifier.size(20.dp),
-        )
-        Column(
-            modifier = Modifier.weight(1f).padding(horizontal = 12.dp),
-        ) {
-            Text(
-                text = "Testujemy aplikację!",
-                fontFamily = NunitoFamily,
-                fontWeight = FontWeight.Bold,
-                fontSize = 14.sp,
-                color = TextPrimary,
+        val rowModifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(10.dp))
+                .background(Primary.copy(alpha = 0.08f))
+                .clickable(onClick = onClick)
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        Row(modifier = rowModifier, verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = PhosphorIcons.Regular.ChatTeardropText,
+                contentDescription = null,
+                tint = Primary,
+                modifier = Modifier.size(16.dp),
             )
+            Box(modifier = Modifier.size(width = 8.dp, height = 1.dp))
             Text(
-                text = "Zostaw opinię — dotknij, aby otworzyć",
+                text = "masz uwagi? zostaw opinię",
                 fontFamily = NunitoFamily,
-                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+                fontSize = 13.sp,
                 color = TextSecondary,
             )
         }
-        Icon(
-            imageVector = PhosphorIcons.Bold.X,
-            contentDescription = "Zamknij",
-            tint = TextSecondary,
-            modifier = Modifier.size(20.dp).clickable(onClick = onDismiss),
-        )
     }
 }


### PR DESCRIPTION
Smaller pill-shaped banner with friendlier copy and swipe-to-dismiss in either direction.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace close button with swipe-to-dismiss in `FeedbackBanner`
> - Wraps the banner in a `SwipeToDismissBox` and triggers `onDismiss()` when the swipe state leaves `Settled`, removing the explicit 'X' close button.
> - Adjusts visuals: icon size reduced (20dp→16dp), corner radius (12dp→10dp), background alpha (0.12f→0.08f), and content padding (vertical 10dp→8dp).
> - Behavioral Change: tapping the close icon no longer dismisses the banner; swipe is now the only dismiss gesture.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30914c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->