### PR TITLE
ci(ios): TestFlight auto-deploy + 0.21.5

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,0 +1,104 @@
+name: iOS Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to publish, for example v0.21.4
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: [self-hosted, macOS, arm64]
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate tag matches MARKETING_VERSION
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          version_name="$(sed -n 's/^MARKETING_VERSION=\(.*\)$/\1/p' mobile/iosApp/Configuration/Config.xcconfig | head -n1)"
+          if [[ -z "$version_name" ]]; then
+            echo "Could not read MARKETING_VERSION" >&2
+            exit 1
+          fi
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            release_tag="${INPUT_TAG_NAME}"
+            if [[ -z "$release_tag" ]]; then
+              release_tag="v${version_name}"
+            fi
+          else
+            release_tag="${GITHUB_REF_NAME}"
+          fi
+          if [[ "$release_tag" != "v${version_name}" ]]; then
+            echo "Release tag ${release_tag} does not match MARKETING_VERSION ${version_name}" >&2
+            exit 1
+          fi
+          echo "VERSION_NAME=$version_name" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
+
+      - name: Restore iOS GoogleService-Info.plist
+        env:
+          IOS_GOOGLE_SERVICE_INFO_PLIST_B64: ${{ secrets.IOS_GOOGLE_SERVICE_INFO_PLIST_B64 }}
+        run: |
+          if [[ -z "${IOS_GOOGLE_SERVICE_INFO_PLIST_B64}" ]]; then
+            echo "::error::IOS_GOOGLE_SERVICE_INFO_PLIST_B64 secret is not set" >&2
+            exit 1
+          fi
+          echo "$IOS_GOOGLE_SERVICE_INFO_PLIST_B64" | base64 --decode > mobile/iosApp/iosApp/GoogleService-Info.plist
+          if ! /usr/bin/plutil -lint mobile/iosApp/iosApp/GoogleService-Info.plist >/dev/null; then
+            echo "::error::GoogleService-Info.plist failed plutil lint" >&2
+            exit 1
+          fi
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2.9"
+          bundler-cache: true
+          working-directory: mobile/iosApp
+
+      - name: Compute TestFlight build number
+        run: |
+          build_number="$(date +%y%m%d%H%M)"
+          echo "IOS_BUILD_NUMBER=$build_number" >> "$GITHUB_ENV"
+          echo "Using build number: $build_number"
+
+      - name: Build and upload to TestFlight
+        working-directory: mobile/iosApp
+        env:
+          CI: "true"
+          LC_ALL: en_US.UTF-8
+          LANG: en_US.UTF-8
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          IOS_BUNDLE_ID: app.poziomki.ios
+          IOS_MARKETING_VERSION: ${{ env.VERSION_NAME }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_P8: ${{ secrets.ASC_KEY_P8_B64 }}
+          MATCH_GIT_URL: git@github-certs:poziomki-app/certs.git
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_READONLY: "true"
+          FASTLANE_HIDE_CHANGELOG: "true"
+          FASTLANE_SKIP_UPDATE_CHECK: "true"
+        run: bundle exec fastlane beta

--- a/docs/ios-deploy.md
+++ b/docs/ios-deploy.md
@@ -1,0 +1,99 @@
+# iOS TestFlight auto-deploy
+
+Pushing a `v*` tag triggers `.github/workflows/ios-release.yml`, which builds the
+iOS app on the self-hosted Mac mini runner and uploads it to TestFlight via
+fastlane. Manual `workflow_dispatch` is supported too.
+
+## One-time setup
+
+### 1. App Store Connect API key
+
+1. Go to <https://appstoreconnect.apple.com> → **Users and Access** →
+   **Integrations** → **App Store Connect API** → **Team Keys**.
+2. Generate a key with **App Manager** role (Admin also works).
+3. Note the **Issuer ID**, **Key ID**, and download the `.p8` file (one-time
+   download — keep it safe).
+4. Base64-encode the `.p8`:
+
+   ```bash
+   base64 -i AuthKey_XXXXXXXXXX.p8 | tr -d '\n' | pbcopy
+   ```
+
+### 2. fastlane match private repo
+
+`match` stores the encrypted distribution certificate and provisioning profile
+in `poziomki-app/certs` (private). The Mac mini runner authenticates via SSH
+deploy key (already configured at `~/.ssh/poziomki_certs` with a `github-certs`
+host alias).
+
+Bootstrap (one time, on the Mac mini):
+
+```bash
+cd ~/poziomki/mobile/iosApp   # or wherever the repo is checked out
+bundle install
+export MATCH_GIT_URL=git@github-certs:poziomki-app/certs.git
+export MATCH_PASSWORD='choose-a-strong-passphrase'
+export APPLE_TEAM_ID=ABCDE12345
+export IOS_BUNDLE_ID=app.poziomki.ios
+export ASC_KEY_ID=XXXXXXXXXX
+export ASC_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+export ASC_KEY_P8="$(base64 -i ~/AuthKey_XXXXXXXXXX.p8 | tr -d '\n')"
+bundle exec fastlane match appstore
+```
+
+This creates the distribution cert + App Store provisioning profile and
+commits them (encrypted) to the certs repo. After this, CI runs in `readonly`
+mode and never modifies the repo.
+
+### 3. GitHub repo secrets
+
+Add the following at **Settings → Secrets and variables → Actions**:
+
+| Secret | Value |
+|---|---|
+| `APPLE_TEAM_ID` | 10-char team ID from <https://developer.apple.com/account> → Membership |
+| `ASC_KEY_ID` | App Store Connect API Key ID |
+| `ASC_ISSUER_ID` | App Store Connect API Issuer ID |
+| `ASC_KEY_P8_B64` | base64 of the `.p8` file (single line, no newlines) |
+| `MATCH_PASSWORD` | the passphrase used to encrypt the match repo |
+| `IOS_GOOGLE_SERVICE_INFO_PLIST_B64` | base64 of the real `GoogleService-Info.plist` |
+
+### 4. Self-hosted runner on the Mac mini
+
+1. In the repo: **Settings → Actions → Runners → New self-hosted runner**,
+   select macOS / arm64. Copy the registration token.
+2. On `macmini`:
+
+   ```bash
+   mkdir -p ~/actions-runner && cd ~/actions-runner
+   curl -O -L https://github.com/actions/runner/releases/download/v2.319.1/actions-runner-osx-arm64-2.319.1.tar.gz
+   tar xzf ./actions-runner-osx-arm64-2.319.1.tar.gz
+   ./config.sh --url https://github.com/<owner>/<repo> --token <token> --labels self-hosted,macOS,arm64
+   ./svc.sh install
+   ./svc.sh start
+   ```
+
+3. Install fastlane prerequisites once:
+
+   ```bash
+   /opt/homebrew/bin/brew install rbenv ruby-build
+   rbenv install 3.2.9 && rbenv global 3.2.9
+   gem install bundler
+   ```
+
+## Releasing
+
+Bump `MARKETING_VERSION` in `mobile/iosApp/Configuration/Config.xcconfig`,
+commit, then tag:
+
+```bash
+git tag v0.21.5
+git push origin v0.21.5
+```
+
+The workflow validates the tag matches `MARKETING_VERSION`, builds, and
+uploads. `CURRENT_PROJECT_VERSION` (TestFlight build number) is auto-derived
+from the current timestamp so it always monotonically increases.
+
+After upload, TestFlight needs ~10–30 minutes to process the build before it's
+testable.

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.21.4" // x-release-please-version
+val appVersionName = "0.21.5" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/iosApp/.gitignore
+++ b/mobile/iosApp/.gitignore
@@ -1,0 +1,8 @@
+build/
+fastlane/report.xml
+fastlane/README.md
+fastlane/test_output
+Gemfile.lock
+vendor/bundle/
+*.ipa
+*.dSYM.zip

--- a/mobile/iosApp/Configuration/Config.xcconfig
+++ b/mobile/iosApp/Configuration/Config.xcconfig
@@ -1,3 +1,5 @@
 TEAM_ID=
-BUNDLE_ID=com.poziomki.app
+BUNDLE_ID=app.poziomki.ios
 APP_NAME=Poziomki
+MARKETING_VERSION=0.21.5
+CURRENT_PROJECT_VERSION=1

--- a/mobile/iosApp/Gemfile
+++ b/mobile/iosApp/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/mobile/iosApp/fastlane/Appfile
+++ b/mobile/iosApp/fastlane/Appfile
@@ -1,0 +1,2 @@
+app_identifier(ENV["IOS_BUNDLE_ID"] || "app.poziomki.ios")
+team_id(ENV["APPLE_TEAM_ID"])

--- a/mobile/iosApp/fastlane/Fastfile
+++ b/mobile/iosApp/fastlane/Fastfile
@@ -1,0 +1,69 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Sync signing assets from match (read-only in CI)"
+  lane :signing do
+    setup_ci if ENV["CI"]
+    app_store_connect_api_key(
+      key_id: ENV["ASC_KEY_ID"],
+      issuer_id: ENV["ASC_ISSUER_ID"],
+      key_content: ENV["ASC_KEY_P8"],
+      is_key_content_base64: true,
+      in_house: false
+    )
+    match(type: "appstore")
+  end
+
+  desc "Build and upload a new TestFlight build"
+  lane :beta do
+    setup_ci if ENV["CI"]
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV["ASC_KEY_ID"],
+      issuer_id: ENV["ASC_ISSUER_ID"],
+      key_content: ENV["ASC_KEY_P8"],
+      is_key_content_base64: true,
+      in_house: false
+    )
+
+    match(type: "appstore")
+
+    bundle_id = ENV["IOS_BUNDLE_ID"] || "app.poziomki.ios"
+    profile_name = ENV["sigh_#{bundle_id}_appstore_profile-name"] ||
+                   "match AppStore #{bundle_id}"
+
+    build_app(
+      project: "iosApp.xcodeproj",
+      scheme: "iosApp",
+      configuration: "Release",
+      clean: true,
+      output_directory: "build",
+      output_name: "Poziomki.ipa",
+      export_method: "app-store",
+      xcargs: [
+        "MARKETING_VERSION=#{ENV['IOS_MARKETING_VERSION']}",
+        "CURRENT_PROJECT_VERSION=#{ENV['IOS_BUILD_NUMBER']}",
+        "CODE_SIGN_STYLE=Manual",
+        "DEVELOPMENT_TEAM=#{ENV['APPLE_TEAM_ID']}",
+        "PROVISIONING_PROFILE_SPECIFIER=#{profile_name}",
+        "TEAM_ID=",
+        "BUNDLE_ID=#{bundle_id}"
+      ].join(" "),
+      export_options: {
+        method: "app-store",
+        signingStyle: "manual",
+        teamID: ENV["APPLE_TEAM_ID"],
+        provisioningProfiles: {
+          bundle_id => profile_name
+        }
+      }
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: "build/Poziomki.ipa",
+      skip_waiting_for_build_processing: true,
+      skip_submission: true
+    )
+  end
+end

