### PR TITLE
feat(events): admin-only featured flag + wyróżnione badge

### DIFF
--- a/backend/migrations/2026-05-19-220000_events_is_featured/down.sql
+++ b/backend/migrations/2026-05-19-220000_events_is_featured/down.sql
@@ -1,0 +1,3 @@
+DROP FUNCTION IF EXISTS app.admin_set_event_featured(uuid, boolean);
+DROP INDEX IF EXISTS events_is_featured_idx;
+ALTER TABLE public.events DROP COLUMN is_featured;

--- a/backend/migrations/2026-05-19-220000_events_is_featured/up.sql
+++ b/backend/migrations/2026-05-19-220000_events_is_featured/up.sql
@@ -1,0 +1,40 @@
+-- Featured events: admin-only flag that floats an event to the top of
+-- listings and gets a "wyróżnione" badge on the card. Not exposed
+-- through the public event-create payload — only togglable via
+-- POST /api/v1/admin/events/{id}/feature.
+
+ALTER TABLE public.events
+    ADD COLUMN is_featured BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX events_is_featured_idx ON public.events (is_featured) WHERE is_featured;
+
+-- SECURITY DEFINER helper so the admin endpoint can toggle is_featured
+-- without a viewer context (events is RLS-gated by viewer policies).
+-- Returns true iff a row was updated. UPDATE-only — never creates events.
+CREATE OR REPLACE FUNCTION app.admin_set_event_featured(p_event_id uuid, p_is_featured boolean)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+DECLARE
+    rows_updated integer;
+BEGIN
+    UPDATE public.events
+    SET is_featured = p_is_featured,
+        updated_at = now()
+    WHERE id = p_event_id;
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    RETURN rows_updated > 0;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION app.admin_set_event_featured(uuid, boolean) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.admin_set_event_featured(uuid, boolean) TO poziomki_api';
+    END IF;
+END
+$$;

--- a/backend/src/api/admin.rs
+++ b/backend/src/api/admin.rs
@@ -50,6 +50,11 @@ pub(super) struct BroadcastBody {
     pub deep_link: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct FeatureEventBody {
+    pub is_featured: bool,
+}
+
 fn admin_auth(headers: &HeaderMap) -> Result<(), Box<Response>> {
     let Some(expected) = std::env::var("ADMIN_TOKEN")
         .ok()
@@ -232,4 +237,70 @@ pub(super) async fn broadcast_push(
         })),
     )
         .into_response()
+}
+
+/// Toggle an event's `is_featured` flag. The public event-create payload
+/// does NOT accept this — only operators can mark an event featured via
+/// this endpoint. Featured events sort to the top of the wydarzenia list
+/// and render with a "wyróżnione" badge.
+pub(super) async fn feature_event(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(event_id): Path<Uuid>,
+    Json(body): Json<FeatureEventBody>,
+) -> Response {
+    if let Err(resp) = crate::api::ip_rate_limit::enforce_ip_rate_limit(
+        &headers,
+        crate::api::ip_rate_limit::IpRateLimitAction::AdminAuth,
+    )
+    .await
+    {
+        return *resp;
+    }
+    if let Err(resp) = admin_auth(&headers) {
+        return *resp;
+    }
+
+    let Ok(mut conn) = crate::db::conn().await else {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &headers,
+            ErrorSpec {
+                error: "DB unavailable".to_string(),
+                code: "INTERNAL_ERROR",
+                details: None,
+            },
+        );
+    };
+
+    // events is RLS-gated by the viewer policy; admin has no viewer
+    // context. Route through a narrow SECURITY DEFINER helper.
+    let rows = diesel::sql_query("SELECT app.admin_set_event_featured($1, $2) AS updated")
+        .bind::<SqlUuid, _>(event_id)
+        .bind::<diesel::sql_types::Bool, _>(body.is_featured)
+        .execute(&mut conn)
+        .await;
+
+    match rows {
+        Ok(_) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "event_id": event_id,
+                "is_featured": body.is_featured,
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::warn!(error = %e, "admin feature_event failed");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &headers,
+                ErrorSpec {
+                    error: "feature toggle failed".to_string(),
+                    code: "INTERNAL_ERROR",
+                    details: None,
+                },
+            )
+        }
+    }
 }

--- a/backend/src/api/events/repo.rs
+++ b/backend/src/api/events/repo.rs
@@ -18,7 +18,9 @@ pub(in crate::api) async fn list_upcoming_events(
                 .and(events::starts_at.ge(now))
                 .or(events::ends_at.ge(now)),
         )
