### PR TITLE
feat(nav): unread dots on messages tab icon

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/navigation/AppNavigation.kt
@@ -114,6 +114,44 @@ data class BottomNavItem(
     val route: Route,
 )
 
+@Composable
+private fun NavBarIcon(
+    icon: ImageVector,
+    contentDescription: String,
+    tint: Color,
+    showTopDot: Boolean,
+    showBottomDot: Boolean,
+) {
+    Box(contentAlignment = Alignment.Center) {
+        Icon(
+            icon,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(26.dp),
+            tint = tint,
+        )
+        if (showTopDot) {
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.TopCenter)
+                        .size(5.dp)
+                        .clip(CircleShape)
+                        .background(Primary),
+            )
+        }
+        if (showBottomDot) {
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .size(5.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)),
+            )
+        }
+    }
+}
+
 val LocalNavBarPadding = compositionLocalOf { 0.dp }
 
 /**
@@ -524,7 +562,7 @@ private fun handleBroadcastDeepLink(
     NotificationDeepLinkTarget.consume(link)
 }
 
-@Suppress("LongMethod", "LongParameterList")
+@Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
 @Composable
 fun MainScreen(
     onNavigateToEventDetail: (String) -> Unit,
@@ -550,6 +588,11 @@ fun MainScreen(
     val profileViewModel: ProfileViewModel = koinViewModel()
     val profileState by profileViewModel.state.collectAsState()
     val profilePicture = profileState.profile?.profilePicture
+
+    val chatClient = koinInject<ChatClient>()
+    val chatRooms by chatClient.rooms.collectAsState()
+    val hasUnreadFriendMessages = chatRooms.any { it.isDirect && it.unreadCount > 0 }
+    val hasUnreadEventMessages = chatRooms.any { !it.isDirect && it.unreadCount > 0 }
 
     val feedbackViewModel: FeedbackViewModel = koinViewModel()
     val feedbackState by feedbackViewModel.state.collectAsState()
@@ -682,11 +725,13 @@ fun MainScreen(
                                                 },
                                         horizontalAlignment = Alignment.CenterHorizontally,
                                     ) {
-                                        Icon(
-                                            if (selected) item.selectedIcon else item.icon,
+                                        val isMessagesTab = item.route is Route.Messages
+                                        NavBarIcon(
+                                            icon = if (selected) item.selectedIcon else item.icon,
                                             contentDescription = item.label,
-                                            modifier = Modifier.size(26.dp),
                                             tint = tint,
+                                            showTopDot = isMessagesTab && hasUnreadFriendMessages,
+                                            showBottomDot = isMessagesTab && hasUnreadEventMessages,
                                         )
                                     }
                                 }


### PR DESCRIPTION
Cyan kropka u góry — nieprzeczytane DM-y znajomych. Szara u dołu — nieprzeczytane wiadomości w eventach.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unread message dot indicators to the Messages tab icon in bottom navigation
> - Adds a `NavBarIcon` composable that renders an icon with optional top and bottom circular dot indicators (5.dp each).
> - The Messages tab shows a top dot (Primary color) for unread direct messages and a bottom dot (muted color) for unread event/group messages, driven by `ChatClient.rooms`.
> - All other bottom nav tabs are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff47228.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->