### PR TITLE
ui: small zapisz pill + opis reuses bio editor

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.24.7" // x-release-please-version
+val appVersionName = "0.24.8" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventChatStateViews.kt
@@ -325,7 +325,7 @@ private fun AttendeesCluster(
 }
 
 @Composable
-private fun JoinPillButton(
+internal fun JoinPillButton(
     text: String,
     onClick: () -> Unit,
     enabled: Boolean = true,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -80,6 +81,7 @@ import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.designsystem.theme.White
+import com.poziomki.app.ui.feature.profile.BioEditorDialog
 import com.poziomki.app.ui.shared.POLISH_MONTHS_GENITIVE
 import com.poziomki.app.ui.shared.decodeImageBytes
 import com.poziomki.app.ui.shared.formatPolishDateFromMillis
@@ -126,6 +128,7 @@ fun EventCreateScreen(
     var showDatePicker by remember { mutableStateOf(false) }
     var showTimePicker by remember { mutableStateOf(false) }
     var showEndTimePicker by remember { mutableStateOf(false) }
+    var showDescriptionEditor by remember { mutableStateOf(false) }
     var selectedDateMillis by remember { mutableStateOf<Long?>(null) }
     var selectedHour by remember { mutableStateOf(18) }
     var selectedMinute by remember { mutableStateOf(0) }
@@ -450,16 +453,39 @@ fun EventCreateScreen(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
-            // Description
+            // Description — same UX as bio editor (full-screen on tap, no images).
             SectionLabel("opis")
-            PoziomkiTextField(
-                value = state.description,
-                onValueChange = viewModel::updateDescription,
-                placeholder = "co, dla kogo, jak się przygotować",
-                singleLine = false,
-                maxLines = 5,
-                minLines = 3,
-            )
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .defaultMinSize(minHeight = 48.dp)
+                        .background(SurfaceColor, RoundedCornerShape(PoziomkiTheme.radius.md))
+                        .border(1.dp, Border, RoundedCornerShape(PoziomkiTheme.radius.md))
+                        .clip(RoundedCornerShape(PoziomkiTheme.radius.md))
+                        .clickable { showDescriptionEditor = true }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+            ) {
+                if (state.description.isBlank()) {
+                    Text(
+                        text = "co, dla kogo, jak się przygotować",
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 16.sp,
+                        color = TextMuted,
+                    )
+                } else {
+                    Text(
+                        text = state.description,
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 16.sp,
+                        color = TextPrimary,
+                        maxLines = 4,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    )
+                }
+            }
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
 
@@ -711,6 +737,20 @@ fun EventCreateScreen(
                 },
             )
         }
+    }
+
+    // Description editor — reuses the bio editor full-screen, no image inserts.
+    if (showDescriptionEditor) {
+        BioEditorDialog(
+            bio = state.description,
+            isBioImageUploading = false,
+            onBioChange = viewModel::updateDescription,
+            onAddImage = {},
+            onDismiss = { showDescriptionEditor = false },
+            title = "opis",
+            maxChars = 4000,
+            allowImages = false,
+        )
     }
 
     // Location Picker Sheet

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
@@ -92,6 +92,7 @@ import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import com.poziomki.app.ui.designsystem.theme.White
+import com.poziomki.app.ui.feature.event.JoinPillButton
 import com.poziomki.app.ui.shared.rememberSingleImagePicker
 import com.poziomki.app.ui.shared.resolveImageUrl
 import org.koin.compose.viewmodel.koinViewModel
@@ -330,14 +331,17 @@ fun ProfileEditScreen(
 
                 Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
 
-                // Save button
-                AppButton(
-                    text = "zapisz",
-                    onClick = { viewModel.save(onBack) },
-                    variant = ButtonVariant.PRIMARY,
-                    loading = state.isSaving,
+                // Save button — small pill, right-aligned to match dołącz style.
+                Row(
                     modifier = Modifier.fillMaxWidth(),
-                )
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    JoinPillButton(
+                        text = "zapisz",
+                        onClick = { viewModel.save(onBack) },
+                        loading = state.isSaving,
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(navBarBottom + PoziomkiTheme.spacing.xl))
             }
@@ -798,13 +802,17 @@ private object BioImageVisualTransformation : VisualTransformation {
     }
 }
 
