### PR TITLE
store compliance: remove donation, iOS photo picker, EULA gate, block+report

### DIFF
--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -101,6 +101,7 @@ fn profiles_routes() -> Router<AppContext> {
             "/{id}/block",
             post(profiles::profile_block_handler).delete(profiles::profile_unblock_handler),
         )
+        .route("/{id}/report", post(profiles::profile_report_handler))
         .layer(cache_layer("no-store"))
 }
 

--- a/backend/src/api/profiles/blocks.rs
+++ b/backend/src/api/profiles/blocks.rs
@@ -9,7 +9,8 @@ use uuid::Uuid;
 use crate::api::state::{DataResponse, SuccessResponse};
 use crate::api::{error_response, ErrorSpec};
 use crate::db::models::profile_blocks::ProfileBlock;
-use crate::db::schema::{profile_blocks, profiles};
+use crate::db::models::reports::NewReport;
+use crate::db::schema::{profile_blocks, profiles, reports};
 
 pub(in crate::api) async fn profile_block(
     conn: &mut AsyncPgConnection,
@@ -49,7 +50,7 @@ pub(in crate::api) async fn profile_block(
     }
 
     let now = Utc::now();
-    diesel::insert_into(profile_blocks::table)
+    let inserted = diesel::insert_into(profile_blocks::table)
         .values(&ProfileBlock {
             blocker_id: my_profile_id,
             blocked_id: target_id,
@@ -60,10 +61,50 @@ pub(in crate::api) async fn profile_block(
         .execute(conn)
         .await?;
 
+    // Apple guideline 1.2: blocking notifies the developer of the offending
+    // user. Record a moderation report (deduped by the unique target index)
+    // and fire a best-effort dev push. Only on a fresh block, to avoid spam.
+    if inserted > 0 {
+        let report = NewReport {
+            reporter_id: my_profile_id,
+            target_type: "profile".to_string(),
+            target_id,
+            reason: "block".to_string(),
+            description: None,
+        };
+        if let Err(err) = diesel::insert_into(reports::table)
+            .values(&report)
+            .on_conflict_do_nothing()
+            .execute(conn)
+            .await
+        {
+            tracing::warn!(%target_id, error = %err, "failed to record block report");
+        }
+        tokio::spawn(notify_block_dev(my_profile_id, target_id));
+    }
+
     Ok(Json(DataResponse {
         data: SuccessResponse { success: true },
     })
     .into_response())
+}
+
+/// Best-effort developer notification when a user blocks another user.
+/// Posts to an ntfy topic; failures are swallowed so blocking never breaks.
+async fn notify_block_dev(blocker: Uuid, target: Uuid) {
+    let url = std::env::var("NTFY_DEV_URL")
+        .unwrap_or_else(|_| "https://ntfy.poziomki.app/poziomki-dev".to_string());
+    let body = format!("block: {blocker} -> {target}");
+    let result = reqwest::Client::new()
+        .post(&url)
+        .header("Title", "Poziomki: użytkownik zablokowany")
+        .header("Tags", "no_entry")
+        .body(body)
+        .send()
+        .await;
+    if let Err(err) = result {
+        tracing::warn!(error = %err, "failed to send block dev notification");
+    }
 }
 
 pub(in crate::api) async fn profile_unblock(

--- a/backend/src/api/profiles/mod.rs
+++ b/backend/src/api/profiles/mod.rs
@@ -6,6 +6,8 @@ mod profiles_bookmarks;
 mod profiles_http;
 #[path = "repo.rs"]
 mod profiles_repo;
+#[path = "report.rs"]
+mod profiles_report;
 #[path = "tags_repo.rs"]
 mod profiles_tags_repo;
 #[path = "tags_service.rs"]
@@ -290,6 +292,54 @@ pub(super) async fn profile_block_handler(
                 profiles_blocks::profile_block(conn, &headers_clone, my_profile.id, target_uuid)
                     .await
                     .map_err(|_| diesel::result::Error::RollbackTransaction)?;
+            Ok(Some(response))
+        }
+        .scope_boxed()
+    })
+    .await?;
+
+    Ok(outcome.unwrap_or_else(|| not_found_profile(&headers, "me")))
+}
+
+#[derive(serde::Deserialize)]
+pub(super) struct ReportProfileRequest {
+    pub reason: String,
+    pub description: Option<String>,
+}
+
+pub(super) async fn profile_report_handler(
+    State(_ctx): State<AppContext>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<ReportProfileRequest>,
+) -> Result<Response> {
+    let (_session, user) = auth_or_respond!(headers);
+    let viewer = db::DbViewer {
+        user_id: user.id,
+        is_review_stub: user.is_review_stub,
+    };
+    let user_id = user.id;
+    let target_uuid = super::parse_uuid(&id, "profile")?;
+    let headers_clone = headers.clone();
+
+    let outcome = db::with_viewer_tx(viewer, move |conn| {
+        async move {
+            let Some(my_profile) = profiles_repo::load_profile_by_user_id(conn, user_id)
+                .await
+                .map_err(|_| diesel::result::Error::RollbackTransaction)?
+            else {
+                return Ok::<Option<Response>, diesel::result::Error>(None);
+            };
+            let response = profiles_report::profile_report(
+                conn,
+                &headers_clone,
+                my_profile.id,
+                target_uuid,
+                body.reason,
+                body.description,
+            )
+            .await
+            .map_err(|_| diesel::result::Error::RollbackTransaction)?;
             Ok(Some(response))
         }
         .scope_boxed()

--- a/backend/src/api/profiles/report.rs
+++ b/backend/src/api/profiles/report.rs
@@ -1,0 +1,93 @@
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use uuid::Uuid;
+
+use crate::api::state::{DataResponse, SuccessResponse};
+use crate::api::{error_response, ErrorSpec};
+use crate::db::models::reports::NewReport;
+use crate::db::schema::{profiles, reports};
+
+const VALID_REASONS: &[&str] = &[
+    "spam",
+    "inappropriate",
+    "misleading",
+    "harassment",
+    "hate_speech",
+    "violence",
+    "scam",
+    "other",
+];
+const MAX_DESCRIPTION_LEN: usize = 2000;
+
+pub(in crate::api) async fn profile_report(
+    conn: &mut AsyncPgConnection,
+    headers: &HeaderMap,
+    my_profile_id: Uuid,
+    target_id: Uuid,
+    reason: String,
+    description: Option<String>,
+) -> crate::error::AppResult<Response> {
+    if my_profile_id == target_id {
+        return Ok(validation_error(headers, "Nie możesz zgłosić siebie"));
+    }
+    if !VALID_REASONS.contains(&reason.as_str()) {
+        return Ok(validation_error(headers, "Nieprawidłowy powód zgłoszenia"));
+    }
+    if description
+        .as_ref()
+        .is_some_and(|d| d.len() > MAX_DESCRIPTION_LEN)
+    {
+        return Ok(validation_error(headers, "Opis jest zbyt długi"));
+    }
+
+    let target_exists = profiles::table
+        .find(target_id)
+        .select(profiles::id)
+        .first::<Uuid>(conn)
+        .await
+        .optional()?;
+    if target_exists.is_none() {
+        return Ok(error_response(
+            StatusCode::NOT_FOUND,
+            headers,
+            ErrorSpec {
+                error: "Profile not found".to_string(),
+                code: "NOT_FOUND",
+                details: None,
+            },
+        ));
+    }
+
+    let new = NewReport {
+        reporter_id: my_profile_id,
+        target_type: "profile".to_string(),
+        target_id,
+        reason,
+        description,
+    };
+    diesel::insert_into(reports::table)
+        .values(&new)
+        .on_conflict_do_nothing()
+        .execute(conn)
+        .await?;
+
+    Ok(Json(DataResponse {
+        data: SuccessResponse { success: true },
+    })
+    .into_response())
+}
+
+fn validation_error(headers: &HeaderMap, message: &str) -> Response {
+    error_response(
+        StatusCode::BAD_REQUEST,
+        headers,
+        ErrorSpec {
+            error: message.to_string(),
+            code: "VALIDATION_ERROR",
+            details: None,
+        },
+    )
+}

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/AuthLandingScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/AuthLandingScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +16,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
@@ -45,6 +51,7 @@ import poziomki_mobile.app_ui.generated.resources.login_background
  * Hero photo + tagline up top, then three entry points: continue with
  * Google (placeholder), sign up with email, sign in with email.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Suppress("LongMethod")
 @Composable
 fun AuthLandingScreen(
@@ -52,6 +59,8 @@ fun AuthLandingScreen(
     onSignInWithEmail: () -> Unit,
 ) {
     val backgroundColor = MaterialTheme.colorScheme.background
+    var showRegulamin by remember { mutableStateOf(false) }
+    var showPolicy by remember { mutableStateOf(false) }
 
     Box(
         modifier =
@@ -148,9 +157,59 @@ fun AuthLandingScreen(
                     Modifier
                         .fillMaxWidth()
                         .clickable { onSignInWithEmail() }
-                        .padding(bottom = PoziomkiTheme.spacing.xl),
+                        .padding(bottom = PoziomkiTheme.spacing.lg),
                 textAlign = TextAlign.Center,
             )
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = "kontynuując, akceptujesz ",
+                    fontFamily = NunitoFamily,
+                    fontSize = 12.sp,
+                    color = TextSecondary,
+                )
+                Text(
+                    text = "regulamin",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 12.sp,
+                    color = Primary,
+                    modifier = Modifier.clickable { showRegulamin = true },
+                )
+                Text(
+                    text = " i ",
+                    fontFamily = NunitoFamily,
+                    fontSize = 12.sp,
+                    color = TextSecondary,
+                )
+                Text(
+                    text = "politykę prywatności",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 12.sp,
+                    color = Primary,
+                    modifier = Modifier.clickable { showPolicy = true },
+                )
+            }
         }
+    }
+
+    if (showRegulamin) {
+        LegalDocumentDialog(
+            title = "regulamin",
+            body = regulaminText,
+            onDismiss = { showRegulamin = false },
+        )
+    }
+
+    if (showPolicy) {
+        LegalDocumentDialog(
+            title = "polityka prywatności",
+            body = privacyPolicyText,
+            onDismiss = { showPolicy = false },
+        )
     }
 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/Legal.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/Legal.kt
@@ -1,0 +1,143 @@
+package com.poziomki.app.ui.feature.auth
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.poziomki.app.ui.designsystem.Text
+import com.poziomki.app.ui.designsystem.components.AppButton
+import com.poziomki.app.ui.designsystem.theme.MontserratFamily
+import com.poziomki.app.ui.designsystem.theme.NunitoFamily
+import com.poziomki.app.ui.designsystem.theme.TextPrimary
+import com.poziomki.app.ui.designsystem.theme.TextSecondary
+
+/** Full-screen scrollable dialog for a legal document (terms / privacy). */
+@Composable
+internal fun LegalDocumentDialog(
+    title: String,
+    body: String,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            shape = RoundedCornerShape(20.dp),
+            color = MaterialTheme.colorScheme.background,
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(24.dp),
+            ) {
+                Text(
+                    text = title,
+                    fontFamily = MontserratFamily,
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 22.sp,
+                    color = TextPrimary,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = body,
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 14.sp,
+                    color = TextSecondary,
+                    lineHeight = 22.sp,
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                AppButton(
+                    text = "zamknij",
+                    onClick = onDismiss,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+internal val regulaminText =
+    """
+    Niniejszy Regulamin określa zasady korzystania z aplikacji Poziomki oraz prawa i obowiązki użytkowników.
+
+    1. Akceptacja regulaminu
+    Korzystając z aplikacji Poziomki, akceptujesz niniejszy Regulamin oraz Politykę prywatności. Jeśli nie zgadzasz się z którymkolwiek z postanowień, nie korzystaj z aplikacji.
+
+    2. Wymagania
+    Z aplikacji mogą korzystać wyłącznie osoby, które ukończyły 16 lat. Zakładając konto, oświadczasz, że podane dane są prawdziwe.
+
+    3. Treści użytkowników
+    Aplikacja umożliwia publikowanie treści (zdjęcia profilowe, opisy, wydarzenia, wiadomości). Ponosisz pełną odpowiedzialność za treści, które publikujesz, oraz za swoje zachowanie wobec innych użytkowników.
+
+    4. Zakaz treści niedozwolonych
+    Obowiązuje zasada zera tolerancji dla treści i zachowań niedozwolonych. Zabronione jest publikowanie oraz przesyłanie treści, które są: obraźliwe, nękające, nawołujące do nienawiści, dyskryminujące, brutalne, o charakterze seksualnym, nielegalne, wprowadzające w błąd, spamerskie lub naruszające prawa innych osób. Zabronione jest również nękanie, zastraszanie i podszywanie się pod inne osoby.
+
+    5. Zgłaszanie i blokowanie
+    Każdy użytkownik może zgłosić niewłaściwe treści oraz zablokować innego użytkownika bezpośrednio w aplikacji. Zablokowanie użytkownika natychmiast usuwa jego treści z Twojego widoku i powiadamia zespół Poziomki.
+
+    6. Moderacja
+    Zgłoszenia są rozpatrywane bez zbędnej zwłoki, zwykle w ciągu 24 godzin. Treści naruszające Regulamin są usuwane, a konta użytkowników dopuszczających się naruszeń mogą zostać zawieszone lub trwale usunięte.
+
+    7. Spotkania i wydarzenia
+    Aplikacja umożliwia organizację i udział w spotkaniach. Uczestnictwo w wydarzeniach odbywa się na własną odpowiedzialność. Zachowaj zdrowy rozsądek i ostrożność podczas spotkań z osobami poznanymi w aplikacji.
+
+    8. Zawieszenie i usunięcie konta
+    Zespół Poziomki może zawiesić lub usunąć konto użytkownika naruszającego Regulamin. Użytkownik może w każdej chwili usunąć własne konto w ustawieniach aplikacji.
+
+    9. Zmiany regulaminu
+    O istotnych zmianach Regulaminu użytkownicy zostaną poinformowani poprzez powiadomienie w aplikacji.
+
+    10. Kontakt
+    Pytania dotyczące Regulaminu prosimy kierować na adres: kontakt@poziomki.app
+
+    Data ostatniej aktualizacji: czerwiec 2026
+    """.trimIndent()
+
+internal val privacyPolicyText =
+    """
+    Niniejsza Polityka Prywatności określa zasady przetwarzania danych osobowych użytkowników aplikacji Poziomki.
+
+    1. Administrator danych
+    Administratorem danych osobowych jest zespół Poziomki. Kontakt: kontakt@poziomki.app
+
+    2. Zakres zbieranych danych
+    Zbieramy następujące dane: adres e-mail, imię, zdjęcia profilowe, zainteresowania oraz dane dotyczące uczestnictwa w wydarzeniach.
+
+    3. Cel przetwarzania
+    Dane przetwarzamy w celu: świadczenia usług aplikacji, dopasowywania rekomendacji wydarzeń i profili, komunikacji między użytkownikami oraz zapewnienia bezpieczeństwa.
+
+    4. Udostępnianie danych
+    Dane osobowe nie są sprzedawane ani udostępniane podmiotom trzecim w celach marketingowych. Dane mogą być udostępniane wyłącznie na żądanie organów uprawnionych na podstawie przepisów prawa.
+
+    5. Przechowywanie danych
+    Dane przechowywane są na serwerach zlokalizowanych w Unii Europejskiej. Dane są przechowywane przez okres korzystania z aplikacji oraz do 30 dni po usunięciu konta.
+
+    6. Prawa użytkownika
+    Każdy użytkownik ma prawo do: dostępu do swoich danych, ich sprostowania, usunięcia, ograniczenia przetwarzania, przenoszenia danych oraz wniesienia sprzeciwu. Eksport i usunięcie danych dostępne są w ustawieniach aplikacji.
+
+    7. Pliki cookies i analityka
+    Aplikacja nie wykorzystuje plików cookies. Zbieramy anonimowe dane analityczne w celu poprawy jakości usług.
+
+    8. Zmiany polityki
+    O istotnych zmianach w polityce prywatności użytkownicy zostaną poinformowani poprzez powiadomienie w aplikacji.
+
+    9. Kontakt
+    Pytania dotyczące prywatności prosimy kierować na adres: kontakt@poziomki.app
+
+    Data ostatniej aktualizacji: marzec 2026
+    """.trimIndent()

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/RegisterScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/auth/RegisterScreen.kt
@@ -2,7 +2,10 @@ package com.poziomki.app.ui.feature.auth
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -36,14 +39,14 @@ import com.poziomki.app.ui.designsystem.components.AppButton
 import com.poziomki.app.ui.designsystem.components.PoziomkiLogo
 import com.poziomki.app.ui.designsystem.components.PoziomkiPasswordField
 import com.poziomki.app.ui.designsystem.components.PoziomkiTextField
-import com.poziomki.app.ui.designsystem.theme.MontserratFamily
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
 import com.poziomki.app.ui.designsystem.theme.Primary
-import com.poziomki.app.ui.designsystem.theme.TextPrimary
 import com.poziomki.app.ui.designsystem.theme.TextSecondary
 import org.koin.compose.viewmodel.koinViewModel
 
+@OptIn(ExperimentalLayoutApi::class)
+@Suppress("LongMethod")
 @Composable
 fun RegisterScreen(
     onNavigateToLogin: () -> Unit,
@@ -57,6 +60,7 @@ fun RegisterScreen(
     var confirmPassword by remember { mutableStateOf("") }
     var acceptedPolicy by remember { mutableStateOf(false) }
     var showPolicy by remember { mutableStateOf(false) }
+    var showRegulamin by remember { mutableStateOf(false) }
     var showPasswordMismatch by remember { mutableStateOf(false) }
 
     Column(
@@ -163,28 +167,45 @@ fun RegisterScreen(
                         checkmarkColor = MaterialTheme.colorScheme.background,
                     ),
             )
-            Text(
-                text = "akceptuję ",
-                fontFamily = NunitoFamily,
-                fontWeight = FontWeight.Normal,
-                fontSize = 14.sp,
-                color = TextSecondary,
-            )
-            Text(
-                text = "politykę prywatności",
-                fontFamily = NunitoFamily,
-                fontWeight = FontWeight.SemiBold,
-                fontSize = 14.sp,
-                color = Primary,
-                modifier = Modifier.clickable { showPolicy = true },
-            )
-            Text(
-                text = " *",
-                fontFamily = NunitoFamily,
-                fontWeight = FontWeight.Bold,
-                fontSize = 14.sp,
-                color = MaterialTheme.colorScheme.error,
-            )
+            FlowRow(verticalArrangement = Arrangement.Center) {
+                Text(
+                    text = "akceptuję ",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 14.sp,
+                    color = TextSecondary,
+                )
+                Text(
+                    text = "regulamin",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                    color = Primary,
+                    modifier = Modifier.clickable { showRegulamin = true },
+                )
+                Text(
+                    text = " i ",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 14.sp,
+                    color = TextSecondary,
+                )
+                Text(
+                    text = "politykę prywatności",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                    color = Primary,
+                    modifier = Modifier.clickable { showPolicy = true },
+                )
+                Text(
+                    text = " *",
+                    fontFamily = NunitoFamily,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(PoziomkiTheme.spacing.lg))
@@ -225,88 +246,19 @@ fun RegisterScreen(
         }
     }
 
+    if (showRegulamin) {
+        LegalDocumentDialog(
+            title = "regulamin",
+            body = regulaminText,
+            onDismiss = { showRegulamin = false },
+        )
+    }
+
     if (showPolicy) {
-        androidx.compose.ui.window.Dialog(
-            onDismissRequest = { showPolicy = false },
-            properties =
-                androidx.compose.ui.window
-                    .DialogProperties(usePlatformDefaultWidth = false),
-        ) {
-            androidx.compose.material3.Surface(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(16.dp),
-                shape =
-                    androidx.compose.foundation.shape
-                        .RoundedCornerShape(20.dp),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .verticalScroll(rememberScrollState())
-                            .padding(24.dp),
-                ) {
-                    Text(
-                        text = "polityka prywatności",
-                        fontFamily = MontserratFamily,
-                        fontWeight = FontWeight.ExtraBold,
-                        fontSize = 22.sp,
-                        color = TextPrimary,
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = privacyPolicyText,
-                        fontFamily = NunitoFamily,
-                        fontWeight = FontWeight.Normal,
-                        fontSize = 14.sp,
-                        color = TextSecondary,
-                        lineHeight = 22.sp,
-                    )
-                    Spacer(modifier = Modifier.height(24.dp))
-                    AppButton(
-                        text = "zamknij",
-                        onClick = { showPolicy = false },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
-            }
-        }
+        LegalDocumentDialog(
+            title = "polityka prywatności",
+            body = privacyPolicyText,
+            onDismiss = { showPolicy = false },
+        )
     }
 }
-
-private val privacyPolicyText =
-    """
-    Niniejsza Polityka Prywatności określa zasady przetwarzania danych osobowych użytkowników aplikacji Poziomki.
-
-    1. Administrator danych
-    Administratorem danych osobowych jest zespół Poziomki. Kontakt: kontakt@poziomki.app
-
-    2. Zakres zbieranych danych
-    Zbieramy następujące dane: adres e-mail, imię, zdjęcia profilowe, zainteresowania oraz dane dotyczące uczestnictwa w wydarzeniach.
-
-    3. Cel przetwarzania
-    Dane przetwarzamy w celu: świadczenia usług aplikacji, dopasowywania rekomendacji wydarzeń i profili, komunikacji między użytkownikami oraz zapewnienia bezpieczeństwa.
-
-    4. Udostępnianie danych
-    Dane osobowe nie są sprzedawane ani udostępniane podmiotom trzecim w celach marketingowych. Dane mogą być udostępniane wyłącznie na żądanie organów uprawnionych na podstawie przepisów prawa.
-
-    5. Przechowywanie danych
-    Dane przechowywane są na serwerach zlokalizowanych w Unii Europejskiej. Dane są przechowywane przez okres korzystania z aplikacji oraz do 30 dni po usunięciu konta.
-
-    6. Prawa użytkownika
-    Każdy użytkownik ma prawo do: dostępu do swoich danych, ich sprostowania, usunięcia, ograniczenia przetwarzania, przenoszenia danych oraz wniesienia sprzeciwu. Eksport i usunięcie danych dostępne są w ustawieniach aplikacji.
-
-    7. Pliki cookies i analityka
-    Aplikacja nie wykorzystuje plików cookies. Zbieramy anonimowe dane analityczne w celu poprawy jakości usług.
-
-    8. Zmiany polityki
-    O istotnych zmianach w polityce prywatności użytkownicy zostaną poinformowani poprzez powiadomienie w aplikacji.
-
-    9. Kontakt
-    Pytania dotyczące prywatności prosimy kierować na adres: kontakt@poziomki.app
-
-    Data ostatniej aktualizacji: marzec 2026
-    """.trimIndent()

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/home/ProfileScreen.kt
@@ -39,7 +39,6 @@ import com.adamglin.phosphoricons.bold.Bell
 import com.adamglin.phosphoricons.bold.BookmarkSimple
 import com.adamglin.phosphoricons.bold.CaretRight
 import com.adamglin.phosphoricons.bold.ChatTeardropText
-import com.adamglin.phosphoricons.bold.Coffee
 import com.adamglin.phosphoricons.bold.PencilSimple
 import com.adamglin.phosphoricons.bold.Shield
 import com.adamglin.phosphoricons.bold.SignOut
@@ -50,7 +49,6 @@ import com.poziomki.app.ui.designsystem.components.EmptyView
 import com.poziomki.app.ui.designsystem.components.LoadingView
 import com.poziomki.app.ui.designsystem.components.ProfileCard
 import com.poziomki.app.ui.designsystem.components.ScreenHeader
-import com.poziomki.app.ui.designsystem.components.rememberExternalLinkOpener
 import com.poziomki.app.ui.designsystem.theme.Border
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.PoziomkiTheme
@@ -75,7 +73,6 @@ fun ProfileScreen(
 ) {
     val state by viewModel.state.collectAsState()
     var showLogoutDialog by remember { mutableStateOf(false) }
-    val openExternal = rememberExternalLinkOpener()
 
     Column(
         modifier =
@@ -147,12 +144,6 @@ fun ProfileScreen(
                                         label = "zostaw opinię",
                                         onClick = onOpenFeedback,
                                         badge = "testy",
-                                    )
-                                    HorizontalDivider(color = Border, thickness = 1.dp)
-                                    SettingsMenuItem(
-                                        icon = PhosphorIcons.Bold.Coffee,
-                                        label = "postaw kawę",
-                                        onClick = { openExternal("https://buycoffee.to/poziomki-app") },
                                     )
                                 }
 

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewScreen.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -30,16 +32,24 @@ import com.adamglin.PhosphorIcons
 import com.adamglin.phosphoricons.Bold
 import com.adamglin.phosphoricons.Fill
 import com.adamglin.phosphoricons.bold.BookmarkSimple
+import com.adamglin.phosphoricons.bold.DotsThreeVertical
+import com.adamglin.phosphoricons.bold.Flag
+import com.adamglin.phosphoricons.bold.Prohibit
 import com.adamglin.phosphoricons.bold.X
 import com.adamglin.phosphoricons.fill.BookmarkSimple
 import com.adamglin.phosphoricons.fill.PaperPlaneRight
 import com.poziomki.app.ui.designsystem.Text
+import com.poziomki.app.ui.designsystem.components.ConfirmDialog
 import com.poziomki.app.ui.designsystem.components.ProfileImage
 import com.poziomki.app.ui.designsystem.components.ProfilePreview
+import com.poziomki.app.ui.designsystem.components.ReportDialog
 import com.poziomki.app.ui.designsystem.theme.Background
+import com.poziomki.app.ui.designsystem.theme.Error
 import com.poziomki.app.ui.designsystem.theme.NunitoFamily
 import com.poziomki.app.ui.designsystem.theme.Primary
+import com.poziomki.app.ui.designsystem.theme.SurfaceElevated
 import com.poziomki.app.ui.designsystem.theme.White
+import com.poziomki.app.ui.feature.chat.ActionMenuItem
 import com.poziomki.app.ui.shared.isImageUrl
 import kotlinx.coroutines.delay
 import org.koin.compose.viewmodel.koinViewModel
@@ -52,6 +62,9 @@ fun ProfileViewScreen(
     viewModel: ProfileViewViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
+    var showMenu by remember { mutableStateOf(false) }
+    var showReportDialog by remember { mutableStateOf(false) }
+    var showBlockConfirm by remember { mutableStateOf(false) }
 
     when {
         state.profile != null -> {
@@ -118,6 +131,41 @@ fun ProfileViewScreen(
                                                 modifier = Modifier.size(22.dp),
                                             )
                                         }
+                                        Box {
+                                            IconButton(onClick = { showMenu = true }) {
+                                                Icon(
+                                                    imageVector = PhosphorIcons.Bold.DotsThreeVertical,
+                                                    contentDescription = "Więcej",
+                                                    tint = White,
+                                                    modifier = Modifier.size(22.dp),
+                                                )
+                                            }
+                                            DropdownMenu(
+                                                expanded = showMenu,
+                                                onDismissRequest = { showMenu = false },
+                                                shape = RoundedCornerShape(16.dp),
+                                                containerColor = SurfaceElevated,
+                                            ) {
+                                                ActionMenuItem(
+                                                    icon = PhosphorIcons.Bold.Flag,
+                                                    label = "Zgłoś",
+                                                    onClick = {
+                                                        showMenu = false
+                                                        showReportDialog = true
+                                                    },
+                                                )
+                                                ActionMenuItem(
+                                                    icon = PhosphorIcons.Bold.Prohibit,
+                                                    label = "Zablokuj",
+                                                    onClick = {
+                                                        showMenu = false
+                                                        showBlockConfirm = true
+                                                    },
+                                                    iconTint = Error,
+                                                    labelColor = Error,
+                                                )
+                                            }
+                                        }
                                     }
                                 }
                             } else {
@@ -144,6 +192,30 @@ fun ProfileViewScreen(
                             contentDescription = "Zamknij",
                             tint = White,
                             modifier = Modifier.size(24.dp),
+                        )
+                    }
+
+                    if (showReportDialog) {
+                        ReportDialog(
+                            onConfirm = { reason, _ ->
+                                showReportDialog = false
+                                viewModel.reportUser(reason)
+                            },
+                            onDismiss = { showReportDialog = false },
+                        )
+                    }
+
+                    if (showBlockConfirm) {
+                        ConfirmDialog(
+                            title = "zablokuj użytkownika",
+                            message = "nie będziesz już widzieć tej osoby ani jej treści. zgłosimy ją do moderacji.",
+                            confirmText = "zablokuj",
+                            isDestructive = true,
+                            onConfirm = {
+                                showBlockConfirm = false
+                                viewModel.blockUser(onBlocked = onBack)
+                            },
+                            onDismiss = { showBlockConfirm = false },
                         )
                     }
                 }

--- a/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewViewModel.kt
+++ b/mobile/app-ui/src/commonMain/kotlin/com/poziomki/app/ui/feature/profile/ProfileViewViewModel.kt
@@ -107,6 +107,22 @@ class ProfileViewViewModel(
         }
     }
 
+    /** Block the viewed user. Backend removes their content from the feed and
+     *  notifies the developer; on success the caller navigates away. */
+    fun blockUser(onBlocked: () -> Unit) {
+        viewModelScope.launch {
+            apiService.blockProfile(profileId)
+            onBlocked()
+        }
+    }
+
+    /** Report the viewed user for objectionable content. */
+    fun reportUser(reason: String) {
+        viewModelScope.launch {
+            apiService.reportProfile(profileId, reason)
+        }
+    }
+
     fun toggleBookmark() {
         if (bookmarkInFlight) return
         bookmarkInFlight = true

--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/ImagePicker.ios.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/ImagePicker.ios.kt
@@ -1,18 +1,229 @@
 package com.poziomki.app.ui.shared
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.useContents
+import kotlinx.cinterop.usePinned
+import org.jetbrains.skia.Image
+import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGSizeMake
+import platform.Foundation.NSData
+import platform.Foundation.NSItemProvider
+import platform.PhotosUI.PHPickerConfiguration
+import platform.PhotosUI.PHPickerFilter
+import platform.PhotosUI.PHPickerResult
+import platform.PhotosUI.PHPickerViewController
+import platform.PhotosUI.PHPickerViewControllerDelegateProtocol
+import platform.UIKit.UIApplication
+import platform.UIKit.UIGraphicsBeginImageContextWithOptions
+import platform.UIKit.UIGraphicsEndImageContext
+import platform.UIKit.UIGraphicsGetImageFromCurrentImageContext
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
+import platform.UIKit.UIImagePickerController
+import platform.UIKit.UIImagePickerControllerDelegateProtocol
+import platform.UIKit.UIImagePickerControllerOriginalImage
+import platform.UIKit.UIImagePickerControllerSourceType
+import platform.UIKit.UINavigationControllerDelegateProtocol
+import platform.darwin.NSObject
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
+import platform.posix.memcpy
+
+private const val MAX_DIMENSION = 1920.0
+private const val MAX_BYTES = 700 * 1024
+private const val START_QUALITY = 0.85
+private const val MIN_QUALITY = 0.5
+private const val QUALITY_STEP = 0.1
+private const val IMAGE_UTI = "public.image"
 
 @Composable
-actual fun rememberCameraCapture(onResult: (ByteArray?) -> Unit): () -> Unit = { /* TODO: iOS camera */ }
+actual fun rememberCameraCapture(onResult: (ByteArray?) -> Unit): () -> Unit {
+    val coordinator = remember { CameraCoordinator() }
+    DisposableEffect(Unit) { onDispose { coordinator.onResult = null } }
+    return {
+        coordinator.onResult = onResult
+        presentCamera(coordinator)
+    }
+}
 
 @Composable
-actual fun rememberSingleImagePicker(onResult: (ByteArray?) -> Unit): () -> Unit = { /* TODO: iOS image picker */ }
+actual fun rememberSingleImagePicker(onResult: (ByteArray?) -> Unit): () -> Unit {
+    val coordinator = remember { PhotoPickerCoordinator() }
+    DisposableEffect(Unit) { onDispose { coordinator.onComplete = null } }
+    return {
+        coordinator.onComplete = { images -> onResult(images.firstOrNull()) }
+        presentPhotoPicker(coordinator, selectionLimit = 1)
+    }
+}
 
 @Composable
-actual fun rememberMultiImagePicker(onResult: (List<ByteArray>) -> Unit): () -> Unit = { /* TODO: iOS image picker */ }
+actual fun rememberMultiImagePicker(onResult: (List<ByteArray>) -> Unit): () -> Unit {
+    val coordinator = remember { PhotoPickerCoordinator() }
+    DisposableEffect(Unit) { onDispose { coordinator.onComplete = null } }
+    return {
+        coordinator.onComplete = onResult
+        presentPhotoPicker(coordinator, selectionLimit = 0)
+    }
+}
 
 @Composable
-actual fun rememberSingleFilePicker(onResult: (PickedFile?) -> Unit): () -> Unit = { /* TODO: iOS file picker */ }
+actual fun rememberSingleFilePicker(onResult: (PickedFile?) -> Unit): () -> Unit = { /* not used on iOS */ }
 
-actual fun decodeImageBytes(bytes: ByteArray): ImageBitmap? = null
+actual fun decodeImageBytes(bytes: ByteArray): ImageBitmap? =
+    try {
+        Image.makeFromEncoded(bytes).toComposeImageBitmap()
+    } catch (_: Throwable) {
+        null
+    }
+
+// --- PHPicker (photo library) ---
+
+private class PhotoPickerCoordinator :
+    NSObject(),
+    PHPickerViewControllerDelegateProtocol {
+    var onComplete: ((List<ByteArray>) -> Unit)? = null
+
+    override fun picker(
+        picker: PHPickerViewController,
+        didFinishPicking: List<*>,
+    ) {
+        picker.dismissViewControllerAnimated(flag = true, completion = null)
+        val callback = onComplete ?: return
+        val providers = didFinishPicking.mapNotNull { (it as? PHPickerResult)?.itemProvider }
+        loadImages(providers, callback)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun presentPhotoPicker(
+    coordinator: PhotoPickerCoordinator,
+    selectionLimit: Int,
+) {
+    val config =
+        PHPickerConfiguration().apply {
+            this.selectionLimit = selectionLimit.toLong()
+            this.filter = PHPickerFilter.imagesFilter()
+        }
+    val picker = PHPickerViewController(configuration = config)
+    picker.delegate = coordinator
+    rootViewController()?.presentViewController(picker, animated = true, completion = null)
+}
+
+private fun loadImages(
+    providers: List<NSItemProvider>,
+    onComplete: (List<ByteArray>) -> Unit,
+) {
+    if (providers.isEmpty()) {
+        onComplete(emptyList())
+        return
+    }
+    val collected = mutableListOf<ByteArray>()
+    var remaining = providers.size
+    providers.forEach { provider ->
+        provider.loadDataRepresentationForTypeIdentifier(IMAGE_UTI) { data, _ ->
+            // Completion runs off the main thread; hop to main for UIKit + serialized accumulation.
+            dispatch_async(dispatch_get_main_queue()) {
+                data?.let { encodeFromData(it) }?.let(collected::add)
+                remaining -= 1
+                if (remaining == 0) onComplete(collected.toList())
+            }
+        }
+    }
+}
+
+// --- Camera ---
+
+private class CameraCoordinator :
+    NSObject(),
+    UIImagePickerControllerDelegateProtocol,
+    UINavigationControllerDelegateProtocol {
+    var onResult: ((ByteArray?) -> Unit)? = null
+
+    override fun imagePickerController(
+        picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo: Map<Any?, *>,
+    ) {
+        picker.dismissViewControllerAnimated(flag = true, completion = null)
+        val callback = onResult
+        onResult = null
+        val image = didFinishPickingMediaWithInfo[UIImagePickerControllerOriginalImage] as? UIImage
+        callback?.invoke(image?.let(::encodeImage))
+    }
+
+    override fun imagePickerControllerDidCancel(picker: UIImagePickerController) {
+        picker.dismissViewControllerAnimated(flag = true, completion = null)
+        val callback = onResult
+        onResult = null
+        callback?.invoke(null)
+    }
+}
+
+private fun presentCamera(coordinator: CameraCoordinator) {
+    if (!UIImagePickerController.isSourceTypeAvailable(
+            UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera,
+        )
+    ) {
+        coordinator.onResult?.invoke(null)
+        coordinator.onResult = null
+        return
+    }
+    val picker =
+        UIImagePickerController().apply {
+            sourceType = UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
+            delegate = coordinator
+        }
+    rootViewController()?.presentViewController(picker, animated = true, completion = null)
+}
+
+// --- Helpers ---
+
+private fun rootViewController() = UIApplication.sharedApplication.keyWindow?.rootViewController
+
+private fun encodeFromData(data: NSData): ByteArray? = UIImage(data = data)?.let(::encodeImage)
+
+@OptIn(ExperimentalForeignApi::class)
+private fun encodeImage(image: UIImage): ByteArray? {
+    val resized = resizeImage(image, MAX_DIMENSION)
+    var quality = START_QUALITY
+    var data = UIImageJPEGRepresentation(resized, quality)
+    while (data != null && data.length.toInt() > MAX_BYTES && quality > MIN_QUALITY) {
+        quality -= QUALITY_STEP
+        data = UIImageJPEGRepresentation(resized, quality)
+    }
+    return data?.toByteArray()
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun resizeImage(
+    image: UIImage,
+    maxDimension: Double,
+): UIImage {
+    val size = image.size.useContents { width to height }
+    val maxSide = maxOf(size.first, size.second)
+    if (maxSide <= maxDimension || maxSide == 0.0) return image
+    val scale = maxDimension / maxSide
+    val newWidth = size.first * scale
+    val newHeight = size.second * scale
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(newWidth, newHeight), false, 1.0)
+    image.drawInRect(CGRectMake(0.0, 0.0, newWidth, newHeight))
+    val result = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+    return result ?: image
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSData.toByteArray(): ByteArray {
+    val size = length.toInt()
+    if (size == 0) return ByteArray(0)
+    val out = ByteArray(size)
+    out.usePinned { pinned ->
+        memcpy(pinned.addressOf(0), bytes, length)
+    }
+    return out
+}

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/network/ApiService.kt
@@ -102,6 +102,16 @@ class ApiService(
 
     suspend fun unblockProfile(id: String): ApiResult<SuccessResponse> = client.delete("/api/v1/profiles/$id/block")
 
+    suspend fun reportProfile(
+        id: String,
+        reason: String,
+        description: String? = null,
+    ): ApiResult<SuccessResponse> =
+        client.post(
+            "/api/v1/profiles/$id/report",
+            ReportConversationRequest(reason = reason, description = description),
+        )
+
     suspend fun createProfile(request: CreateProfileRequest): ApiResult<Profile> = client.post("/api/v1/profiles", request)
 
     suspend fun updateProfile(

--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -22,6 +22,10 @@
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Poziomki używa Twojej lokalizacji, aby pokazać wydarzenia w pobliżu na mapie.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Poziomki potrzebuje dostępu do zdjęć, aby ustawić zdjęcie profilowe i okładki wydarzeń.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Poziomki używa aparatu, aby zrobić zdjęcie profilowe.</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
Addresses App Store rejection (build 0.22.4).

- 3.1.1: remove external donation button
- 2.1: implement iOS photo picker (PHPicker/camera) — was a no-op stub
- 1.2: EULA/regulamin acceptance before sign-in; block + report users from profile, with backend report row + dev notification

Backend adds POST /profiles/{id}/report and makes block notify the dev + file a report.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784210011&installation_id=133691716&pr_number=572&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F572&signature=8348c31a7897eb3935163fcbe0ec78baf5c174e513e4b530b7452dd0479575ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add block/report profile actions, iOS photo picker, and legal disclosure UI for store compliance
> - Adds a report profile endpoint (`POST /api/v1/profiles/{id}/report`) in the backend with input validation, self-report prevention, reason allowlist, and conflict-safe deduplication.
> - Recording a block now also inserts a moderation report and fires a best-effort ntfy developer notification in the background.
> - Adds block and report actions to the profile view screen, with a reason-capture dialog for reports and a confirmation dialog for blocks.
> - Implements iOS photo picker and camera capture in [ImagePicker.ios.kt](https://github.com/poziomki-app/poziomki/pull/572/files#diff-27d0b80ad8426ea0e7cd8f138c157aab92b073a15dc761c2edcce1ddcfc8ffbc) with JPEG resize/compress and adds required `Info.plist` usage descriptions.
> - Adds legal disclosure (terms + privacy policy) on the landing and registration screens via a reusable `LegalDocumentDialog`, and removes the donation menu item from the profile screen.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 320ea13. 13 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->