### PR TITLE
fix(ios): shell-escape xcodebuild xcargs values

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -72,11 +72,13 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.2.9"
-          bundler-cache: true
-          working-directory: mobile/iosApp
+      - name: Install fastlane gems
+        working-directory: mobile/iosApp
+        run: |
+          export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:/opt/homebrew/bin:$PATH"
+          ruby --version
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs 4 --retry 3
 
       - name: Compute TestFlight build number
         run: |
@@ -101,4 +103,6 @@ jobs:
           MATCH_READONLY: "true"
           FASTLANE_HIDE_CHANGELOG: "true"
           FASTLANE_SKIP_UPDATE_CHECK: "true"
-        run: bundle exec fastlane beta
+        run: |
+          export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:/opt/homebrew/bin:$PATH"
+          bundle exec fastlane beta

--- a/mobile/iosApp/fastlane/Fastfile
+++ b/mobile/iosApp/fastlane/Fastfile
@@ -1,3 +1,5 @@
+require "shellwords"
+
 default_platform(:ios)
 
 platform :ios do
@@ -40,15 +42,15 @@ platform :ios do
       output_directory: "build",
       output_name: "Poziomki.ipa",
       export_method: "app-store",
-      xcargs: [
-        "MARKETING_VERSION=#{ENV['IOS_MARKETING_VERSION']}",
-        "CURRENT_PROJECT_VERSION=#{ENV['IOS_BUILD_NUMBER']}",
-        "CODE_SIGN_STYLE=Manual",
-        "DEVELOPMENT_TEAM=#{ENV['APPLE_TEAM_ID']}",
-        "PROVISIONING_PROFILE_SPECIFIER=#{profile_name}",
-        "TEAM_ID=",
-        "BUNDLE_ID=#{bundle_id}"
-      ].join(" "),
+      xcargs: {
+        "MARKETING_VERSION" => ENV["IOS_MARKETING_VERSION"],
+        "CURRENT_PROJECT_VERSION" => ENV["IOS_BUILD_NUMBER"],
+        "CODE_SIGN_STYLE" => "Manual",
+        "DEVELOPMENT_TEAM" => ENV["APPLE_TEAM_ID"],
+        "PROVISIONING_PROFILE_SPECIFIER" => profile_name,
+        "TEAM_ID" => "",
+        "BUNDLE_ID" => bundle_id
+      }.map { |k, v| "#{k}=#{Shellwords.escape(v.to_s)}" }.join(" "),
       export_options: {
         method: "app-store",
         signingStyle: "manual",


### PR DESCRIPTION
PROVISIONING_PROFILE_SPECIFIER value contains spaces (`match AppStore <bundle>`); without escaping, xcodebuild parses subsequent words as build actions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782251570&installation_id=133691716&pr_number=536&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F536&signature=eb84e810b99376f77a1c5f527e833a227e7dfe220f1dff1e6c85beb625bcbbaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Shell-escape `xcargs` values in the iOS `gym` fastlane invocation
> - Adds `require "shellwords"` to [Fastfile](https://github.com/poziomki-app/poziomki/pull/536/files#diff-4bf0b460c4e7a49397eedf82de73fde83fae253b24be1648ab2933b4be392cff) and rewrites xcargs construction to use `Shellwords.escape` on each value, preventing xcodebuild from misparsing values that contain special characters.
> - Updates the [ios-release workflow](https://github.com/poziomki-app/poziomki/pull/536/files#diff-4b7cd12057679e964ecd3635db894e799a1c04e845628673c21ca95ad6563a84) to install gems via a bundler shell script using rbenv/Homebrew paths instead of `ruby/setup-ruby`, and exports the same PATH before invoking `bundle exec fastlane beta`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85e4f31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->