### PR TITLE
fix(ios): scope manual signing to iosApp target only

### DIFF
--- a/mobile/iosApp/fastlane/Fastfile
+++ b/mobile/iosApp/fastlane/Fastfile
@@ -46,6 +46,7 @@ platform :ios do
         "MARKETING_VERSION" => ENV["IOS_MARKETING_VERSION"],
         "CURRENT_PROJECT_VERSION" => ENV["IOS_BUILD_NUMBER"],
         "CODE_SIGN_STYLE" => "Manual",
+        "CODE_SIGN_IDENTITY" => "Apple Distribution",
         "DEVELOPMENT_TEAM" => ENV["APPLE_TEAM_ID"],
         "PROVISIONING_PROFILE_SPECIFIER" => profile_name,
         "TEAM_ID" => "",

--- a/mobile/iosApp/fastlane/Fastfile
+++ b/mobile/iosApp/fastlane/Fastfile
@@ -34,6 +34,16 @@ platform :ios do
     profile_name = ENV["sigh_#{bundle_id}_appstore_profile-name"] ||
                    "match AppStore #{bundle_id}"
 
+    update_code_signing_settings(
+      path: "iosApp.xcodeproj",
+      use_automatic_signing: false,
+      team_id: ENV["APPLE_TEAM_ID"],
+      bundle_identifier: bundle_id,
+      profile_name: profile_name,
+      code_sign_identity: "Apple Distribution",
+      targets: ["iosApp"]
+    )
+
     build_app(
       project: "iosApp.xcodeproj",
       scheme: "iosApp",
@@ -45,10 +55,6 @@ platform :ios do
       xcargs: {
         "MARKETING_VERSION" => ENV["IOS_MARKETING_VERSION"],
         "CURRENT_PROJECT_VERSION" => ENV["IOS_BUILD_NUMBER"],
-        "CODE_SIGN_STYLE" => "Manual",
-        "CODE_SIGN_IDENTITY" => "Apple Distribution",
-        "DEVELOPMENT_TEAM" => ENV["APPLE_TEAM_ID"],
-        "PROVISIONING_PROFILE_SPECIFIER" => profile_name,
         "TEAM_ID" => "",
         "BUNDLE_ID" => bundle_id
       }.map { |k, v| "#{k}=#{Shellwords.escape(v.to_s)}" }.join(" "),


### PR DESCRIPTION
SPM dependencies (Firebase, GoogleDataTransport) error when a global PROVISIONING_PROFILE_SPECIFIER is passed. Use update_code_signing_settings to apply signing only to the iosApp target.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782252082&installation_id=133691716&pr_number=539&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F539&signature=dd15a3de9b9a4331435c63d76e979ab3292b89711728ecdafca4eafceebe2d90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope manual code signing to `iosApp` target only in Fastfile
> - Adds an `update_code_signing_settings` step before `build_app` in [Fastfile](https://github.com/poziomki-app/poziomki/pull/539/files#diff-4bf0b460c4e7a49397eedf82de73fde83fae253b24be1648ab2933b4be392cff) to apply manual signing directly to the Xcode project for the `iosApp` target only.
> - Removes `CODE_SIGN_STYLE`, `DEVELOPMENT_TEAM`, and `PROVISIONING_PROFILE_SPECIFIER` from `xcargs`, relying on project-level settings instead.
> - Behavioral Change: signing configuration is now applied via Fastlane's project mutation rather than xcodebuild arguments, which limits the signing scope to the `iosApp` target rather than all targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3711246.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->