### PR TITLE
fix(push): make Android notifications actually fire

### DIFF
--- a/backend/migrations/2026-05-19-000000_user_settings_default_trigger/down.sql
+++ b/backend/migrations/2026-05-19-000000_user_settings_default_trigger/down.sql
@@ -1,0 +1,41 @@
+-- Restore the original INNER-JOIN filter.
+CREATE OR REPLACE FUNCTION app.push_targets_filtered(
+    p_user_ids integer[],
+    p_conversation_id uuid
+)
+RETURNS TABLE (user_id integer)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT u.uid
+    FROM unnest(p_user_ids) AS u(uid)
+    JOIN public.user_settings s ON s.user_id = u.uid
+    JOIN public.conversations c ON c.id = p_conversation_id
+    WHERE s.notifications_enabled
+      AND CASE c.kind
+            WHEN 'dm'    THEN s.notify_dms
+            WHEN 'event' THEN s.notify_event_chats
+            ELSE TRUE
+          END
+      AND NOT EXISTS (
+        SELECT 1 FROM public.conversation_mutes m
+        WHERE m.user_id = u.uid
+          AND m.conversation_id = p_conversation_id
+      )
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.push_targets_filtered(integer[], uuid) TO poziomki_api';
+    END IF;
+END
+$$;
+
+DROP TRIGGER IF EXISTS user_settings_default_after_user_insert ON public.users;
+DROP FUNCTION IF EXISTS app.user_settings_default_for_new_user();
+
+-- Backfilled rows are not reversed; deleting auto-created rows would
+-- destroy user preferences and is not safe to undo blindly.

--- a/backend/migrations/2026-05-19-000000_user_settings_default_trigger/up.sql
+++ b/backend/migrations/2026-05-19-000000_user_settings_default_trigger/up.sql
@@ -1,0 +1,100 @@
+-- Guarantee every user has a `user_settings` row.
+--
+-- Push delivery filters recipients through `app.push_targets_filtered`,
+-- which historically INNER-JOIN'd `user_settings`. The settings row was
+-- only inserted lazily by `PUT /settings` (api/settings.rs) — users who
+-- never opened the Powiadomienia screen had no row, and the inner join
+-- silently dropped them, so they never received any push. Prod was
+-- carrying 16/36 users in that broken state until we noticed Celina
+-- wasn't getting Dawid's DMs.
+--
+-- Three-layer fix:
+--   1. backfill any user missing a settings row, using schema defaults
+--   2. AFTER INSERT trigger on `public.users` so every future user gets
+--      a row automatically, regardless of which code path inserts them
+--   3. relax `app.push_targets_filtered` to LEFT JOIN + COALESCE so push
+--      keeps working with sensible defaults even if (1)/(2) ever miss
+
+-- 1. Backfill -----------------------------------------------------------
+-- Several user_settings columns are NOT NULL with no schema default
+-- (theme/language/privacy_*/notifications_enabled), so we have to spell
+-- the defaults out here. These match the values the lazy PUT /settings
+-- handler creates (api/settings.rs).
+INSERT INTO public.user_settings (
+    user_id, theme, language,
+    notifications_enabled, privacy_show_age, privacy_show_program, privacy_discoverable
+)
+SELECT u.id, 'system', 'pl', TRUE, TRUE, TRUE, TRUE
+FROM public.users u
+WHERE NOT EXISTS (
+    SELECT 1 FROM public.user_settings s WHERE s.user_id = u.id
+);
+
+-- 2. Trigger ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION app.user_settings_default_for_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    INSERT INTO public.user_settings (
+        user_id, theme, language,
+        notifications_enabled, privacy_show_age, privacy_show_program, privacy_discoverable
+    )
+    VALUES (NEW.id, 'system', 'pl', TRUE, TRUE, TRUE, TRUE)
+    ON CONFLICT (user_id) DO NOTHING;
+    RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION app.user_settings_default_for_new_user() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS user_settings_default_after_user_insert ON public.users;
+CREATE TRIGGER user_settings_default_after_user_insert
+AFTER INSERT ON public.users
+FOR EACH ROW EXECUTE FUNCTION app.user_settings_default_for_new_user();
+
+-- 3. Resilient filter ---------------------------------------------------
+-- Defense in depth: even if a settings row is somehow missing (manual
+-- DB intervention, future schema migration, etc.) push still works
+-- using the same defaults the schema declares for new columns.
+CREATE OR REPLACE FUNCTION app.push_targets_filtered(
+    p_user_ids integer[],
+    p_conversation_id uuid
+)
+RETURNS TABLE (user_id integer)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT u.uid
+    FROM unnest(p_user_ids) AS u(uid)
+    JOIN public.conversations c ON c.id = p_conversation_id
+    LEFT JOIN public.user_settings s ON s.user_id = u.uid
+    WHERE COALESCE(s.notifications_enabled, TRUE)
+      AND CASE c.kind
+            WHEN 'dm'    THEN COALESCE(s.notify_dms, TRUE)
+            WHEN 'event' THEN COALESCE(s.notify_event_chats, FALSE)
+            ELSE TRUE
+          END
+      AND NOT EXISTS (
+        SELECT 1 FROM public.conversation_mutes m
+        WHERE m.user_id = u.uid
+          AND m.conversation_id = p_conversation_id
+      )
+$$;
+
+COMMENT ON FUNCTION app.push_targets_filtered(integer[], uuid) IS
+    'Filter push recipients by per-channel preferences and per-conversation mute. LEFT JOIN with COALESCE so missing user_settings rows fall back to schema defaults instead of silently dropping.';
+
+REVOKE EXECUTE ON FUNCTION app.push_targets_filtered(integer[], uuid) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.push_targets_filtered(integer[], uuid) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/migrations/2026-05-19-000000_user_settings_default_trigger/up.sql
+++ b/backend/migrations/2026-05-19-000000_user_settings_default_trigger/up.sql
@@ -15,16 +15,24 @@
 --   3. relax `app.push_targets_filtered` to LEFT JOIN + COALESCE so push
 --      keeps working with sensible defaults even if (1)/(2) ever miss
 
