### PR TITLE
ci: scorecard cron-only

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -152,7 +152,9 @@ jobs:
   # pinned deps, token permissions, etc.). Runs on schedule + default-branch
   # pushes; results flow to the Security tab.
   scorecard:
-    if: github.event_name == 'schedule' || github.event_name == 'push'
+    # Weekly cron only — pushes to main don't need it (results are
+    # repo-level posture, not per-commit signal).
+    if: github.event_name == 'schedule'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       security-events: write


### PR DESCRIPTION
Drops scorecard from main pushes — cron weekly is enough.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict scorecard CI job to scheduled runs only
> Updates the `if:` condition in the scorecard job in [security.yml](https://github.com/poziomki-app/poziomki/pull/520/files#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dc) to trigger only on `schedule` events, removing the previous behavior of also running on `push` events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fabac3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->