### PR TITLE
infra(caddy): CORS for api.poziomki.app + prod drift sync

### DIFF
--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -149,6 +149,30 @@ cdn.poziomki.app {
 api.poziomki.app {
 	import secure_headers
 	header Referrer-Policy "strict-origin-when-cross-origin"
+
+	# CORS for first-party browser callers (landing at poziomki.app +
+	# www / staging). Mobile + server-to-server clients don't send
+	# Origin, so they're unaffected. Allow-list is exact-match — never
+	# reflect an arbitrary Origin.
+	@cors_origin header_regexp Origin ^https://(www\.|staging\.)?poziomki\.app$
+	header @cors_origin {
+		Access-Control-Allow-Origin {http.request.header.Origin}
+		Access-Control-Allow-Credentials true
+		Vary Origin
+	}
+	@cors_preflight {
+		method OPTIONS
+		header_regexp Origin ^https://(www\.|staging\.)?poziomki\.app$
+	}
+	handle @cors_preflight {
+		header {
+			Access-Control-Allow-Methods "GET, POST, PATCH, PUT, DELETE, OPTIONS"
+			Access-Control-Allow-Headers "Content-Type, Authorization"
+			Access-Control-Max-Age 86400
+		}
+		respond 204
+	}
+
 	log {
 		output file /var/log/caddy/api-access.log {
 			roll_size 50MiB

--- a/infra/caddy/Caddyfile.prod
+++ b/infra/caddy/Caddyfile.prod
@@ -48,9 +48,9 @@
 	}
 }
 
-poziomki.app, www.poziomki.app {
+poziomki.app, www.poziomki.app, mobile.poziomki.app {
 	import secure_headers
-	encode zstd br gzip
+	encode zstd gzip
 	# Landing URLs are public; ship the full referrer so we can see *which* page on
 	# GitHub/Mastodon/etc. linked here. Other vhosts keep the strict default.
 	header Referrer-Policy "no-referrer-when-downgrade"
@@ -253,3 +253,27 @@ max_age: 31557600
 # file, which would pull prod's own (stale) Caddyfile.staging copy.
 import /home/ubuntu/poziomki-rs-staging/infra/caddy/Caddyfile.staging
 
+
+lm.poziomki.app {
+	# Tailnet-only: served on the public IP so Let's Encrypt HTTP-01 works,
+	# but Caddy rejects any source IP outside the tailscale CGNAT range
+	# (100.64.0.0/10). Listmonk's app.root_url stays as lm.poziomki.app so
+	# unsubscribe / archive links in outbound mail keep working.
+
+	tls {
+		protocols tls1.3
+	}
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "SAMEORIGIN"
+		Content-Security-Policy "frame-ancestors 'self'"
+		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"
+		Cross-Origin-Opener-Policy "same-origin"
+		Cross-Origin-Resource-Policy "same-site"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		-Server
+	}
+	encode zstd gzip
+	reverse_proxy 127.0.0.1:9500
+}


### PR DESCRIPTION
CORS preflight + ACAO for api.poziomki.app so the landing's cross-origin POST stops failing at preflight. Allow-list is exact-match (poziomki.app / www / staging) — no Origin reflection. Mobile + server-to-server callers don't send Origin and are unaffected. Already live on prod, verified end-to-end.

Second commit syncs the rest of the live → repo drift: mobile.poziomki.app alias on landing vhost, lm.poziomki.app tailnet-only vhost, drop br from landing encoder.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CORS headers to api.poziomki.app and introduce lm.poziomki.app vhost in Caddy
> Updates [Caddyfile.prod](https://github.com/poziomki-app/poziomki/pull/526/files#diff-507ac62fa8220af2d08c3d8f2ef5aee0806600e1d1085fc4c641c643ea9f4e36) with three changes:
> - Adds explicit CORS handling to `api.poziomki.app` for first-party origins matching `^https://(www\.|staging\.)?poziomki\.app$`, including a 204 OPTIONS preflight response with allowed methods, headers, and max-age.
> - Adds a new `lm.poziomki.app` vhost enforcing TLS 1.3, security headers (HSTS with `includeSubDomains`/`preload`), zstd/gzip compression, and reverse proxy to `127.0.0.1:9500`.
> - Adds `mobile.poziomki.app` to the `poziomki.app` vhost and removes brotli encoding, leaving only zstd and gzip.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fc9b53f. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->