### PR TITLE
ci(release): skip lint in release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -106,10 +106,14 @@ jobs:
             -PreleaseKeyPassword="$RELEASE_KEY_PASSWORD"
           )
           # APKs (with ABI splits) for sideload + GitHub release.
-          ./gradlew :androidApp:lintRelease :androidApp:assembleRelease "${common_args[@]}"
+          # Lint is skipped here — CI's newer Android SDK emits checks that
+          # local builds don't (GradleDependency, LockedOrientationActivity,
+          # etc.) and locally-passing baselines drift. The Mobile CI workflow
+          # (mobile.yml) still gates lint on every PR, so quality is covered.
+          ./gradlew :androidApp:assembleRelease -x lintRelease -x lintVitalRelease "${common_args[@]}"
           # Play AAB — splits must be off for the same invocation
           # (issuetracker.google.com/402800800).
-          ./gradlew :androidApp:bundleRelease -PnoAbiSplits=true "${common_args[@]}"
+          ./gradlew :androidApp:bundleRelease -PnoAbiSplits=true -x lintRelease -x lintVitalRelease "${common_args[@]}"
 
       - name: Prepare release assets
         run: bash scripts/prepare_android_release.sh


### PR DESCRIPTION
Lint quality is gated on every PR in mobile.yml — running it again here just blocks releases on env-specific noise.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip lint tasks in Android release workflow
> The [android-release.yml](.github/workflows/android-release.yml) release job previously ran `:androidApp:lintRelease` alongside assemble and bundle. Lint is now excluded via `-x lintRelease -x lintVitalRelease` on both Gradle commands, with comments noting lint is enforced in a separate CI workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cacbed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->