### PR TITLE
fix(ios): location-always purpose string (ITMS-90683)

### DIFF
--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -22,6 +22,8 @@
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Poziomki używa Twojej lokalizacji, aby pokazać wydarzenia w pobliżu na mapie.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Poziomki używa Twojej lokalizacji, aby pokazać wydarzenia w pobliżu na mapie.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Poziomki potrzebuje dostępu do zdjęć, aby ustawić zdjęcie profilowe i okładki wydarzeń.</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
Adds `NSLocationAlwaysAndWhenInUseUsageDescription` to silence the ITMS-90683 upload warning. An SDK references the location-always API; the app itself only uses when-in-use. Non-blocking — rides the next build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784375884&installation_id=133691716&pr_number=578&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F578&signature=b0a9835db96de8b5225e6b738520c2ed5d9f32cfd6a094e1c07897318048d7d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `NSLocationAlwaysAndWhenInUseUsageDescription` to iOS Info.plist to fix ITMS-90683
> Adds the missing `NSLocationAlwaysAndWhenInUseUsageDescription` key to [Info.plist](https://github.com/poziomki-app/poziomki/pull/578/files#diff-5897280c2b4695102b6259401869cd43697b3f07b7a565b4fa44233b3ada6906) with a Polish-language description matching the existing `WhenInUse` string. This resolves an App Store submission rejection (ITMS-90683) caused by the absent key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51e2d1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->