### PR TITLE
build: raise gradle JVM heap for K/Native linker

### DIFF
--- a/mobile/gradle.properties
+++ b/mobile/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=512m
 
 #Gradle
-org.gradle.jvmargs=-Xmx3072M -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
Kotlin/Native linker inherits heap from org.gradle.jvmargs not kotlin.daemon.jvmargs. Bump to 8g.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782256145&installation_id=133691716&pr_number=546&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F546&signature=f544d028ee77a2c68e16cb64cbc5778fdd9c796ae0486e0996cca522731c0183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise Gradle JVM max heap to 8g for K/Native linker
> Increases `org.gradle.jvmargs` max heap in [gradle.properties](https://github.com/poziomki-app/poziomki/pull/546/files#diff-8b4ac3bc7b2b616e6c6b5266ebd2c44f020c9d1bd30c686a03a068785ccfcc65) from `-Xmx3072M` to `-Xmx8g` to support the K/Native linker. Risk: Gradle daemon processes for this module will now consume up to 8g of heap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0643206.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->