### PR TITLE
ui: char counter left + utwórz wydarzenie SECONDARY

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.24.8" // x-release-please-version
+val appVersionName = "0.24.9" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/event/EventCreateScreen.kt
@@ -64,7 +64,6 @@ import com.adamglin.phosphoricons.bold.X
 import com.poziomki.app.network.Tag
 import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.components.AppButton
-import com.poziomki.app.ui.designsystem.components.ButtonVariant
 import com.poziomki.app.ui.designsystem.components.LocationPickerSheet
 import com.poziomki.app.ui.designsystem.components.PoziomkiTextField
 import com.poziomki.app.ui.designsystem.components.ScreenHeader
@@ -669,11 +668,10 @@ fun EventCreateScreen(
 
             Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.xl))
 
-            // Submit
+            // Submit — matches wyloguj (SECONDARY default) for visual consistency.
             AppButton(
                 text = if (isEditMode) "zapisz zmiany" else "utwórz wydarzenie",
                 onClick = { viewModel.saveEvent(onCreated) },
-                variant = ButtonVariant.PRIMARY,
                 enabled =
                     state.title.isNotBlank() &&
                         state.startsAt.isNotBlank() &&

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
@@ -960,8 +960,8 @@ internal fun BioEditorDialog(
                                         .clickable(onClick = onAddImage),
                             )
                         }
+                        Spacer(modifier = Modifier.width(12.dp))
                     }
-                    Spacer(modifier = Modifier.weight(1f))
                     val visibleLength =
                         remember(bio) {
                             bio.replace(Regex("""!\[\]\([^)]*\)"""), "").length
@@ -978,7 +978,7 @@ internal fun BioEditorDialog(
                                 TextMuted
                             },
                     )
-                    Spacer(modifier = Modifier.width(12.dp))
+                    Spacer(modifier = Modifier.weight(1f))
                     JoinPillButton(
                         text = "zapisz",
                         onClick = onDismiss,


### PR DESCRIPTION
Two small fixes. Bump 0.24.9.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change event creation submit button to default variant and fix bio editor spacer layout
> - The submit button in [EventCreateScreen.kt](https://github.com/poziomki-app/poziomki/pull/511/files#diff-9e272942315a25548e3ad7e20394cb37de4deefa7fd99982d2c6b3e59469b028) now uses `AppButton`'s default variant instead of the explicit `PRIMARY` variant, aligning its appearance with other buttons like the logout button.
> - The bio editor dialog in [ProfileEditScreen.kt](https://github.com/poziomki-app/poziomki/pull/511/files#diff-765a0bfa960ac3d97ec00ad0eaefbb004cfc044f0cd7c99d27ef9ccbdedcc95a) replaces a fixed-width spacer with a weight-based spacer, pushing trailing controls to the end of the row.
> - Bumps Android `appVersionName` to `0.24.9`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8663128.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->