### PR TITLE
is_system flag to hide curator accounts from discover

### DIFF
--- a/backend/migrations/2026-05-19-230000_users_is_system/down.sql
+++ b/backend/migrations/2026-05-19-230000_users_is_system/down.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION app.users_for_event_tag_match(
+    p_event_id uuid,
+    p_creator_user_id integer
+)
+RETURNS TABLE (user_id integer)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT DISTINCT p.user_id
+    FROM public.profile_tags pt
+    JOIN public.event_tags et ON et.tag_id = pt.tag_id
+    JOIN public.profiles p ON p.id = pt.profile_id
+    JOIN public.users u ON u.id = p.user_id
+    LEFT JOIN public.user_settings s ON s.user_id = p.user_id
+    WHERE et.event_id = p_event_id
+      AND p.user_id <> p_creator_user_id
+      AND u.banned_at IS NULL
+      AND COALESCE(u.is_review_stub, FALSE) = FALSE
+      AND COALESCE(s.notifications_enabled, TRUE)
+      AND COALESCE(s.notify_tag_events, FALSE)
+$$;
+
+DROP FUNCTION IF EXISTS app.system_user_ids();
+DROP INDEX IF EXISTS users_is_system_idx;
+ALTER TABLE public.users DROP COLUMN is_system;

--- a/backend/migrations/2026-05-19-230000_users_is_system/up.sql
+++ b/backend/migrations/2026-05-19-230000_users_is_system/up.sql
@@ -1,0 +1,68 @@
+-- is_system marks accounts that exist only to author official content
+-- (e.g. the "Poziomki" account that owns events curated from external
+-- sources). System users must never appear in matching candidates,
+-- people search, or tag-event push fanout. Their content (events,
+-- messages they may post in event chats) stays visible — only the
+-- author surface is hidden.
+
+ALTER TABLE public.users
+    ADD COLUMN is_system BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX users_is_system_idx ON public.users (is_system) WHERE is_system;
+
+-- Refresh the tag-match push helper to also skip system authors. They
+-- have no tags today, so this is belt-and-braces, but it keeps the
+-- exclusion explicit alongside banned + stub.
+CREATE OR REPLACE FUNCTION app.users_for_event_tag_match(
+    p_event_id uuid,
+    p_creator_user_id integer
+)
+RETURNS TABLE (user_id integer)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT DISTINCT p.user_id
+    FROM public.profile_tags pt
+    JOIN public.event_tags et ON et.tag_id = pt.tag_id
+    JOIN public.profiles p ON p.id = pt.profile_id
+    JOIN public.users u ON u.id = p.user_id
+    LEFT JOIN public.user_settings s ON s.user_id = p.user_id
+    WHERE et.event_id = p_event_id
+      AND p.user_id <> p_creator_user_id
+      AND u.banned_at IS NULL
+      AND COALESCE(u.is_review_stub, FALSE) = FALSE
+      AND COALESCE(u.is_system, FALSE) = FALSE
+      AND COALESCE(s.notifications_enabled, TRUE)
+      AND COALESCE(s.notify_tag_events, FALSE)
+$$;
+
+-- SECURITY DEFINER lookup of system user ids. The users RLS policy is
+-- own-row, so a regular SELECT from the API role can't enumerate other
+-- users. Matching needs the full set to exclude system authors from
+-- candidates; narrow projection (just ids) so no sensitive columns
+-- leak even if the caller is unexpected.
+CREATE OR REPLACE FUNCTION app.system_user_ids()
+RETURNS TABLE (id integer)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+STABLE
+AS $$
+    SELECT id FROM public.users WHERE is_system = TRUE
+$$;
+
+REVOKE EXECUTE ON FUNCTION app.system_user_ids() FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'poziomki_api') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION app.system_user_ids() TO poziomki_api';
+    END IF;
+END
+$$;
+
+-- Backfill the existing Poziomki account (created by hand on prod for
+-- external event curation) so it stops appearing in discover.
+UPDATE public.users SET is_system = TRUE WHERE email = 'system@poziomki.app';

