### PR TITLE
fix(backend): bump diesel and cmov to patched versions

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.9"
+version = "2.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
+checksum = "e54d1f576cd3a3460f212a4615fd12ce1b6303c095b79a44449ffbe627753dc1"
 dependencies = [
  "bitflags",
  "byteorder",


### PR DESCRIPTION
## Summary
- Bump `diesel` 2.3.9 → 2.3.11 (GHSA-ggxf-9f6j-w742: SQLite use-after-free in `deserialize_readonly_database`)
- Bump `cmov` 0.5.3 → 0.5.4 (GHSA-3rjw-m598-pq24: wrong cmov results on aarch64)
- `diesel-async` stays on 0.8.x: the GHSA-ff9q-rm55-q7qr fix only landed in 0.9 (breaking release, drops `scoped-futures`), and the bug is MySQL-only — we only enable the `postgres` feature, so it isn't exploitable here. Will dismiss that Dependabot alert as not applicable.

## Test plan
- `cargo build --workspace` passes
- `cargo clippy --workspace` clean
- pre-commit hook (fmt + clippy) passed on commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787220614&installation_model_id=21872&pr_number=595&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F595&signature=3a46e043dbf571fe27e632795e55a5c0059e96a2051718b6dab59c8e18102f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `diesel` and `cmov` backend dependencies to patched versions
> Updates [Cargo.lock](https://github.com/poziomki-app/poziomki/pull/595/files#diff-3f79cdab9fc995768557231190d727e9226b25084a58a51c003a80247c3c9fe4) to pin `diesel` and `cmov` to patched versions, likely addressing security or correctness issues in those crates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc6d84d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->