### PR TITLE
fix: nearby map panel safe area + Play internal auto-upload + Firebase config guard

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -76,19 +76,32 @@ jobs:
       - name: Restore google-services.json
         env:
           GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
-        # The real Firebase project file is gitignored, so CI needs it from
-        # a secret. Without this, processReleaseGoogleServices fails and
-        # the resulting bundle would have no FCM/Crashlytics wiring even
-        # if it built. Fall back to the .sample stub for branches where
-        # the secret isn't available (PR builds use mobile.yml's stub).
+        # Release builds MUST use the real Firebase config. No stub fallback:
+        # a stub builds successfully but ships an invalid API key, so Firebase
+        # init throws on first launch and Crashlytics can't even report the
+        # crash (it depends on the same config). PR builds use mobile.yml's
+        # explicit stub for debug-only assembly.
         run: |
-          if [[ -n "${GOOGLE_SERVICES_JSON_B64}" ]]; then
-            echo "$GOOGLE_SERVICES_JSON_B64" | base64 --decode > mobile/androidApp/google-services.json
-          elif [[ -f mobile/androidApp/google-services.json.sample ]]; then
-            echo "GOOGLE_SERVICES_JSON_B64 not set; falling back to .sample (release will not wire to real Firebase)" >&2
-            cp mobile/androidApp/google-services.json.sample mobile/androidApp/google-services.json
-          else
-            echo "GOOGLE_SERVICES_JSON_B64 is not configured and no .sample file" >&2
+          if [[ -z "${GOOGLE_SERVICES_JSON_B64}" ]]; then
+            echo "::error::GOOGLE_SERVICES_JSON_B64 secret is not set; refusing to build a release with a stub Firebase config" >&2
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON_B64" | base64 --decode > mobile/androidApp/google-services.json
+          # Guard against an empty/corrupt secret, or someone base64-ing the
+          # .sample file by mistake. Both produce builds that crash on init.
+          if ! jq -e '.client[0].api_key[0].current_key' mobile/androidApp/google-services.json >/dev/null; then
+            echo "::error::google-services.json is missing api_key after decode" >&2
+            exit 1
+          fi
+          api_key="$(jq -r '.client[0].api_key[0].current_key' mobile/androidApp/google-services.json)"
+          project_id="$(jq -r '.project_info.project_id' mobile/androidApp/google-services.json)"
+          package_name="$(jq -r '.client[0].client_info.android_client_info.package_name' mobile/androidApp/google-services.json)"
+          if [[ "$api_key" == "REPLACE_ME" || "$project_id" == "your-firebase-project-id" ]]; then
+            echo "::error::GOOGLE_SERVICES_JSON_B64 decodes to the .sample stub; configure the real Firebase config" >&2
+            exit 1
+          fi
+          if [[ "$package_name" != "app.poziomki" ]]; then
+            echo "::error::google-services.json package_name is '$package_name', expected 'app.poziomki'" >&2
             exit 1
           fi
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -128,3 +128,17 @@ jobs:
             dist/android-release/*.aab
             dist/android-release/*.txt
             dist/android-release/*.tar.gz
+
+      # Auto-publish the signed AAB to Play Console's internal testing
+      # track. First-ever upload still has to be done manually via the
+      # Console (Google's bootstrap requirement); subsequent tag pushes
+      # ship automatically. Requires PLAY_SERVICE_ACCOUNT_JSON secret
+      # (service account with "Release manager" role on app.poziomki).
+      - name: Upload AAB to Play internal track
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: app.poziomki
+          releaseFiles: dist/android-release/*.aab
+          track: internal
+          status: completed

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -122,6 +122,31 @@ if (
     android.buildTypes.getByName("release").signingConfig = android.signingConfigs.getByName("release")
 }
 
+// Refuse to assemble a release with the stub google-services.json. The stub's
+// REPLACE_ME api_key produces an APK that throws IllegalArgumentException on
+// Firebase init at first launch, and Crashlytics can't report it because it
+// depends on the same config. Debug builds keep using the stub freely.
+gradle.taskGraph.whenReady {
+    val buildingRelease =
+        allTasks.any { task ->
+            val n = task.name
+            (n.startsWith("assemble") || n.startsWith("bundle") || n.startsWith("package")) &&
+                n.contains("Release")
+        }
+    if (!buildingRelease) return@whenReady
+    val configFile = file("google-services.json")
+    if (!configFile.exists()) {
+        throw GradleException("google-services.json is missing; release builds require the real Firebase config")
+    }
+    val text = configFile.readText()
+    if (text.contains("REPLACE_ME") || text.contains("your-firebase-project-id")) {
+        throw GradleException(
+            "google-services.json looks like the .sample stub; drop the real Firebase config at " +
+                "mobile/androidApp/google-services.json before building a release",
+        )
+    }
+}
+
 dependencies {
     implementation(projects.appUi)
     implementation(projects.core)

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.21.1" // x-release-please-version
+val appVersionName = "0.21.2" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/NearbyEventsContent.kt
@@ -13,9 +13,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -381,6 +384,11 @@ internal fun NearbyEventsContent(
         // No background image, no scroll: title + date + location + attendees,
         // tap → full event screen.
         if (selectedEvent != null) {
+            // Immersive mode hides the in-app navbar (LocalNavBarPadding=0),
+            // so fall back to the system navigation-bar inset to keep the
+            // panel above the Android gesture/3-button bar.
+            val systemNavInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+            val bottomSafe = maxOf(LocalNavBarPadding.current, systemNavInset)
             Row(
                 modifier =
                     Modifier
@@ -389,7 +397,7 @@ internal fun NearbyEventsContent(
                         .background(Background)
                         .clickable { onEventClick(selectedEvent.id) }
                         .padding(horizontal = 16.dp)
-                        .padding(top = 10.dp, bottom = LocalNavBarPadding.current + 20.dp),
+                        .padding(top = 10.dp, bottom = bottomSafe + 20.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 val cover = selectedEvent.coverImage


### PR DESCRIPTION
- Map event panel respects system nav inset in immersive mode (no longer hidden behind Android nav bar).
- Bump to 0.21.2.
- Release workflow uploads signed AAB to Play internal track on tag push (needs `PLAY_SERVICE_ACCOUNT_JSON` secret).
- Release build refuses to ship with the `.sample` Firebase stub — root cause of the on-init `IllegalArgumentException` users hit on 0.21.1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nearby map panel safe area insets, add Play internal auto-upload, and guard Firebase config
> - Fixes bottom padding in `NearbyEventsContent` to use the max of `LocalNavBarPadding` and the system navigation bar inset, preventing overlap with system gesture areas in immersive mode.
> - Adds a Gradle `whenReady` hook in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/523/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be) that fails Release builds early if `google-services.json` is missing or is the sample stub.
> - Tightens the CI `Restore google-services.json` step in [android-release.yml](https://github.com/poziomki-app/poziomki/pull/523/files#diff-2bd036fee148e164b04b1752776190a94d546194cfea150a5936f4ed3930f1d8) to require `GOOGLE_SERVICES_JSON_B64`, validate the decoded file with `jq`, and reject stub or wrong-package configs.
> - Adds a CI step to upload the signed AAB to the Play Console internal track via `r0adkll/upload-google-play` after a successful build.
> - Bumps `versionName` to `0.21.2`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9abdb9a. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->