-        .order(events::starts_at.asc())
+        // Featured events float to the top; otherwise chronological by
+        // start time. Admin sets is_featured via POST /admin/events/{id}/feature.
+        .order((events::is_featured.desc(), events::starts_at.asc()))
         .limit(limit)
         .load::<Event>(conn)
         .await?;

--- a/backend/src/api/events/view.rs
+++ b/backend/src/api/events/view.rs
@@ -97,6 +97,7 @@ fn build_from_context(
         is_saved,
         is_pending,
         requires_approval: event.requires_approval,
+        is_featured: event.is_featured,
         conversation_id: event.conversation_id.clone(),
         score: None,
     }

--- a/backend/src/api/matching/scoring.rs
+++ b/backend/src/api/matching/scoring.rs
@@ -315,6 +315,7 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
             requires_approval: false,
+            is_featured: false,
         };
 
         let score = score_event(

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -43,6 +43,7 @@ fn admin_routes() -> Router<AppContext> {
     Router::new()
         .route("/users/{pid}/ban", post(admin::ban_user))
         .route("/broadcast", post(admin::broadcast_push))
+        .route("/events/{event_id}/feature", post(admin::feature_event))
         .layer(cache_layer("no-store"))
 }
 

--- a/backend/src/api/state/event_responses.rs
+++ b/backend/src/api/state/event_responses.rs
@@ -40,6 +40,8 @@ pub(in crate::api) struct EventResponse {
     pub(in crate::api) is_pending: bool,
     #[serde(rename = "requiresApproval")]
     pub(in crate::api) requires_approval: bool,
+    #[serde(rename = "isFeatured")]
+    pub(in crate::api) is_featured: bool,
     #[serde(rename = "conversationId")]
     pub(in crate::api) conversation_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/backend/src/db/models/events.rs
+++ b/backend/src/db/models/events.rs
@@ -23,6 +23,7 @@ pub struct Event {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub requires_approval: bool,
+    pub is_featured: bool,
 }
 
 #[derive(Debug, Insertable)]
@@ -62,4 +63,5 @@ pub struct EventChangeset {
     pub max_attendees: Option<Option<i32>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub requires_approval: Option<bool>,
+    pub is_featured: Option<bool>,
 }

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -155,6 +155,7 @@ diesel::table! {
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
         requires_approval -> Bool,
+        is_featured -> Bool,
     }
 }
 

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.24.6" // x-release-please-version
+val appVersionName = "0.24.7" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -402,6 +402,16 @@ private fun EventCard(
                                 bottom = PoziomkiTheme.spacing.sm,
                             ),
                 ) {
+                    if (event.isFeatured) {
+                        Text(
+                            text = "wyróżnione",
+                            fontFamily = NunitoFamily,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 11.sp,
+                            color = Primary,
+                        )
+                        Spacer(modifier = Modifier.height(2.dp))
+                    }
                     // Title
                     Text(
                         text = event.title,

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/Models.kt
@@ -172,6 +172,7 @@ data class Event(
     val isSaved: Boolean = false,
     val isPending: Boolean = false,
     val requiresApproval: Boolean = false,
+    val isFeatured: Boolean = false,
     val creator: EventCreator? = null,
     val attendeesPreview: List<EventAttendeePreview> = emptyList(),
     val tags: List<Tag> = emptyList(),


### PR DESCRIPTION
- New is_featured column on events (admin-only, not exposed via public create payload)
- POST /api/v1/admin/events/{id}/feature toggles via SECURITY DEFINER helper
- Listing sort puts featured first
- Android shows small wyróżnione label above title
- Bump 0.24.7

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add admin-only `is_featured` flag to events with 'wyróżnione' badge in mobile UI
> - Adds `is_featured` boolean column to the `events` table via migration, with a partial index for efficient lookups and a `SECURITY DEFINER` DB function `app.admin_set_event_featured` for privileged updates.
> - Exposes a new admin HTTP endpoint `POST /events/{event_id}/feature` that toggles the featured flag and returns the updated state.
> - Featured events sort to the top of `list_upcoming_events` results (by `is_featured DESC, starts_at ASC`) and the `isFeatured` field is included in event API responses.
> - The mobile [EventCard](https://github.com/poziomki-app/poziomki/pull/509/files#diff-b1aad26129722f5aa103f55ac1d883a2b472203a3df536f251798d2ab83260dd) renders a small 'wyróżnione' label in primary color above the title when `isFeatured` is true.
> - Behavioral Change: the upcoming events sort order now puts featured events first, which changes the default listing order for all callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7d1cad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->