### PR TITLE
feat(push): admin broadcast notifications

### DIFF
--- a/backend/migrations/2026-05-19-120000_all_push_tokens/down.sql
+++ b/backend/migrations/2026-05-19-120000_all_push_tokens/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS app.all_push_tokens();

--- a/backend/migrations/2026-05-19-120000_all_push_tokens/up.sql
+++ b/backend/migrations/2026-05-19-120000_all_push_tokens/up.sql
@@ -1,0 +1,30 @@
+-- SECURITY DEFINER helper for admin broadcast push.
+-- Returns every registered FCM token regardless of user. Used only by
+-- the admin broadcast endpoint, which does not honour per-user
+-- notification preferences (broadcasts are operational announcements,
+-- not chat). The narrow projection matches push_tokens_for_users —
+-- never expose user_id to the caller.
+
+CREATE OR REPLACE FUNCTION app.all_push_tokens()
+RETURNS TABLE (fcm_token text, platform varchar)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT fcm_token, platform
+    FROM public.push_subscriptions
+$$;
+
+COMMENT ON FUNCTION app.all_push_tokens() IS
+    'Return every registered FCM token + platform. Admin broadcast path only; bypasses per-user notification preferences.';
+
+REVOKE EXECUTE ON FUNCTION app.all_push_tokens() FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.all_push_tokens() TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/api/admin.rs
+++ b/backend/src/api/admin.rs
@@ -42,6 +42,14 @@ pub(super) struct BanBody {
     pub reason: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct BroadcastBody {
+    pub title: String,
+    pub body: String,
+    #[serde(default)]
+    pub deep_link: Option<String>,
+}
+
 fn admin_auth(headers: &HeaderMap) -> Result<(), Box<Response>> {
     let Some(expected) = std::env::var("ADMIN_TOKEN")
         .ok()
@@ -164,6 +172,64 @@ pub(super) async fn ban_user(
     (
         StatusCode::OK,
         Json(serde_json::json!({ "banned_at": now })),
+    )
+        .into_response()
+}
+
+/// Fan-out broadcast push to every registered device. Bypasses
+/// per-user notification preferences — operators use this for
+/// announcements, outages, etc., not for normal product traffic.
+pub(super) async fn broadcast_push(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Json(body): Json<BroadcastBody>,
+) -> Response {
+    if let Err(resp) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::AdminAuth,
+    )
+    .await
+    {
+        return *resp;
+    }
+    if let Err(resp) = admin_auth(&headers) {
+        return *resp;
+    }
+
+    let title = body.title.trim();
+    let body_text = body.body.trim();
+    if title.is_empty() || body_text.is_empty() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            &headers,
+            ErrorSpec {
+                error: "title and body are required".to_string(),
+                code: "BAD_REQUEST",
+                details: None,
+            },
+        );
+    }
+
+    let (delivered, rejected) = crate::push::fcm::send_broadcast(
+        title.to_string(),
+        body_text.to_string(),
+        body.deep_link.clone().filter(|s| !s.trim().is_empty()),
+    )
+    .await;
+
+    tracing::info!(
+        delivered,
+        rejected,
+        deep_link = ?body.deep_link.as_deref(),
+        "fcm_broadcast_sent"
+    );
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "delivered": delivered,
+            "rejected": rejected,
+        })),
     )
         .into_response()
 }

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -42,6 +42,7 @@ fn cache_layer(value: &'static str) -> SetResponseHeaderLayer<HeaderValue> {
 fn admin_routes() -> Router<AppContext> {
     Router::new()
         .route("/users/{pid}/ban", post(admin::ban_user))
+        .route("/broadcast", post(admin::broadcast_push))
         .layer(cache_layer("no-store"))
 }
 

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -3,7 +3,7 @@ pub mod schema;
 pub mod viewer;
 
 pub use viewer::{
-    complete_password_reset, create_session_for_user, create_user_for_signup,
+    all_push_tokens, complete_password_reset, create_session_for_user, create_user_for_signup,
     delete_session_by_token, filter_push_targets, find_user_for_login,
     find_user_for_password_reset, mark_email_verified, profile_owner_user_id,
     profile_program_visibility, push_tokens_for_users, resolve_session, set_anon_context,

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -472,6 +472,16 @@ pub async fn push_tokens_for_users(
     Ok(rows)
 }
 
+/// Return every registered FCM token + platform. Admin broadcast path
+/// only — bypasses per-user notification preferences.
+pub async fn all_push_tokens(
+    conn: &mut AsyncPgConnection,
+) -> Result<Vec<PushTokenRow>, diesel::result::Error> {
+    diesel::sql_query("SELECT * FROM app.all_push_tokens()")
+        .load::<PushTokenRow>(conn)
+        .await
+}
+
 #[derive(Debug, Clone, QueryableByName)]
 struct UserIdRow {
     #[diesel(sql_type = Integer)]

--- a/backend/src/push/fcm.rs
+++ b/backend/src/push/fcm.rs
@@ -342,6 +342,185 @@ pub async fn send_wake(user_ids: Vec<i32>, conversation_id: Uuid) {
     }
 }
 
+/// Build a broadcast push payload (title + body + optional deep link).
+/// Unlike the data-only chat wake, broadcasts carry visible content
+/// directly in the payload since there's no per-conversation API to
+/// fetch from. Android uses a `notification` block so the system can
+/// render the alert even when the app process is dead; iOS uses the
+/// standard `apns.alert` shape. The deep link is mirrored into `data`
+/// so the client can route on tap.
+pub(crate) fn build_broadcast_message(
+    token: &str,
+    platform: &str,
+    title: &str,
+    body: &str,
+    deep_link: Option<&str>,
+) -> serde_json::Value {
+    let mut data = serde_json::Map::new();
+    data.insert(
+        "type".to_string(),
+        serde_json::Value::String("broadcast".to_string()),
+    );
+    data.insert(
+        "v".to_string(),
+        serde_json::Value::String(PAYLOAD_VERSION.to_string()),
+    );
+    data.insert(
+        "title".to_string(),
+        serde_json::Value::String(title.to_string()),
+    );
+    data.insert(
+        "body".to_string(),
+        serde_json::Value::String(body.to_string()),
+    );
+    if let Some(dl) = deep_link {
+        data.insert(
+            "deep_link".to_string(),
+            serde_json::Value::String(dl.to_string()),
+        );
+    }
+    let data = serde_json::Value::Object(data);
+    let msg = match platform {
+        "ios" => serde_json::json!({
+            "token": token,
+            "data": data,
+            "apns": {
+                "headers": { "apns-priority": "10" },
+                "payload": {
+                    "aps": {
+                        "alert": { "title": title, "body": body },
+                        "sound": "default",
+                    }
+                }
+            },
+        }),
+        _ => serde_json::json!({
+            "token": token,
+            "data": data,
+            "notification": { "title": title, "body": body },
+            "android": {
+                "priority": "high",
+                "ttl": "86400s",
+                "notification": { "channel_id": "poz_messages" },
+            },
+        }),
+    };
+    serde_json::json!({ "message": msg })
+}
+
+/// Send a broadcast to every registered device. Returns `(delivered, rejected)`.
+///
+/// Visible title + body land directly on the device; optional `deep_link`
+/// is forwarded in `data` for the client to route on tap. Bypasses
+/// per-user notification preferences — operator-driven announcements only.
+pub async fn send_broadcast(
+    title: String,
+    body: String,
+    deep_link: Option<String>,
+) -> (usize, usize) {
+    let Some(fcm) = client() else {
+        return (0, 0);
+    };
+    let rows = {
+        let mut conn = match db::conn().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "fcm_broadcast: db conn failed");
+                return (0, 0);
+            }
+        };
+        match db::all_push_tokens(&mut conn).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "fcm_broadcast: token lookup failed");
+                return (0, 0);
+            }
+        }
+    };
+    if rows.is_empty() {
+        tracing::info!("fcm_broadcast: no registered tokens, nothing to send");
+        return (0, 0);
+    }
+
+    let access = match fcm.access_token().await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(error = %e, "fcm_broadcast: access token failed");
+            return (0, 0);
+        }
+    };
+    let url = fcm.send_url();
+
+    let delivered = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let rejected = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let mut handles = Vec::with_capacity(rows.len());
+    for row in rows {
+        let sem = fcm.sem.clone();
+        let http = fcm.http.clone();
+        let access = access.clone();
+        let url = url.clone();
+        let title = title.clone();
+        let body = body.clone();
+        let deep_link = deep_link.clone();
+        let delivered = delivered.clone();
+        let rejected = rejected.clone();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire_owned().await.ok();
+            let payload = build_broadcast_message(
+                &row.fcm_token,
+                &row.platform,
+                &title,
+                &body,
+                deep_link.as_deref(),
+            );
+            let masked = mask_token(&row.fcm_token);
+            let resp = http
+                .post(&url)
+                .bearer_auth(&access)
+                .json(&payload)
+                .send()
+                .await;
+            match resp {
+                Ok(r) => {
+                    let status = r.status();
+                    if status.is_success() {
+                        delivered.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tracing::info!(token = %masked, "fcm_broadcast_delivered");
+                    } else if status == reqwest::StatusCode::NOT_FOUND
+                        || status == reqwest::StatusCode::BAD_REQUEST
+                        || status == reqwest::StatusCode::UNAUTHORIZED
+                    {
+                        let detail = r.text().await.unwrap_or_default();
+                        let stale = detail.contains("UNREGISTERED")
+                            || detail.contains("INVALID_ARGUMENT")
+                            || status == reqwest::StatusCode::NOT_FOUND;
+                        rejected.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tracing::warn!(token = %masked, status = %status, stale, "fcm_broadcast_rejected");
+                        if stale {
+                            cleanup_stale_token(&row.fcm_token).await;
+                        }
+                    } else {
+                        rejected.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tracing::warn!(token = %masked, status = %status, "fcm_broadcast_error");
+                    }
+                }
+                Err(e) => {
+                    rejected.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    tracing::warn!(token = %masked, error = %e, "fcm_broadcast_send_failed");
+                }
+            }
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+    (
+        delivered.load(std::sync::atomic::Ordering::Relaxed),
+        rejected.load(std::sync::atomic::Ordering::Relaxed),
+    )
+}
+
 async fn cleanup_stale_token(fcm_token: &str) {
     use crate::db::schema::push_subscriptions;
     use diesel::prelude::*;

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.24.0" // x-release-please-version
+val appVersionName = "0.24.1" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/com/poziomki/app/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.poziomki.app.chat.push.NotificationChatTarget
+import com.poziomki.app.chat.push.NotificationDeepLinkTarget
 import com.poziomki.app.chat.push.NotificationHelper
 import com.poziomki.app.chat.push.PushManager
 import com.poziomki.app.session.AppPreferences
@@ -120,6 +121,7 @@ class MainActivity : ComponentActivity() {
 
     private fun handleIntent(intent: Intent?) {
         NotificationChatTarget.open(intent?.getStringExtra(NotificationChatTarget.EXTRA_OPEN_CHAT_ROOM_ID))
+        NotificationDeepLinkTarget.open(intent?.getStringExtra(NotificationDeepLinkTarget.EXTRA_OPEN_DEEP_LINK))
     }
 
     // On API 33+, POST_NOTIFICATIONS defaults to denied — without this prompt,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -59,6 +59,7 @@ import com.adamglin.phosphoricons.bold.GearSix
 import com.adamglin.phosphoricons.fill.PaperPlaneTilt
 import com.poziomki.app.chat.api.ChatClient
 import com.poziomki.app.chat.push.NotificationChatTarget
+import com.poziomki.app.chat.push.NotificationDeepLinkTarget
 import com.poziomki.app.data.repository.ChatRoomRepository
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.components.OfflineBanner
@@ -188,6 +189,11 @@ fun AppNavigation(
         }
         navController.navigate(Route.Chat(roomId))
         NotificationChatTarget.consume(roomId)
+    }
+
+    val deepLink by NotificationDeepLinkTarget.link.collectAsState()
+    LaunchedEffect(isLoggedIn, deepLink) {
+        handleBroadcastDeepLink(deepLink, isLoggedIn, startDestination)
     }
 
     val navigateToChat: (String, String?) -> Unit = navigateToChat@{ chatTargetId, avatarHint ->
@@ -477,6 +483,28 @@ fun AppNavigation(
             )
         }
     }