--- a/mobile/iosApp/fastlane/Matchfile
+++ b/mobile/iosApp/fastlane/Matchfile
@@ -1,0 +1,6 @@
+git_url(ENV["MATCH_GIT_URL"])
+storage_mode("git")
+type("appstore")
+app_identifier([ENV["IOS_BUNDLE_ID"] || "app.poziomki.ios"])
+team_id(ENV["APPLE_TEAM_ID"])
+readonly(ENV["MATCH_READONLY"] == "true")

--- a/mobile/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/mobile/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7555FF7A242A565900829871"
+               BuildableName = "KMP App.app"
+               BlueprintName = "iosApp"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7555FF7A242A565900829871"
+            BuildableName = "KMP App.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7555FF7A242A565900829871"
+            BuildableName = "KMP App.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
- iOS TestFlight pipeline via fastlane match on self-hosted Mac mini
- Bump Android + iOS to 0.21.5

Setup: `docs/ios-deploy.md`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782250627&installation_id=133691716&pr_number=533&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F533&signature=fe79a45322e75bad6ce7fa7b4a4c5157a3d19735c98b030cd5640ee1634029e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TestFlight auto-deploy CI workflow for iOS and bump version to 0.21.5
> - Adds [ios-release.yml](https://github.com/poziomki-app/poziomki/pull/533/files#diff-4b7cd12057679e964ecd3635db894e799a1c04e845628673c21ca95ad6563a84) that triggers on `v*` tags or manual dispatch, validates the tag against `MARKETING_VERSION` in [Config.xcconfig](https://github.com/poziomki-app/poziomki/pull/533/files#diff-4005ec7ee766a872d2af605635e72a69c1ff7b8514920948a800f9eff38af0d7), and uploads an IPA to TestFlight via `fastlane beta` on a self-hosted macOS arm64 runner.
> - Adds fastlane setup ([Fastfile](https://github.com/poziomki-app/poziomki/pull/533/files#diff-4bf0b460c4e7a49397eedf82de73fde83fae253b24be1648ab2933b4be392cff), [Matchfile](https://github.com/poziomki-app/poziomki/pull/533/files#diff-49c6864946b82516fa8530d8650aa7981bcad80192ff2fc2b773c9a6b5f7c066), [Appfile](https://github.com/poziomki-app/poziomki/pull/533/files#diff-d68ee24841105a790186805ad3b34abab797606957d51ae8367d6e8885fb0b78), [Gemfile](https://github.com/poziomki-app/poziomki/pull/533/files#diff-7ef5a2b1a07d06a759dbc9d0f007f8310829ba47bd30019660b18f54ffeca2fb)) using App Store Connect API credentials and `match` for code signing from a git repo.
> - Bumps version to 0.21.5 in both [Config.xcconfig](https://github.com/poziomki-app/poziomki/pull/533/files#diff-4005ec7ee766a872d2af605635e72a69c1ff7b8514920948a800f9eff38af0d7) and [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/533/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be); iOS bundle ID changes from `com.poziomki.app` to `app.poziomki.ios`.
> - `Info.plist` version fields now reference `$(MARKETING_VERSION)` and `$(CURRENT_PROJECT_VERSION)` build settings instead of hardcoded values.
> - Risk: bundle ID change will break any existing App Store Connect app record or provisioning profiles using the old identifier.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 81761a4. 9 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->