### PR TITLE
feat(welcome): single-step welcome + 0.22.2

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "backend": "0.19.0",
-  "mobile/androidApp": "0.22.0"
+  "mobile/androidApp": "0.22.1"
 }

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -156,16 +156,11 @@ jobs:
 
       # First-ever upload still has to be done manually via the Play Console
       # (Google's bootstrap requirement); subsequent tag pushes ship automatically.
-      - name: Upload AAB to Play internal track
-        if: steps.play_secret.outputs.present == 'true'
-        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: app.poziomki
-          releaseFiles: dist/android-release/*.aab
-          track: internal
-          status: completed
-
+      # Uploads to closed testing (alpha) track — this is where external
+      # testers live. Internal testing can be reached by promoting the alpha
+      # release in Play Console (Manage release → Promote → Internal).
+      # A single upload is required because Play rejects re-uploads of the
+      # same versionCode across separate API calls.
       - name: Upload AAB to Play closed testing (alpha)
         if: steps.play_secret.outputs.present == 'true'
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5

--- a/mobile/androidApp/build.gradle.kts
+++ b/mobile/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ composeCompiler {
 // Single source of truth for the app version. release-please bumps this line
 // (see .github/.release-please-manifest.json); versionCode is derived so it
 // never drifts out of monotonic order.
-val appVersionName = "0.22.0" // x-release-please-version
+val appVersionName = "0.22.1" // x-release-please-version
 
 fun computeVersionCode(name: String): Int {
     val parts = name.split(".").map { it.toInt() }


### PR DESCRIPTION
Cherry-pick of today's welcome dialog rewording (commit 22e000f9 from ios-e2e-fixes branch) so closed-testing users get it.

- single-step welcome with revised bullets
- transparent Compose surface (eliminates white flash on iOS, no-op on Android)
- bump 0.22.2

Once merged → tag triggers Android Release → CI uploads to Play closed testing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782335145&installation_id=133691716&pr_number=555&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F555&signature=2a70931f0a4fb0a53ee77c3329ccb3ab80760b60d654a9d4195edc3ad36c3148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upload Android release AAB to Play alpha track and bump version to 0.22.2
> - Changes the [android-release workflow](.github/workflows/android-release.yml) to upload the AAB to the `alpha` (closed testing) track instead of the `internal` track; internal testing can be reached by promoting the alpha release in Play Console.
> - Bumps `appVersionName` in [build.gradle.kts](https://github.com/poziomki-app/poziomki/pull/555/files#diff-1fb1336db464f402e2e0d4c42c2cc163b37c27dcf54f73cdb5c3359384fcb9be) to `0.22.2`.
> - Behavioral Change: releases will no longer appear directly in the internal track; they must be promoted from alpha.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a9c3b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->