### PR TITLE
fix(ios): native WebSocket transport for chat (2.1)

### DIFF
--- a/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/ws/IosWebSocketBridge.kt
+++ b/mobile/app-ui/src/iosMain/kotlin/com/poziomki/app/ui/ws/IosWebSocketBridge.kt
@@ -1,0 +1,44 @@
+package com.poziomki.app.ui.ws
+
+import com.poziomki.app.chat.ws.IosWsHandle
+import com.poziomki.app.chat.ws.IosWsTransportRegistry
+
+/** Callbacks the native socket fires back into Kotlin. */
+interface NativeWebSocketListener {
+    fun onText(text: String)
+
+    fun onError(message: String)
+}
+
+/** A live native socket, implemented in Swift over `URLSessionWebSocketTask`. */
+interface NativeWebSocket {
+    fun send(text: String)
+
+    fun close()
+}
+
+/** Swift-provided factory; opens a connected socket and streams frames to [listener]. */
+interface NativeWebSocketFactory {
+    fun create(
+        url: String,
+        origin: String,
+        listener: NativeWebSocketListener,
+    ): NativeWebSocket
+}
+
+/** Call once from Swift before chat is used (e.g. in the app initializer). */
+fun registerIosWebSocket(factory: NativeWebSocketFactory) {
+    IosWsTransportRegistry.connect = { url, origin, onText, onError ->
+        val socket =
+            factory.create(
+                url,
+                origin,
+                object : NativeWebSocketListener {
+                    override fun onText(text: String) = onText(text)
+
+                    override fun onError(message: String) = onError(message)
+                },
+            )
+        IosWsHandle(send = { socket.send(it) }, close = { socket.close() })
+    }
+}

--- a/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/ws/WsTransport.android.kt
+++ b/mobile/core/src/androidMain/kotlin/com/poziomki/app/chat/ws/WsTransport.android.kt
@@ -1,0 +1,48 @@
+package com.poziomki.app.chat.ws
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.http.URLProtocol
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.cancel
+
+actual class WsTransport actual constructor(
+    engine: HttpClientEngine,
+) {
+    private val client = HttpClient(engine) { install(WebSockets) }
+    private var session: DefaultClientWebSocketSession? = null
+
+    actual suspend fun connect(
+        host: String,
+        port: Int,
+        useTls: Boolean,
+        path: String,
+    ) {
+        session =
+            client.webSocketSession(host = host, port = port, path = path) {
+                url.protocol = if (useTls) URLProtocol.WSS else URLProtocol.WS
+                headers.append("Origin", "${if (useTls) "https" else "http"}://$host")
+            }
+    }
+
+    actual suspend fun send(text: String) {
+        session?.send(Frame.Text(text))
+    }
+
+    actual suspend fun receive(): String {
+        val s = checkNotNull(session) { "WebSocket not connected" }
+        while (true) {
+            val frame = s.incoming.receive()
+            if (frame is Frame.Text) return frame.readText()
+        }
+    }
+
+    actual fun close() {
+        session?.cancel()
+        session = null
+    }
+}

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsConnection.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsConnection.kt
@@ -1,14 +1,6 @@
 package com.poziomki.app.chat.ws
 
