### PR TITLE
fix(ios): restore Kotlin/Native compilation

### DIFF
--- a/mobile/app-ui/src/androidMain/kotlin/com/poziomki/app/ui/cache/CoilCacheDir.android.kt
+++ b/mobile/app-ui/src/androidMain/kotlin/com/poziomki/app/ui/cache/CoilCacheDir.android.kt
@@ -1,0 +1,7 @@
+package com.poziomki.app.ui.cache
+
+import coil3.PlatformContext
+import okio.Path
+import okio.Path.Companion.toOkioPath
+
+actual fun coilImageCacheDir(context: PlatformContext): Path = context.cacheDir.resolve("coil_images").toOkioPath()

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/App.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/App.kt
@@ -21,13 +21,13 @@ import com.poziomki.app.data.sync.SyncEngine
 import com.poziomki.app.session.SessionBootstrapState
 import com.poziomki.app.session.SessionManager
 import com.poziomki.app.ui.cache.AppUpdateMigrator
+import com.poziomki.app.ui.cache.coilImageCacheDir
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
 import com.poziomki.app.ui.navigation.AppNavigation
 import com.poziomki.app.ui.navigation.Route
 import com.poziomki.app.ui.shared.ImgproxyCacheInterceptor
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
-import okio.Path.Companion.toOkioPath
 import org.koin.compose.koinInject
 import org.koin.mp.KoinPlatform
 
@@ -144,7 +144,7 @@ internal fun buildImageLoaderFactory(imageHttpClient: HttpClient): (PlatformCont
             }.diskCache {
                 DiskCache
                     .Builder()
-                    .directory(context.cacheDir.resolve("coil_images").toOkioPath())
+                    .directory(coilImageCacheDir(context))
                     .maxSizeBytes(COIL_DISK_CACHE_MAX_SIZE_BYTES)
                     .build()
             }.components {

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/cache/CoilCacheDir.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/cache/CoilCacheDir.kt
@@ -1,0 +1,6 @@
+package com.poziomki.app.ui.cache
+
+import coil3.PlatformContext
+import okio.Path
+
+expect fun coilImageCacheDir(context: PlatformContext): Path

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
@@ -52,6 +52,7 @@ import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.White
+import kotlin.math.roundToLong
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -169,7 +170,7 @@ fun LocationPickerSheet(
                     results = emptyList()
                     scope.launch {
                         val name = geocoding.reverse(position.latitude, position.longitude)
-                        selectedName = name ?: "%.4f, %.4f".format(position.latitude, position.longitude)
+                        selectedName = name ?: "${formatCoord(position.latitude)}, ${formatCoord(position.longitude)}"
                         query = selectedName
                     }
                     ClickResult.Consume
@@ -313,4 +314,12 @@ fun LocationPickerSheet(
             }
         }
     }
