### PR TITLE
ui: lowercase opt-in zamiast default

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/Text.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/Text.kt
@@ -16,8 +16,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.material3.Text as M3Text
 
-// Lowercases static UI copy by project convention. Pass preserveCase = true for
-// user-generated content (names, messages, emails) and acronyms/codes (OTP, QR, URLs).
+// Default preserves case. Opt-in to lowercase = true only for deliberately styled
+// static copy (section labels, chips). Never use lowercase on user-generated content,
+// acronyms (OTP, QR), proper nouns, or localized strings (city names, university names).
 @Composable
 @Suppress("LongParameterList")
 fun Text(
@@ -38,10 +39,10 @@ fun Text(
     minLines: Int = 1,
     onTextLayout: ((TextLayoutResult) -> Unit)? = null,
     style: TextStyle = LocalTextStyle.current,
-    preserveCase: Boolean = false,
+    lowercase: Boolean = false,
 ) {
     M3Text(
-        text = if (preserveCase) text else text.lowercase(),
+        text = if (lowercase) text.lowercase() else text,
         modifier = modifier,
         color = color,
         fontSize = fontSize,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ExternalLink.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ExternalLink.kt
@@ -39,7 +39,6 @@ fun rememberExternalLinkOpener(): (String) -> Unit {
             title = {
                 Text(
                     text = if (isMaps) "otworzyć w mapach?" else "otworzyć link zewnętrzny?",
-                    preserveCase = false,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.Bold,
                     fontSize = 18.sp,
@@ -49,7 +48,6 @@ fun rememberExternalLinkOpener(): (String) -> Unit {
             text = {
                 Text(
                     text = humanReadable(url),
-                    preserveCase = true,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.Normal,
                     fontSize = 13.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
@@ -248,7 +248,6 @@ fun LocationPickerSheet(
                             results.forEach { result ->
                                 Text(
                                     text = result.name,
-                                    preserveCase = true,
                                     fontFamily = NunitoFamily,
                                     fontSize = 14.sp,
                                     color = TextPrimary,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -121,7 +121,6 @@ fun ProfileCard(
             ) {
                 Text(
                     text = name,
-                    preserveCase = true,
                     fontFamily = MontserratFamily,
                     fontWeight = FontWeight.ExtraBold,
                     fontSize = 19.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
@@ -271,7 +271,6 @@ fun ProfilePreview(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = name.ifBlank { "imi\u0119" },
-                        preserveCase = true,
                         fontFamily = montserrat,
                         fontWeight = FontWeight.ExtraBold,
                         fontSize = 28.sp,
@@ -354,7 +353,6 @@ private fun RichBio(bio: String) {
     if (!bio.contains("![](")) {
         Text(
             text = bio,
-            preserveCase = true,
             fontFamily = nunito,
             fontWeight = FontWeight.Normal,
             fontSize = 15.sp,
@@ -372,7 +370,6 @@ private fun RichBio(bio: String) {
                     if (segment.text.isNotBlank()) {
                         Text(
                             text = segment.text,
-                            preserveCase = true,
                             fontFamily = nunito,
                             fontWeight = FontWeight.Normal,
                             fontSize = 15.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/ResetPasswordScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/ResetPasswordScreen.kt
@@ -78,7 +78,6 @@ fun ResetPasswordScreen(
 
         Text(
             text = email,
-            preserveCase = true,
             fontFamily = NunitoFamily,
             fontWeight = FontWeight.SemiBold,
             fontSize = 14.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
@@ -92,7 +92,6 @@ fun VerifyScreen(
 
         Text(
             text = email,
-            preserveCase = true,
             fontFamily = NunitoFamily,
             fontWeight = FontWeight.SemiBold,
             fontSize = 16.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
@@ -475,7 +475,6 @@ private fun MessageActionDialog(
                     listOf("❤️", "👍", "👎", "😂", "😮", "😢", "🔥", "🎉").forEach { emoji ->
                         Text(
                             text = emoji,
-                            preserveCase = true,
                             style = MaterialTheme.typography.headlineSmall,
                             modifier =
                                 Modifier
@@ -492,7 +491,6 @@ private fun MessageActionDialog(
                 ) {
                     Text(
                         text = event.body,
-                        preserveCase = true,
                         style = MaterialTheme.typography.bodyMedium,
                         color = TextPrimary,
                         maxLines = 3,
@@ -641,7 +639,6 @@ private fun ReactionBreakdownSheet(
 
                     Text(
                         text = name,
-                        preserveCase = true,
                         style = MaterialTheme.typography.bodyLarge,
                         color = TextPrimary,
                         maxLines = 1,
@@ -651,7 +648,6 @@ private fun ReactionBreakdownSheet(
 
                     Text(
                         text = emoji,
-                        preserveCase = true,
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
@@ -770,7 +766,6 @@ internal fun ComposerModeBanner(
                         )
                         Text(
                             text = mode.bodyPreview,
-                            preserveCase = true,
                             style = MaterialTheme.typography.bodySmall,
                             color = TextSecondary,
                             maxLines = 1,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -271,7 +271,6 @@ private fun ChatTopBar(
                     color = TextPrimary,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    preserveCase = true,
                 )
             }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -241,7 +241,6 @@ internal fun MessageEventRow(
                                             ) {
                                                 Text(
                                                     text = reaction.emoji,
-                                                    preserveCase = true,
                                                     style = MaterialTheme.typography.labelSmall,
                                                 )
                                                 if (reactionCount > 1) {
@@ -278,7 +277,6 @@ internal fun MessageEventRow(
                                     val senderNameColor = ChatNameColors[abs(event.senderId.hashCode()) % ChatNameColors.size]
                                     Text(
                                         text = event.senderDisplayName ?: event.senderId,
-                                        preserveCase = true,
                                         style = MaterialTheme.typography.labelSmall,
                                         color = senderNameColor,
                                         maxLines = 1,
@@ -359,7 +357,6 @@ internal fun MessageEventRow(
                                                 ) {
                                                     Text(
                                                         text = reaction.emoji,
-                                                        preserveCase = true,
                                                         style = MaterialTheme.typography.labelSmall,
                                                     )
                                                     if (reactionCount > 1) {
@@ -406,7 +403,6 @@ private fun BubbleContent(
         }
         Text(
             text = event.body,
-            preserveCase = true,
             style = MaterialTheme.typography.bodyLarge,
             color = TextPrimary,
         )
@@ -579,7 +575,6 @@ private fun ReplyReference(
             Column {
                 Text(
                     text = reply.senderDisplayName ?: "wiadomość",
-                    preserveCase = true,
                     style = MaterialTheme.typography.labelSmall,
                     color = TextSecondary,
                     maxLines = 1,
@@ -587,7 +582,6 @@ private fun ReplyReference(
                 )
                 Text(
                     text = reply.body ?: "odpowiedź",
-                    preserveCase = true,
                     style = MaterialTheme.typography.bodySmall,
                     color = TextPrimary,
                     maxLines = 1,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -174,7 +174,6 @@ fun EventMetaRows(
                 icon = PhosphorIcons.Fill.MapPin,
                 text = formatEventLocation(location),
                 onClick = onLocationClick,
-                preserveCase = true,
                 modifier = Modifier.weight(1f, fill = false),
             )
         }
@@ -208,7 +207,6 @@ private fun MetaChip(
     text: String,
     onClick: (() -> Unit)? = null,
     accent: Boolean = false,
-    preserveCase: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val shape = RoundedCornerShape(50)
@@ -217,11 +215,11 @@ private fun MetaChip(
 
     if (onClick != null) {
         Surface(onClick = onClick, shape = shape, color = bgColor, modifier = modifier) {
-            ChipContent(icon = icon, text = text, tint = contentColor, preserveCase = preserveCase)
+            ChipContent(icon = icon, text = text, tint = contentColor)
         }
     } else {
         Surface(shape = shape, color = bgColor, modifier = modifier) {
-            ChipContent(icon = icon, text = text, tint = contentColor, preserveCase = preserveCase)
+            ChipContent(icon = icon, text = text, tint = contentColor)
         }
     }
 }
@@ -231,7 +229,6 @@ private fun ChipContent(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     text: String,
     tint: Color,
-    preserveCase: Boolean = false,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -255,7 +252,6 @@ private fun ChipContent(
             color = tint,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            preserveCase = preserveCase,
         )
     }
 }
@@ -397,7 +393,6 @@ fun EventChatHeader(
                 }
             Text(
                 text = event.title,
-                preserveCase = true,
                 fontFamily = MontserratFamily,
                 fontSize = titleFontSize,
                 lineHeight = titleFontSize * 1.15f,
@@ -422,7 +417,6 @@ fun EventChatHeader(
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = creator.name,
-                        preserveCase = true,
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = Primary,
@@ -531,7 +525,6 @@ private fun AttendeesDialog(
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = attendee.name,
-                                preserveCase = true,
                                 fontFamily = NunitoFamily,
                                 fontWeight = FontWeight.SemiBold,
                                 fontSize = 14.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -174,7 +174,6 @@ fun EventChatJoinRequiredView(
             ) {
                 Text(
                     text = event.title,
-                    preserveCase = true,
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.ExtraBold,
                     color = Color.White,
@@ -244,7 +243,6 @@ fun EventChatJoinRequiredView(
                     Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xs))
                     Text(
                         text = description,
-                        preserveCase = true,
                         style = MaterialTheme.typography.bodyMedium,
                         color = TextSecondary,
                     )

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -397,7 +397,6 @@ private fun EventCard(
                     // Title
                     Text(
                         text = event.title,
-                        preserveCase = true,
                         style = MaterialTheme.typography.titleMedium,
                         color = TextPrimary,
                         fontWeight = FontWeight.Bold,
@@ -432,7 +431,6 @@ private fun EventCard(
                             Spacer(modifier = Modifier.width(2.dp))
                             Text(
                                 text = formatEventLocation(location),
-                                preserveCase = true,
                                 fontFamily = NunitoFamily,
                                 fontWeight = FontWeight.Normal,
                                 fontSize = 14.sp,
@@ -459,7 +457,6 @@ private fun EventCard(
                             }
                             Text(
                                 text = event.attendeeUsageLabel(),
-                                preserveCase = true,
                                 fontFamily = NunitoFamily,
                                 fontWeight = FontWeight.Bold,
                                 fontSize = 15.sp,
@@ -535,7 +532,6 @@ private fun CategoryFloatingChip(
         Spacer(modifier = Modifier.width(6.dp))
         Text(
             text = info.displayName,
-            preserveCase = true,
             fontFamily = NunitoFamily,
             fontWeight = FontWeight.SemiBold,
             fontSize = 12.sp,
@@ -693,7 +689,6 @@ private fun EventRowContent(
     Column(modifier = modifier) {
         Text(
             text = event.title,
-            preserveCase = true,
             fontFamily = MontserratFamily,
             fontWeight = FontWeight.ExtraBold,
             fontSize = 18.sp,
@@ -720,7 +715,6 @@ private fun EventRowContent(
                 Spacer(modifier = Modifier.width(3.dp))
                 Text(
                     text = formatEventLocation(location),
-                    preserveCase = true,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.Normal,
                     fontSize = 13.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
@@ -408,7 +408,6 @@ internal fun NearbyEventsContent(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = selectedEvent.title,
-                        preserveCase = true,
                         fontFamily = MontserratFamily,
                         fontWeight = FontWeight.ExtraBold,
                         fontSize = 18.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/PoziomkiMapStyle.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/PoziomkiMapStyle.kt
@@ -90,8 +90,7 @@ internal val POZIOMKI_MAP_STYLE_JSON: String =
             "text-field": ["coalesce", ["get", "name:pl"], ["get", "name:latin"], ["get", "name"]],
             "text-font": ["Noto Sans Bold"],
             "text-size": ["interpolate", ["linear"], ["zoom"], 11, 12, 16, 20],
-            "text-letter-spacing": 0.04,
-            "text-transform": "lowercase"
+            "text-letter-spacing": 0.04
           },
           "paint": { "text-color": "#1F2A33" } },
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/RecommendedPeopleRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/RecommendedPeopleRow.kt
@@ -136,7 +136,6 @@ private fun RecommendedPersonItem(
 
         Text(
             text = firstName,
-            preserveCase = true,
             fontFamily = NunitoFamily,
             fontWeight = FontWeight.Medium,
             fontSize = 12.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -79,7 +79,6 @@ fun RoomRow(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = displayName,
-                    preserveCase = true,
                     style = MaterialTheme.typography.titleMedium,
                     color = TextPrimary,
                     fontWeight = FontWeight.SemiBold,
@@ -106,7 +105,6 @@ fun RoomRow(
                         room.latestModerationVerdict in setOf("flag", "block")
                 Text(
                     text = room.latestMessagePreview(),
-                    preserveCase = true,
                     style = MaterialTheme.typography.bodyMedium,
                     color = if (room.unreadCount > 0) TextPrimary else TextSecondary,
                     fontStyle = if (flagged) FontStyle.Italic else null,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
@@ -260,7 +260,6 @@ private fun ProfilePreviewCard(
             ) {
                 Text(
                     text = state.name.ifBlank { "imi\u0119" },
-                    preserveCase = true,
                     fontFamily = MontserratFamily,
                     fontWeight = FontWeight.ExtraBold,
                     fontSize = 19.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangeEmailDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangeEmailDialog.kt
@@ -104,7 +104,6 @@ private fun EnterEmailStep(
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
                         text = it,
-                        preserveCase = true,
                         fontFamily = NunitoFamily,
                         fontWeight = FontWeight.Medium,
                         fontSize = 13.sp,
@@ -171,7 +170,6 @@ private fun OtpStep(
                 )
                 Text(
                     text = newEmail,
-                    preserveCase = true,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.SemiBold,
                     fontSize = 14.sp,
@@ -187,7 +185,6 @@ private fun OtpStep(
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
                         text = it,
-                        preserveCase = true,
                         fontFamily = NunitoFamily,
                         fontWeight = FontWeight.Medium,
                         fontSize = 13.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
@@ -221,7 +221,6 @@ private fun PrivacyContent(
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
         Text(
             text = state.currentEmail.orEmpty(),
-            preserveCase = true,
             fontFamily = nunito,
             fontWeight = FontWeight.SemiBold,
             fontSize = 15.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
@@ -268,7 +268,6 @@ fun ProfileEditScreen(
                 ) {
                     Text(
                         text = state.program.ifEmpty { "Wybierz kierunek" },
-                        preserveCase = true,
                         fontFamily = nunito,
                         fontWeight = FontWeight.Normal,
                         fontSize = 16.sp,
@@ -1100,7 +1099,6 @@ private fun GradientPickerDialog(
                 Column {
                     Text(
                         text = name.ifBlank { "imię" },
-                        preserveCase = true,
                         fontFamily = montserrat,
                         fontWeight = FontWeight.ExtraBold,
                         fontSize = 22.sp,
@@ -1119,7 +1117,6 @@ private fun GradientPickerDialog(
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(
                             text = bio,
-                            preserveCase = true,
                             fontFamily = nunito,
                             fontWeight = FontWeight.Normal,
                             fontSize = 14.sp,


### PR DESCRIPTION
- `Text()` domyślnie zachowuje case, lowercase trzeba włączyć przez `lowercase = true`
- usunięte stare `preserveCase = true` z 19 plików (no-op po flipie)
- usunięty `text-transform: lowercase` z labeli dzielnic Warszawy na mapie

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change `Text` composable default from lowercase to preserve original casing
> - Inverts the `Text` composable's casing behavior by renaming the `preserveCase` parameter to `lowercase` and flipping its default from lowercasing to preserving case.
> - Removes `preserveCase=true` arguments across all call sites (chat, events, profiles, auth screens, home screen, map style) since preserve-case is now the default.
> - Also removes the `"text-transform": "lowercase"` property from the map style JSON, so map place labels render with their original casing.
> - Behavioral Change: all text previously rendered in lowercase by default will now display with its original casing unless callers explicitly pass `lowercase=true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53b2904.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->