### PR TITLE
chore: bump to 0.22.0 + auto-deploy to closed testing

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "backend": "0.19.0",
-  "mobile/androidApp": "0.20.0"
+  "mobile/androidApp": "0.22.0"
 }

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -165,3 +165,13 @@ jobs:
           releaseFiles: dist/android-release/*.aab
           track: internal
           status: completed
+
+      - name: Upload AAB to Play closed testing (alpha)
+        if: steps.play_secret.outputs.present == 'true'
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: app.poziomki
+          releaseFiles: dist/android-release/*.aab
+          track: alpha
+          status: completed

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.21.9" // x-release-please-version
+val appVersionName = "0.22.0" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/designsystem/components/LocationPickerSheet.kt
@@ -52,7 +52,6 @@ import com.poziomki.app.ui.designsystem.theme.Primary
 import com.poziomki.app.ui.designsystem.theme.TextMuted
 import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.White
-import kotlin.math.roundToLong
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -68,6 +67,7 @@ import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.util.ClickResult
 import org.maplibre.spatialk.geojson.Position
+import kotlin.math.roundToLong
 
 private const val DEBOUNCE_MS = 350L
 private const val DEFAULT_ZOOM = 13.0


### PR DESCRIPTION
- bump appVersionName 0.21.9 -> 0.22.0
- workflow android-release.yml: add upload step to Play alpha (closed testing) alongside existing internal

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782329091&installation_id=133691716&pr_number=553&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F553&signature=7e2b1cade3732579f2c8e4dcb7607e82ac65e78fa2b6ced041c01b0d207896cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump Android app to 0.22.0 and add auto-deploy to closed testing track
> - Updates `appVersionName` to `0.22.0` in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/553/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be) and records the new version in the release-please manifest.
> - Adds a step to [android-release.yml](https://github.com/poziomki-app/poziomki/pull/553/files#diff-2bd036fee148e164b04b1752776190a94d546194cfea150a5936f4ed3930f1d8) that uploads the AAB to the Google Play `alpha` (closed testing) track via `r0adkll/upload-google-play`, in addition to the existing internal track upload.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 19ce532. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->