### PR TITLE
build: raise Kotlin daemon heap to 8g

### DIFF
--- a/mobile/gradle.properties
+++ b/mobile/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-kotlin.daemon.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m
+kotlin.daemon.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=512m
 
 #Gradle
 org.gradle.jvmargs=-Xmx3072M -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8


### PR DESCRIPTION
6g still OOMs during linkReleaseFrameworkIosArm64 on the Mac runner. Bump to 8g (mini has 16g).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782255714&installation_id=133691716&pr_number=545&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F545&signature=ef40c1b2e5d894be7a9a3627d3c29d20b627c26e7f49155b7ac47dfb8125d194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise Kotlin daemon heap size to 8g in mobile build
> Increases `kotlin.daemon.jvmargs` max heap from `-Xmx6g` to `-Xmx8g` in [gradle.properties](https://github.com/poziomki-app/poziomki/pull/545/files#diff-8b4ac3bc7b2b616e6c6b5266ebd2c44f020c9d1bd30c686a03a068785ccfcc65). `MaxMetaspaceSize` remains at 512m.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 860bd11.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->