### PR TITLE
ci(lint): disable GradleDependency

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -94,7 +94,11 @@ android {
         baseline = file("lint-baseline.xml")
         // CI lint is one minor version ahead of local and flags 36 as
         // "old"; the release-please bot owns targetSdk bumps anyway.
+        // GradleDependency: CI hosts a newer Android SDK (37) than the
+        // pinned compileSdk (36) and lint treats that as an error.
+        // Same rationale as OldTargetApi — let the bot handle SDK bumps.
         disable += "OldTargetApi"
+        disable += "GradleDependency"
     }
 }
 


### PR DESCRIPTION
Unblocks Android Release on tag v0.21.0 — CI runners have SDK 37, lint complains about pinned compileSdk=36.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable `GradleDependency` lint check in Android build
> Adds `GradleDependency` to the disabled lint issues in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/516/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be), alongside the existing `OldTargetApi` suppression. A comment explains the rationale for the suppression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb6dd4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->