+}
+
+// Broadcast deep links. Today we only recognise poziomki://chat/<roomId>
+// (forwarded into the existing chat target). Unknown schemes fall through
+// — the app just opens at its current destination and the link is dropped
+// so taps still open the app from a notification.
+private fun handleBroadcastDeepLink(
+    deepLink: String?,
+    isLoggedIn: Boolean,
+    startDestination: Route,
+) {
+    val link = deepLink ?: return
+    if (!isLoggedIn || startDestination == Route.OnboardingGraph) {
+        NotificationDeepLinkTarget.consume(link)
+        return
+    }
+    val chatPrefix = "poziomki://chat/"
+    if (link.startsWith(chatPrefix)) {
+        val roomId = link.removePrefix(chatPrefix).takeIf { it.isNotBlank() }
+        if (roomId != null) NotificationChatTarget.open(roomId)
+    }
+    NotificationDeepLinkTarget.consume(link)
 }
 
 @Suppress("LongMethod", "LongParameterList")

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/NotificationHelper.kt
@@ -136,6 +136,39 @@ class NotificationHelper(
     }
 
     /**
+     * Show a broadcast (admin announcement) notification. Unlike chat
+     * pushes, broadcasts carry visible title + body directly in the
+     * payload and bypass per-conversation grouping. Tapping launches
+     * the app, with the optional deep link forwarded so the nav layer
+     * can route to a specific destination.
+     */
+    fun showBroadcastNotification(
+        title: String,
+        body: String,
+        deepLink: String?,
+        timestampMs: Long? = null,
+    ) {
+        val notificationTime = timestampMs ?: System.currentTimeMillis()
+        val builder =
+            Notification
+                .Builder(context, CHANNEL_MESSAGES)
+                .setContentTitle(title)
+                .setContentText(body)
+                .setStyle(Notification.BigTextStyle().bigText(body))
+                .setSmallIcon(smallIconRes)
+                .setColor(accentColor)
+                .setAutoCancel(true)
+                .setWhen(notificationTime)
+                .setShowWhen(true)
+
+        deepLink
+            ?.let(::buildDeepLinkPendingIntent)
+            ?.let(builder::setContentIntent)
+
+        notificationManager.notify(notificationIdCounter.getAndIncrement(), builder.build())
+    }
+
+    /**
      * Builds an EXPLICIT PendingIntent that opens the launcher activity.
      *
      * Returns null if — for any reason — the package manager cannot resolve our own
@@ -151,6 +184,25 @@ class NotificationHelper(
         return PendingIntent.getActivity(
             context,
             roomId.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    /**
+     * EXPLICIT PendingIntent that opens the launcher activity and
+     * forwards an arbitrary deep-link string. The nav graph reads it
+     * via [NotificationDeepLinkTarget] and routes based on URL shape.
+     */
+    private fun buildDeepLinkPendingIntent(deepLink: String): PendingIntent? {
+        val intent =
+            context.packageManager.getLaunchIntentForPackage(context.packageName)
+                ?: return null
+        intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        intent.putExtra(NotificationDeepLinkTarget.EXTRA_OPEN_DEEP_LINK, deepLink)
+        return PendingIntent.getActivity(
+            context,
+            deepLink.hashCode(),
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/PoziomkiFirebaseMessagingService.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/push/PoziomkiFirebaseMessagingService.kt
@@ -31,14 +31,30 @@ class PoziomkiFirebaseMessagingService :
 
     override fun onMessageReceived(message: RemoteMessage) {
         val data = message.data
-        val roomId = data["conversation_id"]?.takeIf { it.isNotBlank() }
-        if (roomId != null && roomId == ActiveChat.roomId) return
-        notificationHelper.showMessageNotification(
-            sender = null,
-            roomId = roomId,
-            body = null,
-            avatarUrl = null,
-            timestampMs = message.sentTime.takeIf { it > 0 },
-        )
+        when (data["type"]) {
+            "broadcast" -> {
+                val title = data["title"]?.takeIf { it.isNotBlank() } ?: "Poziomki"
+                val body = data["body"]?.takeIf { it.isNotBlank() } ?: ""
+                val deepLink = data["deep_link"]?.takeIf { it.isNotBlank() }
+                notificationHelper.showBroadcastNotification(
+                    title = title,
+                    body = body,
+                    deepLink = deepLink,
+                    timestampMs = message.sentTime.takeIf { it > 0 },
+                )
+            }
+
+            else -> {
+                val roomId = data["conversation_id"]?.takeIf { it.isNotBlank() }
+                if (roomId != null && roomId == ActiveChat.roomId) return
+                notificationHelper.showMessageNotification(
+                    sender = null,
+                    roomId = roomId,
+                    body = null,
+                    avatarUrl = null,
+                    timestampMs = message.sentTime.takeIf { it > 0 },
+                )
+            }
+        }
     }
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/push/NotificationDeepLinkTarget.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/push/NotificationDeepLinkTarget.kt
@@ -1,0 +1,29 @@
+package com.poziomki.app.chat.push
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Holds a deep-link URL queued by a broadcast notification tap until the
+ * Compose nav graph consumes it. Mirrors [NotificationChatTarget], but
+ * carries a free-form string the navigation layer parses by itself.
+ *
+ * Recognised forms today: `poziomki://chat/<roomId>`. Unknown schemes are
+ * a no-op (the app just opens at its current destination).
+ */
+object NotificationDeepLinkTarget {
+    const val EXTRA_OPEN_DEEP_LINK = "open_deep_link"
+
+    private val _link = MutableStateFlow<String?>(null)
+    val link: StateFlow<String?> = _link
+
+    fun open(deepLink: String?) {
+        _link.value = deepLink?.takeIf { it.isNotBlank() }
+    }
+
+    fun consume(deepLink: String) {
+        if (_link.value == deepLink) {
+            _link.value = null
+        }
+    }
+}


### PR DESCRIPTION
- Backend: `POST /api/v1/admin/broadcast` (X-Admin-Token gate). Body: `{title, body, deep_link?}`. Fan-out to every registered FCM token, returns `{delivered, rejected}`. Bypasses per-user prefs — operator announcements only.
- Migration adds `app.all_push_tokens()` SECURITY DEFINER helper.
- Android: FCM service dispatches on `data.type`. Broadcasts show via `showBroadcastNotification` with bigText style; `deep_link` flows into `NotificationDeepLinkTarget` and the nav graph routes `poziomki://chat/<id>`. Unknown schemes just open the app.
- Bump 0.24.1.

Test plan:
- [ ] `curl -X POST -H "X-Admin-Token: ..." -H "content-type: application/json" -d '{"title":"...","body":"...","deep_link":"poziomki://chat/<id>"}' https://api.poziomki.app/api/v1/admin/broadcast` returns 200 with delivered/rejected counts
- [ ] Notification appears on a 0.24.1 device with strawberry icon, title, body
- [ ] Tap with `poziomki://chat/<id>` opens the chat
- [ ] Tap without deep_link just opens the app

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add admin broadcast push notification endpoint with deep link support
> - Adds a `POST /admin/broadcast` endpoint that fans out a push notification with title, body, and optional deep link to all registered devices via FCM, returning delivered/rejected counts.
> - Adds `app.all_push_tokens()` as a security-definer SQL function and a corresponding `db::all_push_tokens` query used by the broadcast sender.
> - On Android, a new `broadcast` FCM data type is handled by `PoziomkiFirebaseMessagingService`, which shows a notification via `NotificationHelper.showBroadcastNotification`; tapping with a deep link routes to the appropriate chat room via `NotificationDeepLinkTarget`.
> - Bumps Android `appVersionName` to 0.24.1.
> - Risk: stale token cleanup is triggered on specific FCM errors during broadcast fan-out, which may silently delete push subscriptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0663933.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->