### PR TITLE
polish: white-primary CTA, ghost secondary, soft-red destructive

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/AppButton.kt
@@ -18,42 +18,39 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.poziomki.app.ui.designsystem.Text
-import com.poziomki.app.ui.designsystem.theme.Border
-import com.poziomki.app.ui.designsystem.theme.Error
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
-import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.White
 
 enum class ButtonVariant { PRIMARY, SECONDARY, DESTRUCTIVE }
 
 private val ButtonShape = RoundedCornerShape(28.dp)
 
-private val DefaultGradient =
-    Brush.verticalGradient(listOf(Color(0xFF1A2029), Color(0xFF161B22)))
-
-private val PrimaryGradient =
-    Brush.verticalGradient(listOf(Color(0xFF182028), Color(0xFF141A22)))
-
-private val DestructiveGradient =
-    Brush.verticalGradient(listOf(Color(0xFF2A1215), Color(0xFF1E0D0F)))
+// New CTA palette — replaces the previous dark-gradient-with-cyan-text variants.
+// Primary is a solid off-white pill so primary actions read loudest; secondary
+// is a ghost outline; destructive keeps a soft-red translucent fill.
+private val PrimaryFill = Color(0xFFF2F4F7)
+private val PrimaryText = Color(0xFF0B0F14)
+private val DestructiveFill = Color(0xFFFF4D4F).copy(alpha = 0.15f)
+private val DestructiveText = Color(0xFFFF6B6B)
 
 private fun contentColor(variant: ButtonVariant): Color =
     when (variant) {
-        ButtonVariant.PRIMARY -> Primary
+        ButtonVariant.PRIMARY -> PrimaryText
         ButtonVariant.SECONDARY -> White
-        ButtonVariant.DESTRUCTIVE -> Error
+        ButtonVariant.DESTRUCTIVE -> DestructiveText
     }
 
 private fun backgroundFor(variant: ButtonVariant): Brush =
     when (variant) {
-        ButtonVariant.PRIMARY -> PrimaryGradient
-        ButtonVariant.DESTRUCTIVE -> DestructiveGradient
-        ButtonVariant.SECONDARY -> DefaultGradient
+        ButtonVariant.PRIMARY -> SolidColor(PrimaryFill)
+        ButtonVariant.DESTRUCTIVE -> SolidColor(DestructiveFill)
+        ButtonVariant.SECONDARY -> SolidColor(Color.Transparent)
     }
 
 private fun borderColor(
@@ -61,8 +58,17 @@ private fun borderColor(
     enabled: Boolean,
 ): Color =
     when (variant) {
-        ButtonVariant.DESTRUCTIVE -> if (enabled) Error.copy(alpha = 0.5f) else Error.copy(alpha = 0.15f)
-        else -> if (enabled) Border else Border.copy(alpha = 0.3f)
+        ButtonVariant.PRIMARY -> {
+            Color.Transparent
+        }
+
+        ButtonVariant.DESTRUCTIVE -> {
+            if (enabled) DestructiveText.copy(alpha = 0.45f) else DestructiveText.copy(alpha = 0.15f)
+        }
+
+        ButtonVariant.SECONDARY -> {
+            if (enabled) White.copy(alpha = 0.22f) else White.copy(alpha = 0.08f)
+        }
     }
 
 @Suppress("LongParameterList")


### PR DESCRIPTION
drops the dark-gradient + cyan-text combo on AppButton. primary CTA is a solid off-white pill with dark text; secondary is a ghost outline; destructive is a softly tinted red. no behaviour change.

## Test plan
- [ ] login + register screens — primary stands out against the photo bg
- [ ] event detail dołącz / opuść / send message — hierarchy reads correctly
- [ ] feedback dialog buttons

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restyle primary, secondary, and destructive buttons with solid colors and ghost treatment
> - Primary buttons switch from a gradient to a solid off-white fill (`PrimaryFill`) with near-black text (`PrimaryText`) and no border.
> - Secondary buttons become ghost-style: transparent background with a semi-transparent white border.
> - Destructive buttons use a translucent red fill (`DestructiveFill`) with red text (`DestructiveText`) and a red border at reduced opacity.
> - Changes are in [`AppButton.kt`](https://github.com/poziomki-app/poziomki/pull/488/files#diff-37fe2ab8c56db3e0875e1c8e6619d97b409e8d8e26307952be43e980635367fd); gradient `Brush` vals are removed in favor of `SolidColor`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b6a746.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->