### PR TITLE
Revert lowercase opt-in

### DIFF
--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/Text.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/Text.kt
@@ -16,9 +16,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.material3.Text as M3Text
 
-// Default preserves case. Opt-in to lowercase = true only for deliberately styled
-// static copy (section labels, chips). Never use lowercase on user-generated content,
-// acronyms (OTP, QR), proper nouns, or localized strings (city names, university names).
+// Lowercases static UI copy by project convention. Pass preserveCase = true for
+// user-generated content (names, messages, emails) and acronyms/codes (OTP, QR, URLs).
 @Composable
 @Suppress("LongParameterList")
 fun Text(
@@ -39,10 +38,10 @@ fun Text(
     minLines: Int = 1,
     onTextLayout: ((TextLayoutResult) -> Unit)? = null,
     style: TextStyle = LocalTextStyle.current,
-    lowercase: Boolean = false,
+    preserveCase: Boolean = false,
 ) {
     M3Text(
-        text = if (lowercase) text.lowercase() else text,
+        text = if (preserveCase) text else text.lowercase(),
         modifier = modifier,
         color = color,
         fontSize = fontSize,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ExternalLink.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ExternalLink.kt
@@ -39,6 +39,7 @@ fun rememberExternalLinkOpener(): (String) -> Unit {
             title = {
                 Text(
                     text = if (isMaps) "otworzyć w mapach?" else "otworzyć link zewnętrzny?",
+                    preserveCase = false,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.Bold,
                     fontSize = 18.sp,
@@ -48,6 +49,7 @@ fun rememberExternalLinkOpener(): (String) -> Unit {
             text = {
                 Text(
                     text = humanReadable(url),
+                    preserveCase = true,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.Normal,
                     fontSize = 13.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
@@ -248,6 +248,7 @@ fun LocationPickerSheet(
                             results.forEach { result ->
                                 Text(
                                     text = result.name,
+                                    preserveCase = true,
                                     fontFamily = NunitoFamily,
                                     fontSize = 14.sp,
                                     color = TextPrimary,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt
@@ -121,6 +121,7 @@ fun ProfileCard(
             ) {
                 Text(
                     text = name,
+                    preserveCase = true,
                     fontFamily = MontserratFamily,
                     fontWeight = FontWeight.ExtraBold,
                     fontSize = 19.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt
@@ -271,6 +271,7 @@ fun ProfilePreview(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = name.ifBlank { "imi\u0119" },
+                        preserveCase = true,
                         fontFamily = montserrat,
                         fontWeight = FontWeight.ExtraBold,
                         fontSize = 28.sp,
@@ -353,6 +354,7 @@ private fun RichBio(bio: String) {
     if (!bio.contains("![](")) {
         Text(
             text = bio,
+            preserveCase = true,
             fontFamily = nunito,
             fontWeight = FontWeight.Normal,
             fontSize = 15.sp,
@@ -370,6 +372,7 @@ private fun RichBio(bio: String) {
                     if (segment.text.isNotBlank()) {
                         Text(
                             text = segment.text,
+                            preserveCase = true,
                             fontFamily = nunito,
                             fontWeight = FontWeight.Normal,
                             fontSize = 15.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/ResetPasswordScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/ResetPasswordScreen.kt
@@ -78,6 +78,7 @@ fun ResetPasswordScreen(
 
         Text(
             text = email,
+            preserveCase = true,
             fontFamily = NunitoFamily,
             fontWeight = FontWeight.SemiBold,
             fontSize = 14.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/VerifyScreen.kt
@@ -92,6 +92,7 @@ fun VerifyScreen(
 
         Text(
             text = email,
+            preserveCase = true,
             fontFamily = NunitoFamily,
             fontWeight = FontWeight.SemiBold,
             fontSize = 16.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt
@@ -475,6 +475,7 @@ private fun MessageActionDialog(
                     listOf("❤️", "👍", "👎", "😂", "😮", "😢", "🔥", "🎉").forEach { emoji ->
                         Text(
                             text = emoji,
+                            preserveCase = true,
                             style = MaterialTheme.typography.headlineSmall,
                             modifier =
                                 Modifier
@@ -491,6 +492,7 @@ private fun MessageActionDialog(
                 ) {
                     Text(
                         text = event.body,
+                        preserveCase = true,
                         style = MaterialTheme.typography.bodyMedium,
                         color = TextPrimary,
                         maxLines = 3,
@@ -639,6 +641,7 @@ private fun ReactionBreakdownSheet(
 
                     Text(
                         text = name,
+                        preserveCase = true,
                         style = MaterialTheme.typography.bodyLarge,
                         color = TextPrimary,
                         maxLines = 1,
@@ -648,6 +651,7 @@ private fun ReactionBreakdownSheet(
 
                     Text(
                         text = emoji,
+                        preserveCase = true,
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
@@ -766,6 +770,7 @@ internal fun ComposerModeBanner(
                         )
                         Text(
                             text = mode.bodyPreview,
+                            preserveCase = true,
                             style = MaterialTheme.typography.bodySmall,
                             color = TextSecondary,
                             maxLines = 1,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatScreen.kt
@@ -271,6 +271,7 @@ private fun ChatTopBar(
                     color = TextPrimary,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                    preserveCase = true,
                 )
             }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/MessageEventRow.kt
@@ -241,6 +241,7 @@ internal fun MessageEventRow(
                                             ) {
                                                 Text(
                                                     text = reaction.emoji,
+                                                    preserveCase = true,
                                                     style = MaterialTheme.typography.labelSmall,
                                                 )
                                                 if (reactionCount > 1) {
@@ -277,6 +278,7 @@ internal fun MessageEventRow(
                                     val senderNameColor = ChatNameColors[abs(event.senderId.hashCode()) % ChatNameColors.size]
                                     Text(
                                         text = event.senderDisplayName ?: event.senderId,
+                                        preserveCase = true,
                                         style = MaterialTheme.typography.labelSmall,
                                         color = senderNameColor,
                                         maxLines = 1,
@@ -357,6 +359,7 @@ internal fun MessageEventRow(
                                                 ) {
                                                     Text(
                                                         text = reaction.emoji,
+                                                        preserveCase = true,
                                                         style = MaterialTheme.typography.labelSmall,
                                                     )
                                                     if (reactionCount > 1) {
@@ -403,6 +406,7 @@ private fun BubbleContent(
         }
         Text(
             text = event.body,
+            preserveCase = true,
             style = MaterialTheme.typography.bodyLarge,
             color = TextPrimary,
         )
@@ -575,6 +579,7 @@ private fun ReplyReference(
             Column {
                 Text(
                     text = reply.senderDisplayName ?: "wiadomość",
+                    preserveCase = true,
                     style = MaterialTheme.typography.labelSmall,
                     color = TextSecondary,
                     maxLines = 1,
@@ -582,6 +587,7 @@ private fun ReplyReference(
                 )
                 Text(
                     text = reply.body ?: "odpowiedź",
+                    preserveCase = true,
                     style = MaterialTheme.typography.bodySmall,
                     color = TextPrimary,
                     maxLines = 1,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatHeader.kt
@@ -174,6 +174,7 @@ fun EventMetaRows(
                 icon = PhosphorIcons.Fill.MapPin,
                 text = formatEventLocation(location),
                 onClick = onLocationClick,
+                preserveCase = true,
                 modifier = Modifier.weight(1f, fill = false),
             )
         }
@@ -207,6 +208,7 @@ private fun MetaChip(
     text: String,
     onClick: (() -> Unit)? = null,
     accent: Boolean = false,
+    preserveCase: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val shape = RoundedCornerShape(50)
@@ -215,11 +217,11 @@ private fun MetaChip(
 
     if (onClick != null) {
         Surface(onClick = onClick, shape = shape, color = bgColor, modifier = modifier) {
-            ChipContent(icon = icon, text = text, tint = contentColor)
+            ChipContent(icon = icon, text = text, tint = contentColor, preserveCase = preserveCase)
         }
     } else {
         Surface(shape = shape, color = bgColor, modifier = modifier) {
-            ChipContent(icon = icon, text = text, tint = contentColor)
+            ChipContent(icon = icon, text = text, tint = contentColor, preserveCase = preserveCase)
         }
     }
 }
@@ -229,6 +231,7 @@ private fun ChipContent(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     text: String,
     tint: Color,
+    preserveCase: Boolean = false,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -252,6 +255,7 @@ private fun ChipContent(
             color = tint,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
+            preserveCase = preserveCase,
         )
     }
 }
@@ -393,6 +397,7 @@ fun EventChatHeader(
                 }
             Text(
                 text = event.title,
+                preserveCase = true,
                 fontFamily = MontserratFamily,
                 fontSize = titleFontSize,
                 lineHeight = titleFontSize * 1.15f,
@@ -417,6 +422,7 @@ fun EventChatHeader(
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = creator.name,
+                        preserveCase = true,
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = Primary,
@@ -525,6 +531,7 @@ private fun AttendeesDialog(
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = attendee.name,
+                                preserveCase = true,
                                 fontFamily = NunitoFamily,
                                 fontWeight = FontWeight.SemiBold,
                                 fontSize = 14.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -183,6 +183,7 @@ fun EventChatJoinRequiredView(
             ) {
                 Text(
                     text = event.title,
+                    preserveCase = true,
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.ExtraBold,
                     color = Color.White,
@@ -262,6 +263,7 @@ fun EventChatJoinRequiredView(
                     Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xs))
                     Text(
                         text = description,
+                        preserveCase = true,
                         style = MaterialTheme.typography.bodyMedium,
                         color = TextSecondary,
                     )

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -397,6 +397,7 @@ private fun EventCard(
                     // Title
                     Text(
                         text = event.title,
+                        preserveCase = true,
                         style = MaterialTheme.typography.titleMedium,
                         color = TextPrimary,
                         fontWeight = FontWeight.Bold,
@@ -431,6 +432,7 @@ private fun EventCard(
                             Spacer(modifier = Modifier.width(2.dp))
                             Text(
                                 text = formatEventLocation(location),
+                                preserveCase = true,
                                 fontFamily = NunitoFamily,
                                 fontWeight = FontWeight.Normal,
                                 fontSize = 14.sp,
@@ -457,6 +459,7 @@ private fun EventCard(
                             }
                             Text(
                                 text = event.attendeeUsageLabel(),
+                                preserveCase = true,
                                 fontFamily = NunitoFamily,
                                 fontWeight = FontWeight.Bold,
                                 fontSize = 15.sp,
@@ -532,6 +535,7 @@ private fun CategoryFloatingChip(
         Spacer(modifier = Modifier.width(6.dp))
         Text(
             text = info.displayName,
+            preserveCase = true,
             fontFamily = NunitoFamily,
             fontWeight = FontWeight.SemiBold,
             fontSize = 12.sp,
@@ -689,6 +693,7 @@ private fun EventRowContent(
     Column(modifier = modifier) {
         Text(
             text = event.title,
+            preserveCase = true,
             fontFamily = MontserratFamily,
             fontWeight = FontWeight.ExtraBold,
             fontSize = 18.sp,
@@ -715,6 +720,7 @@ private fun EventRowContent(
                 Spacer(modifier = Modifier.width(3.dp))
                 Text(
                     text = formatEventLocation(location),
+                    preserveCase = true,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.Normal,
                     fontSize = 13.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
@@ -408,6 +408,7 @@ internal fun NearbyEventsContent(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = selectedEvent.title,
+                        preserveCase = true,
                         fontFamily = MontserratFamily,
                         fontWeight = FontWeight.ExtraBold,
                         fontSize = 18.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/PoziomkiMapStyle.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/PoziomkiMapStyle.kt
@@ -90,7 +90,8 @@ internal val POZIOMKI_MAP_STYLE_JSON: String =
             "text-field": ["coalesce", ["get", "name:pl"], ["get", "name:latin"], ["get", "name"]],
             "text-font": ["Noto Sans Bold"],
             "text-size": ["interpolate", ["linear"], ["zoom"], 11, 12, 16, 20],
-            "text-letter-spacing": 0.04
+            "text-letter-spacing": 0.04,
+            "text-transform": "lowercase"
           },
           "paint": { "text-color": "#1F2A33" } },
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/RecommendedPeopleRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/RecommendedPeopleRow.kt
@@ -136,6 +136,7 @@ private fun RecommendedPersonItem(
 
         Text(
             text = firstName,
+            preserveCase = true,
             fontFamily = NunitoFamily,
             fontWeight = FontWeight.Medium,
             fontSize = 12.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/messages/RoomRow.kt
@@ -80,6 +80,7 @@ fun RoomRow(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = displayName,
+                    preserveCase = true,
                     style = MaterialTheme.typography.titleMedium,
                     color = TextPrimary,
                     fontWeight = FontWeight.SemiBold,
@@ -107,6 +108,7 @@ fun RoomRow(
                         room.latestModerationVerdict in setOf("flag", "block")
                 Text(
                     text = room.latestMessagePreview(),
+                    preserveCase = true,
                     style = MaterialTheme.typography.bodyMedium,
                     color = if (room.unreadCount > 0) TextPrimary else TextSecondary,
                     fontStyle = if (flagged) FontStyle.Italic else null,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
@@ -260,6 +260,7 @@ private fun ProfilePreviewCard(
             ) {
                 Text(
                     text = state.name.ifBlank { "imi\u0119" },
+                    preserveCase = true,
                     fontFamily = MontserratFamily,
                     fontWeight = FontWeight.ExtraBold,
                     fontSize = 19.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangeEmailDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ChangeEmailDialog.kt
@@ -104,6 +104,7 @@ private fun EnterEmailStep(
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
                         text = it,
+                        preserveCase = true,
                         fontFamily = NunitoFamily,
                         fontWeight = FontWeight.Medium,
                         fontSize = 13.sp,
@@ -170,6 +171,7 @@ private fun OtpStep(
                 )
                 Text(
                     text = newEmail,
+                    preserveCase = true,
                     fontFamily = NunitoFamily,
                     fontWeight = FontWeight.SemiBold,
                     fontSize = 14.sp,
@@ -185,6 +187,7 @@ private fun OtpStep(
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
                         text = it,
+                        preserveCase = true,
                         fontFamily = NunitoFamily,
                         fontWeight = FontWeight.Medium,
                         fontSize = 13.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/PrivacyScreen.kt
@@ -221,6 +221,7 @@ private fun PrivacyContent(
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.sm))
         Text(
             text = state.currentEmail.orEmpty(),
+            preserveCase = true,
             fontFamily = nunito,
             fontWeight = FontWeight.SemiBold,
             fontSize = 15.sp,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
@@ -268,6 +268,7 @@ fun ProfileEditScreen(
                 ) {
                     Text(
                         text = state.program.ifEmpty { "Wybierz kierunek" },
+                        preserveCase = true,
                         fontFamily = nunito,
                         fontWeight = FontWeight.Normal,
                         fontSize = 16.sp,
@@ -1099,6 +1100,7 @@ private fun GradientPickerDialog(
                 Column {
                     Text(
                         text = name.ifBlank { "imię" },
+                        preserveCase = true,
                         fontFamily = montserrat,
                         fontWeight = FontWeight.ExtraBold,
                         fontSize = 22.sp,
@@ -1117,6 +1119,7 @@ private fun GradientPickerDialog(
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(
                             text = bio,
+                            preserveCase = true,
                             fontFamily = nunito,
                             fontWeight = FontWeight.Normal,
                             fontSize = 14.sp,


### PR DESCRIPTION
Revert #500. Default flip zostawia mixed case w copy napisanym z myślą o auto-lowercase (Anuluj/OK/Zmień email itp.). Wracam do starego zachowania.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the design system `Text` composable lowercase by default and opt-out with `preserveCase`
> - Renames the `lowercase` parameter on the `Text` composable to `preserveCase` (default `false`), inverting the behavior so text is lowercased unless `preserveCase = true` is passed.
> - Updates all call sites across auth, chat, event, home, onboarding, and profile features to pass `preserveCase = true` wherever user-generated or data-driven strings (names, emails, bios, message bodies, emoji) must retain their original casing.
> - Adds `"text-transform": "lowercase"` to the `place-label` layer in the map style JSON so map labels also render lowercase.
> - Behavioral Change: any existing `Text` call that does not explicitly set `preserveCase = true` will now render its content in lowercase.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1d34efb. 21 files reviewed, 10 issues evaluated, 6 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 134](https://github.com/poziomki-app/poziomki/blob/1d34efbe0723a668770a7c466b029024a739483d/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfileCard.kt#L134): The `program` field at line 134 is missing `preserveCase = true`. After the `Text` component's default changed from preserving case to lowercasing, this user-generated content (university program names like "Computer Science", "MBA", etc.) will now be incorrectly lowercased. The developer correctly added `preserveCase = true` to `name` but appears to have overlooked `program`, which is the same category of user content per the `Text` component's documentation. <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 282](https://github.com/poziomki-app/poziomki/blob/1d34efbe0723a668770a7c466b029024a739483d/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/ProfilePreview.kt#L282): The `program` text at line 282 does not specify `preserveCase = true`, so it will be lowercased due to the changed default behavior in the `Text` composable. Since `program` is profile data (similar to `name` which correctly has `preserveCase = true` at line 274), academic program names like "Informatyka" or "Computer Science" will be incorrectly displayed in lowercase. The fix is to add `preserveCase = true` to the `Text` call at line 282. <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 766](https://github.com/poziomki-app/poziomki/blob/1d34efbe0723a668770a7c466b029024a739483d/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/chat/ChatContent.kt#L766): The `Text` at line 766 renders `mode.senderDisplayName` (user-generated content) without `preserveCase = true`, causing the user's display name to be lowercased. Per the `Text` function's documented convention, `preserveCase = true` should be passed for user-generated content like names. The string `"Odpowiedź do ${mode.senderDisplayName ?: "użytkownik"}"` will have the entire interpolated result lowercased, so a name like "Jan Kowalski" becomes "jan kowalski". <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 457](https://github.com/poziomki-app/poziomki/blob/1d34efbe0723a668770a7c466b029024a739483d/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt#L457): The `displayLocation` Text on line 457 is missing `preserveCase = true`. This field contains either `selectedEvent.location` (user-provided) or `geocodedLocation` (reverse-geocoded street/place names from `GeocodingService`). With the default behavior change to lowercase, proper nouns like street names (e.g., "Krakowskie Przedmieście", "Uniwersytet Warszawski") will be incorrectly lowercased. The developer correctly added `preserveCase = true` to the event title at line 411 but missed the location text. <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 214](https://github.com/poziomki-app/poziomki/blob/1d34efbe0723a668770a7c466b029024a739483d/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt#L214): The bio text preview at line 214 displays user-generated content (`textOnly` derived from `state.bio`) without `preserveCase = true`. With the new default behavior in `Text.kt` that lowercases all text unless `preserveCase = true` is set, the user's bio will be incorrectly displayed in lowercase in the preview box. The convention comment explicitly states "Pass preserveCase = true for user-generated content (names, messages, emails)". <b>[ Out of scope ]</b>
> - [line 1111](https://github.com/poziomki-app/poziomki/blob/1d34efbe0723a668770a7c466b029024a739483d/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt#L1111): The `program` field at line 1111 is missing `preserveCase = true`. This is user-generated content (university degree names) that will be incorrectly lowercased. The diff added `preserveCase = true` to `name` and `bio` but missed `program`. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->