### PR TITLE
fix(onboarding): adaptive footer + backend tag search + 0.21.3

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.21.2" // x-release-please-version
+val appVersionName = "0.21.3" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/OnboardingLayout.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/OnboardingLayout.kt
@@ -1,6 +1,7 @@
 package com.poziomki.app.ui.designsystem.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,11 +16,11 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -27,36 +28,57 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.bold.ArrowLeft
+import com.poziomki.app.ui.designsystem.Text
 import com.poziomki.app.ui.designsystem.theme.Background
 import com.poziomki.app.ui.designsystem.theme.Border
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
 import com.poziomki.app.ui.designsystem.theme.Secondary
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 
+data class OnboardingPrimaryAction(
+    val text: String,
+    val onClick: () -> Unit,
+    val enabled: Boolean = true,
+    val loading: Boolean = false,
+    val variant: ButtonVariant = ButtonVariant.PRIMARY,
+)
+
 @Composable
+@Suppress("LongParameterList", "LongMethod")
 fun OnboardingLayout(
     currentStep: Int,
     totalSteps: Int,
+    primaryAction: OnboardingPrimaryAction,
     showBack: Boolean = true,
     onBack: (() -> Unit)? = null,
-    footer: @Composable () -> Unit,
+    footerExtras: (@Composable () -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     Scaffold(
         containerColor = Background,
         bottomBar = {
-            // Union with IME so the footer lifts above the keyboard instead of
-            // being covered. Falls back to nav bar inset (or xl spacing,
-            // whichever is larger) when the keyboard is closed.
+            // IME visibility drives footer presentation: full-width primary
+            // pill when the keyboard is closed, and a compact right-aligned
+            // pill when it's open (so the action stays reachable without
+            // crowding the input). Extra breathing room separates the pill
+            // from the keyboard so the user's thumb has space.
+            val imeBottom = WindowInsets.ime.asPaddingValues().calculateBottomPadding()
+            val navBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+            val imeOpen = imeBottom > navBottom
             val bottomInset =
-                WindowInsets.navigationBars
-                    .union(WindowInsets.ime)
-                    .asPaddingValues()
-                    .calculateBottomPadding()
+                if (imeOpen) {
+                    imeBottom + PoziomkiTheme.spacing.md
+                } else {
+                    maxOf(PoziomkiTheme.spacing.xl, navBottom)
+                }
             Column(
                 modifier =
                     Modifier
@@ -64,11 +86,26 @@ fun OnboardingLayout(
                         .background(Background)
                         .padding(horizontal = PoziomkiTheme.spacing.lg)
                         .padding(top = PoziomkiTheme.spacing.sm)
-                        .padding(
-                            bottom = maxOf(PoziomkiTheme.spacing.xl, bottomInset),
-                        ),
+                        .padding(bottom = bottomInset),
             ) {
-                footer()
+                footerExtras?.invoke()
+                if (imeOpen) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        OnboardingPillAction(action = primaryAction)
+                    }
+                } else {
+                    AppButton(
+                        text = primaryAction.text,
+                        onClick = primaryAction.onClick,
+                        enabled = primaryAction.enabled,
+                        loading = primaryAction.loading,
+                        variant = primaryAction.variant,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         },
     ) { padding ->
@@ -121,6 +158,38 @@ fun OnboardingLayout(
             // Content
             content()
         }
+    }
+}
+
+@Composable
+private fun OnboardingPillAction(action: OnboardingPrimaryAction) {
+    val isEnabled = action.enabled && !action.loading
+    val fill = Color(0xFFF2F4F7)
+    val contentColor = Color(0xFF0B0F14).let { if (isEnabled) it else it.copy(alpha = 0.35f) }
+    Row(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(50))
+                .background(fill)
+                .then(if (isEnabled) Modifier.clickable(onClick = action.onClick) else Modifier)
+                .padding(horizontal = 22.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (action.loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                color = contentColor,
+                strokeWidth = 2.dp,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text(
+            text = action.text,
+            fontFamily = NunitoFamily,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 15.sp,
+            color = contentColor,
+        )
     }
 }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/BasicInfoScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/BasicInfoScreen.kt
@@ -31,8 +31,8 @@ import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.bold.X
 import com.poziomki.app.ui.designsystem.Text
-import com.poziomki.app.ui.designsystem.components.AppButton
 import com.poziomki.app.ui.designsystem.components.OnboardingLayout
+import com.poziomki.app.ui.designsystem.components.OnboardingPrimaryAction
 import com.poziomki.app.ui.designsystem.components.PoziomkiTextField
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
@@ -59,14 +59,12 @@ fun BasicInfoScreen(
         // dead end than just staying on the form. Hide the affordance.
         showBack = false,
         onBack = onBack,
-        footer = {
-            AppButton(
+        primaryAction =
+            OnboardingPrimaryAction(
                 text = "dalej",
                 onClick = onNext,
                 enabled = state.name.isNotBlank(),
-                modifier = Modifier.fillMaxWidth(),
-            )
-        },
+            ),
     ) {
         Column(
             modifier =

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/InterestsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/InterestsScreen.kt
@@ -45,9 +45,9 @@ import com.adamglin.phosphoricons.bold.Plus
 import com.adamglin.phosphoricons.bold.X
 import com.poziomki.app.network.Tag
 import com.poziomki.app.ui.designsystem.Text
-import com.poziomki.app.ui.designsystem.components.AppButton
 import com.poziomki.app.ui.designsystem.components.ButtonVariant
 import com.poziomki.app.ui.designsystem.components.OnboardingLayout
+import com.poziomki.app.ui.designsystem.components.OnboardingPrimaryAction
 import com.poziomki.app.ui.designsystem.theme.AppTheme
 import com.poziomki.app.ui.designsystem.theme.MontserratFamily
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
@@ -64,7 +64,7 @@ fun InterestsScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
-    var searchQuery by remember { mutableStateOf("") }
+    val searchQuery = state.tagSearchQuery
     var showCategoryPicker by remember { mutableStateOf(false) }
     val selectedCount = state.selectedTagIds.size
     val ready = selectedCount >= 3
@@ -74,7 +74,7 @@ fun InterestsScreen(
             tagName = searchQuery.trim(),
             onCategorySelected = { category ->
                 viewModel.createInterestTag(searchQuery, category.key, category.rootId)
-                searchQuery = ""
+                viewModel.updateTagSearchQuery("")
                 showCategoryPicker = false
             },
             onDismiss = { showCategoryPicker = false },
@@ -86,20 +86,18 @@ fun InterestsScreen(
         totalSteps = 3,
         showBack = true,
         onBack = onBack,
-        footer = {
-            AppButton(
+        primaryAction =
+            OnboardingPrimaryAction(
                 text = "dalej",
                 onClick = onNext,
                 enabled = ready,
                 variant = if (ready) ButtonVariant.PRIMARY else ButtonVariant.SECONDARY,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        },
+            ),
     ) {
         InterestsContent(
             state = state,
             searchQuery = searchQuery,
-            onSearchQueryChange = { searchQuery = it },
+            onSearchQueryChange = { viewModel.updateTagSearchQuery(it) },
             onToggleTag = { viewModel.toggleTag(it) },
             onCreateTag = { showCategoryPicker = true },
         )
@@ -118,21 +116,29 @@ private fun InterestsContent(
         derivedStateOf { state.availableTags.filter { it.category != "root" } }
     }
 
-    val filteredTags by remember(selectableTags, searchQuery) {
+    // Search results: local seed for instant feedback at <2 chars, plus the
+    // backend-debounced result set for ≥2 chars. Backend results are merged
+    // by id so the local seed always shows immediately while richer matches
+    // arrive after the 300ms debounce.
+    val searchResults by remember(selectableTags, state.tagSearchResults, searchQuery) {
         derivedStateOf {
             if (searchQuery.isBlank()) {
-                selectableTags
+                emptyList()
             } else {
-                selectableTags.filter { it.name.contains(searchQuery, ignoreCase = true) }
+                val local = selectableTags.filter { it.name.contains(searchQuery, ignoreCase = true) }
+                val byId = linkedMapOf<String, Tag>()
+                local.forEach { byId[it.id] = it }
+                state.tagSearchResults.forEach { if (it.id !in byId) byId[it.id] = it }
+                byId.values.toList()
             }
         }
     }
 
-    val groupedTags by remember(filteredTags, searchQuery) {
+    val groupedTags by remember(selectableTags, searchQuery) {
         derivedStateOf {
             if (searchQuery.isBlank()) {
                 INTEREST_CATEGORIES.mapNotNull { category ->
-                    val tags = filteredTags.filter { it.category == category.key }
+                    val tags = selectableTags.filter { it.category == category.key }
                     if (tags.isNotEmpty()) category to tags else null
                 }
             } else {
@@ -168,7 +174,7 @@ private fun InterestsContent(
         Spacer(modifier = Modifier.height(AppTheme.spacing.lg))
 
         if (searchQuery.isNotBlank()) {
-            SearchResults(filteredTags, state.selectedTagIds, searchQuery, onToggleTag, onCreateTag)
+            SearchResults(searchResults, state.selectedTagIds, searchQuery, onToggleTag, onCreateTag)
         } else {
             CategoryList(groupedTags, state.selectedTagIds, onToggleTag)
         }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/OnboardingViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/OnboardingViewModel.kt
@@ -12,9 +12,12 @@ import com.poziomki.app.network.Degree
 import com.poziomki.app.network.Tag
 import com.poziomki.app.network.UpdateProfileRequest
 import com.poziomki.app.session.SessionManager
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -27,6 +30,9 @@ data class OnboardingState(
     val bio: String = "",
     val selectedTagIds: Set<String> = emptySet(),
     val availableTags: List<Tag> = emptyList(),
+    val tagSearchQuery: String = "",
+    val tagSearchResults: List<Tag> = emptyList(),
+    val isSearchingTags: Boolean = false,
     val degreeSearchResults: List<Degree> = emptyList(),
     val galleryImages: List<ByteArray> = emptyList(),
     val isLoading: Boolean = false,
@@ -64,11 +70,41 @@ class OnboardingViewModel(
 
     private var allDegrees: List<Degree> = emptyList()
     private var createdProfileId: String? = null
+    private val tagSearchFlow = MutableStateFlow("")
 
     init {
         restoreDraft()
         loadTags()
         loadDegrees()
+        setupTagSearch()
+    }
+
+    @OptIn(FlowPreview::class)
+    private fun setupTagSearch() {
+        viewModelScope.launch {
+            tagSearchFlow
+                .debounce(300)
+                .distinctUntilChanged()
+                .collect { query ->
+                    val trimmed = query.trim()
+                    if (trimmed.length < 2) {
+                        updateState(persist = false) {
+                            it.copy(tagSearchResults = emptyList(), isSearchingTags = false)
+                        }
+                        return@collect
+                    }
+                    updateState(persist = false) { it.copy(isSearchingTags = true) }
+                    val results = tagRepository.searchTags("interest", trimmed)
+                    updateState(persist = false) {
+                        it.copy(tagSearchResults = results, isSearchingTags = false)
+                    }
+                }
+        }
+    }
+
+    fun updateTagSearchQuery(query: String) {
+        updateState(persist = false) { it.copy(tagSearchQuery = query) }
+        tagSearchFlow.value = query
     }
 
     private fun restoreDraft() {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfileSetupScreen.kt
@@ -49,9 +49,8 @@ import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.bold.PencilSimple
 import com.adamglin.phosphoricons.bold.User
 import com.poziomki.app.ui.designsystem.Text
-import com.poziomki.app.ui.designsystem.components.AppButton
-import com.poziomki.app.ui.designsystem.components.ButtonVariant
 import com.poziomki.app.ui.designsystem.components.OnboardingLayout
+import com.poziomki.app.ui.designsystem.components.OnboardingPrimaryAction
 import com.poziomki.app.ui.designsystem.theme.AppTheme
 import com.poziomki.app.ui.designsystem.theme.Black
 import com.poziomki.app.ui.designsystem.theme.Border
@@ -99,25 +98,25 @@ fun ProfileSetupScreen(
         totalSteps = 3,
         showBack = true,
         onBack = onBack,
-        footer = {
-            state.error?.let { error ->
-                Text(
-                    text = error,
-                    fontFamily = NunitoFamily,
-                    fontWeight = FontWeight.Medium,
-                    fontSize = 14.sp,
-                    color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.padding(bottom = AppTheme.spacing.sm),
-                )
-            }
-            AppButton(
+        primaryAction =
+            OnboardingPrimaryAction(
                 text = "potwierd\u017a",
                 onClick = { viewModel.createProfile(onComplete) },
                 loading = state.isLoading,
-                variant = ButtonVariant.PRIMARY,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        },
+            ),
+        footerExtras =
+            state.error?.let { error ->
+                {
+                    Text(
+                        text = error,
+                        fontFamily = NunitoFamily,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(bottom = AppTheme.spacing.sm),
+                    )
+                }
+            },
     ) {
         ProfileSetupContent(
             state = state,


### PR DESCRIPTION
- Footer pill in onboarding adapts to the keyboard: full-width below the form when IME is closed, compact right-aligned pill with breathing room above the keyboard when it's open. Matches the `dołącz` / `zapisz` style elsewhere.
- Tag search now hits the backend (debounced 300ms) on top of the local seed, so users can find anything in the catalog from step 2.
- Bumps to 0.21.3 to validate the end-to-end Play auto-deploy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add adaptive onboarding footer and debounced backend tag search in interests screen
> - Refactors [`OnboardingLayout`](https://github.com/poziomki-app/poziomki/pull/525/files#diff-9004ee762b92e08e7a2180eb211b0ba88918eee19ce0b96bdb5f77c5292f9c95) to accept a typed `OnboardingPrimaryAction` instead of a generic footer composable; shows a full-width button when the keyboard is closed and a compact pill when the IME is open.
> - Adds debounced (300ms) backend tag search in [`OnboardingViewModel`](https://github.com/poziomki-app/poziomki/pull/525/files#diff-7434d372fa18227ceef222c48ce671e53989e7810dc34e0acb847c3ecbd9bc00) for queries ≥2 characters, storing results and a loading flag in `OnboardingState`.
> - Merges local and backend tag search results in [`InterestsScreen`](https://github.com/poziomki-app/poziomki/pull/525/files#diff-afed1ab97ab0704dce3b90c50685d0f4a43fa27947b344048f179b08bf63df97), with local matches taking precedence by id.
> - Updates `BasicInfoScreen` and `ProfileSetupScreen` to use the new `OnboardingLayout` API.
> - Bumps Android versionName to 0.21.3.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 749c7cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->