### PR TITLE
fix(push): actually delete stale FCM tokens

### DIFF
--- a/backend/migrations/2026-05-19-160000_delete_push_token/down.sql
+++ b/backend/migrations/2026-05-19-160000_delete_push_token/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS app.delete_push_token(text);

--- a/backend/migrations/2026-05-19-160000_delete_push_token/up.sql
+++ b/backend/migrations/2026-05-19-160000_delete_push_token/up.sql
@@ -1,0 +1,32 @@
+-- SECURITY DEFINER helper so the API role can prune dead FCM tokens.
+--
+-- `push_subscriptions` is RLS-protected by user_id, and the API role
+-- runs without a viewer context for server-side push delivery. That
+-- meant `cleanup_stale_token` in src/push/fcm.rs silently no-op'd
+-- (DELETE matched zero rows under RLS) and dead tokens accumulated
+-- forever — every broadcast wasted FCM quota on them. This helper
+-- bypasses RLS for the narrow "delete by exact token value" case
+-- without exposing user identities to the caller.
+
+CREATE OR REPLACE FUNCTION app.delete_push_token(p_fcm_token text)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+    DELETE FROM public.push_subscriptions
+    WHERE fcm_token = p_fcm_token
+$$;
+
+COMMENT ON FUNCTION app.delete_push_token(text) IS
+    'Delete a stale FCM token. Called from the server-side push path after FCM rejects a token (UNREGISTERED / INVALID_ARGUMENT / 404). Bypasses RLS to prune dead rows.';
+
+REVOKE EXECUTE ON FUNCTION app.delete_push_token(text) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.delete_push_token(text) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/push/fcm.rs
+++ b/backend/src/push/fcm.rs
@@ -522,18 +522,18 @@ pub async fn send_broadcast(
 }
 
 async fn cleanup_stale_token(fcm_token: &str) {
-    use crate::db::schema::push_subscriptions;
-    use diesel::prelude::*;
     use diesel_async::RunQueryDsl;
 
     let Ok(mut conn) = db::conn().await else {
         return;
     };
-    let _ = diesel::delete(
-        push_subscriptions::table.filter(push_subscriptions::fcm_token.eq(fcm_token)),
-    )
-    .execute(&mut conn)
-    .await;
+    // Route through a SECURITY DEFINER helper — the API role hits RLS
+    // on push_subscriptions and would silently match zero rows from a
+    // plain DELETE. See migration 2026-05-19-160000_delete_push_token.
+    let _ = diesel::sql_query("SELECT app.delete_push_token($1)")
+        .bind::<diesel::sql_types::Text, _>(fcm_token)
+        .execute(&mut conn)
+        .await;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- `cleanup_stale_token` was hitting RLS on `push_subscriptions` and silently matching zero rows from the API role. Dead tokens accumulated forever; every broadcast wasted FCM quota (`delivered=2 rejected=21` on prod).
- Route deletion through a new `app.delete_push_token(text)` SECURITY DEFINER helper.

Test plan:
- [ ] Send a broadcast on prod, watch `rejected` count drop after each subsequent send

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale FCM token deletion to bypass RLS in `cleanup_stale_token`
> The previous implementation issued a plain `DELETE` against `push_subscriptions` that was blocked by row-level security, so stale tokens were never actually removed.
>
> - Adds a `SECURITY DEFINER` SQL function [`app.delete_push_token(text)`](https://github.com/poziomki-app/poziomki/pull/493/files#diff-d0b50f9465f90efe972e544148588f1344db2df3c2c068d579d6a93404290cde) that deletes from `public.push_subscriptions` under the function owner's privileges, bypassing RLS.
> - Updates [`cleanup_stale_token`](https://github.com/poziomki-app/poziomki/pull/493/files#diff-d49de8e6304b089b779dce9ca856dea13fe99695707c94e57eea09b068c863b1) to call `app.delete_push_token($1)` via `diesel::sql_query` instead of a direct Diesel DELETE.
> - The function is restricted to the `poziomki_api` role; `PUBLIC` execute is revoked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48e14f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->