### PR TITLE
fix(chat): fail send fast (3s grace) to avoid burst on reconnect

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatViewModel.kt
@@ -176,7 +176,7 @@ class ChatViewModel(
             val timeline = awaitTimelineForSend()
             if (timeline == null) {
                 _uiState.update {
-                    it.copy(error = "Conversation is still connecting. Please wait a few seconds.")
+                    it.copy(error = "brak połączenia, spróbuj jeszcze raz")
                 }
                 return@launch
             }
@@ -944,7 +944,7 @@ class ChatViewModel(
     private fun currentDraftRoomId(): String? = activeRoom?.roomId?.takeIf { it.isNotBlank() } ?: boundRoomId
 
     private suspend fun awaitTimelineForSend(
-        attempts: Int = 120,
+        attempts: Int = 6,
         delayMs: Long = 500L,
     ): Timeline? {
         repeat(attempts) { attempt ->


### PR DESCRIPTION
Lowers `awaitTimelineForSend` from 60s to 3s and updates the error to Polish. With the old timeout, each tap of send while the WS was reconnecting stacked up a coroutine that all fired together when the WS came back, producing a burst.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail chat send fast with a 3s grace period to avoid burst on reconnect
> - Reduces `awaitTimelineForSend` default attempts from 120 to 6 (≈3s at 500ms each), so failed sends surface an error quickly instead of waiting up to 60s.
> - Updates the no-timeline error message in [ChatViewModel.kt](https://github.com/poziomki-app/poziomki/pull/491/files#diff-016868bdd2fb23a6d4dc15c4e4202b05086c17c7c1400f9aa0c1c50c8a01f6ab) from English to Polish: `"brak połączenia, spróbuj jeszcze raz"`.
> - Behavioral Change: any send attempted while the timeline is unavailable now fails after ~3s instead of ~60s, which prevents a backlog of queued messages from firing all at once on reconnect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9dffd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->