### PR TITLE
fix(onboarding): tag search input was uninteractive + image dedupe (0.21.4)

### DIFF
--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.21.3" // x-release-please-version
+val appVersionName = "0.21.4" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/InterestsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/InterestsScreen.kt
@@ -64,7 +64,11 @@ fun InterestsScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
-    val searchQuery = state.tagSearchQuery
+    // Keep the text-field value in local Compose state. Routing the value
+    // through the StateFlow round-trip introduced a recomposition lag that
+    // dropped keystrokes when typing fast — the input felt broken. The VM
+    // still gets every change for backend search; we just don't read back.
+    var searchQuery by remember { mutableStateOf("") }
     var showCategoryPicker by remember { mutableStateOf(false) }
     val selectedCount = state.selectedTagIds.size
     val ready = selectedCount >= 3
@@ -74,6 +78,7 @@ fun InterestsScreen(
             tagName = searchQuery.trim(),
             onCategorySelected = { category ->
                 viewModel.createInterestTag(searchQuery, category.key, category.rootId)
+                searchQuery = ""
                 viewModel.updateTagSearchQuery("")
                 showCategoryPicker = false
             },
@@ -97,7 +102,10 @@ fun InterestsScreen(
         InterestsContent(
             state = state,
             searchQuery = searchQuery,
-            onSearchQueryChange = { viewModel.updateTagSearchQuery(it) },
+            onSearchQueryChange = {
+                searchQuery = it
+                viewModel.updateTagSearchQuery(it)
+            },
             onToggleTag = { viewModel.toggleTag(it) },
             onCreateTag = { showCategoryPicker = true },
         )
@@ -343,6 +351,11 @@ private fun SearchBar(
                     value = query,
                     onValueChange = onQueryChange,
                     singleLine = true,
+                    // Without fillMaxWidth the empty text field has zero hit
+                    // area, so taps on the search row land on the placeholder
+                    // Text (or the surrounding padding) instead of focusing
+                    // the input — the bar feels uninteractive.
+                    modifier = Modifier.fillMaxWidth(),
                     textStyle =
                         TextStyle(
                             fontFamily = NunitoFamily,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/OnboardingViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/OnboardingViewModel.kt
@@ -30,7 +30,6 @@ data class OnboardingState(
     val bio: String = "",
     val selectedTagIds: Set<String> = emptySet(),
     val availableTags: List<Tag> = emptyList(),
-    val tagSearchQuery: String = "",
     val tagSearchResults: List<Tag> = emptyList(),
     val isSearchingTags: Boolean = false,
     val degreeSearchResults: List<Degree> = emptyList(),
@@ -103,7 +102,6 @@ class OnboardingViewModel(
     }
 
     fun updateTagSearchQuery(query: String) {
-        updateState(persist = false) { it.copy(tagSearchQuery = query) }
         tagSearchFlow.value = query
     }
 
@@ -203,7 +201,16 @@ class OnboardingViewModel(
             updateState { it.copy(error = "One or more photos are too large. Choose smaller images.") }
             return
         }
-        val combined = (_state.value.galleryImages + images).take(6)
+        // Dedupe by byte-content hash so an accidental double-fire from the
+        // activity-result launcher (seen in the field after a recompose) can't
+        // append the same image twice.
+        val seen =
+            _state.value.galleryImages
+                .map { it.contentHashCode() }
+                .toHashSet()
+        val unique = images.filter { seen.add(it.contentHashCode()) }
+        if (unique.isEmpty()) return
+        val combined = (_state.value.galleryImages + unique).take(6)
         updateState { it.copy(galleryImages = combined, error = null) }
     }
 
@@ -216,10 +223,20 @@ class OnboardingViewModel(
     }
 
     fun toggleTag(tagId: String) {
-        val current = _state.value.selectedTagIds
+        val snapshot = _state.value
+        val current = snapshot.selectedTagIds
+        // Backend-only search results aren't part of the local interest seed;
+        // without persisting them into availableTags the chip would vanish from
+        // the category list the moment the user cleared the search box (which
+        // looked like the selection had been lost).
+        val tagToPersist =
+            snapshot.tagSearchResults
+                .firstOrNull { it.id == tagId }
+                ?.takeIf { snapshot.availableTags.none { existing -> existing.id == tagId } }
         updateState {
             it.copy(
                 selectedTagIds = if (tagId in current) current - tagId else current + tagId,
+                availableTags = if (tagToPersist != null) it.availableTags + tagToPersist else it.availableTags,
                 error = null,
             )
         }


### PR DESCRIPTION
- Search input now actually accepts input — empty BasicTextField had zero hit area, so taps landed on the placeholder.
- Tag selections from backend search stay visible after clearing the search box.
- Gallery image add deduped by byte-content hash so a recompose double-fire can't duplicate.
- 0.21.4.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unresponsive tag search input and deduplicate image selection in onboarding
> - Moves `searchQuery` state from the `OnboardingViewModel` into local Compose state in `InterestsScreen`, fixing the search field being uninteractive due to recomposition issues.
> - Adds `Modifier.fillMaxWidth()` to the `SearchBar` text field to expand its tap target for focus and input.
> - Deduplicates images in `OnboardingViewModel.addImages` using `contentHashCode`, ignoring batches that contain only already-added images.
> - Persists tags selected from search results into `availableTags` so they remain visible after the search is cleared.
> - Bumps version to 0.21.4.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8b8c7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->