### PR TITLE
ci(lint): disable LockedOrientationActivity

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -99,6 +99,9 @@ android {
         // Same rationale as OldTargetApi — let the bot handle SDK bumps.
         disable += "OldTargetApi"
         disable += "GradleDependency"
+        // Portrait-only is a product decision. CI's newer SDK emits this
+        // even though the local baseline captured it.
+        disable += "LockedOrientationActivity"
     }
 }
 


### PR DESCRIPTION
Next lint error blocking v0.21.0 release. Portrait-only is intentional.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable `LockedOrientationActivity` lint check in Android build
> Adds `LockedOrientationActivity` to the disabled lint checks in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/517/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be), with a comment noting that portrait-only orientation is a product decision rather than a lint concern.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d71364.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->