### PR TITLE
fix(backend): resolve cargo-deny advisory failures blocking CI

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1138,7 +1138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1369,7 +1369,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -2316,9 +2316,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -2549,7 +2549,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3124,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -3142,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3879,7 +3879,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4355,7 +4355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4371,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -4686,9 +4686,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5409,7 +5409,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -9,12 +9,6 @@ ignore = [
     # exists; re-evaluate when RustCrypto/RSA lands constant-time fixes
     # or when lettre drops the rsa dependency.
     "RUSTSEC-2023-0071",
-    # RUSTSEC-2026-0097: rand 0.8 is unsound when a custom logger calls
-    # `rand::rng()`. We do not install a custom logger that calls into rand,
-    # and the dependency is only transitively pulled in by lettre → rsa →
-    # num-bigint-dig for email crypto. Re-evaluate when lettre ships an
-    # update that no longer depends on rand 0.8.
-    "RUSTSEC-2026-0097",
     # RUSTSEC-2024-0436: paste 1.0.15 is archived / unmaintained. Pulled in
     # transitively by tokenizers via macro_rules_attribute — a proc-macro
     # helper used at build time only, no runtime code path. No CVE, no
@@ -29,6 +23,22 @@ ignore = [
     # affected code path is not compiled. Drop this ignore when we bump
     # diesel-async to >=0.9.
     "RUSTSEC-2026-0138",
+    # RUSTSEC-2026-0173: proc-macro-error2 is unmaintained (no CVE), pulled
+    # in transitively by validator_derive (build-time proc-macro only, no
+    # runtime code path). No safe upgrade exists upstream; validator 0.20.0
+    # is already the latest release. Re-evaluate when validator migrates
+    # off proc-macro-error2.
+    "RUSTSEC-2026-0173",
+    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml < 0.41 is vulnerable
+    # to CPU/memory DoS when parsing untrusted XML with many attributes or
+    # namespace declarations on a single tag. Pulled in transitively via
+    # rust-s3 -> aws-creds, which hard-pins `quick-xml = "^0.38"`; rust-s3
+    # 0.37.2 is the latest release and cannot be bumped past this pin. We
+    # only parse XML responses from our own trusted S3-compatible storage
+    # backend, not attacker-controlled input. Re-evaluate when rust-s3
+    # ships a release that allows quick-xml >=0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- The `cargo-deny` job has failed on every push to `main` since RUSTSEC-2026-0097's `rand` advisory got fully patched, leaving a stale `ignore` entry that cargo-deny flags as `advisory-not-detected`.
- Updates `crossbeam-epoch`, `tokio-postgres`, `metrics`, `spin` to patched/non-yanked versions.
- Adds justified `ignore` entries for two advisories with no available upgrade path: `proc-macro-error2` (unmaintained, via `validator` 0.20.0, already latest) and `quick-xml` DoS (pinned to `^0.38` by `rust-s3` 0.37.2, already latest).

## Test plan
- [x] `cargo deny check advisories licenses bans sources` → `advisories ok, bans ok, licenses ok, sources ok`
- [x] `cargo build --workspace` succeeds

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/poziomki-app/codesmith/poziomki/pr/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787221908&installation_model_id=21872&pr_number=598&repository=poziomki-app%2Fpoziomki&return_to=https%3A%2F%2Fgithub.com%2Fpoziomki-app%2Fpoziomki%2Fpull%2F598&signature=305aa0b327d0d3de02e7a5b7752929fe69ea7c485d05d9bd4417a1193474528d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cargo-deny advisory failures blocking CI by updating ignored advisories
> Updates [deny.toml](https://github.com/poziomki-app/poziomki/pull/598/files#diff-69d451b15b98b99acc2765158eecfbfd80089037eb487d1cdba9b2f1062eb982) to swap out stale advisory ignores: removes `RUSTSEC-2026-0097` (no longer needed) and adds `RUSTSEC-2026-0173`, `RUSTSEC-2026-0194`, and `RUSTSEC-2026-0195` with explanatory comments. `Cargo.lock` is updated alongside.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c2c1ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->