### PR TITLE
feat(chat): persist room list across launches

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesScreen.kt
@@ -49,13 +49,21 @@ fun MessagesScreen(
     var searchActive by remember { mutableStateOf(false) }
 
     val filteredRooms =
-        state.rooms.filterMessagesRooms(
+        remember(
+            state.rooms,
             selectedFilter,
             state.searchQuery,
             state.eventRoomIds,
             state.searchMatchingRoomIds,
-        )
-    val roomFilterTabs = roomFilterTabs()
+        ) {
+            state.rooms.filterMessagesRooms(
+                selectedFilter,
+                state.searchQuery,
+                state.eventRoomIds,
+                state.searchMatchingRoomIds,
+            )
+        }
+    val roomFilterTabs = remember { roomFilterTabs() }
 
     Column(
         modifier =

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/MessagesViewModel.kt
@@ -3,7 +3,6 @@ package com.poziomki.app.ui.feature.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.poziomki.app.chat.api.ChatClient
-import com.poziomki.app.chat.api.ChatClientState
 import com.poziomki.app.chat.api.RoomSummary
 import com.poziomki.app.connectivity.ConnectivityMonitor
 import com.poziomki.app.data.repository.EventRepository
@@ -33,7 +32,7 @@ class MessagesViewModel(
 ) : ViewModel() {
     private companion object {
         const val PROFILE_PICTURE_REFRESH_INTERVAL_MS = 30 * 60 * 1000L
-        const val EMPTY_ROOMS_FALLBACK_MS = 15_000L
+        const val EMPTY_ROOMS_FALLBACK_MS = 4_000L
         const val PREVIEW_WARMUP_BATCH_SIZE = 4
     }
 
@@ -60,7 +59,6 @@ class MessagesViewModel(
             _state.value = _state.value.copy(rooms = cachedRooms, isLoading = false)
         }
         observeConnectivity()
-        observeClientState()
         observeRooms()
         observeEventRooms()
         observeEventRoomAvatars()
@@ -176,14 +174,6 @@ class MessagesViewModel(
                     pendingConnectivityRetry = false
                     refresh()
                 }
-            }
-        }
-    }
-
-    private fun observeClientState() {
-        viewModelScope.launch {
-            chatClient.state.collect { chatState ->
-                _state.update { current -> current.copy(chatState = chatState) }
             }
         }
     }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/MessagesUiState.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/MessagesUiState.kt
@@ -1,11 +1,9 @@
 package com.poziomki.app.ui.feature.home.messages
 