--- a/backend/src/api/matching/repo.rs
+++ b/backend/src/api/matching/repo.rs
@@ -21,6 +21,12 @@ use crate::db::schema::{
 
 pub(super) struct MatchingRepository;
 
+#[derive(diesel::QueryableByName)]
+struct SystemUserId {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    id: i32,
+}
+
 pub(super) struct MatchingProfileContext {
     pub(super) profile: Option<Profile>,
     pub(super) profile_tag_ids: HashSet<Uuid>,
@@ -199,9 +205,21 @@ impl MatchingRepository {
         // is unnecessary here. `viewer_is_stub` is still resolved above
         // because some callers depend on it; matching itself doesn't.
         let _ = viewer_is_stub;
+        // is_system accounts (e.g. the Poziomki author for curated
+        // external events) must never surface in matching. The users
+        // RLS policy is own-row only, so we can't enumerate other
+        // users directly — go through the SECURITY DEFINER helper.
+        let system_user_ids: Vec<i32> = diesel::sql_query("SELECT id FROM app.system_user_ids()")
+            .load::<SystemUserId>(conn)
+            .await?
+            .into_iter()
+            .map(|r| r.id)
+            .collect();
+
         profiles::table
             .left_join(user_settings::table.on(user_settings::user_id.eq(profiles::user_id)))
             .filter(profiles::user_id.ne(user_id))
+            .filter(profiles::user_id.ne_all(&system_user_ids))
             .filter(
                 user_settings::privacy_discoverable
                     .eq(true)

--- a/backend/src/db/models/users.rs
+++ b/backend/src/db/models/users.rs
@@ -25,6 +25,7 @@ pub struct User {
     pub is_review_stub: bool,
     pub banned_at: Option<DateTime<Utc>>,
     pub banned_reason: Option<String>,
+    pub is_system: bool,
 }
 
 #[derive(Debug, Insertable)]

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -340,6 +340,7 @@ diesel::table! {
         is_review_stub -> Bool,
         banned_at -> Nullable<Timestamptz>,
         banned_reason -> Nullable<Text>,
+        is_system -> Bool,
     }
 }
 

--- a/backend/src/search.rs
+++ b/backend/src/search.rs
@@ -141,6 +141,7 @@ async fn search_profiles(
         LEFT JOIN tags t_agg ON t_agg.id = pt_agg.tag_id
         WHERE
             (COALESCE(us.privacy_discoverable, true) = true OR p.user_id = $4)
+            AND p.user_id NOT IN (SELECT id FROM app.system_user_ids())
             AND NOT EXISTS (
                 SELECT 1 FROM profile_blocks pb
                 JOIN profiles vp ON vp.user_id = $4


### PR DESCRIPTION
- new `users.is_system` flag + `app.system_user_ids()` definer helper
- matching candidates and people search exclude system users
- backfills `system@poziomki.app` (Poziomki curator for external events)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `is_system` flag to hide curator accounts from profile discovery and matching
> - Adds an `is_system` boolean column to the `users` table and backfills `system@poziomki.app` as a system account.
> - Excludes system users from profile search results via a subquery against the new `app.system_user_ids()` security-definer function in [search.rs](https://github.com/poziomki-app/poziomki/pull/512/files#diff-f157aaca4d578281c5d617b3970ba00ee9a8915ac4d1d1251a5744e61ff62fe1).
> - Excludes system users from matching candidates in [matching/repo.rs](https://github.com/poziomki-app/poziomki/pull/512/files#diff-fe2cacd26eb8e974a5e780381831fead540ac7b253e064e48b07dd2ceef85ba9) using the same function.
> - The `app.users_for_event_tag_match` function is updated to skip system users from push notification fanout.
> - `app.system_user_ids()` is restricted to the `poziomki_api` role via revoked PUBLIC execute.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aad226b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->