### PR TITLE
fix(feedback): RLS-aware insert + scrollable dialog

### DIFF
--- a/backend/src/api/feedback.rs
+++ b/backend/src/api/feedback.rs
@@ -9,6 +9,7 @@ use axum::{
     Json,
 };
 use chrono::Utc;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::RunQueryDsl;
 use serde::Deserialize;
 use uuid::Uuid;
@@ -16,6 +17,7 @@ use uuid::Uuid;
 use super::state::DataResponse;
 use crate::api::common::{auth_or_respond, error_response, ErrorSpec};
 use crate::app::AppContext;
+use crate::db;
 use crate::db::models::user_feedback::NewUserFeedback;
 use crate::db::schema::user_feedback;
 
@@ -92,11 +94,26 @@ pub(super) async fn create(
         feature_request: feature_request.clone(),
     };
 
-    let mut conn = crate::db::conn().await?;
-    diesel::insert_into(user_feedback::table)
-        .values(&row)
-        .execute(&mut conn)
-        .await?;
+    // user_feedback is RLS-gated by user_id = app.current_user_id(). The
+    // viewer-context wrapper sets that for the duration of the tx; a
+    // plain db::conn() insert has no viewer and hits a WITH CHECK
+    // violation (the bug that was masking submissions before).
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let insert_row = row.clone();
+    db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            diesel::insert_into(user_feedback::table)
+                .values(&insert_row)
+                .execute(conn)
+                .await?;
+            Ok::<_, diesel::result::Error>(())
+        }
+        .scope_boxed()
+    })
+    .await?;
 
     // Notify the operator inbox in the background. Failure to send mail
     // must never make the user think their submission was lost — they

--- a/backend/src/db/models/user_feedback.rs
+++ b/backend/src/db/models/user_feedback.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::db::schema::user_feedback;
 
-#[derive(Debug, Insertable)]
+#[derive(Debug, Clone, Insertable)]
 #[diesel(table_name = user_feedback)]
 pub struct NewUserFeedback {
     pub id: Uuid,

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.24.3" // x-release-please-version
+val appVersionName = "0.24.4" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/feedback/FeedbackDialog.kt
@@ -1,5 +1,6 @@
 package com.poziomki.app.ui.feature.feedback
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -8,11 +9,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -56,7 +59,8 @@ fun FeedbackDialog(
             )
         },
         text = {
-            Column {
+            val scrollState = remember { ScrollState(0) }
+            Column(modifier = Modifier.verticalScroll(scrollState)) {
                 Text(
                     text = "Jak oceniasz aplikację?",
                     fontFamily = NunitoFamily,


### PR DESCRIPTION
- `/api/v1/feedback` insert now runs inside `db::with_viewer_tx` so the `user_feedback` RLS `WITH CHECK (user_id = app.current_user_id())` policy passes. Every feedback submission since #499 was returning 500 (Sentry RUST-1).
- Zostaw opinię dialog content is now scrollable — second text area + kontakt footer were clipped by the AlertDialog height on smaller screens.
- Bump 0.24.4

Test plan:
- [ ] Open the dialog on a small device → scroll reveals both text areas + kontakt footer
- [ ] Submit feedback → 200, row lands in `user_feedback` with `feature_request`, email arrives at kontakt@poziomki.app

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLS violation in feedback insert by wrapping it in a viewer-scoped transaction
> - The `api.feedback.create` handler now runs the `user_feedback` insert inside a `db::with_viewer_tx` transaction scoped to the authenticated user, fixing RLS `WITH CHECK` violations that caused inserts to fail silently.
> - `NewUserFeedback` derives `Clone` to support use inside the async closure.
> - The `FeedbackDialog` composable adds vertical scroll to its content `Column`, allowing access to content that overflows the visible area on small screens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6841549.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->