### PR TITLE
docs: align badge heights in README

### DIFF
--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -13,7 +13,7 @@
     <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store" height="55">
   </a>
   <a href="https://play.google.com/store/apps/details?id=app.poziomki">
-    <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="55">
+    <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" height="72">
   </a>
 </p>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@
     <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/pl-pl?size=250x83" alt="Pobierz z App Store" height="55">
   </a>
   <a href="https://play.google.com/store/apps/details?id=app.poziomki">
-    <img src="https://play.google.com/intl/pl/badges/static/images/badges/pl_badge_web_generic.png" alt="Pobierz z Google Play" height="55">
+    <img src="https://play.google.com/intl/pl/badges/static/images/badges/pl_badge_web_generic.png" alt="Pobierz z Google Play" height="72">
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- Bump Google Play badge img height from 55 to 72 so its visible pill matches the App Store badge's height (Google's PNG has built-in transparent padding, Apple's SVG doesn't)

## Test plan
- N/A (docs only)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787218627&installation_model_id=21872&pr_number=591&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F591&signature=3d20802b48861b2727bb7ef6093e6a391ad44e24fd3bcd25a9e626345443ba62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase Google Play badge height to 72px in README files
> Updates the `height` attribute on the Google Play badge `<img>` tag from 55 to 72 in both [README.md](https://github.com/poziomki-app/poziomki/pull/591/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [README.en.md](https://github.com/poziomki-app/poziomki/pull/591/files#diff-a07710d2e14ffbe03aaa3617bceedf4aded5796b87c9e23dbbd0646da5ac6bdf) to align badge heights consistently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f6b49d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->