### PR TITLE
feat(push): notify on tag-matched new events

### DIFF
--- a/backend/migrations/2026-05-19-180000_users_for_event_tag_match/down.sql
+++ b/backend/migrations/2026-05-19-180000_users_for_event_tag_match/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS app.users_for_event_tag_match(uuid, integer);

--- a/backend/migrations/2026-05-19-180000_users_for_event_tag_match/up.sql
+++ b/backend/migrations/2026-05-19-180000_users_for_event_tag_match/up.sql
@@ -1,0 +1,46 @@
+-- SECURITY DEFINER helper for tag-matched event push notifications.
+--
+-- Returns user_ids whose profile_tags overlap with a given event's
+-- event_tags, gated by user_settings (master switch on, notify_tag_events
+-- on — resilient COALESCE defaults so missing rows fall back to schema
+-- defaults), excluding the creator and banned/review-stub users.
+--
+-- Server-side push delivery only. Narrow projection: user_id only —
+-- the API role can fetch tokens via push_tokens_for_users.
+
+CREATE OR REPLACE FUNCTION app.users_for_event_tag_match(
+    p_event_id uuid,
+    p_creator_user_id integer
+)
+RETURNS TABLE (user_id integer)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT DISTINCT p.user_id
+    FROM public.profile_tags pt
+    JOIN public.event_tags et ON et.tag_id = pt.tag_id
+    JOIN public.profiles p ON p.id = pt.profile_id
+    JOIN public.users u ON u.id = p.user_id
+    LEFT JOIN public.user_settings s ON s.user_id = p.user_id
+    WHERE et.event_id = p_event_id
+      AND p.user_id <> p_creator_user_id
+      AND u.banned_at IS NULL
+      AND COALESCE(u.is_review_stub, FALSE) = FALSE
+      AND COALESCE(s.notifications_enabled, TRUE)
+      AND COALESCE(s.notify_tag_events, FALSE)
+$$;
+
+COMMENT ON FUNCTION app.users_for_event_tag_match(uuid, integer) IS
+    'Resolve users who opted in to tag-event push and have at least one matching tag on this event. Server-side push only; bypasses RLS.';
+
+REVOKE EXECUTE ON FUNCTION app.users_for_event_tag_match(uuid, integer) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.users_for_event_tag_match(uuid, integer) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/api/events/write_handler.rs
+++ b/backend/src/api/events/write_handler.rs
@@ -317,6 +317,22 @@ pub(in crate::api) async fn event_create(
         CreateOutcome::NoProfile => Ok(profile_not_found(&headers)),
         CreateOutcome::CoverInvalid(response) => Ok(*response),
         CreateOutcome::Created { event, profile_id } => {
+            // Fan out tag-matched event push notifications in the background.
+            // Audience + opt-in filtering happens in the SECURITY DEFINER
+            // helper; this can never block or fail the response.
+            let event_id = event.id;
+            let event_title = event.title.clone();
+            tokio::spawn(async move {
+                let (delivered, rejected) =
+                    crate::push::fcm::send_event_tag_match(event_id, event_title, user_id).await;
+                tracing::info!(
+                    %event_id,
+                    delivered,
+                    rejected,
+                    "fcm_event_tag_match_sent"
+                );
+            });
+
             let mut response = build_response_after_tx(viewer, &event, profile_id).await?;
             resolve_single(&mut response).await;
             Ok(created_event_response(response))

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -8,8 +8,9 @@ pub use viewer::{
     find_user_for_password_reset, mark_email_verified, profile_owner_user_id,
     profile_program_visibility, push_tokens_for_users, resolve_session, set_anon_context,
     set_password_reset_token, set_viewer_context, user_id_for_pid, user_pid_for_id,
-    user_pids_for_ids, user_review_stubs, with_anon_tx, with_viewer_tx, AuthSessionRow,
-    AuthUserRow, CreatedSessionRow, DbViewer, PasswordResetUserRow, UserPidRow, UserReviewStubRow,
+    user_pids_for_ids, user_review_stubs, users_for_event_tag_match, with_anon_tx, with_viewer_tx,
+    AuthSessionRow, AuthUserRow, CreatedSessionRow, DbViewer, PasswordResetUserRow, UserPidRow,
+    UserReviewStubRow,
 };
 
 use deadpool::managed::Timeouts;

--- a/backend/src/db/viewer.rs
+++ b/backend/src/db/viewer.rs
@@ -488,6 +488,22 @@ struct UserIdRow {
     user_id: i32,
 }
 
+/// Resolve users with at least one tag matching the given event's tags,
+/// gated by `notify_tag_events` opt-in. Used to fan out tag-matched
+/// event push notifications from `event_create`.
+pub async fn users_for_event_tag_match(
+    conn: &mut AsyncPgConnection,
+    event_id: uuid::Uuid,
+    creator_user_id: i32,
+) -> Result<Vec<i32>, diesel::result::Error> {
+    let rows = diesel::sql_query("SELECT * FROM app.users_for_event_tag_match($1, $2)")
+        .bind::<diesel::sql_types::Uuid, _>(event_id)
+        .bind::<diesel::sql_types::Integer, _>(creator_user_id)
+        .load::<UserIdRow>(conn)
+        .await?;
+    Ok(rows.into_iter().map(|r| r.user_id).collect())
+}
+
 /// Filter push recipients by notification preferences.
 ///
 /// Returns only those whose master switch is on, channel for the

--- a/backend/src/push/fcm.rs
+++ b/backend/src/push/fcm.rs
@@ -521,6 +521,136 @@ pub async fn send_broadcast(
     )
 }
 
+/// Send a tag-matched event recommendation push.
+///
+/// Resolves the audience from `app.users_for_event_tag_match` (already
+/// filtered by opt-in preferences, ban status, and creator exclusion),
+/// then fans out per-user with a visible title + deep link to the event page.
+pub async fn send_event_tag_match(
+    event_id: Uuid,
+    event_title: String,
+    creator_user_id: i32,
+) -> (usize, usize) {
+    let Some(fcm) = client() else {
+        return (0, 0);
+    };
+    let (user_ids, rows) = {
+        let mut conn = match db::conn().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "fcm_event_tag: db conn failed");
+                return (0, 0);
+            }
+        };
+        let user_ids =
+            match db::users_for_event_tag_match(&mut conn, event_id, creator_user_id).await {
+                Ok(u) => u,
+                Err(e) => {
+                    tracing::warn!(error = %e, "fcm_event_tag: audience lookup failed");
+                    return (0, 0);
+                }
+            };
+        if user_ids.is_empty() {
+            return (0, 0);
+        }
+        let rows = match db::push_tokens_for_users(&mut conn, &user_ids).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "fcm_event_tag: token lookup failed");
+                return (0, 0);
+            }
+        };
+        (user_ids, rows)
+    };
+    if rows.is_empty() {
+        tracing::info!(
+            audience = user_ids.len(),
+            "fcm_event_tag: matched users have no registered tokens"
+        );
+        return (0, 0);
+    }
+
+    let access = match fcm.access_token().await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(error = %e, "fcm_event_tag: access token failed");
+            return (0, 0);
+        }
+    };
+    let url = fcm.send_url();
+    let deep_link = format!("poziomki://event/{event_id}");
+    let body_text = "Nowe wydarzenie pasujące do Twoich tagów".to_string();
+
+    let delivered = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let rejected = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let mut handles = Vec::with_capacity(rows.len());
+    for row in rows {
+        let sem = fcm.sem.clone();
+        let http = fcm.http.clone();
+        let access = access.clone();
+        let url = url.clone();
+        let title = event_title.clone();
+        let body = body_text.clone();
+        let deep_link = deep_link.clone();
+        let delivered = delivered.clone();
+        let rejected = rejected.clone();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire_owned().await.ok();
+            let payload = build_broadcast_message(
+                &row.fcm_token,
+                &row.platform,
+                &title,
+                &body,
+                Some(&deep_link),
+            );
+            let masked = mask_token(&row.fcm_token);
+            let resp = http
+                .post(&url)
+                .bearer_auth(&access)
+                .json(&payload)
+                .send()
+                .await;
+            match resp {
+                Ok(r) => {
+                    let status = r.status();
+                    if status.is_success() {
+                        delivered.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tracing::info!(token = %masked, "fcm_event_tag_delivered");
+                    } else if status == reqwest::StatusCode::NOT_FOUND
+                        || status == reqwest::StatusCode::BAD_REQUEST
+                        || status == reqwest::StatusCode::UNAUTHORIZED
+                    {
+                        let detail = r.text().await.unwrap_or_default();
+                        let stale = detail.contains("UNREGISTERED")
+                            || detail.contains("INVALID_ARGUMENT")
+                            || status == reqwest::StatusCode::NOT_FOUND;
+                        rejected.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tracing::warn!(token = %masked, status = %status, stale, "fcm_event_tag_rejected");
+                        if stale {
+                            cleanup_stale_token(&row.fcm_token).await;
+                        }
+                    } else {
+                        rejected.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tracing::warn!(token = %masked, status = %status, "fcm_event_tag_error");
+                    }
+                }
+                Err(e) => {
+                    rejected.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    tracing::warn!(token = %masked, error = %e, "fcm_event_tag_send_failed");
+                }
+            }
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+    (
+        delivered.load(std::sync::atomic::Ordering::Relaxed),
+        rejected.load(std::sync::atomic::Ordering::Relaxed),
+    )
+}
+
 async fn cleanup_stale_token(fcm_token: &str) {
     use diesel_async::RunQueryDsl;
 

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.24.1" // x-release-please-version
+val appVersionName = "0.24.2" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -60,6 +60,7 @@ import com.adamglin.phosphoricons.fill.PaperPlaneTilt
 import com.poziomki.app.chat.api.ChatClient
 import com.poziomki.app.chat.push.NotificationChatTarget
 import com.poziomki.app.chat.push.NotificationDeepLinkTarget
+import com.poziomki.app.chat.push.NotificationEventTarget
 import com.poziomki.app.data.repository.ChatRoomRepository
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.components.OfflineBanner
@@ -148,6 +149,7 @@ private fun rememberGraphEntry(
     }
 }
 
