### PR TITLE
fix(ci): use rbenv Ruby on self-hosted Mac runner

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -72,11 +72,13 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.2.9"
-          bundler-cache: true
-          working-directory: mobile/iosApp
+      - name: Install fastlane gems
+        working-directory: mobile/iosApp
+        run: |
+          export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:/opt/homebrew/bin:$PATH"
+          ruby --version
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs 4 --retry 3
 
       - name: Compute TestFlight build number
         run: |
@@ -101,4 +103,6 @@ jobs:
           MATCH_READONLY: "true"
           FASTLANE_HIDE_CHANGELOG: "true"
           FASTLANE_SKIP_UPDATE_CHECK: "true"
-        run: bundle exec fastlane beta
+        run: |
+          export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:/opt/homebrew/bin:$PATH"
+          bundle exec fastlane beta


### PR DESCRIPTION
ruby/setup-ruby assumes /Users/runner; self-hosted runner is /Users/miniserver. Use the pre-installed rbenv Ruby instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782251366&installation_id=133691716&pr_number=535&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F535&signature=91f966082782b02484cb710fa33ab3797117cf55cbab82f45672c035eaa6221c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iOS release CI to use rbenv Ruby on self-hosted Mac runner
> Replaces the `ruby/setup-ruby` action with a shell-based gem install step that explicitly prepends rbenv and Homebrew paths to `PATH`, installs gems via Bundler into `vendor/bundle`, and runs `bundle exec fastlane beta` with the same PATH override. This fixes gem resolution failures caused by `ruby/setup-ruby` not working correctly on self-hosted macOS runners.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29c1a2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->