+}
+
+private fun formatCoord(v: Double): String {
+    val scaled = (v * 10_000.0).roundToLong()
+    val whole = scaled / 10_000
+    val frac = (if (scaled < 0) -scaled else scaled) % 10_000
+    val sign = if (v < 0 && whole == 0L) "-" else ""
+    return "$sign$whole.${frac.toString().padStart(4, '0')}"
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/EventsScreen.kt
@@ -624,7 +624,8 @@ private fun WeekEventsContent(
         remember(events) {
             events
                 .groupBy { eventDateKey(it.startsAt) }
-                .toSortedMap()
+                .entries
+                .sortedBy { it.key }
         }
     val collapsedDays = remember { mutableStateMapOf<Long, Boolean>() }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfilePreviewDialog.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/onboarding/ProfilePreviewDialog.kt
@@ -21,11 +21,7 @@ fun ProfilePreviewDialog(
 
     Dialog(
         onDismissRequest = onDismiss,
-        properties =
-            DialogProperties(
-                usePlatformDefaultWidth = false,
-                decorFitsSystemWindows = false,
-            ),
+        properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         ProfilePreview(
             name = name,

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileEditScreen.kt
@@ -823,7 +823,7 @@ internal fun BioEditorDialog(
 
     Dialog(
         onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+        properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         Box(
             modifier =
@@ -1080,7 +1080,7 @@ private fun GradientPickerDialog(
 
     Dialog(
         onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+        properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         Column(
             modifier =

--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/cache/CoilCacheDir.ios.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/cache/CoilCacheDir.ios.kt
@@ -1,0 +1,19 @@
+package com.poziomki.app.ui.cache
+
+import coil3.PlatformContext
+import okio.Path
+import okio.Path.Companion.toPath
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSUserDomainMask
+
+actual fun coilImageCacheDir(context: PlatformContext): Path {
+    val cachesDir =
+        NSSearchPathForDirectoriesInDomains(
+            directory = NSCachesDirectory,
+            domainMask = NSUserDomainMask,
+            expandTilde = true,
+        ).firstOrNull() as? String ?: NSTemporaryDirectory()
+    return "$cachesDir/coil_images".toPath()
+}

--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/ExportSaver.ios.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/ExportSaver.ios.kt
@@ -2,6 +2,8 @@ package com.poziomki.app.ui.shared
 
 import androidx.compose.runtime.Composable
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSURL
@@ -50,7 +52,7 @@ private fun ByteArray.toNSData(): NSData =
     if (isEmpty()) {
         NSData()
     } else {
-        kotlinx.cinterop.usePinned { pinned ->
+        usePinned { pinned ->
             NSData.create(
                 bytes = pinned.addressOf(0),
                 length = size.toULong(),


### PR DESCRIPTION
Compiler errors that accumulated since the last iOS build:

- App.kt: extract coil disk cache directory behind an expect/actual (Android Context.cacheDir was leaking into commonMain)
- LocationPickerSheet.kt: drop JVM String.format; small fixed-decimal helper
- EventsScreen.kt: replace JVM-only toSortedMap with sorted entries
- ProfilePreviewDialog.kt + ProfileEditScreen.kt: drop Android-only decorFitsSystemWindows DialogProperties arg
- ExportSaver.ios.kt: add missing kotlinx.cinterop imports (usePinned/addressOf)

Verified locally: iosArm64 + iosSimulatorArm64 + iosX64 + androidMain compile; iosArm64 release framework links.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782254358&installation_id=133691716&pr_number=542&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F542&signature=e4a73286b35a19c27ed0ca68a7e69c84f171998c15fb886ddb548ef38794a81f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Kotlin/Native compilation on iOS by replacing incompatible API calls
> - Replaces `String.format("%.4f, %.4f", lat, lon)` in [LocationPickerSheet.kt](https://github.com/poziomki-app/poziomki/pull/542/files#diff-ff1627a8902784b566577f1309d019d601f2991e0bf42d9388e6daffa86f809c) with a custom `formatCoord` helper using integer math, since `String.format` is not available in Kotlin/Native
> - Extracts Coil cache directory resolution into an `expect`/`actual` function ([CoilCacheDir.kt](https://github.com/poziomki-app/poziomki/pull/542/files#diff-4891f1dd4f8792c05b56f21e15d8ef71a9e55f512400404b2df9128495a22d6b)) with platform-specific implementations for Android and iOS, replacing a direct `toOkioPath()` call that was unavailable on iOS
> - Fixes `ExportSaver.ios.kt` to use imported `usePinned` instead of a fully-qualified reference
> - Removes `decorFitsSystemWindows = false` from dialog properties in profile and onboarding screens, which is Android-only and caused Native compilation failures
> - Changes `groupBy(...).toSortedMap()` in `WeekEventsContent` to `groupBy(...).entries.sortedBy { it.key }` since `toSortedMap()` is JVM-only
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4e1e9c3. 9 files reviewed, 4 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->