### PR TITLE
fix(welcome): preserve welcome_seen on logout; pill cta

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/AuthLandingScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/AuthLandingScreen.kt
@@ -75,7 +75,7 @@ fun AuthLandingScreen(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .alpha(0.75f),
+                        .alpha(0.92f),
             )
             Box(
                 modifier =

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/LoginScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/LoginScreen.kt
@@ -2,6 +2,7 @@ package com.poziomki.app.ui.feature.auth
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -27,14 +28,18 @@ import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.components.AppButton
-import com.poziomki.app.ui.designsystem.components.ButtonVariant
 import com.poziomki.app.ui.designsystem.components.PoziomkiLogo
 import com.poziomki.app.ui.designsystem.components.PoziomkiPasswordField
 import com.poziomki.app.ui.designsystem.components.PoziomkiTextField
@@ -156,13 +161,29 @@ fun LoginScreen(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.md))
+        Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
-        AppButton(
-            text = "zarejestruj si\u0119",
-            onClick = onNavigateToRegister,
-            variant = ButtonVariant.PRIMARY,
-            modifier = Modifier.fillMaxWidth(),
+        Text(
+            text =
+                buildAnnotatedString {
+                    withStyle(
+                        SpanStyle(
+                            color = Primary,
+                            fontFamily = NunitoFamily,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 15.sp,
+                            textDecoration = TextDecoration.Underline,
+                        ),
+                    ) {
+                        append("zarejestruj si\u0119")
+                    }
+                },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToRegister() }
+                    .padding(vertical = PoziomkiTheme.spacing.sm),
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -1,7 +1,10 @@
 package com.poziomki.app.ui.feature.event
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,8 +13,10 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -21,6 +26,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -216,20 +222,23 @@ fun EventChatJoinRequiredView(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
-            if (event.isPending) {
-                AppButton(
-                    text = "oczekuje na akceptację",
-                    onClick = {},
-                    variant = ButtonVariant.SECONDARY,
-                    enabled = false,
-                )
-            } else {
-                AppButton(
-                    text = "dołącz",
-                    onClick = onJoin,
-                    variant = ButtonVariant.PRIMARY,
-                    loading = isUpdatingAttendance,
-                )
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                if (event.isPending) {
+                    JoinPillButton(
+                        text = "oczekuje na akceptację",
+                        onClick = {},
+                        enabled = false,
+                    )
+                } else {
+                    JoinPillButton(
+                        text = "dołącz",
+                        onClick = onJoin,
+                        loading = isUpdatingAttendance,
+                    )
+                }
             }
 
             event.description?.let { description ->
@@ -253,5 +262,42 @@ fun EventChatJoinRequiredView(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
         }
+    }
+}
+
+@Composable
+private fun JoinPillButton(
+    text: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    loading: Boolean = false,
+) {
+    val isEnabled = enabled && !loading
+    val fill = Color(0xFFF2F4F7)
+    val contentColor = Color(0xFF0B0F14).let { if (isEnabled) it else it.copy(alpha = 0.35f) }
+    Row(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(50))
+                .background(fill)
+                .then(if (isEnabled) Modifier.clickable(onClick = onClick) else Modifier)
+                .padding(horizontal = 22.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                color = contentColor,
+                strokeWidth = 2.dp,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text(
+            text = text,
+            fontFamily = NunitoFamily,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 15.sp,
+            color = contentColor,
+        )
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/WelcomeDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/WelcomeDialog.kt
@@ -2,6 +2,8 @@ package com.poziomki.app.ui.feature.feedback
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,13 +20,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.poziomki.app.ui.designsystem.Text
-import com.poziomki.app.ui.designsystem.components.AppButton
-import com.poziomki.app.ui.designsystem.components.ButtonVariant
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
@@ -59,7 +60,7 @@ private fun WelcomeBody(onDismiss: () -> Unit) {
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
-            text = "studencka apka eventów. to wciąż wczesna wersja, więc coś może działać dziwnie.",
+            text = "studencka apka eventów - to wciąż wczesna wersja, więc coś może działać dziwnie.",
             fontFamily = NunitoFamily,
             fontSize = 14.sp,
             lineHeight = 20.sp,
@@ -72,7 +73,36 @@ private fun WelcomeBody(onDismiss: () -> Unit) {
         Spacer(modifier = Modifier.height(6.dp))
         WelcomeBullet("napisz co działa, a co nie, w „zostaw opinię”.")
         Spacer(modifier = Modifier.height(24.dp))
-        AppButton(text = "zaczynamy", onClick = onDismiss, variant = ButtonVariant.PRIMARY)
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+            WelcomePillButton(text = "zaczynamy", onClick = onDismiss)
+        }
+    }
+}
+
+@Composable
+private fun WelcomePillButton(
+    text: String,
+    onClick: () -> Unit,
+) {
+    val fill = Color(0xFFF2F4F7)
+    val contentColor = Color(0xFF0B0F14)
+    val rowModifier =
+        Modifier
+            .clip(RoundedCornerShape(50))
+            .background(fill)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 22.dp, vertical = 10.dp)
+    Row(
+        modifier = rowModifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            fontFamily = NunitoFamily,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 15.sp,
+            color = contentColor,
+        )
     }
 }
 

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/SessionManager.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/session/SessionManager.kt
@@ -2,6 +2,7 @@ package com.poziomki.app.session
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -29,6 +30,13 @@ class SessionManager(
         val ONBOARDING_DRAFT = stringPreferencesKey("onboarding_draft")
         val DEVICE_ID = stringPreferencesKey("device_id")
         val LAST_SEEN_VERSION_CODE = intPreferencesKey("last_seen_version_code")
+
+        // Mirrors keys in AppPreferences (same DataStore). Preserved across
+        // logouts so onboarding-style flags don't reappear when a user signs
+        // back in on the same device.
+        val WELCOME_SEEN = booleanPreferencesKey("welcome_seen_v1")
+        val FEEDBACK_BANNER_DISMISSED = booleanPreferencesKey("feedback_banner_dismissed_v1")
+        val SCREENSHOTS_ALLOWED = booleanPreferencesKey("screenshots_allowed")
     }
 
     suspend fun getLastSeenVersionCode(): Int? = dataStore.data.first()[LAST_SEEN_VERSION_CODE]
