### PR TITLE
feat(feedback): feature-request field + email to kontakt@poziomki.app

### DIFF
--- a/backend/migrations/2026-05-19-200000_user_feedback_feature_request/down.sql
+++ b/backend/migrations/2026-05-19-200000_user_feedback_feature_request/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.user_feedback DROP COLUMN feature_request;

--- a/backend/migrations/2026-05-19-200000_user_feedback_feature_request/up.sql
+++ b/backend/migrations/2026-05-19-200000_user_feedback_feature_request/up.sql
@@ -1,0 +1,7 @@
+-- Add a second free-text column to capture feature requests separately
+-- from the general "what works / what doesn't" message. Lets the
+-- Zostaw opinię dialog ask both questions without conflating them in
+-- triage email + dashboard.
+
+ALTER TABLE public.user_feedback
+    ADD COLUMN feature_request TEXT;

--- a/backend/src/api/auth/mod.rs
+++ b/backend/src/api/auth/mod.rs
@@ -12,6 +12,7 @@ mod auth_session;
 use crate::api::auth_or_respond;
 
 use self::auth_rate_limit::{enforce_rate_limit, AuthRateLimitAction};
+pub(in crate::api) use self::auth_service::send_simple_mail;
 use self::auth_service::{
     create_user_or_error, find_user_by_email, forgot_password_verify_inner, generate_otp_code,
     reset_password_inner, send_otp_email, sign_in_success_or_unauthorized, verify_otp_inner,

--- a/backend/src/api/auth/otp_email.rs
+++ b/backend/src/api/auth/otp_email.rs
@@ -364,6 +364,78 @@ pub(in crate::api) async fn send_otp_email(to: &str, code: &str) -> Result<(), S
     }
 }
 
