### PR TITLE
ci(android): skip Play upload when secret unset + setup docs

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -142,12 +142,27 @@ jobs:
             dist/android-release/*.txt
             dist/android-release/*.tar.gz
 
+      # Probe for the Play service-account secret so the upload step can be
+      # cleanly skipped (instead of failing the whole release) when CI runs
+      # before the secret has been provisioned. See docs/play-deploy.md.
+      - name: Check Play upload secret
+        id: play_secret
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [[ -n "${PLAY_SERVICE_ACCOUNT_JSON}" ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PLAY_SERVICE_ACCOUNT_JSON not configured; skipping Play upload. See docs/play-deploy.md." >&2
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Auto-publish the signed AAB to Play Console's internal testing
       # track. First-ever upload still has to be done manually via the
       # Console (Google's bootstrap requirement); subsequent tag pushes
-      # ship automatically. Requires PLAY_SERVICE_ACCOUNT_JSON secret
-      # (service account with "Release manager" role on app.poziomki).
+      # ship automatically. See docs/play-deploy.md for setup.
       - name: Upload AAB to Play internal track
+        if: steps.play_secret.outputs.present == 'true'
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}

--- a/docs/play-deploy.md
+++ b/docs/play-deploy.md
@@ -1,0 +1,73 @@
+# Play Store auto-deploy
+
+Tag pushes (`vX.Y.Z`) trigger `.github/workflows/android-release.yml`, which
+builds a signed AAB, creates a GitHub Release with it attached, and then
+uploads the AAB to Play Console's **internal testing** track.
+
+The upload step is gated on the `PLAY_SERVICE_ACCOUNT_JSON` repo secret. If
+the secret is missing the step is skipped with a warning; the rest of the
+release workflow still succeeds and the AAB is downloadable from the GitHub
+Release.
+
+## One-time setup
+
+You only need to do this once. After it's done, every `vX.Y.Z` tag ships
+to Play internal automatically.
+
+### 1. Create the service account
+
+1. Open [Google Cloud Console → IAM → Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts)
+   for the **same Google account** that owns the Play Console listing.
+2. **Create service account** → name it e.g. `play-publisher`. Skip the
+   optional role grants in step 2 (Play permissions live in Play Console,
+   not GCP). Click **Done**.
+3. Click into the new service account → **Keys** tab → **Add key → Create
+   new key → JSON**. A JSON file downloads. Keep it safe — it's the
+   credential the workflow will use.
+
+### 2. Grant Play Console access
+
+1. Open [Play Console → Users and permissions](https://play.google.com/console/users-and-permissions).
+2. **Invite new users** → paste the service account's email
+   (`play-publisher@<project>.iam.gserviceaccount.com`).
+3. **App permissions** → add `Poziomki` (app.poziomki) → grant at minimum:
+   - **Release to testing tracks** (covers internal/closed/open)
+   - **View app information and download bulk reports**
+4. Save. The grant is effective immediately; no email confirmation needed.
+
+### 3. Store the secret
+
+```bash
+gh secret set PLAY_SERVICE_ACCOUNT_JSON --repo poziomki-app/poziomki < path/to/play-publisher-XXXX.json
+```
+
+(or paste the raw JSON in GitHub → Settings → Secrets and variables → Actions
+→ New repository secret, name `PLAY_SERVICE_ACCOUNT_JSON`).
+
+### 4. Bootstrap the first Play release manually
+
+Google's API refuses to publish if the app has never had a release on the
+target track. So the **first AAB** must be uploaded by hand:
+
+1. Build a tag (`git tag vX.Y.Z && git push origin vX.Y.Z`) — workflow will
+   upload to GitHub Releases but skip Play (no secret yet, or step will
+   fail with "no existing release" if secret was added before bootstrap).
+2. Download the AAB from the GitHub Release.
+3. Play Console → Testing → Internal testing → **Create new release** →
+   upload the AAB → fill release notes → **Save → Review → Start rollout**.
+
+From the next tag onward the workflow upload step takes over.
+
+## Troubleshooting
+
+- **403 / PERMISSION_DENIED on `androidpublisher.edits.insert`**: the
+  service account is not granted on the app. Re-check step 2.
+- **400 / `apkNotificationMessageKeyUpgradeVersionConflict`**: the AAB's
+  `versionCode` is ≤ the latest version on Play. Bump `appVersionName` in
+  `mobile/androidApp/build.gradle.kts`; the code is derived from it.
+- **`Package not found: app.poziomki`**: the bootstrap upload (step 4) was
+  skipped. Do it once manually.
+- **`Track 'internal' is not properly configured`**: same as above.
+- The Play upload step is silently skipped if `PLAY_SERVICE_ACCOUNT_JSON`
+  isn't set. The workflow log shows a `::warning::` line — that's normal
+  pre-bootstrap.


### PR DESCRIPTION
- Play upload step now gracefully skips with a workflow warning when `PLAY_SERVICE_ACCOUNT_JSON` is missing, so the release run stays green pre-bootstrap.
- `docs/play-deploy.md`: step-by-step service account creation, Play Console grant, secret storage, first-release bootstrap.

Once the secret is added, every `vX.Y.Z` tag auto-ships the AAB to Play internal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip Play Store upload in CI when `PLAY_SERVICE_ACCOUNT_JSON` secret is unset
> - Adds a probe step in [android-release.yml](.github/workflows/android-release.yml) that checks whether `PLAY_SERVICE_ACCOUNT_JSON` is configured, sets a `present` output flag, and emits a workflow warning if missing.
> - Gates the 'Upload AAB to Play internal track' step on that flag so the workflow continues without error when the secret is absent.
> - Adds [docs/play-deploy.md](https://github.com/poziomki-app/poziomki/pull/524/files#diff-91ce0370600666d25d4156cb8fe88e9a747a8639fe2c883e40f2738bec7fcf8a) covering one-time service account setup, Play Console permissions, storing the secret in GitHub, initial manual bootstrap, and troubleshooting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf151f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->