### PR TITLE
ci(release): restore google-services.json from secret

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -73,6 +73,25 @@ jobs:
           fi
           echo "$ANDROID_RELEASE_KEYSTORE_B64" | base64 --decode > "$RUNNER_TEMP/android-release.jks"
 
+      - name: Restore google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
+        # The real Firebase project file is gitignored, so CI needs it from
+        # a secret. Without this, processReleaseGoogleServices fails and
+        # the resulting bundle would have no FCM/Crashlytics wiring even
+        # if it built. Fall back to the .sample stub for branches where
+        # the secret isn't available (PR builds use mobile.yml's stub).
+        run: |
+          if [[ -n "${GOOGLE_SERVICES_JSON_B64}" ]]; then
+            echo "$GOOGLE_SERVICES_JSON_B64" | base64 --decode > mobile/androidApp/google-services.json
+          elif [[ -f mobile/androidApp/google-services.json.sample ]]; then
+            echo "GOOGLE_SERVICES_JSON_B64 not set; falling back to .sample (release will not wire to real Firebase)" >&2
+            cp mobile/androidApp/google-services.json.sample mobile/androidApp/google-services.json
+          else
+            echo "GOOGLE_SERVICES_JSON_B64 is not configured and no .sample file" >&2
+            exit 1
+          fi
+
       - name: Build signed Android release
         working-directory: mobile
         env:


### PR DESCRIPTION
Fixes Android Release workflow failure on tag v0.21.0. Requires `GOOGLE_SERVICES_JSON_B64` secret (base64 of mobile/androidApp/google-services.json).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore google-services.json from secret in Android release workflow
> Adds a step to [android-release.yml](.github/workflows/android-release.yml) that decodes `GOOGLE_SERVICES_JSON_B64` from secrets and writes it to `mobile/androidApp/google-services.json` before the build. Falls back to copying `google-services.json.sample` if the secret is absent, and exits with an error if neither is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39d5082.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->