### PR TITLE
perf(chat): cut Messages-screen recompositions

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -49,13 +49,21 @@ fun MessagesScreen(
     var searchActive by remember { mutableStateOf(false) }
 
     val filteredRooms =
-        state.rooms.filterMessagesRooms(
+        remember(
+            state.rooms,
             selectedFilter,
             state.searchQuery,
             state.eventRoomIds,
             state.searchMatchingRoomIds,
-        )
-    val roomFilterTabs = roomFilterTabs()
+        ) {
+            state.rooms.filterMessagesRooms(
+                selectedFilter,
+                state.searchQuery,
+                state.eventRoomIds,
+                state.searchMatchingRoomIds,
+            )
+        }
+    val roomFilterTabs = remember { roomFilterTabs() }
 
     Column(
         modifier =

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesViewModel.kt
@@ -3,7 +3,6 @@ package com.poziomki.app.ui.feature.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.poziomki.app.chat.api.ChatClient
-import com.poziomki.app.chat.api.ChatClientState
 import com.poziomki.app.chat.api.RoomSummary
 import com.poziomki.app.connectivity.ConnectivityMonitor
 import com.poziomki.app.data.repository.EventRepository
@@ -33,7 +32,7 @@ class MessagesViewModel(
 ) : ViewModel() {
     private companion object {
         const val PROFILE_PICTURE_REFRESH_INTERVAL_MS = 30 * 60 * 1000L
-        const val EMPTY_ROOMS_FALLBACK_MS = 15_000L
+        const val EMPTY_ROOMS_FALLBACK_MS = 4_000L
         const val PREVIEW_WARMUP_BATCH_SIZE = 4
     }
 
@@ -60,7 +59,6 @@ class MessagesViewModel(
             _state.value = _state.value.copy(rooms = cachedRooms, isLoading = false)
         }
         observeConnectivity()
-        observeClientState()
         observeRooms()
         observeEventRooms()
         observeEventRoomAvatars()
@@ -176,14 +174,6 @@ class MessagesViewModel(
                     pendingConnectivityRetry = false
                     refresh()
                 }
-            }
-        }
-    }
-
-    private fun observeClientState() {
-        viewModelScope.launch {
-            chatClient.state.collect { chatState ->
-                _state.update { current -> current.copy(chatState = chatState) }
             }
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/MessagesUiState.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/MessagesUiState.kt
@@ -1,11 +1,9 @@
 package com.poziomki.app.ui.feature.home.messages
 
-import com.poziomki.app.chat.api.ChatClientState
 import com.poziomki.app.chat.api.RoomSummary
 
 data class MessagesUiState(
     val rooms: List<RoomSummary> = emptyList(),
-    val chatState: ChatClientState = ChatClientState.Idle,
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val profilePicturesByName: Map<String, String> = emptyMap(),

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
@@ -89,8 +90,9 @@ fun RoomRow(
                 )
                 room.latestTimestampMillis?.let {
                     Spacer(modifier = Modifier.width(8.dp))
+                    val formatted = remember(it) { formatRoomTimestamp(it) }
                     Text(
-                        text = formatRoomTimestamp(it),
+                        text = formatted,
                         style = MaterialTheme.typography.labelSmall,
                         color = if (room.unreadCount > 0) Primary else TextSecondary,
                     )

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -143,14 +143,15 @@ class WsChatClient(
         if (idx >= 0) {
             val isMine = msg.senderId.toString() == wsConnection.userId.value
             val isFocusedRoom = msg.conversationId == activeRoomId
+            val existing = current[idx]
             val nextUnread =
                 if (isMine || isFocusedRoom) {
-                    current[idx].unreadCount
+                    existing.unreadCount
                 } else {
-                    current[idx].unreadCount + 1
+                    existing.unreadCount + 1
                 }
-            current[idx] =
-                current[idx].copy(
+            val updated =
+                existing.copy(
                     latestMessage = msg.body,
                     latestTimestampMillis = parseTimestamp(msg.createdAt),
                     latestMessageIsMine = isMine,
@@ -165,6 +166,8 @@ class WsChatClient(
                     latestModerationVerdict = if (isMine) null else msg.moderationVerdict,
                     latestModerationCategories = if (isMine) emptyList() else msg.moderationCategories,
                 )
+            if (updated == existing) return
+            current[idx] = updated
             current.sortByDescending { it.latestTimestampMillis ?: 0L }
             _rooms.value = current
         } else {
@@ -181,7 +184,7 @@ class WsChatClient(
     private fun clearRoomUnreadCount(roomId: String) {
         val current = _rooms.value.toMutableList()
         val idx = current.indexOfFirst { it.roomId == roomId }
-        if (idx >= 0) {
+        if (idx >= 0 && current[idx].unreadCount != 0) {
             current[idx] = current[idx].copy(unreadCount = 0)
             _rooms.value = current
         }


### PR DESCRIPTION
- drop unused `chatState` from `MessagesUiState`, stop collecting `chatClient.state`
- `remember` filtered rooms + filter tabs in `MessagesScreen`
- memoize `formatRoomTimestamp` per row
- skip `_rooms` re-emit in `WsChatClient` when nothing changed
- empty-rooms spinner fallback 15s → 4s

follow-up: persist room list to the existing (currently unused) `room_preview` table to kill the cold-launch spinner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut recompositions in the Messages screen by memoizing derived state
> - Memoizes `filteredRooms` and `roomFilterTabs` in `MessagesScreen` with `remember`, so they recompute only when their dependencies change instead of on every recomposition.
> - Memoizes timestamp formatting in `RoomRow` with `remember(it)` to avoid redundant work during recompositions.
> - Adds equality guards in `WsChatClient` so the rooms state does not emit when a new message or `clearRoomUnreadCount` call produces no actual change.
> - Removes `chatState` from `MessagesUiState` and stops observing `chatClient.state` in `MessagesViewModel`, eliminating a source of spurious recompositions.
> - Reduces `EMPTY_ROOMS_FALLBACK_MS` from 15 s to 4 s in `MessagesViewModel`.
> - Behavioral Change: `chatState` is no longer available on `MessagesUiState`; any consumer relying on it will need to be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23cf317.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->