### PR TITLE
fix(ios): force-load skiko's libharfbuzz.a (resolves Skia/MapLibre HarfBuzz conflict)

### DIFF
--- a/mobile/app-ui/build.gradle.kts
+++ b/mobile/app-ui/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.File
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidKmpLibrary)
@@ -8,6 +10,17 @@ plugins {
     id("poziomki.ktlint")
     id("poziomki.kotlin-warnings")
 }
+
+// See linkerOpts comment below: skiko leaves Skia's hb_* references undefined.
+// Find the already-resolved skiko klib on the iOS target's compile classpath
+// and return the path where its bundled libharfbuzz.a should be extracted.
+// Extraction itself happens via a doFirst hook on the link task so it runs
+// after gradle's metadata sync has materialized the klib file on disk.
+fun extractedHarfbuzzPath(konanTargetName: String): File =
+    layout.buildDirectory
+        .file("skiko-harfbuzz/$konanTargetName/libharfbuzz.a")
+        .get()
+        .asFile
 
 composeCompiler {
     includeTraceMarkers.set(false)
@@ -26,9 +39,32 @@ kotlin {
         iosArm64(),
         iosSimulatorArm64(),
     ).forEach { iosTarget ->
+        val konanTargetName = iosTarget.konanTarget.name
+        val hbPath = extractedHarfbuzzPath(konanTargetName)
+        val compileDeps = iosTarget.compilations.getByName("main").compileDependencyFiles
+        val skikoKlib = compileDeps.filter { it.name == "skiko.klib" }
+        val extractTask =
+            tasks.register<Sync>("extractSkikoHarfbuzz${konanTargetName.replaceFirstChar { it.uppercase() }}") {
+                from(zipTree(skikoKlib.singleFile)) {
+                    include("default/targets/$konanTargetName/included/libharfbuzz.a")
+                    eachFile { path = "libharfbuzz.a" }
+                    includeEmptyDirs = false
+                }
+                into(hbPath.parentFile)
+            }
         iosTarget.binaries.framework {
             baseName = "ComposeApp"
             isStatic = true
+            // Skiko leaves Skia's hb_* references undefined in its iOS native
+            // libs (libharfbuzz.a ships inside the skiko klib but isn't linked
+            // into the framework). When the iOS app also links
+            // MapLibre.framework — which bundles its own HarfBuzz with an
+            // incompatible hb_script_t ABI — ld binds Skia's hb_* references
+            // to MapLibre's symbols and the app crashes in hb_shape_full on
+            // first text render. Force-loading skiko's libharfbuzz.a here
+            // gives Skia its own HarfBuzz back.
+            linkerOpts("-force_load", hbPath.absolutePath)
+            linkTaskProvider.configure { dependsOn(extractTask) }
         }
     }
 

--- a/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -191,10 +191,11 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/libharfbuzz-skiko.a",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\ncd \"$SRCROOT/..\"\n./gradlew :app-ui:embedAndSignAppleFrameworkForXcode\n";
+			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\ncd \"$SRCROOT/..\"\n./gradlew :app-ui:embedAndSignAppleFrameworkForXcode\n# Map Xcode arch+SDK to konan target, then expose skiko's libharfbuzz.a at a\n# stable BUILT_PRODUCTS_DIR location so OTHER_LDFLAGS can force_load it.\n# Without this, MapLibre's bundled HarfBuzz wins symbol resolution and the\n# app crashes in hb_shape_full on first text render.\ncase \"$PLATFORM_NAME-$ARCHS\" in\n  iphoneos-arm64) KONAN_TARGET=ios_arm64; GRADLE_TASK=extractSkikoHarfbuzzIos_arm64 ;;\n  iphonesimulator-arm64) KONAN_TARGET=ios_simulator_arm64; GRADLE_TASK=extractSkikoHarfbuzzIos_simulator_arm64 ;;\n  iphonesimulator-x86_64) KONAN_TARGET=ios_x64; GRADLE_TASK=extractSkikoHarfbuzzIos_x64 ;;\n  *) echo \"warning: unrecognized $PLATFORM_NAME-$ARCHS; skipping HarfBuzz patch\"; exit 0 ;;\nesac\n./gradlew :app-ui:$GRADLE_TASK\nSRC=\"$SRCROOT/../app-ui/build/skiko-harfbuzz/$KONAN_TARGET/libharfbuzz.a\"\nif [ ! -f \"$SRC\" ]; then\n  echo \"error: expected $SRC after gradle extract\"\n  exit 1\nfi\nmkdir -p \"$BUILT_PRODUCTS_DIR\"\ncp \"$SRC\" \"$BUILT_PRODUCTS_DIR/libharfbuzz-skiko.a\"\n";
 		};
 		F1B1A00000000000000000D1 /* Upload Crashlytics dSYMs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -371,6 +372,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-force_load",
+					"$(BUILT_PRODUCTS_DIR)/libharfbuzz-skiko.a",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				PRODUCT_NAME = "${APP_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -397,6 +403,11 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-force_load",
+					"$(BUILT_PRODUCTS_DIR)/libharfbuzz-skiko.a",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				PRODUCT_NAME = "${APP_NAME}";

--- a/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/mobile/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		F1B1A00000000000000000A1 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B1 /* FirebaseAnalytics */; };
+		F1B1A00000000000000000A5 /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B5 /* MapLibre */; };
 		F1B1A00000000000000000A2 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B2 /* FirebaseCrashlytics */; };
 		F1B1A00000000000000000A3 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1A00000000000000000B3 /* FirebasePerformance */; };
 		F1B1A00000000000000000A4 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F1B1A00000000000000000C1 /* GoogleService-Info.plist */; };
