### PR TITLE
polish(auth): brighter hero, link-style register

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/AuthLandingScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/AuthLandingScreen.kt
@@ -75,7 +75,7 @@ fun AuthLandingScreen(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .alpha(0.75f),
+                        .alpha(0.92f),
             )
             Box(
                 modifier =

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/LoginScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/LoginScreen.kt
@@ -2,6 +2,7 @@ package com.poziomki.app.ui.feature.auth
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -27,14 +28,18 @@ import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.components.AppButton
-import com.poziomki.app.ui.designsystem.components.ButtonVariant
 import com.poziomki.app.ui.designsystem.components.PoziomkiLogo
 import com.poziomki.app.ui.designsystem.components.PoziomkiPasswordField
 import com.poziomki.app.ui.designsystem.components.PoziomkiTextField
@@ -156,13 +161,29 @@ fun LoginScreen(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
-        AppButton(
-            text = "zarejestruj si\u0119",
-            onClick = onNavigateToRegister,
-            variant = ButtonVariant.PRIMARY,
-            modifier = Modifier.fillMaxWidth(),
+        Text(
+            text =
+                buildAnnotatedString {
+                    withStyle(
+                        SpanStyle(
+                            color = Primary,
+                            fontFamily = NunitoFamily,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 15.sp,
+                            textDecoration = TextDecoration.Underline,
+                        ),
+                    ) {
+                        append("zarejestruj si\u0119")
+                    }
+                },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToRegister() }
+                    .padding(vertical = PoziomkiTheme.spacing.sm),
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -1,7 +1,10 @@
 package com.poziomki.app.ui.feature.event
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,8 +13,10 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -21,6 +26,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -216,20 +222,23 @@ fun EventChatJoinRequiredView(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
-            if (event.isPending) {
-                AppButton(
-                    text = "oczekuje na akceptację",
-                    onClick = {},
-                    variant = ButtonVariant.SECONDARY,
-                    enabled = false,
-                )
-            } else {
-                AppButton(
-                    text = "dołącz",
-                    onClick = onJoin,
-                    variant = ButtonVariant.PRIMARY,
-                    loading = isUpdatingAttendance,
-                )
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                if (event.isPending) {
+                    JoinPillButton(
+                        text = "oczekuje na akceptację",
+                        onClick = {},
+                        enabled = false,
+                    )
+                } else {
+                    JoinPillButton(
+                        text = "dołącz",
+                        onClick = onJoin,
+                        loading = isUpdatingAttendance,
+                    )
+                }
             }
 
             event.description?.let { description ->
@@ -253,5 +262,42 @@ fun EventChatJoinRequiredView(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
         }
+    }
+}
+
+@Composable
+private fun JoinPillButton(
+    text: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    loading: Boolean = false,
+) {
+    val isEnabled = enabled && !loading
+    val fill = Color(0xFFF2F4F7)
+    val contentColor = Color(0xFF0B0F14).let { if (isEnabled) it else it.copy(alpha = 0.35f) }
+    Row(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(50))
+                .background(fill)
+                .then(if (isEnabled) Modifier.clickable(onClick = onClick) else Modifier)
+                .padding(horizontal = 22.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                color = contentColor,
+                strokeWidth = 2.dp,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text(
+            text = text,
+            fontFamily = NunitoFamily,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 15.sp,
+            color = contentColor,
+        )
     }
 }


### PR DESCRIPTION
Hero photo a touch lighter on the welcome screen; on the login screen, zarejestruj is now a cyan text link to match the welcome layout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace register button with link-style text and add pill-shaped join button in auth and event chat screens
> - In [LoginScreen.kt](https://github.com/poziomki-app/poziomki/pull/495/files#diff-d4b3243bfcbcb55d6a2d3d6935b2157c75a0f58675c340a358de4002409cceb6), the "zarejestruj się" full-width primary button is replaced with a centered underlined clickable text, with increased vertical spacing above it.
> - In [AuthLandingScreen.kt](https://github.com/poziomki-app/poziomki/pull/495/files#diff-ce2b0c02714ce0a4ff1d19a6ca7f1356645d6658abf32ce6052b33f29663f190), the hero image overlay opacity increases from 0.75 to 0.92 for a brighter appearance.
> - In [EventChatStateViews.kt](https://github.com/poziomki-app/poziomki/pull/495/files#diff-dc77fa9f64ddb97ec56b309fbfe774d102483e0b8dbdce72772de14e65b0380a), the join/pending action is replaced with a new `JoinPillButton` composable — a left-aligned rounded pill that shows a spinner when loading and renders as disabled during pending state.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ab34592. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->