### PR TITLE
fix(ios): restore android google-services.json for iOS release builds

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -53,6 +53,18 @@ jobs:
           echo "VERSION_NAME=$version_name" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
 
+      - name: Restore Android google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
+        # Gradle's release guard fires for assembleIosArm64ReleaseAppleFrameworkForXcode
+        # too, so the iOS build needs the real Android config in place.
+        run: |
+          if [[ -z "${GOOGLE_SERVICES_JSON_B64}" ]]; then
+            echo "::error::GOOGLE_SERVICES_JSON_B64 secret is not set" >&2
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON_B64" | base64 --decode > mobile/androidApp/google-services.json
+
       - name: Restore iOS GoogleService-Info.plist
         env:
           IOS_GOOGLE_SERVICE_INFO_PLIST_B64: ${{ secrets.IOS_GOOGLE_SERVICE_INFO_PLIST_B64 }}


### PR DESCRIPTION
Gradle's release guard in androidApp/build.gradle.kts triggers on assembleIosArm64ReleaseAppleFrameworkForXcode (matches assemble*Release). iOS release build needs the real config dropped in place.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782252645&installation_id=133691716&pr_number=541&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F541&signature=186eb87bebc1c35807efe9b4550456e227c244f9d00cdad4e3e597c747cc6aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore Android `google-services.json` in the iOS release workflow
> The iOS release job in [ios-release.yml](.github/workflows/ios-release.yml) now decodes `GOOGLE_SERVICES_JSON_B64` from secrets and writes it to `mobile/androidApp/google-services.json` before the iOS plist step. The job fails immediately if the secret is missing or invalid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb83aa8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->