### PR TITLE
fix(polecane): keep joined events, show check badge

### DIFF
--- a/backend/src/api/matching/mod.rs
+++ b/backend/src/api/matching/mod.rs
@@ -36,14 +36,6 @@ use matching_scoring::{
 
 const PRIVATE_CACHE_SHORT: HeaderValue = HeaderValue::from_static("private, max-age=60");
 
-fn should_exclude_seen_event(
-    event_id: Uuid,
-    saved_event_ids: &std::collections::HashSet<Uuid>,
-    joined_event_ids: &std::collections::HashSet<Uuid>,
-) -> bool {
-    saved_event_ids.contains(&event_id) || joined_event_ids.contains(&event_id)
-}
-
 pub(super) async fn profiles_recommendations(
     State(_ctx): State<AppContext>,
     headers: HeaderMap,
@@ -175,19 +167,13 @@ pub(super) async fn events_recommendations(
                 .map_err(matching_into_diesel)?;
             let my_profile_id = user_ctx.profile.as_ref().map_or(Uuid::nil(), |p| p.id);
 
+            // Saved/joined events stay in the list — hiding them made events
+            // visibly disappear after a tap, which surprised users. The join
+            // state still feeds scoring weights below.
             let future_events = repo
                 .load_future_events(now, candidate_limit, conn)
                 .await
-                .map_err(matching_into_diesel)?
-                .into_iter()
-                .filter(|event| {
-                    !should_exclude_seen_event(
-                        event.id,
-                        &user_ctx.saved_event_ids,
-                        &user_ctx.joined_event_ids,
-                    )
-                })
-                .collect::<Vec<_>>();
+                .map_err(matching_into_diesel)?;
 
             let event_ids: Vec<Uuid> = future_events.iter().map(|e| e.id).collect();
             let all_event_tags = repo
@@ -293,34 +279,4 @@ pub(super) async fn events_recommendations(
         .headers_mut()
         .insert(axum::http::header::CACHE_CONTROL, PRIVATE_CACHE_SHORT);
     Ok(response)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::should_exclude_seen_event;
-    use std::collections::HashSet;
-    use uuid::Uuid;
-
-    #[test]
-    fn seen_events_are_excluded() {
-        let seen = Uuid::from_u128(1);
-        let saved_event_ids = HashSet::from([seen]);
-        let joined_event_ids = HashSet::from([Uuid::from_u128(2)]);
-
-        assert!(should_exclude_seen_event(
-            seen,
-            &saved_event_ids,
-            &joined_event_ids,
-        ));
-        assert!(should_exclude_seen_event(
-            Uuid::from_u128(2),
-            &saved_event_ids,
-            &joined_event_ids,
-        ));
-        assert!(!should_exclude_seen_event(
-            Uuid::from_u128(3),
-            &saved_event_ids,
-            &joined_event_ids,
-        ));
-    }
 }

--- a/backend/tests/requests/migration_contract.rs
+++ b/backend/tests/requests/migration_contract.rs
@@ -436,7 +436,9 @@ async fn events_flow_matches_phase_3_contract() {
             .into_iter()
             .filter_map(|row| row["id"].as_str().map(ToOwned::to_owned))
             .collect::<Vec<_>>();
-        assert!(!matching_event_ids.iter().any(|id| id == &event_id));
+        // Saved/joined events stay in matching results (they used to be hidden,
+        // which made events visibly disappear after a tap).
+        assert!(matching_event_ids.iter().any(|id| id == &event_id));
         assert!(matching_event_ids
             .iter()
             .any(|id| id == &second_music_event_id));

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -78,6 +78,7 @@ import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Overlay
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
 import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.Success
 import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
@@ -391,7 +392,12 @@ private fun EventCard(
                             .fillMaxWidth()
                             .padding(
                                 start = PoziomkiTheme.spacing.md,
-                                end = if (coverImage == null) 56.dp else PoziomkiTheme.spacing.md,
+                                end =
+                                    when {
+                                        coverImage != null -> PoziomkiTheme.spacing.md
+                                        event.isAttending -> 96.dp
+                                        else -> 56.dp
+                                    },
                                 top = PoziomkiTheme.spacing.sm,
                                 bottom = PoziomkiTheme.spacing.sm,
                             ),
@@ -520,7 +526,7 @@ private fun AttendingBadge(modifier: Modifier = Modifier) {
             PhosphorIcons.Fill.CheckCircle,
             contentDescription = "Bierzesz udział",
             modifier = Modifier.size(22.dp),
-            tint = Primary,
+            tint = Success,
         )
     }
 }
@@ -732,16 +738,28 @@ private fun EventRowContent(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        Text(
-            text = event.title,
-            preserveCase = true,
-            fontFamily = MontserratFamily,
-            fontWeight = FontWeight.ExtraBold,
-            fontSize = 18.sp,
-            color = TextPrimary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = event.title,
+                preserveCase = true,
+                fontFamily = MontserratFamily,
+                fontWeight = FontWeight.ExtraBold,
+                fontSize = 18.sp,
+                color = TextPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+            if (event.isAttending) {
+                Spacer(modifier = Modifier.width(PoziomkiTheme.spacing.xs))
+                Icon(
+                    PhosphorIcons.Fill.CheckCircle,
+                    contentDescription = "Bierzesz udział",
+                    modifier = Modifier.size(18.dp),
+                    tint = Success,
+                )
+            }
+        }
         Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = formatEventDate(event.startsAt),

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -59,6 +59,7 @@ import com.adamglin.phosphoricons.bold.CaretUp
 import com.adamglin.phosphoricons.bold.Plus
 import com.adamglin.phosphoricons.bold.SlidersHorizontal
 import com.adamglin.phosphoricons.fill.BookmarkSimple
+import com.adamglin.phosphoricons.fill.CheckCircle
 import com.adamglin.phosphoricons.fill.MapPin
 import com.poziomki.app.network.Event
 import com.poziomki.app.ui.designsystem.Text
@@ -360,9 +361,10 @@ private fun EventCard(
                         contentScale = ContentScale.Crop,
                     )
 
-                    BookmarkOverlay(
+                    EventCornerActions(
                         isSaved = event.isSaved,
-                        onClick = onSaveClick,
+                        isAttending = event.isAttending,
+                        onSaveClick = onSaveClick,
                         modifier =
                             Modifier
                                 .align(Alignment.TopEnd)
@@ -470,9 +472,10 @@ private fun EventCard(
                 }
 
                 if (coverImage == null) {
-                    BookmarkOverlay(
+                    EventCornerActions(
                         isSaved = event.isSaved,
-                        onClick = onSaveClick,
+                        isAttending = event.isAttending,
+                        onSaveClick = onSaveClick,
                         modifier =
                             Modifier
                                 .align(Alignment.TopEnd)
@@ -481,6 +484,44 @@ private fun EventCard(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun EventCornerActions(
+    isSaved: Boolean,
+    isAttending: Boolean,
+    onSaveClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(PoziomkiTheme.spacing.xs),
+    ) {
+        if (isAttending) {
+            AttendingBadge()
+        }
+        BookmarkOverlay(isSaved = isSaved, onClick = onSaveClick)
+    }
+}
+
+@Composable
+private fun AttendingBadge(modifier: Modifier = Modifier) {
+    Box(
+        modifier =
+            modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(Overlay),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            PhosphorIcons.Fill.CheckCircle,
+            contentDescription = "Bierzesz udział",
+            modifier = Modifier.size(22.dp),
+            tint = Primary,
+        )
     }
 }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsViewModel.kt
@@ -48,6 +48,7 @@ class EventsViewModel(
 
     init {
         observeEvents()
+        observeRecommendedEvents()
         refreshEvents()
         loadRecommendedEvents()
         observeSyncErrors()
@@ -62,15 +63,26 @@ class EventsViewModel(
                         _state.value = _state.value.copy(isLoading = false)
                     }
                 } else {
-                    val byId = events.associateBy { it.id }
-                    val syncedRecommended =
-                        _state.value.recommendedEvents.mapNotNull { byId[it.id] }
                     _state.value =
                         _state.value.copy(
                             allEvents = events,
-                            recommendedEvents = syncedRecommended,
                             isLoading = if (events.isNotEmpty()) false else _state.value.isLoading,
                         )
+                    filterEvents()
+                }
+            }
+        }
+    }
+
+    // Drive the recommended list straight from the DB query rather than
+    // re-projecting through `allEvents` — recommended-only events aren't in
+    // the main list feed, and looking them up by id would silently drop them
+    // (the bug that made joined events vanish).
+    private fun observeRecommendedEvents() {
+        viewModelScope.launch {
+            eventRepository.observeRecommendedEvents().collect { events ->
+                if (!eventsVisuallyEqual(_state.value.recommendedEvents, events)) {
+                    _state.value = _state.value.copy(recommendedEvents = events)
                     filterEvents()
                 }
             }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/data/repository/EventRepository.kt
@@ -55,6 +55,10 @@ class EventRepository(
         private const val SAVED_CACHE_KEY = "saved_events"
         private const val MY_EVENTS_CACHE_KEY_PREFIX = "my_events:"
 
+        // Polecane changes slowly and is expensive to compute; the default
+        // 5-min TTL caused users to see the list shuffle every screen visit.
+        private const val RECOMMENDED_STALE_MS = 60L * 60L * 1000L
+
         @Volatile
         private var lastLat: Double? = null
 
@@ -161,7 +165,7 @@ class EventRepository(
                         .selectByKey(RECOMMENDED_CACHE_KEY)
                         .executeAsOneOrNull()
                         ?.cached_at
-                if (cachedAt != null && !CachePolicy.isStale(cachedAt)) {
+                if (cachedAt != null && !CachePolicy.isStale(cachedAt, RECOMMENDED_STALE_MS)) {
                     return@withContext db.eventQueries
                         .selectRecommended()
                         .executeAsList()


### PR DESCRIPTION
Joining an event made it disappear from polecane — backend excluded saved/joined events from /matching/events.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep joined/saved events in recommendations and show attending badge on event cards
> - Removes the backend filter that excluded saved or joined events from recommendations, so those events remain visible in the list.
> - Adds an `AttendingBadge` (check-circle icon) to event cards and row titles in [EventsScreen.kt](https://github.com/poziomki-app/poziomki/pull/502/files#diff-b1aad26129722f5aa103f55ac1d883a2b472203a3df536f251798d2ab83260dd) when the user is attending.
> - Refactors `EventsViewModel` to drive `recommendedEvents` directly from the repository stream rather than deriving them from `allEvents`, so recommended events can include items not yet in the main list.
> - Extends the recommended events cache TTL to one hour in [EventRepository.kt](https://github.com/poziomki-app/poziomki/pull/502/files#diff-ba799a61c5df483672ec816ebfe3e3afc3f9407eb57b4c6ad827c4576f78043e).
> - Behavioral Change: events the user has saved or joined now appear in recommendations where they were previously hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 018ac67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->