-import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.websocket.WebSockets
-import io.ktor.client.plugins.websocket.webSocket
-import io.ktor.http.URLProtocol
-import io.ktor.websocket.Frame
-import io.ktor.websocket.close
-import io.ktor.websocket.readText
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -26,7 +18,7 @@ import kotlinx.serialization.encodeToString
 class WsConnection(
     private val baseUrl: String,
     private val tokenProvider: suspend () -> String?,
-    engine: HttpClientEngine,
+    private val engine: HttpClientEngine,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val _incoming = MutableSharedFlow<WsServerMessage>(extraBufferCapacity = 64)
@@ -40,15 +32,6 @@ class WsConnection(
 
     private var connectionJob: Job? = null
     private var heartbeatJob: Job? = null
-
-    private val wsClient =
-        HttpClient(engine) {
-            install(WebSockets)
-            defaultRequest {
-                headers.append("Origin", baseUrl.trimEnd('/'))
-            }
-        }
-
     private var sendChannel: (suspend (String) -> Unit)? = null
 
     suspend fun send(msg: WsClientMessage): Boolean {
@@ -101,92 +84,92 @@ class WsConnection(
 
     private suspend fun connectOnce() {
         val (host, port, useTls) = parseBaseUrl(baseUrl)
+        val transport = WsTransport(engine)
+        transport.connect(host = host, port = port, useTls = useTls, path = "/api/v1/chat/ws")
 
-        wsClient.webSocket(
-            host = host,
-            port = port,
-            path = "/api/v1/chat/ws",
-            request = {
-                url.protocol = if (useTls) URLProtocol.WSS else URLProtocol.WS
-            },
-        ) {
-            // Authenticate
+        val pongReceived = MutableStateFlow(true)
+        try {
             val token = checkNotNull(tokenProvider()) { "No auth token" }
-            val authMsg = wsJson.encodeToString<WsClientMessage>(WsClientMessage.Auth(token))
-            send(Frame.Text(authMsg))
+            transport.send(wsJson.encodeToString<WsClientMessage>(WsClientMessage.Auth(token)))
+            authenticate(transport)
+            _isConnected.value = true
+            sendChannel = { outgoing -> transport.send(outgoing) }
+            heartbeatJob = scope.launch { heartbeatLoop(transport, pongReceived) }
+            // `receive()` throws when the socket closes, which bubbles up to the
+            // reconnect loop in connect().
+            readLoop(transport, pongReceived)
+        } finally {
+            heartbeatJob?.cancel()
+            _isConnected.value = false
+            sendChannel = null
+            transport.close()
+        }
+    }
 
-            // Wait for auth response
-            val authFrame = incoming.receive()
-            check(authFrame is Frame.Text) { "Expected text auth response" }
-            val authResponse = wsJson.decodeFromString<WsServerMessage>(authFrame.readText())
-            when (authResponse) {
+    /** Reads frames until the auth response. Throws on auth failure. */
+    private suspend fun authenticate(transport: WsTransport) {
+        while (true) {
+            val msg = decodeFrame(transport.receive()) ?: continue
+            when (msg) {
                 is WsServerMessage.AuthOk -> {
-                    _userId.value = authResponse.userId
-                    _isConnected.value = true
-                    sendChannel = { text -> send(Frame.Text(text)) }
+                    _userId.value = msg.userId
+                    return
                 }
 
                 is WsServerMessage.AuthError -> {
-                    error("Auth failed: ${authResponse.message}")
+                    error("Auth failed: ${msg.message}")
                 }
 
                 else -> {
-                    error("Unexpected auth response: $authResponse")
+                    error("Unexpected auth response: $msg")
                 }
             }
+        }
+    }
 
-            // Start heartbeat only after successful auth
-            val pongReceived = MutableStateFlow(true)
-            heartbeatJob =
-                launch {
-                    while (isActive) {
-                        delay(30_000L)
-                        pongReceived.value = false
-                        try {
-                            val pingText = wsJson.encodeToString<WsClientMessage>(WsClientMessage.Ping)
-                            send(Frame.Text(pingText))
-                        } catch (_: Exception) {
-                            break
-                        }
-                        delay(10_000L)
-                        if (!pongReceived.value) {
-                            // pong timeout, reconnecting
-                            close()
-                            break
-                        }
-                    }
-                }
+    /** Steady-state frame loop. Throws when the socket closes. */
+    private suspend fun readLoop(
+        transport: WsTransport,
+        pongReceived: MutableStateFlow<Boolean>,
+    ) {
+        while (true) {
+            val msg = decodeFrame(transport.receive()) ?: continue
+            if (msg is WsServerMessage.Pong) {
+                pongReceived.value = true
+            } else {
+                _incoming.emit(msg)
+            }
+        }
+    }
 
-            // Read loop
+    private fun decodeFrame(text: String): WsServerMessage? =
+        try {
+            wsJson.decodeFromString<WsServerMessage>(text)
+        } catch (
+            @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
+        ) {
+            null
+        }
+
+    private suspend fun heartbeatLoop(
+        transport: WsTransport,
+        pongReceived: MutableStateFlow<Boolean>,
+    ) {
+        while (true) {
+            delay(30_000L)
+            pongReceived.value = false
             try {
-                for (frame in this.incoming) {
-                    when (frame) {
-                        is Frame.Text -> {
-                            try {
-                                val msg = wsJson.decodeFromString<WsServerMessage>(frame.readText())
-                                if (msg is WsServerMessage.Pong) {
-                                    pongReceived.value = true
-                                } else {
-                                    _incoming.emit(msg)
-                                }
-                            } catch (_: Exception) {
-                                // Skip malformed frames
-                            }
-                        }
-
-                        is Frame.Close -> {
-                            break
-                        }
-
-                        is Frame.Binary -> {}
-
-                        else -> {}
-                    }
-                }
-            } finally {
-                heartbeatJob?.cancel()
-                _isConnected.value = false
-                sendChannel = null
+                transport.send(wsJson.encodeToString<WsClientMessage>(WsClientMessage.Ping))
+            } catch (
+                @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
+            ) {
+                break
+            }
+            delay(10_000L)
+            if (!pongReceived.value) {
+                // Pong timeout — drop the socket so the read loop unblocks and reconnects.
+                transport.close()
+                break
             }
         }
     }

--- a/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTransport.kt
+++ b/mobile/core/src/commonMain/kotlin/com/poziomki/app/chat/ws/WsTransport.kt
@@ -1,0 +1,29 @@
+package com.poziomki.app.chat.ws
+
+import io.ktor.client.engine.HttpClientEngine
+
+/**
+ * Platform WebSocket transport. The chat protocol (auth, heartbeat, reconnect,
+ * framing) lives in [WsConnection]; this is just the raw text pipe.
+ *
+ * Android wraps Ktor/OkHttp. iOS uses a native `URLSessionWebSocketTask`
+ * supplied from Swift — Ktor 3.4.x's Darwin engine caps WebSocket message size
+ * too low (KTOR/#1894), which drops the ~6 KB conversations frame with
+ * "Message too long" and resets the socket in a loop.
+ */
+expect class WsTransport(
+    engine: HttpClientEngine,
+) {
+    suspend fun connect(
+        host: String,
+        port: Int,
+        useTls: Boolean,
+        path: String,
+    )
+
+    suspend fun send(text: String)
+
+    suspend fun receive(): String
+
+    fun close()
+}

--- a/mobile/core/src/iosMain/kotlin/com/poziomki/app/chat/ws/IosWsTransportRegistry.kt
+++ b/mobile/core/src/iosMain/kotlin/com/poziomki/app/chat/ws/IosWsTransportRegistry.kt
@@ -1,0 +1,23 @@
+package com.poziomki.app.chat.ws
+
+/** Handle to a live native socket, returned by [IosWsTransportRegistry.connect]. */
+class IosWsHandle(
+    val send: (String) -> Unit,
+    val close: () -> Unit,
+)
+
+/**
+ * Seam filled in from `app-ui`'s iOS bridge at startup, which in turn is backed
+ * by a Swift `URLSessionWebSocketTask`. Plain function types keep `core`
+ * unexported — the Swift-facing interfaces live in the framework module.
+ */
+object IosWsTransportRegistry {
+    var connect: (
+        (
+            url: String,
+            origin: String,
+            onText: (String) -> Unit,
+            onError: (String) -> Unit,
+        ) -> IosWsHandle
+    )? = null
+}

--- a/mobile/core/src/iosMain/kotlin/com/poziomki/app/chat/ws/WsTransport.ios.kt
+++ b/mobile/core/src/iosMain/kotlin/com/poziomki/app/chat/ws/WsTransport.ios.kt
@@ -1,0 +1,47 @@
+package com.poziomki.app.chat.ws
+
+import io.ktor.client.engine.HttpClientEngine
+import kotlinx.coroutines.channels.Channel
+
+private class IosWsClosed(
+    message: String,
+) : Exception(message)
+
+actual class WsTransport actual constructor(
+    @Suppress("UNUSED_PARAMETER") engine: HttpClientEngine,
+) {
+    // Native socket delivers frames via callback; bridge them to a suspend queue.
+    private val incoming = Channel<String>(Channel.UNLIMITED)
+    private var handle: IosWsHandle? = null
+
+    actual suspend fun connect(
+        host: String,
+        port: Int,
+        useTls: Boolean,
+        path: String,
+    ) {
+        val connectFn =
+            checkNotNull(IosWsTransportRegistry.connect) { "iOS WebSocket bridge not registered" }
+        val scheme = if (useTls) "wss" else "ws"
+        val origin = "${if (useTls) "https" else "http"}://$host"
+        handle =
+            connectFn(
+                "$scheme://$host:$port$path",
+                origin,
+                { text -> incoming.trySend(text) },
+                { err -> incoming.close(IosWsClosed(err)) },
+            )
+    }
+
+    actual suspend fun send(text: String) {
+        handle?.send?.invoke(text)
+    }
+
+    actual suspend fun receive(): String = incoming.receive()
+
+    actual fun close() {
+        handle?.close?.invoke()
+        handle = null
+        incoming.close()
+    }
+}

--- a/mobile/core/src/iosMain/kotlin/com/poziomki/app/di/PlatformModule.ios.kt
+++ b/mobile/core/src/iosMain/kotlin/com/poziomki/app/di/PlatformModule.ios.kt
@@ -3,7 +3,7 @@ package com.poziomki.app.di
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import com.poziomki.app.chat.api.ChatClient
-import com.poziomki.app.chat.api.NoopChatClient
+import com.poziomki.app.chat.ws.WsChatClient
 import com.poziomki.app.connectivity.ConnectivityMonitor
 import com.poziomki.app.connectivity.IosConnectivityMonitor
 import com.poziomki.app.db.PoziomkiDatabase
@@ -23,7 +23,7 @@ actual fun platformModule(): Module =
         single<HttpClientEngine> { Darwin.create() }
         single { createDataStoreIos() }
         single<SessionTokenStore> { IosSecureSessionTokenStore() }
-        single<ChatClient> { NoopChatClient() }
+        single<ChatClient> { WsChatClient(get(), get(), get(), get(), get()) }
         single<SqlDriver> {
             NativeSqliteDriver(PoziomkiDatabase.Schema, "poziomki.db")
         }

--- a/mobile/iosApp/iosApp/iOSApp.swift
+++ b/mobile/iosApp/iosApp/iOSApp.swift
@@ -6,6 +6,9 @@ import FirebaseCore
 struct iOSApp: App {
     init() {
         FirebaseApp.configure()
+        // Chat uses a native URLSessionWebSocketTask instead of Ktor's Darwin
+        // engine, whose WebSocket message-size cap drops the conversations frame.
+        IosWebSocketBridgeKt.registerIosWebSocket(factory: IosWebSocketFactory())
         let versionCode = (Bundle.main.infoDictionary?["CFBundleVersion"] as? String).flatMap(Int32.init) ?? 0
         KoinKt.doInitKoin(versionCode: versionCode)
     }
@@ -14,5 +17,69 @@ struct iOSApp: App {
         WindowGroup {
             ContentView()
         }
+    }
+}
+
+/// Native WebSocket backing the shared chat client on iOS. `URLSessionWebSocketTask`
+/// defaults to a 1 MB message limit, so it carries the conversations/history frames
+/// that Ktor's Darwin engine resets with "Message too long".
+final class IosWebSocketImpl: NSObject, NativeWebSocket {
+    private let listener: NativeWebSocketListener
+    private var task: URLSessionWebSocketTask?
+
+    init(url: String, origin: String, listener: NativeWebSocketListener) {
+        self.listener = listener
+        super.init()
+        guard let parsed = URL(string: url) else {
+            listener.onError(message: "invalid ws url: \(url)")
+            return
+        }
+        var request = URLRequest(url: parsed)
+        request.setValue(origin, forHTTPHeaderField: "Origin")
+        let task = URLSession.shared.webSocketTask(with: request)
+        self.task = task
+        task.resume()
+        receiveLoop()
+    }
+
+    private func receiveLoop() {
+        task?.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .failure(let error):
+                self.listener.onError(message: error.localizedDescription)
+            case .success(let message):
+                switch message {
+                case .string(let text):
+                    self.listener.onText(text: text)
+                case .data(let data):
+                    if let text = String(data: data, encoding: .utf8) {
+                        self.listener.onText(text: text)
+                    }
+                @unknown default:
+                    break
+                }
+                self.receiveLoop()
+            }
+        }
+    }
+
+    func send(text: String) {
+        task?.send(.string(text)) { [weak self] error in
+            if let error {
+                self?.listener.onError(message: error.localizedDescription)
+            }
+        }
+    }
+
+    func close() {
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+    }
+}
+
+final class IosWebSocketFactory: NativeWebSocketFactory {
+    func create(url: String, origin: String, listener: NativeWebSocketListener) -> NativeWebSocket {
+        IosWebSocketImpl(url: url, origin: origin, listener: listener)
     }
 }


### PR DESCRIPTION
iOS chat ran a no-op client because Ktor's Darwin WebSocket engine drops frames larger than its message cap, so conversations and history never loaded and sending was dead in DMs and event chats.

Routes the shared WsConnection through a WsTransport seam: Android keeps Ktor/OkHttp; iOS uses a native URLSessionWebSocketTask injected from Swift. Wires iOS to the real WsChatClient. Protocol, auth, heartbeat, reconnect stay in shared Kotlin.

Verified on iPhone 17 and iPad Air (iOS/iPadOS 26.5): conversations load, timeline renders, DM and event-chat sends persist across cold relaunch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784328040&installation_id=133691716&pr_number=575&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F575&signature=12c96ae4220e8a038fc2db1e52ae8907cd2d9ee25cadf53c34f852558c9005ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native URLSession WebSocket transport for iOS chat
> - Introduces a `WsTransport` expect/actual abstraction so `WsConnection` delegates all WebSocket I/O to a platform-specific implementation instead of managing a Ktor session directly.
> - On iOS, [WsTransport.ios.kt](https://github.com/poziomki-app/poziomki/pull/575/files#diff-28b9388a3e42c6a45499a709240ee73bcdfb5ade6be502841201995cc0a8d8e2) bridges to a Swift `URLSessionWebSocketTask` via [IosWsTransportRegistry](https://github.com/poziomki-app/poziomki/pull/575/files#diff-17f30add66099b0d9203abb0e5e4dfe98aace10281f5ebbcfe5c93f03ea743b7), which is wired at startup in [iOSApp.swift](https://github.com/poziomki-app/poziomki/pull/575/files#diff-8bd9a9fa56e44f279e7d95d8fbd11d2fabda86ccc7473287f605de3bd145519c) before Koin initializes.
> - On Android, [WsTransport.android.kt](https://github.com/poziomki-app/poziomki/pull/575/files#diff-cf8add7ae0154c588dee60f5633ec1355c28bea7b5ca912bb582c945f6289e34) wraps a Ktor `HttpClient` with the WebSockets plugin and adds an `Origin` header.
> - `WsConnection` gains structured auth, read-loop, and heartbeat helpers; missed pongs now close the transport to unblock `receive()` and trigger reconnect.
> - The iOS DI module now provides `WsChatClient` instead of `NoopChatClient`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0de6dd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->