### PR TITLE
fix: picker layout + polecane pins featured first

### DIFF
--- a/backend/src/api/matching/scoring.rs
+++ b/backend/src/api/matching/scoring.rs
@@ -61,14 +61,17 @@ pub(super) fn rank_and_take<'a>(
     scored.iter().copied().take(limit).collect()
 }
 
-/// Sort events by score DESC, break ties by `starts_at` ASC, return top `limit`.
+/// Sort events with featured pinned first, then by score DESC, ties by
+/// `starts_at` ASC. Featured events are operator-curated highlights that
+/// must always lead the polecane list regardless of personal affinity.
 pub(super) fn rank_events_and_take<'a>(
     scored: &mut [(f64, &'a Event)],
     limit: usize,
 ) -> Vec<(f64, &'a Event)> {
     scored.sort_by(|a, b| {
-        b.0.partial_cmp(&a.0)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        b.1.is_featured
+            .cmp(&a.1.is_featured)
+            .then_with(|| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal))
             .then_with(|| a.1.starts_at.cmp(&b.1.starts_at))
     });
     scored.iter().copied().take(limit).collect()

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.24.9" // x-release-please-version
+val appVersionName = "0.24.10" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -195,47 +198,51 @@ fun LocationPickerSheet(
                         .align(Alignment.TopCenter)
                         .padding(top = topPadding + 8.dp, start = 16.dp, end = 16.dp),
             ) {
-                // Back button
-                Surface(
-                    modifier = Modifier.size(40.dp),
-                    shape = CircleShape,
-                    color = Background.copy(alpha = 0.85f),
+                // Back button + search on the same row.
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
-                    IconButton(onClick = onDismiss) {
-                        Icon(
-                            imageVector = PhosphorIcons.Bold.ArrowLeft,
-                            contentDescription = "Wstecz",
-                            tint = TextPrimary,
-                            modifier = Modifier.size(20.dp),
-                        )
+                    Surface(
+                        modifier = Modifier.size(40.dp),
+                        shape = CircleShape,
+                        color = Background.copy(alpha = 0.85f),
+                    ) {
+                        IconButton(onClick = onDismiss) {
+                            Icon(
+                                imageVector = PhosphorIcons.Bold.ArrowLeft,
+                                contentDescription = "Wstecz",
+                                tint = TextPrimary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
                     }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    TextField(
+                        value = query,
+                        onValueChange = { query = it },
+                        placeholder = {
+                            Text("szukaj", color = TextMuted, fontFamily = NunitoFamily)
+                        },
+                        leadingIcon = {
+                            Icon(PhosphorIcons.Bold.MagnifyingGlass, contentDescription = null, tint = TextMuted)
+                        },
+                        colors =
+                            TextFieldDefaults.colors(
+                                focusedContainerColor = Background.copy(alpha = 0.92f),
+                                unfocusedContainerColor = Background.copy(alpha = 0.92f),
+                                focusedTextColor = TextPrimary,
+                                unfocusedTextColor = TextPrimary,
+                                focusedIndicatorColor = Color.Transparent,
+                                unfocusedIndicatorColor = Color.Transparent,
+                                cursorColor = Primary,
+                            ),
+                        textStyle = TextStyle(fontFamily = NunitoFamily, fontSize = 15.sp),
+                        shape = RoundedCornerShape(14.dp),
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                    )
                 }
-
-                // Search
-                TextField(
-                    value = query,
-                    onValueChange = { query = it },
-                    placeholder = {
-                        Text("szukaj", color = TextMuted, fontFamily = NunitoFamily)
-                    },
-                    leadingIcon = {
-                        Icon(PhosphorIcons.Bold.MagnifyingGlass, contentDescription = null, tint = TextMuted)
-                    },
-                    colors =
-                        TextFieldDefaults.colors(
-                            focusedContainerColor = Background.copy(alpha = 0.92f),
-                            unfocusedContainerColor = Background.copy(alpha = 0.92f),
-                            focusedTextColor = TextPrimary,
-                            unfocusedTextColor = TextPrimary,
-                            focusedIndicatorColor = Color.Transparent,
-                            unfocusedIndicatorColor = Color.Transparent,
-                            cursorColor = Primary,
-                        ),
-                    textStyle = TextStyle(fontFamily = NunitoFamily, fontSize = 15.sp),
-                    shape = RoundedCornerShape(14.dp),
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
-                )
 
                 // Results
                 if (results.isNotEmpty()) {


### PR DESCRIPTION
Two fixes. Bump 0.24.10.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin featured events first in ranking and fix location picker layout
> - Updates `rank_events_and_take` in [scoring.rs](https://github.com/poziomki-app/poziomki/pull/513/files#diff-4fa022f8c0ab352baa1b25aa4302aa7a35b7e50b3ec8791160be1d9e413446c7) to sort `is_featured=true` events before non-featured ones, then by score descending, then by `starts_at` ascending.
> - Reworks the `LocationPickerSheet` composable to place the back button and search field in a single `Row`, with the search field taking remaining horizontal space via `Modifier.weight(1f)`.
> - Bumps Android `appVersionName` to `0.24.10`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b4a9d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->