### PR TITLE
fix(ios): add MapLibre SPM dependency

### DIFF
--- a/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		F1B1A00000000000000000A1 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B1 /* FirebaseAnalytics */; };
+		F1B1A00000000000000000A5 /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B5 /* MapLibre */; };
 		F1B1A00000000000000000A2 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B2 /* FirebaseCrashlytics */; };
 		F1B1A00000000000000000A3 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B3 /* FirebasePerformance */; };
 		F1B1A00000000000000000A4 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F1B1A00000000000000000C1 /* GoogleService-Info.plist */; };
@@ -36,6 +37,7 @@
 				F1B1A00000000000000000A1 /* FirebaseAnalytics in Frameworks */,
 				F1B1A00000000000000000A2 /* FirebaseCrashlytics in Frameworks */,
 				F1B1A00000000000000000A3 /* FirebasePerformance in Frameworks */,
+				F1B1A00000000000000000A5 /* MapLibre in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -118,6 +120,7 @@
 				F1B1A00000000000000000B1 /* FirebaseAnalytics */,
 				F1B1A00000000000000000B2 /* FirebaseCrashlytics */,
 				F1B1A00000000000000000B3 /* FirebasePerformance */,
+				F1B1A00000000000000000B5 /* MapLibre */,
 			);
 			productName = iosApp;
 			productReference = 7555FF7B242A565900829871 /* KMP App.app */;
@@ -150,6 +153,7 @@
 			mainGroup = 7555FF72242A565900829871;
 			packageReferences = (
 				F1B1A00000000000000000E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				F1B1A00000000000000000E2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -434,6 +438,14 @@
 				minimumVersion = 11.0.0;
 			};
 		};
+		F1B1A00000000000000000E2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -451,6 +463,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F1B1A00000000000000000E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebasePerformance;
+		};
+		F1B1A00000000000000000B5 /* MapLibre */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F1B1A00000000000000000E2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			productName = MapLibre;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
K/Native ComposeApp.framework references MLN* (MapLibre Native) Objective-C classes via maplibre-compose. Static framework requires the consumer to provide those symbols.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782256996&installation_id=133691716&pr_number=547&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F547&signature=3c60156c7d43e8eef6f61ce0ffc981b4f537faed9f0c9d482f5fbc8c1e787cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MapLibre Swift Package Manager dependency to iOS app
> Adds the MapLibre package to [project.pbxproj](https://github.com/poziomki-app/poziomki/pull/547/files#diff-70b325ad92e073c7012f3fd0d4a4f8b798c4de9c3414f166bcd7661f3d059b99) via SPM, referencing `maplibre-gl-native-distribution` at `>= 6.0.0`. The `MapLibre` product is added to the Frameworks build phase and the target's package product dependencies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bba1c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->