@@ -144,10 +152,16 @@ class SessionManager(
         val snapshot = dataStore.data.first()
         val deviceId = snapshot[DEVICE_ID]
         val lastSeenVersion = snapshot[LAST_SEEN_VERSION_CODE]
+        val welcomeSeen = snapshot[WELCOME_SEEN]
+        val feedbackBannerDismissed = snapshot[FEEDBACK_BANNER_DISMISSED]
+        val screenshotsAllowed = snapshot[SCREENSHOTS_ALLOWED]
         dataStore.edit {
             it.clear()
             if (deviceId != null) it[DEVICE_ID] = deviceId
             if (lastSeenVersion != null) it[LAST_SEEN_VERSION_CODE] = lastSeenVersion
+            if (welcomeSeen != null) it[WELCOME_SEEN] = welcomeSeen
+            if (feedbackBannerDismissed != null) it[FEEDBACK_BANNER_DISMISSED] = feedbackBannerDismissed
+            if (screenshotsAllowed != null) it[SCREENSHOTS_ALLOWED] = screenshotsAllowed
         }
         tokenStore.clearToken()
         runCatching { imageCacheCleaner.clear() }


### PR DESCRIPTION
- Welcome modal no longer reappears after logout (SessionManager.clearSession was wiping the shared DataStore key).
- zaczynamy button in welcome modal is now a right-aligned compact white pill.
- Copy: replace dot with dash in welcome subtitle.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `welcome_seen` and other flags on logout and replace dialog CTAs with pill buttons
> - `SessionManager` now reads `WELCOME_SEEN`, `FEEDBACK_BANNER_DISMISSED`, and `SCREENSHOTS_ALLOWED` from the DataStore before clearing it on logout, then writes them back so they survive session resets.
> - The welcome dialog CTA and the event chat join button are replaced with pill-shaped controls (`WelcomePillButton`, `JoinPillButton`) instead of full-width `AppButton` components.
> - The login screen's register action is replaced with an underlined text link styled in the primary color.
> - The auth landing screen background image alpha is increased from `0.75f` to `0.92f`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f58547.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->