### PR TITLE
docs: use official App Store/Google Play badges

### DIFF
--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -10,10 +10,10 @@
 
 <p align="center">
   <a href="https://apps.apple.com/pl/app/poziomki-poznajmy-si%C4%99/id6769086499?l=pl">
-    <img src="https://img.shields.io/badge/App%20Store-0D96F6?style=for-the-badge&logo=apple&logoColor=white" alt="Download on the App Store">
+    <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store" height="55">
   </a>
   <a href="https://play.google.com/store/apps/details?id=app.poziomki">
-    <img src="https://img.shields.io/badge/Google%20Play-414141?style=for-the-badge&logo=google-play&logoColor=white" alt="Get it on Google Play">
+    <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="55">
   </a>
 </p>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,10 +14,10 @@
 
 <p align="center">
   <a href="https://apps.apple.com/pl/app/poziomki-poznajmy-si%C4%99/id6769086499?l=pl">
-    <img src="https://img.shields.io/badge/App%20Store-0D96F6?style=for-the-badge&logo=apple&logoColor=white" alt="Pobierz z App Store">
+    <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/pl-pl?size=250x83" alt="Pobierz z App Store" height="55">
   </a>
   <a href="https://play.google.com/store/apps/details?id=app.poziomki">
-    <img src="https://img.shields.io/badge/Google%20Play-414141?style=for-the-badge&logo=google-play&logoColor=white" alt="Pobierz z Google Play">
+    <img src="https://play.google.com/intl/pl/badges/static/images/badges/pl_badge_web_generic.png" alt="Pobierz z Google Play" height="55">
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- Replace generic shields.io badges from #589 with the official Apple/Google store badge assets (native look, localized pl/en)

## Test plan
- N/A (docs only)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787218326&installation_model_id=21872&pr_number=590&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F590&signature=52f4278faf7ce76915a4b5f15f491d86b3a4ad2576495d018c4dacfb6caa8b2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace shields.io badge images with official App Store and Google Play badges in docs
> Updates badge `<img>` sources in [README.en.md](https://github.com/poziomki-app/poziomki/pull/590/files#diff-a07710d2e14ffbe03aaa3617bceedf4aded5796b87c9e23dbbd0646da5ac6bdf) and [README.md](https://github.com/poziomki-app/poziomki/pull/590/files#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938) to use official Apple Media Services and Google Play assets instead of shields.io-generated images. Sets `height="55"` on both badges in each file. Locale-appropriate badge URLs are used (en-us for the English README, pl-pl for the Polish README).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50a5d6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->