+-- 0. Drop orphan column ------------------------------------------------
+-- `privacy_show_age` was removed from the mobile sqldelight schema
+-- (migration 9.sqm) and from schema.rs, but no backend migration ever
+-- dropped it from postgres. Prod still has it as NOT NULL with no
+-- default, which would silently break the trigger below. Drop it now
+-- so the canonical schema and prod converge.
+ALTER TABLE public.user_settings DROP COLUMN IF EXISTS privacy_show_age;
+
 -- 1. Backfill -----------------------------------------------------------
 -- Several user_settings columns are NOT NULL with no schema default
--- (theme/language/privacy_*/notifications_enabled), so we have to spell
+-- (theme/language/notifications_enabled/privacy_*), so we have to spell
 -- the defaults out here. These match the values the lazy PUT /settings
 -- handler creates (api/settings.rs).
 INSERT INTO public.user_settings (
     user_id, theme, language,
-    notifications_enabled, privacy_show_age, privacy_show_program, privacy_discoverable
+    notifications_enabled, privacy_show_program, privacy_discoverable
 )
-SELECT u.id, 'system', 'pl', TRUE, TRUE, TRUE, TRUE
+SELECT u.id, 'system', 'pl', TRUE, TRUE, TRUE
 FROM public.users u
 WHERE NOT EXISTS (
     SELECT 1 FROM public.user_settings s WHERE s.user_id = u.id
@@ -40,9 +48,9 @@ AS $$
 BEGIN
     INSERT INTO public.user_settings (
         user_id, theme, language,
-        notifications_enabled, privacy_show_age, privacy_show_program, privacy_discoverable
+        notifications_enabled, privacy_show_program, privacy_discoverable
     )
-    VALUES (NEW.id, 'system', 'pl', TRUE, TRUE, TRUE, TRUE)
+    VALUES (NEW.id, 'system', 'pl', TRUE, TRUE, TRUE)
     ON CONFLICT (user_id) DO NOTHING;
     RETURN NEW;
 END;

--- a/backend/tests/requests/rls_tier_a.rs
+++ b/backend/tests/requests/rls_tier_a.rs
@@ -196,6 +196,9 @@ async fn user_settings_viewer_sees_only_own_row() {
     {
         let mut conn = db::conn().await.expect("pool");
         for u in [&alice.user, &bob.user] {
+            // user_settings rows are auto-created by an AFTER INSERT trigger
+            // on users (migration 2026-05-19-000000). on_conflict_do_nothing
+            // keeps this test compatible — we just want one row per user.
             diesel::insert_into(user_settings::table)
                 .values((
                     user_settings::user_id.eq(u.id),
@@ -205,6 +208,8 @@ async fn user_settings_viewer_sees_only_own_row() {
                     user_settings::privacy_show_program.eq(true),
                     user_settings::privacy_discoverable.eq(true),
                 ))
+                .on_conflict(user_settings::user_id)
+                .do_nothing()
                 .execute(&mut conn)
                 .await
                 .expect("seed settings");

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -15,7 +15,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.23.4" // x-release-please-version
+val appVersionName = "0.24.0" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/androidApp/src/main/AndroidManifest.xml
+++ b/mobile/androidApp/src/main/AndroidManifest.xml
@@ -49,6 +49,15 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_stat_notification" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/notification_accent" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="poz_messages" />
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.poziomki.app
 
+import android.Manifest
 import android.app.ActivityManager
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
@@ -10,7 +12,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.LaunchedEffect
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -30,6 +34,10 @@ class MainActivity : ComponentActivity() {
     private val notificationHelper: NotificationHelper by inject()
     private val pushManager: PushManager by inject()
     private val appUpdateMigrator: AppUpdateMigrator by inject()
+
+    // Result intentionally ignored — see ensureNotificationPermission().
+    private val notificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -75,6 +83,7 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             try {
                 withContext(Dispatchers.Default) { notificationHelper.createChannels() }
+                ensureNotificationPermission()
                 // PushManager observes caches the migrator may wipe — wait for readiness.
                 appUpdateMigrator.ready.await()
                 pushManager.startObserving()
@@ -111,6 +120,20 @@ class MainActivity : ComponentActivity() {
 
     private fun handleIntent(intent: Intent?) {
         NotificationChatTarget.open(intent?.getStringExtra(NotificationChatTarget.EXTRA_OPEN_CHAT_ROOM_ID))
+    }
+
+    // On API 33+, POST_NOTIFICATIONS defaults to denied — without this prompt,
+    // every notificationManager.notify() silently no-ops and FCM appears "flaky"
+    // because messages arrive but never surface. We only ask once per launch;
+    // if the user has already permanently denied, the system suppresses the
+    // dialog and we leave it to in-app settings to redirect them.
+    private fun ensureNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val granted =
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+        if (granted) return
+        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 
     private fun applySecureFlag(secure: Boolean) {

--- a/mobile/androidApp/src/main/res/drawable/ic_stat_notification.xml
+++ b/mobile/androidApp/src/main/res/drawable/ic_stat_notification.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Notification small icon. Path data is the canonical Poziomki strawberry
+  silhouette, ported verbatim from StrawberryIcon.Filled in app-ui. The two
+  seed dots are cut from the body via evenOdd fill so the silhouette reads
+  as the brand mark in the status bar.
+
+  Android API 21+ uses only the alpha channel of the small icon — the
+  fill colour here is irrelevant at runtime; the system tints the
+  silhouette via setColor() or the status-bar palette.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M9.36,2.03 C6.94,2.84 5.22,4.58 3.68,7.78 C2.28,10.67 1.53,13.67 1.51,16.50 C1.50,19.81 2.22,21.16 4.47,22.04 C5.62,22.50 8.57,22.50 10.63,22.04 C14.83,21.11 18.50,19.22 20.32,17.08 C22.01,15.04 22.50,12.21 21.59,9.61 C21.12,8.28 19.79,6.29 18.61,5.13 C17.61,4.15 15.58,2.73 14.61,2.33 C12.91,1.61 10.92,1.50 9.36,2.03 Z M10.6,5.1 C10.6,5.98 9.88,6.7 9.0,6.7 C8.12,6.7 7.4,5.98 7.4,5.1 C7.4,4.22 8.12,3.5 9.0,3.5 C9.88,3.5 10.6,4.22 10.6,5.1 Z M7.8,9.85 C7.8,10.73 7.08,11.45 6.2,11.45 C5.32,11.45 4.6,10.73 4.6,9.85 C4.6,8.97 5.32,8.25 6.2,8.25 C7.08,8.25 7.8,8.97 7.8,9.85 Z" />
+</vector>

--- a/mobile/androidApp/src/main/res/values/colors.xml
+++ b/mobile/androidApp/src/main/res/values/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="splash_background">#000000</color>
+    <color name="notification_accent">#09DDDF</color>
 </resources>

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
@@ -19,6 +19,24 @@ class NotificationHelper(
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     private val notificationIdCounter = AtomicInteger(1000)
 
+    // Resolve the app-provided notification icon at runtime. NotificationHelper
+    // lives in the shared core module and cannot reference the app's R class
+    // directly. If the app forgets to ship ic_stat_notification we fall back
+    // to a system glyph so notifications still appear instead of crashing.
+    private val smallIconRes: Int =
+        context.resources
+            .getIdentifier("ic_stat_notification", "drawable", context.packageName)
+            .takeIf { it != 0 }
+            ?: android.R.drawable.sym_action_chat
+
+    @Suppress("DEPRECATION")
+    private val accentColor: Int =
+        context.resources
+            .getIdentifier("notification_accent", "color", context.packageName)
+            .takeIf { it != 0 }
+            ?.let { context.resources.getColor(it) }
+            ?: 0
+
     fun createChannels() {
         val messagesChannel =
             NotificationChannel(
@@ -45,7 +63,8 @@ class NotificationHelper(
             .Builder(context, CHANNEL_SERVICE)
             .setContentTitle("Poziomki")
             .setContentText("Connected")
-            .setSmallIcon(android.R.drawable.sym_action_chat)
+            .setSmallIcon(smallIconRes)
+            .setColor(accentColor)
             .setOngoing(true)
             .build()
 
@@ -67,7 +86,8 @@ class NotificationHelper(
                 .Builder(context, CHANNEL_MESSAGES)
                 .setContentTitle(title)
                 .setContentText(text)
-                .setSmallIcon(android.R.drawable.sym_action_chat)
+                .setSmallIcon(smallIconRes)
+                .setColor(accentColor)
                 .setAutoCancel(true)
                 .setGroup(groupKey)
                 .setWhen(notificationTime)
@@ -103,7 +123,8 @@ class NotificationHelper(
                 .Builder(context, CHANNEL_MESSAGES)
                 .setContentTitle(title)
                 .setContentText(text)
-                .setSmallIcon(android.R.drawable.sym_action_chat)
+                .setSmallIcon(smallIconRes)
+                .setColor(accentColor)
                 .setGroup(groupKey)
                 .setGroupSummary(true)
                 .setGroupAlertBehavior(Notification.GROUP_ALERT_CHILDREN)


### PR DESCRIPTION
- Backend: missing user_settings rows silently dropped push recipients via INNER JOIN. Backfill, add trigger so every new user gets one, and LEFT JOIN + COALESCE in push_targets_filtered as defense in depth.
- Android: POST_NOTIFICATIONS runtime prompt on API 33+ (was silently denied → no notifications).
- Android: real strawberry silhouette as notification icon (ported from StrawberryIcon.Filled) + FCM default icon/color/channel meta-data.
- Bump 0.24.0.

Test plan:
- [ ] DM between two users → notification fires with strawberry icon
- [ ] Fresh install on Android 13+ → permission prompt appears
- [ ] New user signup → user_settings row auto-created (verified in prod)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android push notifications to fire by requesting POST_NOTIFICATIONS permission and fixing push target filtering
> - Adds a runtime `POST_NOTIFICATIONS` permission request on Android 13+ in `MainActivity`, prompting the user at launch if permission is not already granted.
> - Fixes `app.push_targets_filtered` to use a `LEFT JOIN` with `COALESCE` defaults so users without a `user_settings` row are still included in push targets (previously an `INNER JOIN` silently excluded them).
> - Adds a DB trigger (`user_settings_default_after_user_insert`) and backfill migration so all users have a `user_settings` row with sane defaults going forward.
> - Adds a notification status bar icon (`ic_stat_notification`) and optional accent color to `NotificationHelper`.
> - Behavioral Change: `app.push_targets_filtered` now defaults `notifications_enabled=true` and `notify_dms=true` for users missing settings rows, which may send notifications to users who previously received none.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d4ad8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->