+@Suppress("CyclomaticComplexMethod", "LongMethod")
 @Composable
 fun AppNavigation(
     startDestination: Route,
@@ -194,6 +196,17 @@ fun AppNavigation(
     val deepLink by NotificationDeepLinkTarget.link.collectAsState()
     LaunchedEffect(isLoggedIn, deepLink) {
         handleBroadcastDeepLink(deepLink, isLoggedIn, startDestination)
+    }
+
+    val notificationEventTarget by NotificationEventTarget.eventId.collectAsState()
+    LaunchedEffect(isLoggedIn, notificationEventTarget) {
+        val eventId = notificationEventTarget ?: return@LaunchedEffect
+        if (!isLoggedIn || startDestination == Route.OnboardingGraph) return@LaunchedEffect
+        navController.navigate(Route.MainGraph) {
+            popUpTo(0) { inclusive = true }
+        }
+        navController.navigate(Route.EventDetail(eventId))
+        NotificationEventTarget.consume(eventId)
     }
 
     val navigateToChat: (String, String?) -> Unit = navigateToChat@{ chatTargetId, avatarHint ->
@@ -485,10 +498,12 @@ fun AppNavigation(
     }
 }
 
-// Broadcast deep links. Today we only recognise poziomki://chat/<roomId>
-// (forwarded into the existing chat target). Unknown schemes fall through
-// — the app just opens at its current destination and the link is dropped
-// so taps still open the app from a notification.
+// Broadcast deep links. Recognised schemes:
+//   poziomki://chat/<roomId>   → forwarded into NotificationChatTarget
+//   poziomki://event/<eventId> → forwarded into NotificationEventTarget
+// Unknown schemes fall through — the app just opens at its current
+// destination and the link is dropped so taps still open the app from
+// a notification.
 private fun handleBroadcastDeepLink(
     deepLink: String?,
     isLoggedIn: Boolean,
@@ -500,9 +515,11 @@ private fun handleBroadcastDeepLink(
         return
     }
     val chatPrefix = "poziomki://chat/"
+    val eventPrefix = "poziomki://event/"
     if (link.startsWith(chatPrefix)) {
-        val roomId = link.removePrefix(chatPrefix).takeIf { it.isNotBlank() }
-        if (roomId != null) NotificationChatTarget.open(roomId)
+        link.removePrefix(chatPrefix).takeIf { it.isNotBlank() }?.let(NotificationChatTarget::open)
+    } else if (link.startsWith(eventPrefix)) {
+        link.removePrefix(eventPrefix).takeIf { it.isNotBlank() }?.let(NotificationEventTarget::open)
     }
     NotificationDeepLinkTarget.consume(link)
 }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/push/NotificationEventTarget.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/push/NotificationEventTarget.kt
@@ -1,0 +1,25 @@
+package com.poziomki.app.chat.push
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Queues a `poziomki://event/<id>` deep link until the Compose nav graph
+ * picks it up. Mirrors [NotificationChatTarget] / [NotificationDeepLinkTarget];
+ * kept as a separate target so the broadcast deep-link parser stays a pure
+ * dispatcher.
+ */
+object NotificationEventTarget {
+    private val _eventId = MutableStateFlow<String?>(null)
+    val eventId: StateFlow<String?> = _eventId
+
+    fun open(eventId: String?) {
+        _eventId.value = eventId?.takeIf { it.isNotBlank() }
+    }
+
+    fun consume(eventId: String) {
+        if (_eventId.value == eventId) {
+            _eventId.value = null
+        }
+    }
+}


### PR DESCRIPTION
- Backend: on `event_create`, fan out push to users whose `profile_tags` ∩ event's `event_tags` is non-empty, gated by `notify_tag_events` opt-in (creator + banned + review-stubs excluded).
- Migration adds `app.users_for_event_tag_match(uuid, int)` SECURITY DEFINER helper using the LEFT JOIN + COALESCE pattern from #489.
- Reuses `build_broadcast_message`; deep link `poziomki://event/<id>`.
- Android: nav graph routes `poziomki://event/<id>` to `Route.EventDetail` via a new `NotificationEventTarget`.
- Bump 0.24.2.

Test plan:
- [ ] Two users with overlapping tags, one creates a matching event → other receives push, tap opens event detail
- [ ] Creator does not get pushed for their own event
- [ ] User with `notify_tag_events=false` not pushed
- [ ] Event with no tags → no recipients (audience empty, no error logged)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send push notifications to tag-matched users when a new event is created
> - Adds a new SQL function `app.users_for_event_tag_match` that returns opted-in user IDs whose profile tags overlap with an event's tags, excluding the creator, banned users, and review stubs.
> - Adds `push.fcm.send_event_tag_match` which resolves matched users, fetches their FCM tokens, sends a notification with a `poziomki://event/<id>` deep link, and cleans up stale tokens on FCM errors.
> - Fires the push dispatch asynchronously via `tokio::spawn` after event creation in the HTTP handler, so it does not block the response.
> - On the mobile side, `NotificationEventTarget` queues the event ID from the deep link and `AppNavigation` navigates to the event detail screen when the user is logged in.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ccd066.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->