-import com.poziomki.app.chat.api.ChatClientState
 import com.poziomki.app.chat.api.RoomSummary
 
 data class MessagesUiState(
     val rooms: List<RoomSummary> = emptyList(),
-    val chatState: ChatClientState = ChatClientState.Idle,
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val profilePicturesByName: Map<String, String> = emptyMap(),

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
@@ -89,8 +90,9 @@ fun RoomRow(
                 )
                 room.latestTimestampMillis?.let {
                     Spacer(modifier = Modifier.width(8.dp))
+                    val formatted = remember(it) { formatRoomTimestamp(it) }
                     Text(
-                        text = formatRoomTimestamp(it),
+                        text = formatted,
                         style = MaterialTheme.typography.labelSmall,
                         color = if (room.unreadCount > 0) Primary else TextSecondary,
                     )

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/di/PlatformModule.android.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/di/PlatformModule.android.kt
@@ -85,7 +85,7 @@ actual fun platformModule(): Module =
         }
         single { createDataStore(get<Context>()) }
         single<SessionTokenStore> { AndroidSecureSessionTokenStore(get<Context>()) }
-        single<ChatClient> { WsChatClient(get(), get(), get(), get()) }
+        single<ChatClient> { WsChatClient(get(), get(), get(), get(), get()) }
         single<SqlDriver> {
             val context = get<Context>()
             val dbName = "poziomki.db"

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/RoomPreviewStore.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/cache/RoomPreviewStore.kt
@@ -1,0 +1,91 @@
+package com.poziomki.app.chat.cache
+
+import com.poziomki.app.chat.api.EventSendStatus
+import com.poziomki.app.chat.api.RoomSummary
+import com.poziomki.app.db.PoziomkiDatabase
+import kotlin.time.Clock
+
+interface RoomPreviewStore {
+    fun loadAll(): List<RoomSummary>
+
+    fun upsert(room: RoomSummary)
+
+    fun upsertAll(rooms: List<RoomSummary>)
+
+    fun updateUnreadCount(
+        roomId: String,
+        unreadCount: Int,
+    )
+
+    fun delete(roomId: String)
+}
+
+class SqlDelightRoomPreviewStore(
+    private val db: PoziomkiDatabase,
+) : RoomPreviewStore {
+    override fun loadAll(): List<RoomSummary> =
+        runCatching {
+            db.roomPreviewQueries.selectAll().executeAsList().map { row ->
+                RoomSummary(
+                    roomId = row.room_id,
+                    displayName = row.display_name.orEmpty(),
+                    avatarUrl = row.avatar_url,
+                    isDirect = row.is_direct != 0L,
+                    directUserId = row.direct_user_id,
+                    unreadCount = row.unread_count.toInt(),
+                    latestMessage = row.message.takeIf { it.isNotEmpty() },
+                    latestTimestampMillis = row.timestamp_millis.takeIf { it > 0L },
+                    latestMessageIsMine = row.is_mine != 0L,
+                    latestMessageSendStatus = row.send_status?.let(::parseSendStatus),
+                    latestMessageReadByCount = row.read_by_count.toInt(),
+                )
+            }
+        }.getOrDefault(emptyList())
+
+    override fun upsert(room: RoomSummary) {
+        runCatching {
+            db.roomPreviewQueries.upsertAll(
+                room_id = room.roomId,
+                message = room.latestMessage.orEmpty(),
+                timestamp_millis = room.latestTimestampMillis ?: 0L,
+                is_mine = if (room.latestMessageIsMine) 1L else 0L,
+                send_status = room.latestMessageSendStatus?.name,
+                read_by_count = room.latestMessageReadByCount.toLong(),
+                updated_at = Clock.System.now().toEpochMilliseconds(),
+                display_name = room.displayName,
+                avatar_url = room.avatarUrl,
+                is_direct = if (room.isDirect) 1L else 0L,
+                direct_user_id = room.directUserId,
+                unread_count = room.unreadCount.toLong(),
+            )
+        }
+    }
+
+    override fun upsertAll(rooms: List<RoomSummary>) {
+        if (rooms.isEmpty()) return
+        runCatching {
+            db.roomPreviewQueries.transaction {
+                rooms.forEach { upsert(it) }
+            }
+        }
+    }
+
+    override fun updateUnreadCount(
+        roomId: String,
+        unreadCount: Int,
+    ) {
+        runCatching {
+            db.roomPreviewQueries.updateUnreadCount(
+                unread_count = unreadCount.toLong(),
+                updated_at = Clock.System.now().toEpochMilliseconds(),
+                room_id = roomId,
+            )
+        }
+    }
+
+    override fun delete(roomId: String) {
+        runCatching { db.roomPreviewQueries.deleteByRoomId(roomId) }
+    }
+}
+
+private fun parseSendStatus(raw: String): EventSendStatus? = EventSendStatus.entries.firstOrNull { it.name == raw }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -6,6 +6,7 @@ import com.poziomki.app.chat.api.EventSendStatus
 import com.poziomki.app.chat.api.JoinedRoom
 import com.poziomki.app.chat.api.RoomSummary
 import com.poziomki.app.chat.api.RoomTimelineCacheSnapshot
+import com.poziomki.app.chat.cache.RoomPreviewStore
 import com.poziomki.app.chat.cache.RoomTimelineCacheStore
 import com.poziomki.app.network.ApiResult
 import com.poziomki.app.network.ApiService
@@ -29,6 +30,7 @@ class WsChatClient(
     private val sessionManager: SessionManager,
     private val wsConnection: WsConnection,
     private val roomTimelineCacheStore: RoomTimelineCacheStore,
+    private val roomPreviewStore: RoomPreviewStore,
 ) : ChatClient {
     private val scopeJob = SupervisorJob()
     private val scope = CoroutineScope(scopeJob + Dispatchers.Default)
@@ -36,7 +38,9 @@ class WsChatClient(
     private val _state = MutableStateFlow<ChatClientState>(ChatClientState.Idle)
     override val state: StateFlow<ChatClientState> = _state
 
-    private val _rooms = MutableStateFlow<List<RoomSummary>>(emptyList())
+    // Hydrate from disk so MessagesViewModel sees cached rooms on cold launch
+    // and avoids the "isLoading && rooms.isEmpty()" spinner branch.
+    private val _rooms = MutableStateFlow<List<RoomSummary>>(roomPreviewStore.loadAll())
     override val rooms: StateFlow<List<RoomSummary>> = _rooms
 
     private val openedRoomsMutex = Mutex()
@@ -91,7 +95,9 @@ class WsChatClient(
         when (msg) {
             is WsServerMessage.Conversations -> {
                 latestConversations = msg.conversations
-                _rooms.value = msg.conversations.map { it.toRoomSummary() }
+                val summaries = msg.conversations.map { it.toRoomSummary() }
+                _rooms.value = summaries
+                roomPreviewStore.upsertAll(summaries)
             }
 
             is WsServerMessage.Message -> {
@@ -170,6 +176,7 @@ class WsChatClient(
             current[idx] = updated
             current.sortByDescending { it.latestTimestampMillis ?: 0L }
             _rooms.value = current
+            roomPreviewStore.upsert(updated)
         } else {
             // Unknown room — debounce a conversation list refresh
             refreshJob?.cancel()
@@ -187,6 +194,7 @@ class WsChatClient(
         if (idx >= 0 && current[idx].unreadCount != 0) {
             current[idx] = current[idx].copy(unreadCount = 0)
             _rooms.value = current
+            roomPreviewStore.updateUnreadCount(roomId, 0)
         }
     }
 
@@ -319,6 +327,7 @@ class WsChatClient(
             }
         }
         roomTimelineCacheStore.clear(roomId)
+        roomPreviewStore.delete(roomId)
     }
 
     override suspend fun stop() {

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt
@@ -143,14 +143,15 @@ class WsChatClient(
         if (idx >= 0) {
             val isMine = msg.senderId.toString() == wsConnection.userId.value
             val isFocusedRoom = msg.conversationId == activeRoomId
+            val existing = current[idx]
             val nextUnread =
                 if (isMine || isFocusedRoom) {
-                    current[idx].unreadCount
+                    existing.unreadCount
                 } else {
-                    current[idx].unreadCount + 1
+                    existing.unreadCount + 1
                 }
-            current[idx] =
-                current[idx].copy(
+            val updated =
+                existing.copy(
                     latestMessage = msg.body,
                     latestTimestampMillis = parseTimestamp(msg.createdAt),
                     latestMessageIsMine = isMine,
@@ -165,6 +166,8 @@ class WsChatClient(
                     latestModerationVerdict = if (isMine) null else msg.moderationVerdict,
                     latestModerationCategories = if (isMine) emptyList() else msg.moderationCategories,
                 )
+            if (updated == existing) return
+            current[idx] = updated
             current.sortByDescending { it.latestTimestampMillis ?: 0L }
             _rooms.value = current
         } else {
@@ -181,7 +184,7 @@ class WsChatClient(
     private fun clearRoomUnreadCount(roomId: String) {
         val current = _rooms.value.toMutableList()
         val idx = current.indexOfFirst { it.roomId == roomId }
-        if (idx >= 0) {
+        if (idx >= 0 && current[idx].unreadCount != 0) {
             current[idx] = current[idx].copy(unreadCount = 0)
             _rooms.value = current
         }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/di/SharedModule.kt
@@ -1,6 +1,8 @@
 package com.poziomki.app.di
 
+import com.poziomki.app.chat.cache.RoomPreviewStore
 import com.poziomki.app.chat.cache.RoomTimelineCacheStore
+import com.poziomki.app.chat.cache.SqlDelightRoomPreviewStore
 import com.poziomki.app.chat.cache.SqlDelightRoomTimelineCacheStore
 import com.poziomki.app.chat.draft.RoomComposerDraftStore
 import com.poziomki.app.chat.draft.SqlDelightRoomComposerDraftStore
@@ -34,6 +36,7 @@ val sharedModule =
         single { AppPreferences(get()) }
         single<RoomComposerDraftStore> { SqlDelightRoomComposerDraftStore(get()) }
         single<RoomTimelineCacheStore> { SqlDelightRoomTimelineCacheStore(get()) }
+        single<RoomPreviewStore> { SqlDelightRoomPreviewStore(get()) }
         single {
             val sessionManager = get<SessionManager>()
             ApiClient(

--- a/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/RoomPreview.sq
+++ b/mobile/core/src/commonMain/sqldelight/com/poziomki/app/db/RoomPreview.sq
@@ -16,36 +16,27 @@ CREATE TABLE room_preview (
 selectAll:
 SELECT * FROM room_preview;
 
-upsertMessage:
+upsertAll:
 INSERT INTO room_preview(room_id, message, timestamp_millis, is_mine, send_status, read_by_count, updated_at, display_name, avatar_url, is_direct, direct_user_id, unread_count)
-VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, 0, NULL, 0)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(room_id) DO UPDATE SET
     message = excluded.message,
     timestamp_millis = excluded.timestamp_millis,
     is_mine = excluded.is_mine,
     send_status = excluded.send_status,
     read_by_count = excluded.read_by_count,
-    updated_at = excluded.updated_at;
-
-updateMetadata:
-UPDATE room_preview SET
-    display_name = ?,
-    avatar_url = ?,
-    is_direct = ?,
-    direct_user_id = ?,
-    unread_count = ?
-WHERE room_id = ?;
-
-upsertMetadataOnly:
-INSERT INTO room_preview(room_id, message, timestamp_millis, is_mine, send_status, read_by_count, updated_at, display_name, avatar_url, is_direct, direct_user_id, unread_count)
-VALUES (?, 'Wiadomość', 0, 0, NULL, 0, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(room_id) DO UPDATE SET
+    updated_at = excluded.updated_at,
     display_name = excluded.display_name,
     avatar_url = excluded.avatar_url,
     is_direct = excluded.is_direct,
     direct_user_id = excluded.direct_user_id,
-    unread_count = excluded.unread_count,
-    updated_at = excluded.updated_at;
+    unread_count = excluded.unread_count;
+
+updateUnreadCount:
+UPDATE room_preview SET unread_count = ?, updated_at = ? WHERE room_id = ?;
+
+deleteByRoomId:
+DELETE FROM room_preview WHERE room_id = ?;
 
 deleteAll:
 DELETE FROM room_preview;


### PR DESCRIPTION
Kills the cold-launch spinner on Messages — `room_preview` was a dead schema, now actually backs the in-memory list.

- New `RoomPreviewStore` (SQLDelight) wired through Koin
- `WsChatClient` hydrates from disk in its constructor and writes through on conversations / messages / unread-clears / hide
- Sign-out still wipes via existing `CacheManager.deleteAll()`

Stacks on top of #485.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist room list across app launches using SQLDelight-backed store
> - Introduces `RoomPreviewStore` interface and `SqlDelightRoomPreviewStore` implementation to persist room summaries to the local SQLDelight database.
> - `WsChatClient` now hydrates its `_rooms` flow from the store on startup, so the room list is available immediately before the WebSocket connects.
> - Conversation list updates, per-message updates, unread count resets, and room deletions all sync to the store at runtime.
> - Reduces `EMPTY_ROOMS_FALLBACK_MS` from 15s to 4s and removes `ChatClientState` observation from `MessagesViewModel`, simplifying UI state.
> - Behavioral Change: `MessagesUiState` no longer exposes `chatState`; any callers reading that field will need to be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5ab7be1. 9 files reviewed, 5 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt — 0 comments posted, 3 evaluated, 1 filtered</summary>
>
> - [line 147](https://github.com/poziomki-app/poziomki/blob/5ab7be1e552c163cb516830b7e89f46dfb6b601e/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsChatClient.kt#L147): Race condition: `updateRoomLatestMessage` performs an unsynchronized read-modify-write on `_rooms.value`. While this coroutine is between reading the list and writing it back, external callers can invoke `markRoomReadLocally()`/`setActiveRoom()` (which call `clearRoomUnreadCount`) from another coroutine. The last write wins, silently discarding the other coroutine's updates. For example: user opens room X triggering `setActiveRoom`, while a message arrives for room Y. If `updateRoomLatestMessage` reads, then `clearRoomUnreadCount` reads/writes, then `updateRoomLatestMessage` writes its stale copy—the unread count change is lost. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->