@@ -36,6 +37,7 @@
 				F1B1A00000000000000000A1 /* FirebaseAnalytics in Frameworks */,
 				F1B1A00000000000000000A2 /* FirebaseCrashlytics in Frameworks */,
 				F1B1A00000000000000000A3 /* FirebasePerformance in Frameworks */,
+				F1B1A00000000000000000A5 /* MapLibre in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -118,6 +120,7 @@
 				F1B1A00000000000000000B1 /* FirebaseAnalytics */,
 				F1B1A00000000000000000B2 /* FirebaseCrashlytics */,
 				F1B1A00000000000000000B3 /* FirebasePerformance */,
+				F1B1A00000000000000000B5 /* MapLibre */,
 			);
 			productName = iosApp;
 			productReference = 7555FF7B242A565900829871 /* KMP App.app */;
@@ -150,6 +153,7 @@
 			mainGroup = 7555FF72242A565900829871;
 			packageReferences = (
 				F1B1A00000000000000000E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				F1B1A00000000000000000E2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -434,6 +438,14 @@
 				minimumVersion = 11.0.0;
 			};
 		};
+		F1B1A00000000000000000E2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -451,6 +463,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F1B1A00000000000000000E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebasePerformance;
+		};
+		F1B1A00000000000000000B5 /* MapLibre */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F1B1A00000000000000000E2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			productName = MapLibre;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
Compose Multiplatform on iOS ships Skia with ~1.6k undefined hb_* references — skiko bundles libharfbuzz.a inside its klib but doesn't link it. When the iOS app also links MapLibre.framework (which bundles its own HarfBuzz with an incompatible hb_script_t ABI), ld binds Skia's hb_* references to MapLibre's symbols. Result: app crashes in hb_shape_full on first text render.

Fix: extract skiko's libharfbuzz.a from the cached klib (gradle Sync task) and force-load it into the iosApp link via OTHER_LDFLAGS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782283421&installation_id=133691716&pr_number=548&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F548&signature=64c1115427f818683ac75736833e1795bb3ee52468f0a4155cced20caedbd31e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force-load Skiko's `libharfbuzz.a` in iOS builds to resolve HarfBuzz conflict with MapLibre
> - Adds a Gradle task in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/548/files#diff-bb9b7483473b9b72a33c375a8f5d0c8dc9a338ff62f98ed0e884f4d4079fb24f) that extracts `libharfbuzz.a` from the skiko klib for each iOS Kotlin/Native target, placing it under `build/skiko-harfbuzz/<target>/`.
> - Configures iOS framework link tasks to use `-force_load` on the extracted archive, ensuring Skiko's HarfBuzz symbols take precedence over those from MapLibre.
> - Adds MapLibre as a Swift Package dependency in [project.pbxproj](https://github.com/poziomki-app/poziomki/pull/548/files#diff-70b325ad92e073c7012f3fd0d4a4f8b798c4de9c3414f166bcd7661f3d059b99) and extends the Xcode shell script build phase to invoke the Gradle extraction task, copy the archive to `$(BUILT_PRODUCTS_DIR)/libharfbuzz-skiko.a`, and pass `-force_load` via `OTHER_LDFLAGS`.
> - Risk: the build phase now requires the Gradle extraction task to succeed before linking; build failures in the extraction step will block all iOS app builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6ee83d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->