### PR TITLE
polish(filters): scrollable pill filter row

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/FilterTabs.kt
@@ -2,14 +2,15 @@ package com.poziomki.app.ui.designsystem.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -41,7 +42,7 @@ fun <T> FilterTabs(
     Row(
         modifier =
             modifier
-                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
                 .padding(top = 12.dp, bottom = 16.dp),
         horizontalArrangement = horizontalArrangement,
         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
Make the pill filter row horizontally scrollable in events, wiadomości and zapisane screens.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make pill filter row horizontally scrollable in `FilterTabs`
> Applies `horizontalScroll(rememberScrollState())` to the `FilterTabs` row and removes `fillMaxWidth()`, allowing filter pills to scroll horizontally instead of being constrained to screen width.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fc3717.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->