### PR TITLE
fix(ios): force Apple Distribution signing identity for archive

### DIFF
--- a/mobile/iosApp/fastlane/Fastfile
+++ b/mobile/iosApp/fastlane/Fastfile
@@ -46,6 +46,7 @@ platform :ios do
         "MARKETING_VERSION" => ENV["IOS_MARKETING_VERSION"],
         "CURRENT_PROJECT_VERSION" => ENV["IOS_BUILD_NUMBER"],
         "CODE_SIGN_STYLE" => "Manual",
+        "CODE_SIGN_IDENTITY" => "Apple Distribution",
         "DEVELOPMENT_TEAM" => ENV["APPLE_TEAM_ID"],
         "PROVISIONING_PROFILE_SPECIFIER" => profile_name,
         "TEAM_ID" => "",


### PR DESCRIPTION
Project pbxproj has CODE_SIGN_IDENTITY=Apple Development for both Debug and Release. Override via xcargs so archive picks the dist cert from match.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782251878&installation_id=133691716&pr_number=537&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F537&signature=d09c4d5c9a316f8fb88793cabca022ef06fd9fc430c50f0bedfa952b0bb8f961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force `Apple Distribution` signing identity for iOS archive builds
> Adds `CODE_SIGN_IDENTITY = "Apple Distribution"` to the build settings in [Fastfile](https://github.com/poziomki-app/poziomki/pull/537/files#diff-4bf0b460c4e7a49397eedf82de73fde83fae253b24be1648ab2933b4be392cff), alongside the existing manual signing configuration. This ensures the correct identity is explicitly selected during archiving rather than relying on implicit resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47f13c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->