### PR TITLE
security: pin bench Dockerfile base images by digest

### DIFF
--- a/scripts/guard-bench/Dockerfile.bench
+++ b/scripts/guard-bench/Dockerfile.bench
@@ -10,7 +10,7 @@
 #     --iters 5000 --concurrency 1 --threads 1
 
 # --- builder: trixie, matches the prod backend/Dockerfile ---
-FROM rust:1.93-trixie AS builder
+FROM rust:1.93-trixie@sha256:ecbe59a8408895edd02d9ef422504b8501dd9fa1526de27a45b73406d734d659 AS builder
 # `cargo build --bin moderation-stress` still compiles the full lib crate,
 # so the bench needs the same native deps as the prod Dockerfile
 # (libpq/libwebp/libssl for diesel, rust-s3, image, etc.).
@@ -23,7 +23,7 @@ COPY backend /app/backend
 RUN cargo build --release --bin moderation-stress
 
 # --- runtime: trixie-slim (glibc 2.41, same family as prod distroless) ---
-FROM debian:trixie-slim
+FROM debian:trixie-slim@sha256:8d7a3dca57e62717b0f10897aca189da5d7acde3cc1ced657bdfd06ef5379576
 COPY --from=builder /app/backend/target/release/moderation-stress \
      /usr/local/bin/moderation-stress
 # Reuse the ops-provisioned model directory (same path prod compose


### PR DESCRIPTION
Resolves Scorecard PinnedDependenciesID alerts #462/#463.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782163305&installation_id=133691716&pr_number=532&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F532&signature=10b299c47efd8c8aa7854b8d93fa13900eb0769a7b2c3907030b7aff1fd0fab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin bench Dockerfile base images by digest
> Pins both base images in [Dockerfile.bench](https://github.com/poziomki-app/poziomki/pull/532/files#diff-368d41bc64b9f379a7416ef7a53c004e0ef754f2ca8ddf9010ec6b47e77ffdf6) to immutable SHA256 digests instead of mutable tags, ensuring builds always use the same exact image contents regardless of upstream tag updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed6bf71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->