+@Suppress("LongParameterList", "LongMethod")
 @Composable
-private fun BioEditorDialog(
+internal fun BioEditorDialog(
     bio: String,
     isBioImageUploading: Boolean,
     onBioChange: (String) -> Unit,
     onAddImage: () -> Unit,
     onDismiss: () -> Unit,
+    title: String = "bio",
+    maxChars: Int = 1500,
+    allowImages: Boolean = true,
 ) {
     val nunito = NunitoFamily
     val focusRequester = remember { FocusRequester() }
@@ -830,7 +838,7 @@ private fun BioEditorDialog(
                 // Top bar
                 Spacer(modifier = Modifier.height(WindowInsets.statusBars.asPaddingValues().calculateTopPadding()))
                 ScreenHeader(
-                    title = "bio",
+                    title = title,
                     onBack = onDismiss,
                 )
 
@@ -934,22 +942,24 @@ private fun BioEditorDialog(
                             .padding(horizontal = PoziomkiTheme.spacing.md, vertical = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    if (isBioImageUploading) {
-                        CircularProgressIndicator(
-                            color = Primary,
-                            modifier = Modifier.size(20.dp),
-                            strokeWidth = 2.dp,
-                        )
-                    } else {
-                        Icon(
-                            PhosphorIcons.Bold.Image,
-                            contentDescription = "Dodaj zdjęcie",
-                            tint = TextMuted,
-                            modifier =
-                                Modifier
-                                    .size(20.dp)
-                                    .clickable(onClick = onAddImage),
-                        )
+                    if (allowImages) {
+                        if (isBioImageUploading) {
+                            CircularProgressIndicator(
+                                color = Primary,
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Icon(
+                                PhosphorIcons.Bold.Image,
+                                contentDescription = "Dodaj zdjęcie",
+                                tint = TextMuted,
+                                modifier =
+                                    Modifier
+                                        .size(20.dp)
+                                        .clickable(onClick = onAddImage),
+                            )
+                        }
                     }
                     Spacer(modifier = Modifier.weight(1f))
                     val visibleLength =
@@ -957,22 +967,21 @@ private fun BioEditorDialog(
                             bio.replace(Regex("""!\[\]\([^)]*\)"""), "").length
                         }
                     Text(
-                        text = "$visibleLength/1500",
+                        text = "$visibleLength/$maxChars",
                         fontFamily = nunito,
                         fontWeight = FontWeight.Normal,
                         fontSize = 12.sp,
                         color =
-                            if (visibleLength > 1400) {
+                            if (visibleLength > maxChars - 100) {
                                 com.poziomki.app.ui.designsystem.theme.Error
                             } else {
                                 TextMuted
                             },
                     )
-                    AppButton(
+                    Spacer(modifier = Modifier.width(12.dp))
+                    JoinPillButton(
                         text = "zapisz",
                         onClick = onDismiss,
-                        variant = ButtonVariant.PRIMARY,
-                        modifier = Modifier.padding(start = 12.dp),
                     )
                 }
             }


### PR DESCRIPTION
Pill matches dołącz styling. Opis field gets the same full-screen editor as bio (images disabled). Bump 0.24.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace inline description field in event creation with full-screen `BioEditorDialog`
> - Tapping the description field in `EventCreateScreen` now opens `BioEditorDialog` (no image insertion, 4000-char limit) instead of an inline text field; the field shows a 4-line ellipsized preview or placeholder.
> - `BioEditorDialog` in [ProfileEditScreen.kt](https://github.com/poziomki-app/poziomki/pull/510/files#diff-765a0bfa960ac3d97ec00ad0eaefbb004cfc044f0cd7c99d27ef9ccbdedcc95a) is made `internal` and extended with `title`, `maxChars`, and `allowImages` parameters to support reuse.
> - The 'zapisz' (save) button in both `ProfileEditScreen` and `BioEditorDialog` is replaced with a right-aligned `JoinPillButton` instead of a full-width primary button.
> - App version bumped to 0.24.8.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 281b3b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->