+/// Send a plain-text operational email (e.g. feedback notifications).
+///
+/// Uses the same relay → direct-MX cascade as the OTP path, but builds a
+/// simple text/plain message instead of the OTP MJML/HTML template. No
+/// Resend fallback — these are low volume and the relay handles them.
+/// Returns `Ok(())` when SMTP is disabled so the caller treats mail as
+/// best-effort (matches the OTP behaviour).
+pub(in crate::api) async fn send_simple_mail(
+    to: &str,
+    subject: &str,
+    body: &str,
+) -> Result<(), String> {
+    if !super::env_truthy("SMTP_ENABLE") {
+        tracing::debug!("Mail disabled, skipping simple mail to {to}");
+        return Ok(());
+    }
+
+    let from = std::env::var("SMTP_FROM").unwrap_or_else(|_| "noreply@poziomki.app".into());
+    let from_mbox = parse_from_mailbox(&from).ok_or("Invalid SMTP_FROM")?;
+    let to_mbox: Mailbox = to
+        .parse()
+        .map_err(|e| format!("Invalid recipient {to}: {e}"))?;
+    let msg_id = format!("<{}@poziomki.app>", uuid::Uuid::new_v4());
+
+    let mut email = Message::builder()
+        .from(from_mbox)
+        .to(to_mbox)
+        .message_id(Some(msg_id))
+        .subject(subject)
+        .raw_header(header::HeaderValue::new(
+            header::HeaderName::new_from_ascii_str("Auto-Submitted"),
+            "auto-generated".to_owned(),
+        ))
+        .raw_header(header::HeaderValue::new(
+            header::HeaderName::new_from_ascii_str("Precedence"),
+            "transactional".to_owned(),
+        ))
+        .body(body.to_string())
+        .map_err(|e| format!("Failed to build mail: {e}"))?;
+
+    if let Some(dkim) = dkim_config()? {
+        dkim_sign(&mut email, dkim);
+    }
+
+    let envelope = email.envelope().clone();
+    let raw = email.formatted();
+
+    if let Some(relay_host) = env_nonempty("SMTP_HOST") {
+        match send_via_relay(&envelope, &raw, &relay_host).await {
+            Ok(()) => {
+                tracing::info!("Simple mail delivered to {to} via relay {relay_host}");
+                return Ok(());
+            }
+            Err(e) => {
+                tracing::warn!("Simple mail relay failed ({e}); falling back to MX for {to}");
+            }
+        }
+    }
+
+    let domain = to
+        .split('@')
+        .nth(1)
+        .ok_or_else(|| format!("No domain in {to}"))?;
+    match send_via_mx(&envelope, &raw, domain).await {
+        Ok(mx_host) => {
+            tracing::info!("Simple mail delivered to {to} via MX {mx_host}");
+            Ok(())
+        }
+        Err(e) => Err(format!("Simple mail delivery failed for {to}: {e}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::select_mx_hosts;

--- a/backend/src/api/auth/service.rs
+++ b/backend/src/api/auth/service.rs
@@ -1,6 +1,7 @@
 #[path = "otp_email.rs"]
 mod auth_otp_email;
 pub(super) use auth_otp_email::send_otp_email;
+pub(in crate::api) use auth_otp_email::send_simple_mail;
 
 use axum::response::Response;
 use axum::{http::HeaderMap, response::IntoResponse, Json};

--- a/backend/src/api/feedback.rs
+++ b/backend/src/api/feedback.rs
@@ -23,6 +23,7 @@ type Result<T> = crate::error::AppResult<T>;
 
 const MAX_MESSAGE_LEN: usize = 4000;
 const MAX_APP_VERSION_LEN: usize = 64;
+const FEEDBACK_NOTIFY_TO: &str = "kontakt@poziomki.app";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +33,8 @@ pub(in crate::api) struct CreateFeedbackBody {
     pub message: Option<String>,
     #[serde(default)]
     pub app_version: Option<String>,
+    #[serde(default)]
+    pub feature_request: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -72,13 +75,21 @@ pub(super) async fn create(
         .filter(|s| !s.is_empty())
         .map(|s| s.chars().take(MAX_APP_VERSION_LEN).collect::<String>());
 
+    let feature_request = body
+        .feature_request
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.chars().take(MAX_MESSAGE_LEN).collect::<String>());
+
     let row = NewUserFeedback {
         id: Uuid::new_v4(),
         user_id: user.id,
         rating: body.rating,
-        message,
-        app_version,
+        message: message.clone(),
+        app_version: app_version.clone(),
         created_at: Utc::now(),
+        feature_request: feature_request.clone(),
     };
 
     let mut conn = crate::db::conn().await?;
@@ -87,8 +98,56 @@ pub(super) async fn create(
         .execute(&mut conn)
         .await?;
 
+    // Notify the operator inbox in the background. Failure to send mail
+    // must never make the user think their submission was lost — they
+    // already saw a 200. The body is anonymous: rating + free text only,
+    // no user id or email. Look up the row by id in the DB if needed.
+    let rating = body.rating;
+    let app_version_for_mail = app_version.clone();
+    tokio::spawn(async move {
+        if let Err(e) = send_feedback_email(
+            rating,
+            message.as_deref(),
+            feature_request.as_deref(),
+            app_version_for_mail.as_deref(),
+        )
+        .await
+        {
+            tracing::warn!(error = %e, "feedback notify email failed");
+        }
+    });
+
     Ok(Json(DataResponse {
         data: CreateFeedbackResponse { id: row.id },
     })
     .into_response())
+}
+
+/// Send the operator-facing feedback notification to kontakt@poziomki.app.
+/// Anonymous: just rating + free text + app version.
+async fn send_feedback_email(
+    rating: i16,
+    message: Option<&str>,
+    feature_request: Option<&str>,
+    app_version: Option<&str>,
+) -> std::result::Result<(), String> {
+    use std::fmt::Write;
+
+    let stars: String = (1..=5)
+        .map(|i| if i <= rating { '★' } else { '☆' })
+        .collect();
+    let subject = format!("Nowa opinia {stars} ({rating}/5)");
+
+    let mut body = String::new();
+    let _ = writeln!(body, "Ocena: {stars} ({rating}/5)");
+    if let Some(v) = app_version {
+        let _ = writeln!(body, "Wersja: {v}");
+    }
+    body.push_str("\nWiadomość:\n");
+    body.push_str(message.unwrap_or("(brak)"));
+    body.push_str("\n\nCo dodać do apki:\n");
+    body.push_str(feature_request.unwrap_or("(brak)"));
+    body.push('\n');
+
+    crate::api::auth::send_simple_mail(FEEDBACK_NOTIFY_TO, &subject, &body).await
 }

--- a/backend/src/db/models/user_feedback.rs
+++ b/backend/src/db/models/user_feedback.rs
@@ -13,4 +13,5 @@ pub struct NewUserFeedback {
     pub message: Option<String>,
     pub app_version: Option<String>,
     pub created_at: DateTime<Utc>,
+    pub feature_request: Option<String>,
 }

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -298,6 +298,7 @@ diesel::table! {
         message -> Nullable<Text>,
         app_version -> Nullable<Text>,
         created_at -> Timestamptz,
+        feature_request -> Nullable<Text>,
     }
 }
 

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.24.2" // x-release-please-version
+val appVersionName = "0.24.3" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackDialog.kt
@@ -35,10 +35,12 @@ import com.poziomki.app.ui.designsystem.theme.TextSecondary
 fun FeedbackDialog(
     rating: Int,
     message: String,
+    featureRequest: String,
     isSubmitting: Boolean,
     error: String?,
     onRatingChange: (Int) -> Unit,
     onMessageChange: (String) -> Unit,
+    onFeatureRequestChange: (String) -> Unit,
     onSubmit: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -77,12 +79,19 @@ fun FeedbackDialog(
                     }
                 }
                 Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = "Co działa, co nie, co poprawić?",
+                    fontFamily = NunitoFamily,
+                    fontSize = 14.sp,
+                    color = TextSecondary,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
                 OutlinedTextField(
                     value = message,
                     onValueChange = onMessageChange,
                     placeholder = {
                         Text(
-                            text = "Co działa, co nie, co poprawić?",
+                            text = "Twoja opinia…",
                             fontFamily = NunitoFamily,
                             color = TextMuted,
                         )
@@ -91,6 +100,36 @@ fun FeedbackDialog(
                     maxLines = 6,
                     enabled = !isSubmitting,
                     modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "Nowe funkcjonalności — co dodać do apki?",
+                    fontFamily = NunitoFamily,
+                    fontSize = 14.sp,
+                    color = TextSecondary,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = featureRequest,
+                    onValueChange = onFeatureRequestChange,
+                    placeholder = {
+                        Text(
+                            text = "np. powiadomienia o znajomych w okolicy",
+                            fontFamily = NunitoFamily,
+                            color = TextMuted,
+                        )
+                    },
+                    minLines = 2,
+                    maxLines = 5,
+                    enabled = !isSubmitting,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "Lub napisz: kontakt@poziomki.app",
+                    fontFamily = NunitoFamily,
+                    fontSize = 12.sp,
+                    color = TextMuted,
                 )
                 if (error != null) {
                     Spacer(modifier = Modifier.height(8.dp))

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackViewModel.kt
@@ -19,6 +19,7 @@ data class FeedbackState(
     val dialogOpen: Boolean = false,
     val rating: Int = 0,
     val message: String = "",
+    val featureRequest: String = "",
     val isSubmitting: Boolean = false,
     val submitted: Boolean = false,
     val error: String? = null,
@@ -56,6 +57,7 @@ class FeedbackViewModel(
                 dialogOpen = true,
                 rating = 0,
                 message = "",
+                featureRequest = "",
                 submitted = false,
                 error = null,
             )
@@ -73,6 +75,10 @@ class FeedbackViewModel(
         _state.value = _state.value.copy(message = value)
     }
 
+    fun setFeatureRequest(value: String) {
+        _state.value = _state.value.copy(featureRequest = value)
+    }
+
     fun submit(appVersion: String?) {
         val current = _state.value
         if (current.rating !in 1..5 || current.isSubmitting) return
@@ -83,6 +89,7 @@ class FeedbackViewModel(
                     rating = current.rating,
                     message = current.message.trim().takeIf { it.isNotEmpty() },
                     appVersion = appVersion,
+                    featureRequest = current.featureRequest.trim().takeIf { it.isNotEmpty() },
                 )
             when (apiService.submitFeedback(req)) {
                 is ApiResult.Success -> {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -759,10 +759,12 @@ fun MainScreen(
         FeedbackDialog(
             rating = feedbackState.rating,
             message = feedbackState.message,
+            featureRequest = feedbackState.featureRequest,
             isSubmitting = feedbackState.isSubmitting,
             error = feedbackState.error,
             onRatingChange = { feedbackViewModel.setRating(it) },
             onMessageChange = { feedbackViewModel.setMessage(it) },
+            onFeatureRequestChange = { feedbackViewModel.setFeatureRequest(it) },
             onSubmit = { feedbackViewModel.submit(appVersion = null) },
             onDismiss = { feedbackViewModel.closeDialog() },
         )

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
@@ -500,6 +500,7 @@ data class FeedbackRequest(
     val rating: Int,
     val message: String? = null,
     val appVersion: String? = null,
+    val featureRequest: String? = null,
 )
 
 // Routing models


### PR DESCRIPTION
- New `feature_request` column on `user_feedback` for "co dodać do apki"
- Zostaw opinię dialog now has two text areas (opinion + feature request) and a footer line `Lub napisz: kontakt@poziomki.app`
- On submit, a background task emails `kontakt@poziomki.app` with stars, the message, and the feature request. **Anonymous** — no user id or email in the mail body; look up by row id in `user_feedback` if needed.
- New `send_simple_mail` helper in `otp_email.rs` (plain-text path; relay → MX, skips Resend)
- Bump 0.24.3

Test plan:
- [ ] Submit feedback from a 0.24.3 build → row lands with both fields, email arrives at kontakt@poziomki.app with ★★★★☆ in subject
- [ ] Feature request blank → email says "(brak)" in that section
- [ ] SMTP_ENABLE=false → 200 returned, no email sent, no error in logs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add feature_request field to feedback and send operator notification emails to kontakt@poziomki.app
> - Adds an optional `featureRequest` field to the feedback dialog UI, view model, network model, and backend API, stored in a new `feature_request` DB column via migration.
> - After each successful feedback submission, the backend spawns a background task that sends a formatted plain-text notification email (in Polish) to `kontakt@poziomki.app` using a new `send_simple_mail` helper that supports SMTP relay with DKIM and direct MX fallback.
> - Email sending failures are logged but do not affect the HTTP response.
> - Bumps the Android app version to 0.24.3.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c5333f0. 9 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->