### PR TITLE
fix(ios): present picker via active window scene, not deprecated keyWindow

### DIFF
--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/ImagePicker.ios.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/shared/ImagePicker.ios.kt
@@ -30,6 +30,10 @@ import platform.UIKit.UIImagePickerControllerDelegateProtocol
 import platform.UIKit.UIImagePickerControllerOriginalImage
 import platform.UIKit.UIImagePickerControllerSourceType
 import platform.UIKit.UINavigationControllerDelegateProtocol
+import platform.UIKit.UISceneActivationStateForegroundActive
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
@@ -183,7 +187,20 @@ private fun presentCamera(coordinator: CameraCoordinator) {
 
 // --- Helpers ---
 
-private fun rootViewController() = UIApplication.sharedApplication.keyWindow?.rootViewController
+private fun rootViewController(): UIViewController? {
+    val app = UIApplication.sharedApplication
+    // keyWindow is deprecated and returns nil on iPad / multi-scene apps, which
+    // silently dropped the picker presentation. Resolve via the active window scene.
+    val scenes = app.connectedScenes.mapNotNull { it as? UIWindowScene }
+    val scene =
+        scenes.firstOrNull { it.activationState == UISceneActivationStateForegroundActive }
+            ?: scenes.firstOrNull()
+    val window =
+        scene?.keyWindow
+            ?: scene?.windows?.mapNotNull { it as? UIWindow }?.firstOrNull()
+            ?: app.keyWindow
+    return window?.rootViewController
+}
 
 private fun encodeFromData(data: NSData): ByteArray? = UIImage(data = data)?.let(::encodeImage)
 


### PR DESCRIPTION
App Review 2.1: add-picture button was unresponsive on iPad. keyWindow returns nil on iPad / multi-scene, so the photo picker never presented. Resolve the root view controller from the foreground-active UIWindowScene instead.

Verified: build succeeds; PHPicker presents on iPad Air sim.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784281354&installation_id=133691716&pr_number=574&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F574&signature=259741707f0893ac9eac7eab304ae5290d2d060486190aa4a843793d434d3fea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `rootViewController` to resolve from active `UIWindowScene` instead of deprecated `keyWindow`
> Updates the `rootViewController` helper in [ImagePicker.ios.kt](https://github.com/poziomki-app/poziomki/pull/574/files#diff-27d0b80ad8426ea0e7cd8f138c157aab92b073a15dc761c2edcce1ddcfc8ffbc) to enumerate `connectedScenes`, select the foreground-active `UIWindowScene`, and resolve the root view controller from its key window. Falls back to the first scene or `app.keyWindow` if no foreground-active scene is found.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a18dadf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->