### PR TITLE
polish(event): compact left-aligned join pill

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -1,7 +1,10 @@
 package com.poziomki.app.ui.feature.event
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,8 +13,10 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -21,6 +26,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -216,20 +222,23 @@ fun EventChatJoinRequiredView(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
-            if (event.isPending) {
-                AppButton(
-                    text = "oczekuje na akceptację",
-                    onClick = {},
-                    variant = ButtonVariant.SECONDARY,
-                    enabled = false,
-                )
-            } else {
-                AppButton(
-                    text = "dołącz",
-                    onClick = onJoin,
-                    variant = ButtonVariant.PRIMARY,
-                    loading = isUpdatingAttendance,
-                )
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                if (event.isPending) {
+                    JoinPillButton(
+                        text = "oczekuje na akceptację",
+                        onClick = {},
+                        enabled = false,
+                    )
+                } else {
+                    JoinPillButton(
+                        text = "dołącz",
+                        onClick = onJoin,
+                        loading = isUpdatingAttendance,
+                    )
+                }
             }
 
             event.description?.let { description ->
@@ -253,5 +262,42 @@ fun EventChatJoinRequiredView(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
         }
+    }
+}
+
+@Composable
+private fun JoinPillButton(
+    text: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    loading: Boolean = false,
+) {
+    val isEnabled = enabled && !loading
+    val fill = Color(0xFFF2F4F7)
+    val contentColor = Color(0xFF0B0F14).let { if (isEnabled) it else it.copy(alpha = 0.35f) }
+    Row(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(50))
+                .background(fill)
+                .then(if (isEnabled) Modifier.clickable(onClick = onClick) else Modifier)
+                .padding(horizontal = 22.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                color = contentColor,
+                strokeWidth = 2.dp,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text(
+            text = text,
+            fontFamily = NunitoFamily,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 15.sp,
+            color = contentColor,
+        )
     }
 }


### PR DESCRIPTION
Smaller, left-aligned white pill for the join button on the event view.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace join/pending buttons with a left-aligned pill-style `JoinPillButton` in event chat
> - Adds a new `JoinPillButton` composable in [EventChatStateViews.kt](https://github.com/poziomki-app/poziomki/pull/494/files#diff-dc77fa9f64ddb97ec56b309fbfe774d102483e0b8dbdce72772de14e65b0380a): a rounded pill row with a loading spinner (16dp `CircularProgressIndicator`) and dimmed content when disabled.
> - Replaces the existing `AppButton` usages in `EventChatJoinRequiredView` with `JoinPillButton` wrapped in a `Box` that is left-aligned instead of full-width centered.
> - Click events are suppressed when `enabled=false` or loading is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 259b664. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->