### PR TITLE
ci: speed up PR checks

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Stub google-services.json for CI
         run: cp androidApp/google-services.json.sample androidApp/google-services.json
 
-      - run: ./gradlew :androidApp:assembleDebug
+      # One gradle invocation: assembleDebug + detekt + ktlintCheck.
+      # Single Kotlin daemon + parallel tasks = ~30s saved vs. running
+      # three separate gradlew commands.
+      - run: ./gradlew :androidApp:assembleDebug detekt ktlintCheck --parallel
 
       # Upload debug APK on PR runs so the trusted pr-apk-comment workflow
       # can surface a download link back on the PR. Fork PRs run this step
@@ -50,26 +53,6 @@ jobs:
           path: mobile/androidApp/build/outputs/apk/debug/*.apk
           retention-days: 14
           if-no-files-found: error
-
-  lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-
-    defaults:
-      run:
-        working-directory: mobile
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 21
-
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-
-      - run: ./gradlew detekt
-      - run: ./gradlew ktlintCheck
 
   dependency-updates:
     # Only runs on the weekly schedule and manual dispatch — pull-request

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,10 @@ jobs:
   # produced near-zero signal. We keep `config` because Hadolint doesn't
   # catch compose/k8s/terraform misconfigs that Trivy does.
   trivy:
+    # Skip on PRs — runs on main push + weekly schedule. Config scan is
+    # slow (Docker pull + SARIF upload) and findings are environmental,
+    # not delta to a single PR.
+    if: github.event_name != 'pull_request'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       security-events: write
@@ -49,6 +53,9 @@ jobs:
           category: trivy-config
 
   cargo-deny:
+    # Same rationale as trivy: license/RUSTSEC drift surfaces on the
+    # main push + weekly cron; no need to gate PRs on it.
+    if: github.event_name != 'pull_request'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read


### PR DESCRIPTION
- mobile: merged gradle invocation (assemble+detekt+ktlint parallel)
- security: trivy+cargo-deny skip PRs (run on main+weekly only)
- Already done via API: prod env wait timer 5m → 0

Combined savings: ~3-5 min per PR + 5 min per prod deploy. Blacksmith runners (PR #484) cuts another 30-50% off.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up PR checks by consolidating mobile build tasks and skipping security scans
> - Merges `assembleDebug`, `detekt`, and `ktlintCheck` into a single Gradle invocation with parallel task execution in [mobile.yml](https://github.com/poziomki-app/poziomki/pull/519/files#diff-fba277883616717b49f01e1fa603c38c85603327832ed325c0688d0ee75f1162), removing the separate lint job.
> - Skips the `trivy` and `cargo-deny` jobs in [security.yml](https://github.com/poziomki-app/poziomki/pull/519/files#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dc) on pull request events; they still run on pushes to main and scheduled/dispatch events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c42b18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->